### PR TITLE
docs: port 8 missing specs from nanoclaw and generalize references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,14 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 | `.claude/hooks/tests/` | Hook test infrastructure |
 | `src/hooks/` | TypeScript hooks |
 | `.claude/settings-fragment.json` | Hook registrations for host projects |
+| `docs/hooks-design.md` | Hooks patterns, anti-patterns, regex traps, gate design, testing conventions |
+| `docs/hook-test-dry-spec.md` | DRY refactoring spec for hook test infrastructure |
+| `docs/test-ladder-spec.md` | Test maturity levels and testing methodology |
+| `docs/worktree-first-tooling-spec.md` | Worktree-safe tooling patterns |
+| `docs/kaizen-cases-unification-spec.md` | Kaizen issue + case system unification |
+| `docs/kaizen-ipc-architecture.md` | IPC architecture for kaizen-cases |
+| `docs/case-create-auto-adopt-worktree-spec.md` | Worktree adoption for case system |
+| `docs/test-side-effects-and-kaizen-escalation-spec.md` | Test side-effects and L1→L2 escalation patterns |
 
 ## Skills
 

--- a/docs/case-create-auto-adopt-worktree-spec.md
+++ b/docs/case-create-auto-adopt-worktree-spec.md
@@ -1,0 +1,124 @@
+# Case Creation Auto-Adopt Worktree — Specification
+
+## 1. Problem Statement
+
+Case systems that manage git worktrees often assume they are the sole worktree lifecycle manager. When `case_create` runs, it unconditionally creates a new git worktree — even when the caller is already inside one. This produces duplicate worktrees, orphaned branches, and requires manual cleanup.
+
+**Manual flags** (like `--branch-name`/`--worktree-path`) let callers explicitly say "use this existing worktree." But this is a Level 1 fix — it shifts the burden to the caller. Every new tool that creates worktrees (Claude Code's `EnterWorktree`, future CI tools, other agents) would need to know about and pass these flags.
+
+**The real fix:** case creation should auto-detect that it's already running inside a worktree and adopt it. The information is already available from git.
+
+### Concrete incidents
+
+| Date | What broke | Impact | Root cause |
+|------|-----------|--------|------------|
+| Session 1 | `case-create` from worktree created nested worktree | Multiple retry attempts + manual DB cleanup per case, orphaned worktrees | `createCaseWorkspace` unconditionally calls `git worktree add` |
+| Session 1 | Same bug occurred twice in one session | ~15 min wasted total | No detection of "already in a worktree" |
+
+## 2. Desired End State
+
+When `case_create` is called from inside an existing worktree:
+1. It detects that `process.cwd()` (or the equivalent) is a worktree, not the main checkout
+2. It uses the current worktree path and branch name automatically
+3. It does NOT create a new worktree
+4. The case record is linked to the existing worktree
+
+When `case_create` is called from the main checkout:
+- Behavior is unchanged — it creates a new worktree as before
+
+When explicit `--branch-name`/`--worktree-path` flags are passed:
+- They take precedence over auto-detection
+
+**Out of scope:**
+- Worktree cleanup/lifecycle management (separate concern)
+- Multi-case-per-worktree support (not needed)
+
+## 3. Architecture
+
+### Detection mechanism
+
+Git provides everything needed:
+
+```bash
+# Are we in a worktree? Compare git-common-dir to the default .git
+git rev-parse --git-common-dir   # /path/to/main/.git (always)
+git rev-parse --show-toplevel    # /path/to/worktree (if in worktree)
+git rev-parse --abbrev-ref HEAD  # current branch name
+```
+
+If `show-toplevel` is not a parent of `git-common-dir`, we're in a worktree. The worktree path is `show-toplevel`, the branch is `abbrev-ref HEAD`.
+
+### Where detection runs
+
+There are multiple entry points for case creation. Each needs different handling:
+
+| Entry point | Runs where | Can use `process.cwd()` | Auto-detect approach |
+|------------|-----------|------------------------|---------------------|
+| CLI tool | Host, directly | Yes — the CLI runs in the caller's cwd | Detect at startup via git commands |
+| IPC handler | Host, via service | No — service always runs from main checkout | Caller must pass flags |
+| MCP tool | Remote | No — different git topology | Caller must pass flags |
+
+**Key insight:** Auto-detection only makes sense for the CLI path. IPC and MCP callers don't share `process.cwd()` with the case creation logic — the service process runs from the main checkout regardless of where the requesting agent is.
+
+### Implementation
+
+In the CLI entry point, before workspace creation:
+
+```typescript
+// Auto-detect: if running from inside a worktree and no explicit flags,
+// adopt the current worktree
+if (!branchName && !worktreePath) {
+  const detected = detectCurrentWorktree();
+  if (detected) {
+    resolved = deps.resolveWorktree(detected.worktreePath, detected.branchName);
+  }
+}
+```
+
+The `detectCurrentWorktree()` function:
+
+```typescript
+function detectCurrentWorktree(): { worktreePath: string; branchName: string } | null {
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', { encoding: 'utf-8' }).trim();
+    const toplevel = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+    const mainRoot = path.dirname(path.resolve(gitCommonDir));
+
+    // If toplevel equals main root, we're in the main checkout — no auto-adopt
+    if (path.resolve(toplevel) === mainRoot) return null;
+
+    const branchName = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+    return { worktreePath: toplevel, branchName };
+  } catch {
+    return null;
+  }
+}
+```
+
+This function belongs in the case management module or in a shared `git-paths` utility.
+
+## 4. What Exists vs What Needs Building
+
+### Already Solved
+
+| Capability | Status |
+|------------|--------|
+| Manual worktree adoption via explicit flags | Done |
+| Worktree path validation | Done |
+| Fallback to new worktree when no existing one detected | Done |
+
+### Needs Building
+
+| Component | What | Why it doesn't exist yet |
+|-----------|------|-------------------------|
+| `detectCurrentWorktree()` | Git-based worktree detection function | Initial implementation focused on explicit flags, not auto-detection |
+| CLI auto-adopt | Call detection before workspace creation | Same |
+| Tests | Unit tests for detection (in worktree vs main checkout) | Same |
+
+## 5. Open Questions
+
+1. **Should auto-detect be on by default or opt-in?** The risk of auto-detecting is that someone running `case-create` from a worktree that belongs to a *different* case might accidentally link to the wrong worktree. Mitigation: check if the worktree already has an active case linked to it, and if so, don't auto-adopt (treat it as "occupied"). Lean: on by default with the occupied-check guard.
+
+2. **Should this live in the case module or a shared `git-paths` utility?** A shared `git-paths` utility is a natural fit. But it could ship in the case module now and move later. Lean: ship in place now, refactor when the utility is built.
+
+3. **What about a `--new-worktree` escape hatch?** If auto-detection causes surprises, callers need a way to force new worktree creation. A `--new-worktree` flag would explicitly bypass detection. Lean: add it, default off.

--- a/docs/hook-test-dry-spec.md
+++ b/docs/hook-test-dry-spec.md
@@ -1,0 +1,213 @@
+# Hook Test Infrastructure DRY Refactoring — Specification
+
+## 1. Problem Statement
+
+The hook test suite (`.claude/kaizen/hooks/tests/`) has ~308 lines of duplicated boilerplate across 10+ files. The same mock `gh`, `create_state()`, `setup()`/`teardown()`, and decision-extraction helpers are copy-pasted with minor variations. When a shared function like `find_needs_review_state()` gains a new external dependency (as happened with kaizen #85's `gh pr view` call), every test file must be updated independently — 10 files touched, ~300 lines added, for what should have been a 1-line change.
+
+### Cost
+
+- **Kaizen #85 implementation:** 3 source files changed (35 lines), 10 test files changed (300+ lines). Test boilerplate was 10x the actual fix.
+- **Ongoing maintenance:** Each new hook or shared-function change requires updating N test files instead of 1.
+- **Bug surface:** Pre-existing bugs in duplicated code (e.g., `create_state()` missing BRANCH field in `harness.py`) went undetected because fixes to one copy didn't propagate.
+
+## 2. Desired End State
+
+Each test file contains only:
+1. A `source` line to import shared infrastructure
+2. Hook-specific test cases
+
+All environment setup, mock creation, state management helpers, and decision extractors live in shared files, sourced once.
+
+**What's explicitly NOT in scope:**
+- Consolidating bash and Python test suites (they test different things)
+- Changing hook architecture or behavior
+- Adding new tests — this is purely DRY refactoring of existing infrastructure
+
+## 3. What Exists vs What Needs Building
+
+### Already Solved
+
+| Capability | Current implementation | Status |
+|---|---|---|
+| Assertions | `test-helpers.sh`: assert_eq, assert_contains, assert_not_contains, assert_ok, assert_fails | Good — sourced by all bash tests |
+| Integration harness | `harness.sh`: run_single_hook, build_*_input, validate_deny_output | Good — used by integration tests |
+| Python harness | `harness.py`: HookHarness, MockBinDir, PRReviewState | Good — used by test_hooks.py |
+| Mock creation (harness) | `harness.sh`: setup_gh_git_mocks, setup_mock_dir | Good — but only used by harness-based tests |
+
+### Needs Building
+
+| Component | What | Why it doesn't exist yet |
+|---|---|---|
+| `setup_test_env()` | Shared function: creates STATE_DIR, mock gh (returns OPEN), exports PATH | Each file creates its own independently |
+| `create_state()` in test-helpers.sh | Shared state file creation with mandatory BRANCH field | 4 files have identical copies; harness.py had a buggy copy |
+| `cleanup_test_env()` | Shared teardown: removes STATE_DIR + mock dir | 6 files have identical setup/teardown |
+| Decision extractors | `is_denied()` and `is_blocked()` in test-helpers.sh | 4 files define identical helpers under different names |
+| `backdate_file()` | Cross-platform file backdating helper | 5 files duplicate the `touch -d` / `touch -t` / `date -v` fallback chain |
+
+## 4. Duplication Inventory
+
+| Pattern | Files | Lines per copy | Total waste | Consolidation |
+|---|---|---|---|---|
+| STATE_DIR + DEBUG_LOG setup | 6 | 3 | ~18 | `setup_test_env()` |
+| Mock gh (returns OPEN) | 8 | 7 | ~56 | `setup_test_env()` |
+| `setup()` / `teardown()` | 6 | 6 | ~36 | `reset_state()` / `cleanup_test_env()` |
+| `create_state()` | 4 bash + 1 Python | 8 | ~40 | Move to test-helpers.sh |
+| Decision extractors | 4 | 3 | ~12 | `is_denied()` / `is_blocked()` in test-helpers.sh |
+| `touch -d` backdate pattern | 5 | 2 | ~10 | `backdate_file()` |
+| Hook run wrappers with mock PATH | 4 | 6 | ~24 | Can't fully consolidate (different input JSON shapes) |
+| **Total** | | | **~196** | |
+
+## 5. Design
+
+### Phase 1: Extract shared helpers to test-helpers.sh
+
+Add these functions to the existing `test-helpers.sh`:
+
+```bash
+# Test environment: STATE_DIR, mock gh, PATH
+setup_test_env() {
+  TEST_STATE_DIR="/tmp/.pr-review-state-test-$$"
+  rm -rf "$TEST_STATE_DIR"
+  mkdir -p "$TEST_STATE_DIR"
+  export STATE_DIR="$TEST_STATE_DIR"
+  export DEBUG_LOG="/dev/null"
+
+  TEST_MOCK_DIR=$(mktemp -d)
+  cat > "$TEST_MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "OPEN"
+exit 0
+MOCK_EOF
+  chmod +x "$TEST_MOCK_DIR/gh"
+  export PATH="$TEST_MOCK_DIR:$PATH"
+}
+
+# Reset state between tests (equivalent to current setup())
+reset_state() {
+  rm -rf "$STATE_DIR"
+  mkdir -p "$STATE_DIR"
+}
+
+# Cleanup everything
+cleanup_test_env() {
+  rm -rf "$TEST_STATE_DIR" "$TEST_MOCK_DIR"
+}
+
+# Create PR review state file with mandatory BRANCH
+create_state() {
+  local pr_url="$1"
+  local round="${2:-1}"
+  local status="${3:-needs_review}"
+  local branch="${4:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)}"
+  local filename
+  filename=$(echo "$pr_url" | sed 's|https://github\.com/||;s|/pull/|_|;s|/|_|g')
+  printf 'PR_URL=%s\nROUND=%s\nSTATUS=%s\nBRANCH=%s\n' \
+    "$pr_url" "$round" "$status" "$branch" > "$STATE_DIR/$filename"
+}
+
+# Decision extractors
+is_denied() {
+  echo "$1" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1
+}
+
+is_blocked() {
+  echo "$1" | jq -e '.decision == "block"' >/dev/null 2>&1
+}
+
+# Cross-platform file backdating
+backdate_file() {
+  local file="$1"
+  local hours="${2:-3}"
+  touch -d "$hours hours ago" "$file" 2>/dev/null ||
+    touch -t "$(date -d "$hours hours ago" +%Y%m%d%H%M.%S 2>/dev/null ||
+      date -v-${hours}H +%Y%m%d%H%M.%S)" "$file" 2>/dev/null
+}
+```
+
+### Phase 2: Update each test file
+
+Each file changes from:
+
+```bash
+# BEFORE: ~25 lines of boilerplate per file
+source "$(dirname "$0")/test-helpers.sh"
+
+HOOK="$(dirname "$0")/../enforce-pr-review.sh"
+STATE_DIR="/tmp/.pr-review-state-test-$$"
+export STATE_DIR
+export DEBUG_LOG="/dev/null"
+
+GATE_MOCK_DIR=$(mktemp -d)
+cat > "$GATE_MOCK_DIR/gh" << 'MOCK'
+#!/bin/bash
+echo "OPEN"
+exit 0
+MOCK
+chmod +x "$GATE_MOCK_DIR/gh"
+
+setup() { rm -rf "$STATE_DIR"; mkdir -p "$STATE_DIR"; }
+teardown() { rm -rf "$STATE_DIR"; }
+
+create_state() { ... 8 lines ... }
+run_gate() { ... 4 lines ... }
+is_denied() { ... 2 lines ... }
+```
+
+To:
+
+```bash
+# AFTER: ~5 lines
+source "$(dirname "$0")/test-helpers.sh"
+
+HOOK="$(dirname "$0")/../enforce-pr-review.sh"
+setup_test_env
+
+run_gate() {
+  local input=$(jq -n --arg cmd "$1" '{"tool_input":{"command":$cmd}}')
+  echo "$input" | bash "$HOOK" 2>/dev/null
+}
+```
+
+Note: `run_gate`/`run_stop_hook`/`run_tool_gate` stay per-file because they have different input JSON shapes. But they become 2-3 lines each instead of 6+, since PATH and STATE_DIR are already exported by `setup_test_env`.
+
+### Phase 3: Update harness.py
+
+Update `PRReviewState.create_state()` to always include BRANCH (already done in #125, just ensure it stays correct after refactoring).
+
+## 6. What NOT to Do
+
+- **Don't extract test scenarios.** Cross-worktree isolation tests, legacy file tests, and stale file tests are duplicated across files, but they're testing *different hooks* with the same invariant. That's intentional coverage, not duplication. Each hook needs its own test proving it respects the invariant.
+- **Don't consolidate hook invocation wrappers.** `run_gate`, `run_stop_hook`, and `run_tool_gate` build different JSON input shapes. A generic wrapper would need parameters that make it harder to read than the 3-line specializations.
+- **Don't merge bash and Python tests.** The Python tests cover schema validation and multi-file lifecycle — different value than the bash unit tests.
+
+## 7. Verification
+
+After refactoring, run the full hook test suite:
+
+```bash
+bash .claude/kaizen/hooks/tests/run-all-tests.sh
+```
+
+**Pass criteria:** Same pass/fail counts as before. Zero regressions.
+
+## 8. Open Questions (Resolved)
+
+1. **Should `setup_test_env` create a mock `git` too?** No — mock `git` stays per-test since only specific tests need git mocking (merge-from-main, branch simulation).
+
+2. **Should `run-all-tests.sh` call `cleanup_test_env` as a safety net?** No — `/tmp` is cleaned on reboot, and the dirs are tiny.
+
+## 9. Implementation Record
+
+**Completed:** Phases 1-2 (Phase 3 was already done in #125).
+
+**What was built:**
+- Added 7 shared functions to `test-helpers.sh`: `setup_test_env`, `reset_state`, `cleanup_test_env`, `create_state`, `is_denied`, `is_blocked`, `backdate_file`, `setup_default_gh_mock`
+- Updated 7 test files to use shared helpers: `test-enforce-pr-review.sh`, `test-enforce-pr-review-tools.sh`, `test-enforce-pr-review-stop.sh`, `test-state-utils.sh`, `test-pr-review-loop.sh`, `test-review-enforcement-e2e.sh`, `test-integration-pr-lifecycle.sh`
+- Net change: +114 / -206 lines (92 lines removed)
+
+**Verification:** Baseline 321 pass / 14 fail → After refactoring 321 pass / 14 fail. Same failed files, same pre-existing failures. Zero regressions.
+
+**Learnings:**
+- The e2e test (`test-review-enforcement-e2e.sh`) had `is_stop_blocked` and `is_tool_denied` which are just aliases for `is_blocked` and `is_denied` — kept as thin wrappers for readability in e2e context.
+- Integration tests (harness.sh-based) use a different env management pattern (HARNESS_TEMP), so `setup_default_gh_mock` was added to accept a directory parameter rather than forcing all tests into one pattern.
+- The `run_gate`/`run_tool_gate`/`run_stop_hook` wrappers stayed per-file as the spec predicted — different JSON input shapes make consolidation harder to read.

--- a/docs/hooks-design.md
+++ b/docs/hooks-design.md
@@ -1,0 +1,138 @@
+# Hooks Design — Patterns, Anti-Patterns, and Lessons Learned
+
+This document captures hard-won knowledge about the Claude Code hooks system. It's the reference for anyone writing, debugging, or maintaining hooks.
+
+## Architecture
+
+### Two Independent Systems: Permissions vs Hooks
+
+Claude Code has two enforcement layers that are often confused:
+
+| System | Flag to bypass | What it does |
+|--------|---------------|--------------|
+| **Permissions** | `--dangerously-skip-permissions` | Auto-approves built-in "Allow this tool?" prompts |
+| **Hooks** | `--bare` | Disables custom PreToolUse/PostToolUse/Stop scripts |
+
+**Critical:** `--dangerously-skip-permissions` does NOT bypass hooks. Custom hook `permissionDecision: "deny"` responses still fire and block. This was discovered in kaizen #323 when overnight-dent runs (which use `--dangerously-skip-permissions`) were still blocked by kaizen gates.
+
+`--bare` disables hooks BUT also disables CLAUDE.md, skills, LSP, and other infrastructure. It's a nuclear option, not a surgical one.
+
+### Hook Event Lifecycle
+
+```
+User/Agent action
+  → PreToolUse hooks fire (can DENY — blocks the action)
+  → Tool executes (if not denied)
+  → PostToolUse hooks fire (advisory — can set gates but not block retroactively)
+  → Stop hooks fire (when agent tries to finish — can block completion)
+```
+
+### Gate Pattern
+
+Gates are the primary control flow mechanism:
+
+1. **PostToolUse** creates a state file (e.g., `needs_pr_kaizen`)
+2. **PreToolUse** checks for the state file and denies non-allowlisted commands
+3. An allowlisted action clears the state file
+4. **Stop** hook prevents the agent from finishing with pending gates
+
+This creates a "you must do X before you can do Y" enforcement.
+
+## Writing Hooks
+
+### Language Boundaries
+
+See [`hook-language-boundaries.md`](hook-language-boundaries.md) for the full policy. Summary:
+
+- **Bash hooks** are the execution entry point (Claude Code invokes them)
+- **TypeScript** is preferred for complex logic (via `npx tsx` trampolines)
+- **Shared libraries** (`lib/*.sh`) provide common functions for bash hooks
+- Never mix languages within a single hook's logic — use a trampoline
+
+### Trampoline Pattern
+
+When a hook needs complex logic, use a thin bash wrapper that delegates to TypeScript:
+
+```bash
+#!/bin/bash
+# thin-hook.sh — trampoline to TypeScript implementation
+exec npx tsx "$(dirname "$0")/hook-impl.ts" "$@"
+```
+
+The bash script handles Claude Code's hook protocol (stdin JSON, stdout JSON). The TypeScript handles the logic.
+
+### Regex Patterns — The Alternation Trap
+
+**Anti-pattern (kaizen #323):**
+```bash
+grep -qE "^git[[:space:]]+${subcommand}"
+# Where subcommand="diff|log|show|status|branch|fetch"
+# Expands to: ^git[[:space:]]+diff|log|show|status|branch|fetch
+# The | is top-level alternation! "branch" matches ANYWHERE in the string
+```
+
+**Correct pattern:**
+```bash
+grep -qE "^git[[:space:]]+(${subcommand})"
+# Parentheses group the alternation: ^git[[:space:]]+(diff|log|show|...)
+```
+
+This bug caused `gh pr merge --delete-branch` to pass through readonly monitoring (the `branch` in `--delete-branch` matched the bare `branch` alternative). Always wrap variable alternation patterns in parentheses.
+
+### Allowlist Design
+
+When a gate blocks commands, it needs an allowlist of commands that ARE permitted during the gate.
+
+**Principles:**
+- Allowlist by **intent**, not by syntax. "PR workflow commands" not "commands containing `gh pr`"
+- Include **all variants** of an allowed action. `gh pr merge 42`, `gh pr merge URL`, `gh pr merge --squash` are all the same intent
+- **Segment-split** before matching (kaizen #172). Commands chained with `|`, `&&`, `;` must have each segment checked independently. Otherwise `npm build && echo KAIZEN_IMPEDIMENTS:` bypasses the gate
+- Use `is_gh_pr_command`, `is_git_command` helpers — they handle segment splitting
+
+### State File Conventions
+
+- **Location:** `$STATE_DIR` (defaults to `/tmp/.pr-review-state/`)
+- **Format:** `KEY=value` lines (parseable with `grep` + `cut`)
+- **Required fields:** `PR_URL`, `STATUS`, `BRANCH`
+- **Branch scoping:** State files include `BRANCH=` so hooks can filter to the current worktree
+- **Cross-branch lookup:** Active declarations (KAIZEN_IMPEDIMENTS) use `_any_branch` variants since the agent may submit from a different worktree
+- **Staleness:** Files older than `MAX_STATE_AGE` (2 hours) are ignored
+
+### Testing Hooks
+
+- **Unit tests:** Each hook has `test-{hook-name}.sh` in `tests/`
+- **Integration tests:** `test-hook-interaction-matrix.sh` tests cross-hook behavior
+- **Test isolation:** Tests override `STATE_DIR` to a temp directory. Never rely on real state files
+- **Mock `gh`:** Create a mock `gh` script in a temp dir and prepend to `PATH`
+- **Always test both paths:** the "allowed" path AND the "denied" path
+
+## Anti-Patterns
+
+### 1. Assuming `--dangerously-skip-permissions` Disables Hooks
+It doesn't. See "Two Independent Systems" above.
+
+### 2. Unparenthesized Regex Alternation
+`grep -qE "^prefix${var}"` where `var` contains `|` creates top-level alternation. Always use `(${var})`.
+
+### 3. Gate Without Allowlist
+A gate that blocks ALL commands forces the agent to clear the gate before doing anything — including commands needed to clear the gate. Always include the clearing action in the allowlist.
+
+### 4. Branch-Scoped Lookup for Active Declarations
+When an agent actively submits something (KAIZEN_IMPEDIMENTS), use `_any_branch` variants. The agent may have switched worktrees since the gate was created.
+
+### 5. Testing Against Real State
+Tests that don't override `STATE_DIR` will interact with real gates from other sessions, producing flaky results that depend on system state.
+
+### 6. Silent Failures in Advisory Hooks
+PostToolUse hooks that set gates should log what they're doing. Silent gate creation leads to mysterious blocks later.
+
+## Lessons Learned
+
+| Incident | Lesson | Kaizen |
+|----------|--------|--------|
+| `--delete-branch` matched `branch` in regex | Always parenthesize regex alternation variables | #323 |
+| `--dangerously-skip-permissions` didn't bypass gates | Permissions and hooks are independent systems | #353 |
+| Gate re-fired 3x for same PR in one session | Per-PR reflection markers needed | #288 |
+| Cross-worktree gate clearing failed | Active declarations need `_any_branch` lookup | #239 |
+| `npm build && echo KAIZEN_IMPEDIMENTS:` bypassed gate | Segment-split before matching | #172 |
+| Hook tests flaky due to real state files | Always override `STATE_DIR` in tests | #309 |

--- a/docs/kaizen-cases-unification-spec.md
+++ b/docs/kaizen-cases-unification-spec.md
@@ -1,0 +1,170 @@
+# Kaizen Cases Unification — Specification
+
+## 1. Problem Statement
+
+Kaizen issues are often created and managed via raw `gh` CLI calls, bypassing any cases abstraction. This creates a split-brain architecture where regular work goes through a structured case system, but kaizen work goes through raw CLI calls. The consequences:
+
+- **No validation or required fields.** Agents can create kaizen issues with missing labels, malformed titles, or no body structure.
+- **No collision detection.** Two agents can create duplicate kaizen issues for the same problem.
+- **No local cache.** Every backlog query makes multiple GitHub API calls. If GitHub is slow or rate-limited, skills fail.
+- **Not CRM-agnostic.** The `gh` CLI is hardcoded throughout skills. Switching to a different issue tracker requires rewriting every skill.
+
+### Who experiences this
+
+- **Dev agents** creating kaizen issues after reflections, filing improvement suggestions, or running `/kaizen-prd`.
+- **Admins** receiving malformed or duplicate issues that require manual cleanup.
+- **The system** accumulating technical debt as each skill implements its own GitHub interaction pattern.
+
+### What happens today
+
+| Operation | Current path | Problem |
+|-----------|-------------|---------|
+| Create kaizen issue | Raw `gh issue create` in skills | No validation, no abstraction |
+| Read backlog | Raw `gh issue list` in /kaizen-pick | GitHub-dependent, no cache |
+| Update labels | Raw `gh issue edit` in /kaizen-evaluate | Bypasses any sync layer |
+| Close issue | Auto-close via PR `Fixes` keyword | Works but fragile |
+
+## 2. Desired End State
+
+All kaizen issue lifecycle operations go through a cases abstraction. No agent ever calls `gh issue create/edit/list` directly for kaizen issues.
+
+```
+Skills (/kaizen-prd, /kaizen-pick, /kaizen-evaluate, /kaizen-reflect)
+        |
+Domain model (cases module)
+        |
+Case backend interface (adapter pattern)
+        |
+GitHub adapter
+        |
+GitHub Issues API
+```
+
+**What agents can do:**
+- Create kaizen issues through validated tools (with required fields)
+- Query active cases from local cache (fast, offline-capable)
+- Fetch full backlog from CRM on demand (for /kaizen-pick)
+- Update issue state (labels, status) through the backend adapter
+
+**What agents cannot do:**
+- Call `gh issue create` directly (blocked by L2 hook)
+- Bypass validation (required fields enforced at the tool layer)
+- Create duplicate issues (collision detection in domain model)
+
+**What is NOT in scope:**
+- Bidirectional sync for the full backlog (too complex, not needed)
+- Moving off GitHub as the kaizen CRM (abstraction enables this later)
+
+## 3. Architecture
+
+### Desired layers
+
+```
+Agent (dev or work)
+  |
+  |  kaizen_suggest, kaizen_list_backlog,
+  |  kaizen_view, kaizen_update
+  |
+Domain model (cases module)
+  |
+Case backend adapter
+  |
+GitHub REST API
+```
+
+### New operations for kaizen lifecycle
+
+| Operation | Purpose | Current path |
+|-----------|---------|-------------|
+| `kaizen_suggest` | Create a kaizen issue in CRM | Raw `gh issue create` |
+| `kaizen_list_backlog` | Fetch open issues from CRM | Raw `gh issue list` |
+| `kaizen_view` | Read a specific issue | Raw `gh issue view` |
+| `kaizen_update` | Update labels/status on issue | Raw `gh issue edit` |
+
+These operations route through the backend adapter, which handles:
+- Required field validation (title format, labels, body structure)
+- Collision detection (duplicate title/description matching)
+- Local cache update (for active/claimed issues)
+
+### Read path: hybrid cache
+
+| Data | Source | Cache? | Rationale |
+|------|--------|--------|-----------|
+| Active/claimed kaizen issues | Local DB | Yes | Fast routing, offline-capable |
+| Full backlog (for /kaizen-pick) | GitHub API (on demand) | No | Changes frequently, needs freshness |
+| Specific issue details | GitHub API (on demand) | No | Infrequent, needs latest state |
+
+### L2 enforcement hook
+
+A PreToolUse(Bash) hook that blocks `gh issue create --repo <kaizen-repo>` and `gh issue edit --repo <kaizen-repo>` commands. Must allowlist:
+- `gh issue view` (read-only, always allowed)
+- `gh issue list` (read-only, transitional — eventually replaced by domain model)
+- Commands from within hook/skill context that are part of the backend adapter
+
+## 4. Interaction Models
+
+### Creating a kaizen issue (happy path)
+
+1. Agent identifies improvement during `/kaizen-reflect`
+2. Agent calls `kaizen_suggest` with: description, level (L1/L2/L3), context
+3. Handler validates required fields
+4. Backend adapter creates issue in kaizen repo with standard format
+5. Issue number returned to agent for reference
+6. Local cache updated (if issue is immediately claimed)
+
+### /kaizen-pick reading the backlog
+
+1. Skill calls `kaizen_list_backlog` (or domain model function)
+2. Domain model fetches from GitHub API: open issues, no `status:active` label
+3. Cross-references with local cache: filters out issues with active cases
+4. Returns scored/filtered list to skill
+
+### Error: agent tries raw `gh issue create`
+
+1. Agent runs `gh issue create --repo <kaizen-repo>`
+2. PreToolUse hook detects the command pattern
+3. Hook blocks with: "Use the kaizen_suggest tool instead of raw gh CLI"
+4. Agent uses the proper tool (which goes through the backend adapter)
+
+## 5. What Exists vs What Needs Building
+
+### Already Solved
+
+| Capability | Status |
+|------------|--------|
+| GitHub API client for issues | Working |
+| CLI wrapper for backlog queries | Working |
+| Collision detection (same issue) | Working |
+
+### Needs Building
+
+| Component | What | Why it doesn't exist yet |
+|-----------|------|-------------------------|
+| `kaizen_suggest` tool | Validated kaizen issue creation through backend | Skills use raw `gh` instead |
+| `kaizen_list_backlog` function | Fetch+filter backlog from GitHub through adapter | Skills call `gh issue list` directly |
+| `kaizen_view` function | Read single issue through adapter | Skills call `gh issue view` directly |
+| `kaizen_update` function | Update labels/status through adapter | Skills call `gh issue edit` directly |
+| L2 hook blocking raw kaizen `gh` commands | PreToolUse(Bash) hook | No enforcement exists today |
+| Skill migration | Update skills to use new tools | Skills hardcode `gh` CLI |
+
+## 6. Open Questions
+
+1. **Should the backend adapter handle issue body formatting?** Currently skills format issue bodies differently. Should the adapter enforce a standard format, or should each skill format its own body and pass it through?
+
+2. **How to handle the transition?** Migration options:
+   - Big bang: update all skills at once
+   - Gradual: add the hook as advisory first, migrate skills one by one, then make it blocking
+
+3. **Should `gh issue list` reads be blocked?** The hook could block writes immediately but allow reads (transitional), then block reads once the domain model read path is built.
+
+## 7. Implementation Sequencing
+
+```
+Phase 1: GitHub API read ops + CLI wrapper               Done
+    |
+Phase 2: Domain model tools                              TODO
+    |
+Phase 3: L2 hook + skill migration (together)            TODO
+```
+
+Phases 2 and 3 must ship together — the hook without migrated skills would break them.

--- a/docs/kaizen-ipc-architecture.md
+++ b/docs/kaizen-ipc-architecture.md
@@ -1,0 +1,85 @@
+# Kaizen-Cases Architecture
+
+## The Mental Model
+
+All work is a **case**. There are two types:
+
+- **work** cases — using existing tooling to do useful work
+- **dev** cases — improving the tooling (kaizen)
+
+Both types use the same case system, same lifecycle (`SUGGESTED → BACKLOG → ACTIVE → DONE → REVIEWED → PRUNED`). Dev cases are backed by the kaizen GitHub repo.
+
+**The kaizen feedback loop:**
+- Work agents encounter friction → file improvement requests → these become dev cases
+- Dev agents also encounter friction → file improvement requests → also dev cases
+- On completion, agents reflect → suggest new dev cases
+
+## Architecture
+
+```
+Agent (work or dev)
+  |
+  |  case_create, case_suggest_dev,
+  |  case_mark_done, create_github_issue, ...
+  |
+Domain Model (cases module)
+  |
+  +-- Local DB (SQLite)     Case state, lifecycle
+  |
+  +-- Case Backend Adapter
+        |
+        GitHub REST API
+        +-- kaizen repo      <- dev cases
+        +-- host project repo <- work cases
+```
+
+Host-side skills access the domain model via CLI wrapper:
+
+```
+Host-side skills (/kaizen-pick, /kaizen-evaluate, /kaizen-implement, /kaizen-reflect)
+  |
+CLI wrapper  -->  GitHub API  -->  GitHub REST API
+(backlog queries)
+```
+
+## What Goes Through What
+
+| Who | Operation | Mechanism |
+|-----|-----------|-----------|
+| Agent | Create/manage cases | Domain model tools |
+| Agent | Suggest improvement | `case_suggest_dev` tool |
+| Agent | Create GitHub issue | `create_github_issue` tool |
+| Host-side skill | Query kaizen backlog | CLI wrapper (`list`, `view`) |
+| Backend adapter | Sync case → GitHub | Automatic on state change |
+
+**Rule: All case operations go through domain model tools or CLI wrapper. Never raw `gh` CLI.**
+
+## Dev Workflow
+
+```
+/kaizen-pick      Select next kaizen issue from backlog
+     |
+/kaizen-evaluate  Evaluate: gather incidents, find low-hanging fruit, get admin input
+     |
+/kaizen-implement Create case + worktree, apply five-step algorithm, execute
+     |
+case_mark_done    Agent reflects → kaizen suggestions → new dev cases
+     |
+/kaizen-reflect   Recursive process improvement
+```
+
+## Key Concepts
+
+| Concept | Purpose |
+|---------|---------|
+| Case lifecycle | Unified state machine for all work types |
+| Backend adapter | CRM-agnostic sync (currently GitHub Issues) |
+| CLI wrapper | Host-side skill access to backlog without raw `gh` |
+| Domain model | Case CRUD, collision detection, local cache |
+| Three-way routing | Meta-kaizen → kaizen repo, host-kaizen → host repo, pattern → kaizen repo |
+
+## Related Docs
+
+| Document | What it covers |
+|----------|---------------|
+| [`kaizen-cases-unification-spec.md`](kaizen-cases-unification-spec.md) | Original spec, problem statement, implementation phases |

--- a/docs/test-ladder-spec.md
+++ b/docs/test-ladder-spec.md
@@ -1,0 +1,330 @@
+# Test Ladder — Specification
+
+*"I want to become stronger."* Total victory — perfect testability, perfect validation — is the impossible ideal. We don't need to achieve it. We need to climb toward it, step by practical step.
+
+## 1. Problem Statement
+
+Projects accumulate tests at two extremes: unit tests that verify components in isolation, and manual/E2E tests that verify the system works in production. But between "components work in isolation" and "the system works in production" lies a large, uncharted gap.
+
+### What fails in that gap
+
+Real production incidents that passed all tests:
+
+- **Type errors at boundaries**: Code compiled on one side but failed at runtime on the other. All unit tests passed. The system didn't start.
+- **Interface mismatches**: Both sides tested with mocks that agreed with each other but not with reality. Runtime failure.
+- **Path/config changes**: Unit tests mocked the filesystem or config. The real system couldn't access resources at runtime.
+
+These bugs live at boundaries: between components, between services, between layers. No existing test crosses those boundaries with real components.
+
+### The cost of the gap
+
+Every bug at a component boundary requires a human to discover, diagnose, and fix. This is the single largest blocker to autonomous development. A dev agent that can't verify its changes work end-to-end must always defer to a human for the final "does it actually work?" check.
+
+## 2. Desired End State
+
+A dev agent makes a code change. It runs the test suite. If tests pass, the agent has justified confidence that the change works in production. Not certainty — certainty is the impossible ideal — but justified confidence proportional to the test coverage level achieved.
+
+The test ladder provides:
+
+1. **A shared vocabulary** — when someone says "this capability is tested at L8," everyone knows exactly what that means.
+2. **A climbing strategy** — each rung is a piece of test infrastructure. Building rung N enables that level of testing for all capabilities.
+3. **A capability matrix** — every capability has a current position on the ladder and a target position. We can see gaps and prioritize.
+4. **Incremental progress** — no big bang. Each rung is independently valuable. Each capability can climb independently.
+
+## 3. The Test Ladder
+
+Thirteen rungs, ordered by infrastructure cost, determinism, and what they prove. The ladder has two dimensions: **infrastructure depth** (how much of the real system is exercised) and **security coverage** (a cross-cutting taxonomy).
+
+### Infrastructure Rungs
+
+#### L0: Static Analysis
+**Cost:** Free (<10s). **Determinism:** 100%. **Requires:** Source code only.
+
+TypeScript/language compilation, formatting, schema validation. Catches type errors, missing imports, declaration drift.
+
+**What it proves:** Code is well-formed and type-safe.
+**What it misses:** Everything about runtime behavior.
+
+#### L1: Pure Unit
+**Cost:** Free (<1ms/test). **Determinism:** 100%. **Requires:** Runtime only.
+
+Isolated function tests. All dependencies mocked. No I/O, no filesystem, no network. Tests individual functions produce correct output for given input.
+
+**What it proves:** Function logic is correct in isolation.
+**What it misses:** Whether mocks match reality. Whether components work together.
+
+#### L2: Integrated Unit
+**Cost:** Free (<100ms/test). **Determinism:** 100%. **Requires:** Runtime, temp dirs, in-memory DB.
+
+Multiple real components wired together. Real SQLite (`:memory:`), real file I/O in temp directories. No containers, no network, no external services.
+
+**What it proves:** Components work together. Schema migrations work. File format contracts hold.
+**What it misses:** Container/service behavior. Runtime configuration. Network I/O.
+
+#### L3: Build Verification
+**Cost:** Low (~30s). **Determinism:** 100%. **Requires:** Build toolchain (e.g., Docker).
+
+Build artifacts are produced successfully. Code compiles in the target environment. System dependencies are installed and runnable.
+
+**What it proves:** Build config is valid. All dependencies resolve. Code compiles.
+**What it misses:** Whether the built artifact works at runtime.
+
+#### L4: Service Boot + Registration
+**Cost:** Low (~30s). **Determinism:** 100%. **Requires:** Build toolchain.
+
+Service/container starts, tools register, API surface matches contract.
+
+**What it proves:** Service boots. API surface matches expectations.
+**What it misses:** Whether APIs work when called.
+
+#### L5: Round-Trip (Stub External Services)
+**Cost:** Low (~10s). **Determinism:** 100%. **Requires:** Build + stub server.
+
+System receives input, calls stub external services, produces output with correct structure. No real external APIs.
+
+**What it proves:** Input contract. Output contract. Internal pipeline.
+**What it misses:** Host/orchestrator behavior. Real external API behavior.
+
+#### L6: Host Pipeline Smoke
+**Cost:** Medium (~60s). **Determinism:** 100%. **Requires:** Build + stub APIs + testable host pipeline.
+
+The critical missing rung in many projects. Full host-side pipeline exercised: input arrives → routing → processing → output delivery.
+
+Tests the orchestration code that no other test exercises:
+- Queue serialization and batching
+- Input assembly (configuration, mounts, env, session state)
+- Output parsing and formatting
+- State persistence across requests
+
+**What it proves:** The orchestrator can process a request from ingestion to delivery.
+**What it misses:** Real external service behavior. Real API output.
+
+**Prerequisites:** Refactor orchestrator for dependency injection. Often all dependencies are module-level globals — not testable without refactoring.
+
+#### L7: Observable Pipeline
+**Cost:** Medium (~60s). **Determinism:** 100%. **Requires:** L6 infrastructure + structured event emission.
+
+Same as L6, but the pipeline emits structured events at each processing step. Tests can assert not just on the final output but on the *sequence of internal decisions*:
+
+```
+request_received { id, sender, timestamp }
+  → request_validated { allowed: true, rule: "allowlist-match" }
+  → route_decided { handler: "handler-A", confidence: 0.95 }
+  → processing_started { session_id: "abc", config: [...] }
+  → output_produced { type: "response", target: "..." }
+  → response_delivered { channel: "http", id: "..." }
+```
+
+**Why this matters for testing:**
+- L6 tests "input in, output out." If it fails, you don't know WHERE in the pipeline it broke.
+- L7 tests "input in, these 6 things happened in this order, output out." Failures are immediately localizable.
+- The same event infrastructure enables production observability, debug logging, and cost attribution.
+
+**What it proves:** Internal processing decisions are correct and traceable.
+
+#### L8: Synthetic Input Injection
+**Cost:** Medium (~60s). **Determinism:** 100%. **Requires:** L6 infrastructure + input adapters.
+
+Instead of injecting inputs at the API/queue level (L6), inject them at the *adapter level*. A test adapter emits events indistinguishable from a real input source. The input traverses the same code path as a real request — parsing, validation, routing — and only then enters the pipeline.
+
+**What this adds over L6:**
+- Source-specific input parsing (different formats, protocols)
+- Pattern matching and filtering
+- ID resolution and sender extraction
+
+**Example:**
+```typescript
+TestAdapter.injectInput({
+  source: { id: "test-group-1", type: "group", name: "Test Group" },
+  sender: { id: "user-123", name: "Test User" },
+  content: "process this request",
+  timestamp: Date.now()
+})
+// → assert: input processed, response sent via TestAdapter.sentOutputs
+```
+
+**What it proves:** Source-specific input handling works end-to-end.
+**What it misses:** Real network I/O. Real source API quirks (rate limits, encoding edge cases).
+
+#### L9: Real Service Loopback
+**Cost:** High (~5-30s, requires credentials). **Determinism:** ~95%. **Requires:** Real service credentials, network access.
+
+Send a real request through a real external service and verify it arrives, is processed, and produces a response visible through the same service.
+
+**What this adds over L8:**
+- Real network I/O (TLS, DNS, API auth)
+- Real API behavior (rate limits, formatting, encoding)
+- Real credential/OAuth flow
+
+**What it misses:** Real AI/LLM behavior.
+**Non-determinism sources:** Network latency, API rate limits, delivery timing. Mitigated with retries and generous timeouts.
+
+#### L10: LLM Smoke (Real API, Controlled Prompts)
+**Cost:** ~$0.01-0.05/test, 5-30s. **Determinism:** ~90%. **Requires:** Real API key.
+
+First real LLM call. Carefully designed prompts with near-deterministic expected outputs. Verify the *structure* of the response, not exact wording.
+
+**Examples:**
+- "Reply with exactly the word PONG" → response contains "PONG"
+- "What is 2+2?" → response contains "4"
+- System prompt says "Always start responses with [OK]" → response starts with "[OK]"
+
+**What it proves:** API credentials work. System can make real API calls. Basic prompt → response pipeline works.
+**Cost control:** Use cheapest model (~$0.001/test). Run only on merge to main, not on every PR.
+
+#### L11: LLM Tool Verification (Real API, Tool Calling)
+**Cost:** ~$0.05-0.20/test, 10-60s. **Determinism:** ~85%. **Requires:** Real API key.
+
+Agent calls specific tools in response to prompts. Verify the tool was called with correct parameters.
+
+**Examples:**
+- "Send a message saying 'hello'" → `send_message` called with text "hello"
+- "Create a task called test-task for fixing the login bug" → `create_task` called with name containing "test-task"
+
+**What it proves:** Agent understands tool definitions. Tool parameters are correct.
+**What it misses:** Complex multi-step workflows. Judgment about *when* to use tools.
+
+#### L12: Full Behavioral
+**Cost:** ~$0.10-1.00/test, 30-120s. **Determinism:** ~70-80%. **Requires:** Real API key, possibly real services.
+
+Complex multi-turn scenarios. Agent follows policies, respects restrictions, handles ambiguous routing, creates appropriate work items, asks for clarification when needed.
+
+**These are probabilistic.** Run N times, expect >80% pass rate. Track pass rate over time. Flag regressions when rate drops.
+
+**What it proves:** The system works as a product. Agent behavior matches intent.
+**What it misses:** Nothing — this is the summit we climb toward.
+
+### Summary Table
+
+| Level | Name | Cost | Det. | Requires |
+|-------|------|------|------|----------|
+| L0 | Static Analysis | <10s | 100% | Source |
+| L1 | Pure Unit | <1ms | 100% | Runtime |
+| L2 | Integrated Unit | <100ms | 100% | Runtime + DB |
+| L3 | Build Verification | ~30s | 100% | Build toolchain |
+| L4 | Boot + Registration | ~30s | 100% | Build toolchain |
+| L5 | Round-Trip (Stub) | ~10s | 100% | Build + stub |
+| **L6** | **Host Pipeline** | **~60s** | **100%** | **Build + stub** |
+| L7 | Observable Pipeline | ~60s | 100% | L6 + events |
+| L8 | Synthetic Input | ~60s | 100% | L6 + adapters |
+| L9 | Real Service Loopback | ~30s | ~95% | Real credentials |
+| L10 | LLM Smoke | ~$0.02 | ~90% | Real API key |
+| L11 | LLM Tool Verification | ~$0.10 | ~85% | Real API key |
+| L12 | Full Behavioral | ~$0.50 | ~70% | Real API + services |
+
+## 4. Security Testing Taxonomy
+
+Security is a cross-cutting concern, not a single rung on the ladder. Each security category has a minimum infrastructure level required to test it meaningfully.
+
+### S1: Input Validation
+**Minimum level:** L1 (pure unit). **Determinism:** 100%.
+
+Malformed inputs are rejected before they reach business logic. Covers: invalid JSON, SQL injection, path traversal in strings, oversized payloads.
+
+**Gaps commonly found:**
+- No fuzzing/property-based tests
+- No null byte or Unicode edge case tests
+- No payload size limit tests
+
+### S2: Authorization Gates
+**Minimum level:** L2 (integrated unit). **Target:** L6 (host pipeline).
+
+Unauthorized actions are rejected at the gate. Covers: sender allowlists, action authorization, cross-scope restrictions, privilege levels.
+
+### S3: Resource Isolation
+**Minimum level:** L3 (build verification). **Target:** L6 (host pipeline).
+
+Processes/containers can only access resources they're authorized to see. Read-only access is actually read-only. Blocked paths are inaccessible.
+
+**Gaps commonly found:**
+- No test verifies that a process *actually cannot* read a blocked path at runtime
+- No test for symlink-based escapes
+- No test that read-only resources are actually read-only
+
+### S4: Session & Work Isolation
+**Minimum level:** L6 (host pipeline). **Target:** L7 (observable pipeline).
+
+Work item A's agent cannot see work item B's data, session, or workspace. Sessions don't leak across scopes.
+
+### S5: Instance Isolation
+**Minimum level:** L7 (multi-component). **Target:** L9 (real service loopback).
+
+Staging and production instances cannot interfere. Different instance identifiers produce fully separated systems.
+
+### S6: Input Source Security
+**Minimum level:** L8 (synthetic input). **Target:** L9 (real service loopback).
+
+Inputs from unauthorized sources are dropped before reaching the agent. Source authentication is valid. Outputs go to the correct recipient.
+
+### S7: Behavioral Compliance
+**Minimum level:** L12 (full behavioral). **Determinism:** ~70%.
+
+Agent follows policies even when the LLM "wants" to do something else. Covers: hook compliance, data access policies, escalation behavior.
+
+## 5. The Gap Analysis Framework
+
+### Typical Strengths
+
+**L0-L2:** Most projects have good coverage here. Unit tests, CI enforcement, static analysis.
+
+**L3-L5:** Build verification and stub-based testing cover the deployment pipeline.
+
+### Typical Critical Gaps
+
+**1. L6 Host Pipeline — nobody tests the orchestrator.**
+The central orchestration function often has zero test coverage. All dependencies are module-level globals, making it untestable without refactoring to dependency injection. This is typically the single highest-value improvement.
+
+**2. No test crosses component boundaries with a real host.**
+Stub tests verify components in isolation. L6 would test the host orchestrating components. Nobody tests the seam — the code that assembles input, passes state, parses output, and persists results.
+
+**3. Session continuity is assumed, never verified.**
+Session state is stored and passed to the next invocation. Tests mock this. Nobody verifies that a second request actually resumes where the first left off.
+
+**4. External service behavior is entirely mocked.**
+Every integration test mocks the external library. No test sends a real request or verifies real receipt. Service-specific edge cases are invisible.
+
+## 6. Implementation Sequencing
+
+```
+Phase 1: L6 Foundation
+  +-- Refactor orchestrator for dependency injection
+  +-- Write host pipeline smoke tests (7-10 tests)
+
+Phase 2: Observability & Adapters
+  +-- Processing event emitter (L7)
+  +-- Test input adapters (L8)
+
+Phase 3: Real Services
+  +-- Test service credentials setup
+  +-- Real service loopback tests (L9)
+
+Phase 4: LLM Testing
+  +-- LLM smoke patterns (L10)
+  +-- LLM tool verification (L11)
+  +-- Behavioral test framework (L12)
+```
+
+Each phase is independently valuable. Phase 1 is the highest-value investment. Phases 2-4 can proceed incrementally.
+
+## 7. Keeping the Ladder Current
+
+### The Problem
+
+The capability inventory and coverage matrix are only valuable if they reflect reality. A stale matrix is worse than no matrix — it creates false confidence. The inventory will rot through four predictable failure modes:
+
+1. **New capability, no row.** Someone adds a feature. No one updates the inventory. The matrix silently becomes incomplete.
+2. **Test added, matrix not updated.** Someone writes L6 tests. The matrix still says L1. The gap analysis overstates risk.
+3. **Capability removed, row lingers.** A feature is deprecated. The matrix still tracks it. Noise accumulates.
+4. **No enforcement on new work.** A dev case creates a new feature. Nothing prompts the agent to assess where it lands on the ladder.
+
+### Maturity Scale for Inventory Currency
+
+| Level | What | How it works | Failure mode |
+|-------|------|-------------|-------------|
+| **IC-1** | Instructions | This document says "update the inventory." Agents read it. | Agents forget. Inventory drifts silently. |
+| **IC-2** | Prompted | A workflow step asks "which capabilities did you touch?" before work is marked done. | Agents dismiss the prompt. Inventory drifts slowly. |
+| **IC-3** | Linked | Tests declare which capabilities they cover. Coverage can be computed from the test suite. | New capabilities without tests are invisible. |
+| **IC-4** | Validated | CI checks that the inventory matches reality. | Requires defining "reality" precisely enough to check mechanistically. |
+| **IC-5** | Self-updating | The inventory is generated from the codebase, not maintained by hand. Drift is impossible by construction. | Requires structured codebase. |
+
+The immediate next step is IC-2 — make the workflow *ask the question*. When IC-2 fails repeatedly, that's the signal to escalate to IC-3.

--- a/docs/test-side-effects-and-kaizen-escalation-spec.md
+++ b/docs/test-side-effects-and-kaizen-escalation-spec.md
@@ -1,0 +1,91 @@
+# Test Side Effects & Kaizen Escalation — Specification
+
+## 1. Problem Statement
+
+### A. Test side effects: tracked file mutation
+
+Tests that invoke CLI scripts or build tools can overwrite tracked files as a side effect. For example, a test that runs a code generation script may overwrite a checked-in output file with a fresh timestamp. The surfaces are identical, but the timestamp diff leaves a dirty working tree.
+
+**Who experiences the problem:** Dev agents. A `check-dirty-files` hook blocks `git push` when tracked files have uncommitted changes. The agent must manually `git checkout -- <file>` before every push — and if they forget, the hook blocks them.
+
+**What happened:** This exact pattern blocked pushes **twice in the same session**. Both times, the kaizen reflection correctly identified the root cause. Neither time was the fix applied — the agent just restored the file and moved on.
+
+**Cost of not solving it:** Every future test run dirties the tracked file. Every future push requires manual cleanup. The hook fires, the agent writes a kaizen reflection, restores the file, and pushes again. Wasted cycles, every time.
+
+### B. Kaizen reflection doesn't escalate repeat issues
+
+The kaizen reflection process asks three questions: what happened, what gap led to it, what would prevent it. The agent answered correctly both times. But answering correctly and fixing the problem are different things.
+
+**The gap in the gap-analysis:** When the same root cause appears in multiple kaizen reflections within a session, the process should escalate. The kaizen policy already says:
+
+> "Has this type of failure happened before? If yes, the previous level wasn't enough — escalate."
+
+But there's no mechanism to enforce it. The reflection is Level 1 (instructions). Repeated Level 1 reflections on the same issue should trigger Level 2 (a hook or automation that prevents the problem) or Level 3 (a code fix that eliminates the problem class entirely).
+
+## 2. This Incident as a Case Study for Autonomous Kaizen
+
+This incident is a textbook example of why autonomous kaizen escalation is needed. Let's trace what happened through the lens of a 7-step enhanced reflection protocol:
+
+| Step | What should have happened | What actually happened |
+|------|--------------------------|----------------------|
+| **1. What happened?** | Test overwrites tracked file | Correctly identified both times |
+| **2. What class?** | `test_side_effect` — test modifies tracked artifacts | Not classified. Treated as one-off both times |
+| **3. Root cause chain** | Test calls CLI → CLI writes file → file is tracked → working tree dirty | Identified but stopped at "the test does it" |
+| **4. Blast radius** | Are there other tests that write to tracked files? | Never asked |
+| **5. Fix vs Prevent** | Fix: restore file. Prevent: export function, test in-memory | Fix applied (restore). Prevention described but not implemented |
+| **6. What level?** | L3 — code fix (export function) eliminates the class | Stayed at L1 (instruction to self: "fix it later") |
+| **7. Meta: Did kaizen fail?** | Yes — the reflection protocol produced correct analysis twice but no escalation | Not asked |
+
+### What an autonomous kaizen system would have done differently
+
+1. **Structured incident record** — First occurrence would have been captured with `bug_class: test_side_effect`, not as ephemeral text in a conversation.
+
+2. **Recurrence detection** — Second occurrence would have matched the first by class. The system would flag: "This is recurring. L1 failed. Escalate."
+
+3. **Escalation enforcement** — Instead of allowing the agent to write another reflection and move on, the system would require implementing the prevention before unblocking the push.
+
+4. **Blast radius scan** — "Where else do tests write to tracked files?" — would have been asked automatically as part of the protocol.
+
+The key insight: **the current kaizen system treats reflections as outputs. An autonomous kaizen system treats them as inputs to a learning loop.** A reflection that doesn't change the system is noise, not signal.
+
+### How the kaizen system should improve itself
+
+This incident reveals a specific gap in the kaizen process:
+
+**Current state:** Kaizen reflections are fire-and-forget. The agent writes one, the hook unblocks, and the reflection evaporates. No memory, no recurrence detection, no escalation.
+
+**What's needed:**
+- **Incident store** — reflections are written to persistent storage, not just to conversation text
+- **Recurrence detection** — same `bug_class` appearing twice triggers escalation
+- **Escalation enforcement** — the hook can query the incident store and refuse to unblock if the agent hasn't escalated a recurring issue
+
+## 3. Immediate Fix: Isolate the test
+
+The autonomous kaizen system is the systemic solution. But the specific bug should still be fixed now. This is the "fix the instance AND prevent the class" principle.
+
+**Example pattern** — a test that runs a code generator:
+```typescript
+function getGeneratedOutput() {
+  execSync('tsx scripts/generate-output.ts', { cwd: ROOT, stdio: 'pipe' });
+  return JSON.parse(fs.readFileSync(outputPath, 'utf-8'));
+}
+```
+
+**Fix options:**
+
+| Option | Approach | Pros | Cons |
+|--------|----------|------|------|
+| A1: Restore after test | Save file content before, restore in `afterAll` | Minimal change | Still writes to tracked file during run — race conditions with parallel test runners |
+| A2: Write to temp dir | Pass output path as env var or arg; test uses temp dir | Clean isolation, no tracked file mutation | Requires small refactor to generator script |
+| A3: Export and call directly | Import the generate function, compare in memory | No file I/O in tests, fastest | Requires refactoring generator to export function |
+
+**Lean: A3** — export the generator function, import it in the test, and compare the result in memory. This eliminates the side effect entirely.
+
+## 4. Implementation Sequencing
+
+```
+Fix A (test isolation)        — standalone, ~15min, fixes the instance
+Autonomous kaizen Phase 1     — fixes the class (incident store + recurrence detection)
+```
+
+Fix A eliminates this specific recurring trigger. Phase 1 of autonomous kaizen (incident store + enhanced reflection + recurrence detection) prevents the meta-failure pattern across all future kaizen reflections — not just this one.

--- a/docs/worktree-first-tooling-spec.md
+++ b/docs/worktree-first-tooling-spec.md
@@ -1,0 +1,119 @@
+# Worktree-First Dev Tooling — Specification
+
+## 1. Problem Statement
+
+Kaizen mandates worktree-first development: "All dev work MUST be in a case with its own worktree. Never modify code in main checkout." This is enforced by L2 hooks. But the dev tooling itself — the CLI tools, path resolution, and file management that agents use to create cases and work within them — assumes it runs from the main checkout.
+
+**The result:** agents follow the policy (work in worktrees) but the tools they need to set up that work break when called from worktrees. The hooks enforce isolation at the edit layer, but the infrastructure layer hasn't caught up.
+
+### Concrete incidents
+
+| Date | What broke | Impact | Root cause |
+|------|-----------|--------|------------|
+| Session 1 | `case-create` from worktree printed success but case wasn't persisted to DB | ~5 min manual DB fix | Config resolves `STORE_DIR` via `process.cwd()`, which pointed to the worktree |
+| Session 1 | Lock file created in worktree root, blocked push via dirty-files hook | ~1 min manual cleanup | File not in `.gitignore` |
+
+### Why this is a horizon, not a feature
+
+Every new CLI tool, every new path-dependent utility, every new file created during case setup will face the same question: "does this work when called from a worktree?" Point-fixing individual bugs solves today's problems. But without a shared pattern, the next tool will have the same class of bug.
+
+The hooks layer learned this lesson and built shared utilities — a library that all hooks use for worktree-safe state file access. The CLI/infrastructure layer has no equivalent.
+
+## 2. Taxonomy: Worktree-First Infrastructure Levels
+
+| Level | Name | What it means | Status |
+|-------|------|--------------|--------|
+| **L0** | Main-checkout assumed | Tools hardcode `process.cwd()` or relative paths. Only work from main. | Was here |
+| **L1** | Ad-hoc fixes | Individual tools detect worktrees and resolve paths case-by-case. Each tool has its own `git rev-parse --git-common-dir` logic. | **Current** |
+| **L2** | Shared resolution library | A single utility resolves "main checkout root," "DB path," "worktree root." All tools import it. | **Next step** |
+| **L3** | Enforced usage | A CI check or lint rule detects `process.cwd()` or bare path resolution in tool code and flags it. New tools can't ship without using the shared resolver. | Visible from here |
+| **L4** | Integration-tested | Worktree-from-worktree scenarios (nested worktrees, CLI called from worktree) are part of the test suite. | Visible from here |
+| **L5** | Policy-as-code | The worktree-first mandate is enforced architecturally — the tooling simply doesn't have a code path that uses `process.cwd()` for repo root. It always resolves via git. | Horizon |
+
+## 3. You Are Here
+
+**L0 → L1.** The hooks layer is at L2 (shared utilities). The TypeScript tooling layer is at L0-L1 — config uses `process.cwd()`, CLI tools inherit that, and individual hooks do their own `git rev-parse` ad-hoc.
+
+## 4. Current State — What Exists
+
+### Already solved (hooks layer — L2)
+
+| Component | How it's worktree-aware | Mechanism |
+|-----------|------------------------|-----------|
+| Hook state utilities | Branch field filters state files by current worktree | Shared library, all hooks use it |
+| Case existence hook | Resolves main root via `dirname "$(git rev-parse --git-common-dir)"` | Per-hook, but correct |
+| Worktree write hook | Same pattern — resolves main root, blocks edits there | Per-hook, but correct |
+| State files in `/tmp/` | Attributed to branch, filtered by worktree-aware functions | Shared library with tests |
+
+### Not solved (TypeScript tooling layer — L0)
+
+| Component | What breaks | Why |
+|-----------|------------|-----|
+| Config `PROJECT_ROOT` | Resolves to worktree root instead of main checkout | `process.cwd()` |
+| Config `STORE_DIR` | DB path points to worktree's `store/` (doesn't exist) | Derived from `PROJECT_ROOT` |
+| CLI tools | Case creation succeeds in memory but DB write goes to wrong path | Imports `STORE_DIR` from config |
+| Worktrees directory | Would create nested worktrees if `PROJECT_ROOT` is already a worktree | Derived from `PROJECT_ROOT` |
+| Lock files | Created in worktree root, triggers dirty-files hook | Not in `.gitignore` |
+
+## 5. L2: Shared Resolution Library (next step)
+
+**Problem:** Multiple TypeScript files need "where is the main checkout root?" and "where is the DB?" Currently each resolves this independently (or doesn't).
+
+**Solution:** A single TypeScript utility — `src/git-paths.ts` — that provides:
+
+```typescript
+// Always returns the main checkout root, whether called from main or a worktree
+export function getMainCheckoutRoot(): string;
+
+// Returns the canonical DB path (always in main checkout)
+export function getStorePath(): string;
+
+// Returns true if the current process is running from a worktree
+export function isWorktree(): boolean;
+```
+
+**Implementation approach:**
+- Use `git rev-parse --git-common-dir` (the same pattern hooks use)
+- If `git-common-dir` equals `.git`, we're in main → `process.cwd()` is correct
+- Otherwise, `dirname(git-common-dir)` gives the main checkout root
+- Config imports from `git-paths.ts` instead of using raw `process.cwd()`
+
+**Why this is the right level:** It's the TypeScript equivalent of what the hook state utilities did for bash hooks. One library, tested once, used everywhere. The pattern already proved itself — we're extending it to a new layer.
+
+### Point fixes included in L2
+
+- CLI tools use `getStorePath()` instead of raw config → DB writes always go to main checkout
+- Add lock files to `.gitignore`
+- Config `PROJECT_ROOT = getMainCheckoutRoot()` instead of `process.cwd()`
+
+### What L2 does NOT solve
+
+- No enforcement that new code uses `git-paths.ts` — a developer could still write `process.cwd()` in a new tool
+- No integration test that runs CLI from a worktree
+- The resolution is a function call, not an architectural constraint — it can be forgotten
+
+## 6. L3-L4: Enforcement and Testing (visible from here)
+
+**L3 — Lint/CI enforcement:**
+- A CI check (or grep-based hook) that flags `process.cwd()` usage in `src/` files outside of `git-paths.ts`
+
+**L4 — Integration tests:**
+- Test that `getMainCheckoutRoot()` returns the right path when called from a worktree
+- Test that CLI tools persist to the correct DB when run from a worktree
+- Add "works from worktree" as a dimension in the test ladder
+
+These levels are described as problems, not solutions. The specific mechanism will be clearer after L2 is implemented.
+
+## 7. Open Questions
+
+1. **Should config always resolve to main checkout?** Currently `PROJECT_ROOT = process.cwd()` which is correct for a running service (always started from main). If we change it to `getMainCheckoutRoot()`, does that break anything? Likely not — the service always runs from main — but needs verification.
+
+2. **Should `git-paths.ts` shell out to `git` or use a library?** Shelling out to `git rev-parse` is simple and matches the hook pattern. A library like `simple-git` adds a dependency. Lean: shell out — it's one command, fast, and consistent with hooks.
+
+3. **Where should lock files live instead?** Options: (a) keep in worktree root but `.gitignore` it, (b) move to `/tmp/` or `store/` where it's naturally outside git. Lean: (a) is simplest — the file is useful where it is, just needs to be ignored.
+
+## 8. Relationship to Other Work
+
+- **Autonomous Kaizen:** When agents autonomously select and implement work, they'll always be in worktrees. Reliable worktree tooling is a prerequisite for autonomous operation.
+- **Test Ladder:** "Works from worktree" is a testability dimension that should be added to the ladder for CLI tools.
+- **Incident-Driven Kaizen:** Future incidents of "tool X broke in worktree" should be tagged to this horizon for tracking.


### PR DESCRIPTION
## Summary

- Port 8 kaizen-relevant docs that were left behind during the nanoclaw→kaizen extraction
- 2 pure-kaizen docs (`hooks-design.md`, `hook-test-dry-spec.md`) copied as-is
- 6 docs generalized: replaced all nanoclaw-specific references (Telegram, Gmail, Garsson, container agents, specific file paths) with generic programming concepts
- Added all 8 docs to CLAUDE.md Key Files table for agent discoverability

Fixes #379

## Test plan

- [x] Verified zero nanoclaw/Garsson references remain in ported files (`grep -ri` clean)
- [x] Verified all 8 files exist in `docs/`
- [x] Verified CLAUDE.md Key Files table has correct entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)