### PR TITLE
fix: plugin.json agents must be array not string

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,7 +12,7 @@
   "keywords": ["kaizen", "process-improvement", "hooks", "reflection", "dev-workflow"],
 
   "skills": "./.claude/skills/",
-  "agents": "./.claude/agents/",
+  "agents": ["./.claude/agents/kaizen-bg.md"],
 
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
Fix schema: `agents` field requires an array of file paths, not a directory string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)