### PR TITLE
fix: marketplace.json author field must be object

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "description": "Enforcement hooks, reflection workflows, dev workflow skills, and recursive self-improvement",
       "version": "1.0.0",
       "source": "./",
-      "author": "Garsson-io",
+      "author": { "name": "Garsson-io" },
       "homepage": "https://github.com/Garsson-io/kaizen",
       "repository": "https://github.com/Garsson-io/kaizen",
       "license": "MIT",


### PR DESCRIPTION
## Summary

Fix schema validation error: `author` in marketplace.json plugin entries must be `{ "name": "..." }`, not a bare string.

## Test plan

- [x] Fix matches schema: `"author": { "name": "Garsson-io" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)