### PR TITLE
feat: audit log isolation, skill header DRY, hook shared libs (#429, #430)

### DIFF
--- a/.claude/hooks/kaizen-block-git-rebase.sh
+++ b/.claude/hooks/kaizen-block-git-rebase.sh
@@ -17,9 +17,11 @@
 #   - git rebase --skip (skip conflicting commit)
 
 source "$(dirname "$0")/lib/parse-command.sh"
+source "$(dirname "$0")/lib/input-utils.sh"
+source "$(dirname "$0")/lib/hook-output.sh"
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+read_hook_input
+get_command
 
 if [ -z "$COMMAND" ]; then
   exit 0
@@ -55,8 +57,7 @@ if ! is_rebase_command "$CMD_LINE"; then
 fi
 
 # Block the rebase command
-jq -n \
-  --arg reason "BLOCKED: git rebase is not allowed on PR branches (kaizen #296).
+emit_deny "BLOCKED: git rebase is not allowed on PR branches (kaizen #296).
 
 Rebase rewrites commit history and requires force-push, which is dangerous
 in multi-agent environments. It can silently drop changes and loses the
@@ -71,13 +72,4 @@ normal push (no force-push needed).
 Recovery commands are allowed:
   git rebase --abort     (undo accidental rebase)
   git rebase --continue  (finish in-progress rebase)
-  git rebase --skip      (skip conflicting commit)" \
-  '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $reason
-    }
-  }'
-
-exit 0
+  git rebase --skip      (skip conflicting commit)"

--- a/.claude/hooks/kaizen-debug-stop-cwd.sh
+++ b/.claude/hooks/kaizen-debug-stop-cwd.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Temporary diagnostic hook — captures CWD during stop events.
+# Remove after debugging stop hook "not found" errors.
+LOG="/tmp/kaizen-stop-hook-debug.log"
+{
+  echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+  echo "CWD: $(pwd)"
+  echo "DOLLAR_0: $0"
+  echo "GIT_TOPLEVEL: $(git rev-parse --show-toplevel 2>/dev/null || echo NONE)"
+  echo "HOOKS_DIR_EXISTS: $(test -d ./.claude/hooks && echo YES || echo NO)"
+  echo "LS_CLAUDE: $(ls -d .claude 2>/dev/null || echo MISSING)"
+  echo "---"
+} >> "$LOG" 2>&1
+exit 0

--- a/.claude/hooks/kaizen-enforce-post-merge-stop.sh
+++ b/.claude/hooks/kaizen-enforce-post-merge-stop.sh
@@ -23,8 +23,10 @@
 
 source "$(dirname "$0")/lib/state-utils.sh"
 source "$(dirname "$0")/lib/resolve-main-checkout.sh"
+source "$(dirname "$0")/lib/input-utils.sh"
+source "$(dirname "$0")/lib/hook-output.sh"
 
-INPUT=$(cat)
+read_hook_input
 
 # Check for ALL pending post-merge workflows (kaizen #279)
 ALL_STATES=$(find_all_states_with_status "needs_post_merge")
@@ -60,6 +62,4 @@ You MUST complete these steps before finishing:
 
 The /kaizen skill will clear this gate when complete."
 
-jq -n --arg reason "$REASON" '{ decision: "block", reason: $reason }'
-
-exit 0
+emit_stop_block "$REASON"

--- a/.claude/hooks/kaizen-enforce-pr-review-stop.sh
+++ b/.claude/hooks/kaizen-enforce-pr-review-stop.sh
@@ -21,9 +21,10 @@
 # Exit 0 with JSON {"decision":"block","reason":"..."} = block stop
 
 source "$(dirname "$0")/lib/state-utils.sh"
+source "$(dirname "$0")/lib/input-utils.sh"
+source "$(dirname "$0")/lib/hook-output.sh"
 
-INPUT=$(cat)
-STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+read_hook_input
 
 # Uses shared find_needs_review_state from state-utils.sh
 REVIEW_INFO=$(find_needs_review_state)
@@ -36,13 +37,11 @@ PR_URL=$(echo "$REVIEW_INFO" | cut -d'|' -f1)
 ROUND=$(echo "$REVIEW_INFO" | cut -d'|' -f2)
 
 # Block stop: agent must review the PR first.
-# Use jq --arg for safe string interpolation (no injection risk).
-jq -n \
-  --arg pr_url "$PR_URL" \
-  --arg round "$ROUND" \
-  '{
-    decision: "block",
-    reason: ("STOP BLOCKED: You have a pending PR review that must be completed before you can finish.\n\n  PR: " + $pr_url + " (round " + $round + ")\n\nYou MUST run `gh pr diff " + $pr_url + "` now and complete the self-review checklist.\nOnly after reviewing can you finish your response.\n\nThis is a mandatory part of the PR creation workflow.")
-  }'
+emit_stop_block "STOP BLOCKED: You have a pending PR review that must be completed before you can finish.
 
-exit 0
+  PR: $PR_URL (round $ROUND)
+
+You MUST run \`gh pr diff $PR_URL\` now and complete the self-review checklist.
+Only after reviewing can you finish your response.
+
+This is a mandatory part of the PR creation workflow."

--- a/.claude/hooks/kaizen-pr-reflect-clear.sh
+++ b/.claude/hooks/kaizen-pr-reflect-clear.sh
@@ -43,9 +43,7 @@ source "$(dirname "$0")/lib/parse-command.sh"
 source "$(dirname "$0")/lib/state-utils.sh"
 
 # Audit log for no-action declarations (kaizen #140)
-# Finds the repo root relative to this hook's location (.claude/kaizen/hooks/)
-HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-AUDIT_LOG="${HOOK_DIR}/../audit/no-action.log"
+# AUDIT_LOG is set by state-utils.sh with env var override for test isolation (kaizen #429)
 
 log_no_action() {
   local category="$1"

--- a/.claude/hooks/kaizen-squash-merge-safety.sh
+++ b/.claude/hooks/kaizen-squash-merge-safety.sh
@@ -17,9 +17,11 @@
 # Always allows non-squash merges, non-gh commands, and single-commit PRs.
 
 source "$(dirname "$0")/lib/parse-command.sh"
+source "$(dirname "$0")/lib/input-utils.sh"
+source "$(dirname "$0")/lib/hook-output.sh"
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+read_hook_input
+get_command
 
 if [ -z "$COMMAND" ]; then
   exit 0
@@ -84,8 +86,7 @@ fi
 MISSING_COUNT=$(echo "$MISSING_FILES" | wc -l)
 
 # Block with warning
-jq -n \
-  --arg reason "$(cat <<REASON
+emit_deny "$(cat <<REASON
 WARNING: Squash merge may silently drop $MISSING_COUNT file(s) (kaizen #289).
 
 Files present in branch diff but missing from squash preview:
@@ -103,13 +104,4 @@ To proceed safely:
 
 To skip this check: remove --squash and use --merge instead
 REASON
-)" \
-  '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $reason
-    }
-  }'
-
-exit 0
+)"

--- a/.claude/hooks/lib/hook-output.sh
+++ b/.claude/hooks/lib/hook-output.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Part of kAIzen Agent Control Flow — see .claude/kaizen/README.md
+# hook-output.sh — Shared output helpers for hook scripts (kaizen #429)
+#
+# DRYs up the JSON output patterns used across hooks:
+#   - PreToolUse deny (permissionDecision: "deny")
+#   - Stop block (decision: "block")
+#
+# Usage:
+#   source "$(dirname "$0")/lib/hook-output.sh"
+#   emit_deny "reason text here"
+#   emit_stop_block "reason text here"
+
+# Emit a PreToolUse deny JSON response and exit 0.
+# Usage: emit_deny "BLOCKED: reason..."
+emit_deny() {
+  local reason="$1"
+  jq -n --arg reason "$reason" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: $reason
+      }
+    }'
+  exit 0
+}
+
+# Emit a Stop block JSON response and exit 0.
+# Usage: emit_stop_block "STOP BLOCKED: reason..."
+emit_stop_block() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{ decision: "block", reason: $reason }'
+  exit 0
+}

--- a/.claude/hooks/lib/input-utils.sh
+++ b/.claude/hooks/lib/input-utils.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Part of kAIzen Agent Control Flow — see .claude/kaizen/README.md
+# input-utils.sh — Shared input parsing for hook scripts (kaizen #429)
+#
+# DRYs up the boilerplate pattern duplicated across 12+ hooks:
+#   INPUT=$(cat)
+#   TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+#   COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+#   ...
+#
+# Usage:
+#   source "$(dirname "$0")/lib/input-utils.sh"
+#   read_hook_input          # reads stdin, sets INPUT + TOOL_NAME
+#   get_command              # sets COMMAND
+#   get_stdout               # sets STDOUT
+#   get_exit_code            # sets EXIT_CODE (defaults to "0")
+#   require_tool_bash        # exits 0 if TOOL_NAME != "Bash"
+#   require_success          # exits 0 if EXIT_CODE != "0"
+#
+# All functions set global variables matching the existing naming convention
+# so callers can source and use them as drop-in replacements.
+
+# Read stdin into INPUT and extract TOOL_NAME.
+# Must be called first — stdin can only be read once.
+read_hook_input() {
+  INPUT=$(cat)
+  TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+}
+
+# Extract .tool_input.command into COMMAND.
+get_command() {
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+}
+
+# Extract .tool_response.stdout into STDOUT.
+get_stdout() {
+  STDOUT=$(echo "$INPUT" | jq -r '.tool_response.stdout // empty')
+}
+
+# Extract .tool_response.stderr into STDERR.
+get_stderr() {
+  STDERR=$(echo "$INPUT" | jq -r '.tool_response.stderr // empty')
+}
+
+# Extract .tool_response.exit_code into EXIT_CODE (defaults to "0").
+get_exit_code() {
+  EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // "0"')
+}
+
+# Extract .tool_input.file_path into FILE_PATH (for Edit/Write/Read hooks).
+get_file_path() {
+  FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+}
+
+# Exit 0 (allow) if TOOL_NAME is not "Bash".
+# Use after read_hook_input in PostToolUse hooks that only care about Bash.
+require_tool_bash() {
+  if [ "$TOOL_NAME" != "Bash" ]; then
+    exit 0
+  fi
+}
+
+# Exit 0 (allow) if EXIT_CODE is not "0".
+# Use after get_exit_code in hooks that only process successful commands.
+require_success() {
+  if [ "$EXIT_CODE" != "0" ]; then
+    exit 0
+  fi
+}

--- a/.claude/hooks/lib/state-utils.sh
+++ b/.claude/hooks/lib/state-utils.sh
@@ -15,6 +15,11 @@
 STATE_DIR="${STATE_DIR:-/tmp/.pr-review-state}"
 MAX_STATE_AGE="${MAX_STATE_AGE:-7200}"  # 2 hours
 
+# Default audit log path. Override via AUDIT_LOG env var for test isolation (kaizen #429).
+_STATE_UTILS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="${AUDIT_DIR:-$(cd "$_STATE_UTILS_DIR/../.." && pwd)/kaizen/audit}"
+AUDIT_LOG="${AUDIT_LOG:-${AUDIT_DIR}/no-action.log}"
+
 # Convert a PR URL to a safe state file key.
 # e.g. https://github.com/Garsson-io/kaizen/pull/33 → Garsson-io_kaizen_33
 #

--- a/.claude/hooks/tests/test-helpers.sh
+++ b/.claude/hooks/tests/test-helpers.sh
@@ -188,6 +188,12 @@ setup_test_env() {
   export STATE_DIR="$TEST_STATE_DIR"
   export DEBUG_LOG="/dev/null"
 
+  # Isolate audit log from repo (kaizen #429)
+  TEST_AUDIT_DIR="/tmp/.kaizen-audit-test-$$"
+  rm -rf "$TEST_AUDIT_DIR"
+  mkdir -p "$TEST_AUDIT_DIR"
+  export AUDIT_LOG="$TEST_AUDIT_DIR/no-action.log"
+
   TEST_MOCK_DIR=$(mktemp -d)
   cat > "$TEST_MOCK_DIR/gh" << 'MOCK_EOF'
 #!/bin/bash
@@ -206,7 +212,7 @@ reset_state() {
 
 # Cleanup everything created by setup_test_env
 cleanup_test_env() {
-  rm -rf "$TEST_STATE_DIR" "$TEST_MOCK_DIR"
+  rm -rf "$TEST_STATE_DIR" "$TEST_MOCK_DIR" "$TEST_AUDIT_DIR"
 }
 
 # Create PR review state file with mandatory BRANCH field

--- a/.claude/hooks/tests/test-integration-audit-isolation.sh
+++ b/.claude/hooks/tests/test-integration-audit-isolation.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+# test-integration-audit-isolation.sh — E2E test for audit log path isolation
+#
+# Tests that no-action audit log entries are written to the AUDIT_LOG
+# override path and NOT to the repo's default audit directory.
+#
+# INVARIANT: When AUDIT_LOG env var is set, all no-action declarations
+# (KAIZEN_NO_ACTION and KAIZEN_IMPEDIMENTS: [] reason) write to that
+# path exclusively. The repo's .claude/kaizen/audit/no-action.log is
+# never touched.
+#
+# This test directly addresses kaizen #429 (audit log path isolation).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOKS_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/harness.sh"
+
+# Isolated state and audit directories
+STATE_DIR="$HARNESS_TEMP/pr-review-state"
+AUDIT_DIR="$HARNESS_TEMP/audit"
+ISOLATED_AUDIT_LOG="$AUDIT_DIR/no-action.log"
+mkdir -p "$STATE_DIR" "$AUDIT_DIR"
+export STATE_DIR
+export DEBUG_LOG="$HARNESS_TEMP/debug.log"
+
+# The repo's real audit log path — must NOT be written to
+REPO_AUDIT_LOG="$HOOKS_DIR/../audit/no-action.log"
+
+PR_KAIZEN_CLEAR="$HOOKS_DIR/kaizen-pr-reflect-clear.sh"
+
+# Mock gh to return OPEN for pr view
+INTEG_MOCK_DIR="$HARNESS_TEMP/mock-bin"
+setup_default_gh_mock "$INTEG_MOCK_DIR"
+
+HOOK_ENV_VARS=$(printf 'STATE_DIR=%s\nAUDIT_LOG=%s\nPATH=%s\n' \
+  "$STATE_DIR" "$ISOLATED_AUDIT_LOG" "$INTEG_MOCK_DIR:$PATH")
+
+PR_URL="https://github.com/Garsson-io/kaizen/pull/429"
+
+# Hook runner
+run_post_clear() {
+  local command="$1"
+  local stdout="$2"
+  local exit_code="${3:-0}"
+  local input
+  input=$(build_post_tool_use_input "Bash" \
+    "$(jq -n --arg c "$command" '{command: $c}')" \
+    "$stdout" "" "$exit_code")
+  run_single_hook "$PR_KAIZEN_CLEAR" "$input" 10 "$HOOK_ENV_VARS"
+}
+
+# Helper: create a kaizen gate state file for the current branch
+create_gate() {
+  local pr_url="$1"
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+  local state_key
+  state_key=$(echo "$pr_url" | sed 's|https://github\.com/||;s|/pull/|_|;s|/|_|g')
+  printf 'PR_URL=%s\nSTATUS=%s\nBRANCH=%s\n' \
+    "$pr_url" "needs_pr_kaizen" "$branch" > "$STATE_DIR/pr-kaizen-$state_key"
+}
+
+# Helper: reset state between phases
+reset() {
+  rm -rf "$STATE_DIR"/*
+  rm -f "$ISOLATED_AUDIT_LOG"
+}
+
+# Snapshot the repo audit log modification time (if it exists) to detect writes
+REPO_AUDIT_SNAPSHOT=""
+if [ -f "$REPO_AUDIT_LOG" ]; then
+  REPO_AUDIT_SNAPSHOT=$(stat -c %Y "$REPO_AUDIT_LOG" 2>/dev/null || stat -f %m "$REPO_AUDIT_LOG" 2>/dev/null)
+fi
+
+# ================================================================
+# Test 1: KAIZEN_NO_ACTION writes to AUDIT_LOG override
+# ================================================================
+echo "=== Test 1: KAIZEN_NO_ACTION writes to AUDIT_LOG override ==="
+
+reset
+create_gate "$PR_URL"
+
+run_post_clear \
+  "echo 'KAIZEN_NO_ACTION [docs-only]: updated README formatting'" \
+  "KAIZEN_NO_ACTION [docs-only]: updated README formatting"
+
+if [ -f "$ISOLATED_AUDIT_LOG" ]; then
+  echo "  PASS: audit log created at isolated path"
+  ((PASS++))
+else
+  echo "  FAIL: audit log NOT created at isolated path ($ISOLATED_AUDIT_LOG)"
+  ((FAIL++))
+fi
+
+assert_contains "audit entry contains timestamp" "[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T" "$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)"
+assert_contains "audit entry contains branch" "branch=" "$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)"
+assert_contains "audit entry contains category" "category=docs-only" "$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)"
+assert_contains "audit entry contains pr URL" "pr=$PR_URL" "$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)"
+assert_contains "audit entry contains reason" "reason=updated README formatting" "$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)"
+
+# ================================================================
+# Test 2: Multiple entries append to the same isolated log
+# ================================================================
+echo ""
+echo "=== Test 2: Multiple entries append to the same isolated log ==="
+
+reset
+create_gate "$PR_URL"
+
+# First no-action declaration
+run_post_clear \
+  "echo 'KAIZEN_NO_ACTION [docs-only]: first doc update'" \
+  "KAIZEN_NO_ACTION [docs-only]: first doc update"
+
+# Create a new gate for a second declaration
+create_gate "$PR_URL"
+
+# Second no-action declaration
+run_post_clear \
+  "echo 'KAIZEN_NO_ACTION [typo]: fixed typo in comment'" \
+  "KAIZEN_NO_ACTION [typo]: fixed typo in comment"
+
+LINE_COUNT=$(wc -l < "$ISOLATED_AUDIT_LOG" 2>/dev/null | tr -d ' ')
+assert_eq "two entries appended to audit log" "2" "$LINE_COUNT"
+assert_contains "first entry present" "first doc update" "$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)"
+assert_contains "second entry present" "fixed typo in comment" "$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)"
+
+# ================================================================
+# Test 3: All required fields present (ISO 8601 timestamp, branch, category, pr, reason)
+# ================================================================
+echo ""
+echo "=== Test 3: All required fields present in audit entry ==="
+
+reset
+create_gate "$PR_URL"
+
+run_post_clear \
+  "echo 'KAIZEN_NO_ACTION [config-only]: updated tsconfig'" \
+  "KAIZEN_NO_ACTION [config-only]: updated tsconfig"
+
+AUDIT_ENTRY=$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)
+
+# ISO 8601 timestamp: YYYY-MM-DDTHH:MM:SSZ
+if echo "$AUDIT_ENTRY" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z'; then
+  echo "  PASS: timestamp is ISO 8601 format"
+  ((PASS++))
+else
+  echo "  FAIL: timestamp is NOT ISO 8601 format"
+  echo "    entry: $AUDIT_ENTRY"
+  ((FAIL++))
+fi
+
+assert_contains "branch field present" "branch=" "$AUDIT_ENTRY"
+assert_contains "category field present" "category=config-only" "$AUDIT_ENTRY"
+assert_contains "pr field present" "pr=https://github.com/" "$AUDIT_ENTRY"
+assert_contains "reason field present" "reason=updated tsconfig" "$AUDIT_ENTRY"
+
+# ================================================================
+# Test 4: Empty-array KAIZEN_IMPEDIMENTS also writes to audit log
+# ================================================================
+echo ""
+echo "=== Test 4: Empty-array KAIZEN_IMPEDIMENTS writes to audit log ==="
+
+reset
+create_gate "$PR_URL"
+
+run_post_clear \
+  "echo 'KAIZEN_IMPEDIMENTS: [] straightforward bug fix, no process issues'" \
+  "KAIZEN_IMPEDIMENTS: [] straightforward bug fix, no process issues"
+
+if [ -f "$ISOLATED_AUDIT_LOG" ]; then
+  echo "  PASS: audit log written for empty-array KAIZEN_IMPEDIMENTS"
+  ((PASS++))
+else
+  echo "  FAIL: audit log NOT written for empty-array KAIZEN_IMPEDIMENTS"
+  ((FAIL++))
+fi
+
+EMPTY_ENTRY=$(cat "$ISOLATED_AUDIT_LOG" 2>/dev/null)
+assert_contains "empty-array entry has category" "category=empty-array" "$EMPTY_ENTRY"
+assert_contains "empty-array entry has reason" "reason=straightforward bug fix" "$EMPTY_ENTRY"
+assert_contains "empty-array entry has pr" "pr=$PR_URL" "$EMPTY_ENTRY"
+
+# Verify ISO 8601 timestamp in empty-array entry too
+if echo "$EMPTY_ENTRY" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z'; then
+  echo "  PASS: empty-array entry has ISO 8601 timestamp"
+  ((PASS++))
+else
+  echo "  FAIL: empty-array entry missing ISO 8601 timestamp"
+  echo "    entry: $EMPTY_ENTRY"
+  ((FAIL++))
+fi
+
+# ================================================================
+# Test 5: Repo audit dir untouched
+# ================================================================
+echo ""
+echo "=== Test 5: Repo audit dir untouched ==="
+
+# Check that the repo's actual audit log was NOT written to during our tests
+if [ -f "$REPO_AUDIT_LOG" ]; then
+  REPO_AUDIT_CURRENT=$(stat -c %Y "$REPO_AUDIT_LOG" 2>/dev/null || stat -f %m "$REPO_AUDIT_LOG" 2>/dev/null)
+  if [ "$REPO_AUDIT_SNAPSHOT" = "$REPO_AUDIT_CURRENT" ]; then
+    echo "  PASS: repo audit log untouched (mtime unchanged)"
+    ((PASS++))
+  else
+    echo "  FAIL: repo audit log was modified during tests!"
+    echo "    before: $REPO_AUDIT_SNAPSHOT"
+    echo "    after:  $REPO_AUDIT_CURRENT"
+    ((FAIL++))
+  fi
+else
+  if [ -z "$REPO_AUDIT_SNAPSHOT" ]; then
+    echo "  PASS: repo audit log does not exist (was never created)"
+    ((PASS++))
+  else
+    echo "  FAIL: repo audit log existed before but was deleted during tests!"
+    ((FAIL++))
+  fi
+fi
+
+harness_summary

--- a/.claude/hooks/tests/test-pr-kaizen-clear.sh
+++ b/.claude/hooks/tests/test-pr-kaizen-clear.sh
@@ -412,10 +412,8 @@ echo "=== Audit log is written for no-action declarations ==="
 setup
 create_pr_kaizen_state "https://github.com/Garsson-io/kaizen/pull/42"
 
-# The hook resolves audit log relative to its own location
-# HOOK is set at top of file: "$(dirname "$0")/../kaizen-pr-reflect-clear.sh"
-HOOK_REAL_DIR="$(cd "$(dirname "$HOOK")" && pwd)"
-TEST_AUDIT_LOG="${HOOK_REAL_DIR}/../audit/no-action.log"
+# AUDIT_LOG is set by setup_test_env to an isolated temp path (kaizen #429)
+TEST_AUDIT_LOG="$AUDIT_LOG"
 rm -f "$TEST_AUDIT_LOG"
 
 OUTPUT=$(run_posttool_bash \
@@ -446,9 +444,8 @@ else
   ((FAIL++))
   ((FAIL++))
 fi
-# Clean up audit log after test
+# Clean up audit log after test (isolated via AUDIT_LOG env var — kaizen #429)
 rm -f "$TEST_AUDIT_LOG"
-rmdir "$(dirname "$TEST_AUDIT_LOG")" 2>/dev/null || true
 
 echo ""
 echo "=== gh issue create alone does NOT clear gate ==="

--- a/.claude/kaizen/skill-config-header.md
+++ b/.claude/kaizen/skill-config-header.md
@@ -1,0 +1,13 @@
+## Host Configuration
+
+Before running commands, read the host configuration from `kaizen.config.json`:
+```bash
+KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
+HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
+KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
+ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
+```
+Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
+If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
+
+**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -145,6 +145,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "./.claude/hooks/kaizen-debug-stop-cwd.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "./.claude/hooks/kaizen-enforce-pr-review-stop.sh",
             "timeout": 10
           },

--- a/.claude/skills/kaizen-audit-issues/SKILL.md
+++ b/.claude/skills/kaizen-audit-issues/SKILL.md
@@ -3,19 +3,7 @@ name: kaizen-audit-issues
 description: Periodic issue taxonomy audit — checks label coverage, epic health, incident density, horizon coverage, and unlabeled issues. Produces structured report with suggested fixes. Triggers on "audit issues", "issue health", "label audit", "taxonomy check", "issue hygiene".
 ---
 
-## Host Configuration
-
-Before running commands, read the host configuration from `kaizen.config.json`:
-```bash
-KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
-HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
-KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
-ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
-```
-Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
-If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
-
-**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.
+<!-- Host config: read .claude/kaizen/skill-config-header.md before running commands -->
 
 # /kaizen-audit-issues — Periodic Issue Taxonomy Audit
 

--- a/.claude/skills/kaizen-deep-dive/SKILL.md
+++ b/.claude/skills/kaizen-deep-dive/SKILL.md
@@ -3,19 +3,7 @@ name: kaizen-deep-dive
 description: Autonomous deep-dive into a kaizen domain — find the root cause category behind repeated issues, fix concrete bugs, add interaction tests, and ship one high-impact PR. Triggers on "make a dent", "hero mode", "deep dive kaizen", "fix the category", "autonomous fix".
 ---
 
-## Host Configuration
-
-Before running commands, read the host configuration from `kaizen.config.json`:
-```bash
-KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
-HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
-KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
-ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
-```
-Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
-If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
-
-**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.
+<!-- Host config: read .claude/kaizen/skill-config-header.md before running commands -->
 
 # Make a Dent — Autonomous Category Killer
 

--- a/.claude/skills/kaizen-evaluate/SKILL.md
+++ b/.claude/skills/kaizen-evaluate/SKILL.md
@@ -3,19 +3,7 @@ name: kaizen-evaluate
 description: Evaluate a kaizen case before implementation — gather incidents, find low-hanging fruit, critique specs, get admin input, record lessons. Triggers on "accept case", "evaluate kaizen", "should we do this", "triage kaizen". ALSO triggers when browsing/selecting work — "look at issue #N", "check this PR", "what should we work on", "pick up kaizen #N", "find low hanging fruit", "which case", "what's next", "prioritize", or any discussion of a specific GitHub issue, PR, or kaizen case that precedes implementation.
 ---
 
-## Host Configuration
-
-Before running commands, read the host configuration from `kaizen.config.json`:
-```bash
-KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
-HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
-KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
-ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
-```
-Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
-If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
-
-**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.
+<!-- Host config: read .claude/kaizen/skill-config-header.md before running commands -->
 
 # Accept Case — Kaizen Case Evaluation
 

--- a/.claude/skills/kaizen-gaps/SKILL.md
+++ b/.claude/skills/kaizen-gaps/SKILL.md
@@ -3,19 +3,7 @@ name: kaizen-gaps
 description: Systematic analysis of kaizen issues and incidents to find tooling gaps, testing gaps, horizon concentration, and unnamed dimensions. Produces prioritized lists for filing kaizens, writing feature PRDs, and writing meta/horizon PRDs. Triggers on "gap analysis", "analyze gaps", "what gaps do we have", "tooling gaps", "testing gaps", "horizon analysis", "where are problems concentrated".
 ---
 
-## Host Configuration
-
-Before running commands, read the host configuration from `kaizen.config.json`:
-```bash
-KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
-HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
-KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
-ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
-```
-Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
-If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
-
-**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.
+<!-- Host config: read .claude/kaizen/skill-config-header.md before running commands -->
 
 # Gap Analysis — Strategic Kaizen Intelligence
 

--- a/.claude/skills/kaizen-implement/SKILL.md
+++ b/.claude/skills/kaizen-implement/SKILL.md
@@ -3,19 +3,7 @@ name: kaizen-implement
 description: Take a spec from PRD to working code. Re-examines the spec against current reality, finds concrete next steps, and executes. Guided by the Zen of Kaizen (see .claude/kaizen/zen.md). Triggers on "implement spec", "implement prd", "start implementation", "pick up spec", "execute spec". ALSO triggers on greenlight phrases after discussing concrete work — "lets do it", "go ahead", "build it", "start on this", "do it", "make it happen", "go for it", "ship it", "yes do it". If a specific piece of work (issue, PR, case, spec) was just discussed and the user gives a go-ahead, this skill drives the implementation. Always create a case first (all dev work must be in a case with its own worktree per CLAUDE.md).
 ---
 
-## Host Configuration
-
-Before running commands, read the host configuration from `kaizen.config.json`:
-```bash
-KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
-HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
-KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
-ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
-```
-Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
-If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
-
-**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.
+<!-- Host config: read .claude/kaizen/skill-config-header.md before running commands -->
 
 # Implement Spec — From PRD to Working Code
 

--- a/.claude/skills/kaizen-pick/SKILL.md
+++ b/.claude/skills/kaizen-pick/SKILL.md
@@ -3,19 +3,7 @@ name: kaizen-pick
 description: Intelligently select the next kaizen issue to work on. Filters out claimed issues, balances epic momentum vs topic diversity, and flows into /kaizen-evaluate. Triggers on "pick work", "what's next", "choose issue", "next kaizen", "pick an issue", "what should I work on", "pick a kaizen", "find work", "pick a high value kaizen".
 ---
 
-## Host Configuration
-
-Before running commands, read the host configuration from `kaizen.config.json`:
-```bash
-KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
-HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
-KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
-ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
-```
-Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
-If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
-
-**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.
+<!-- Host config: read .claude/kaizen/skill-config-header.md before running commands -->
 
 # Pick Work — Intelligent Issue Selection
 

--- a/.claude/skills/kaizen-reflect/SKILL.md
+++ b/.claude/skills/kaizen-reflect/SKILL.md
@@ -3,19 +3,7 @@ name: kaizen-reflect
 description: Recursive process improvement — core workflow for continuous improvement across all verticals. Escalation framework (Level 1→2→3), reflection triggers, backlog management. Triggers on "kaizen", "process improvement", "improve processes", "recursive kaizen".
 ---
 
-## Host Configuration
-
-Before running commands, read the host configuration from `kaizen.config.json`:
-```bash
-KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
-HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
-KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
-ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
-```
-Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
-If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
-
-**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.
+<!-- Host config: read .claude/kaizen/skill-config-header.md before running commands -->
 
 # Recursive Kaizen — Core Workflow
 

--- a/.claude/skills/kaizen-wip/SKILL.md
+++ b/.claude/skills/kaizen-wip/SKILL.md
@@ -3,19 +3,7 @@ name: kaizen-wip
 description: Search for in-progress work — worktrees, open PRs, dirty branches, active cases. Triggers on "wip", "in progress", "what's open", "existing work".
 ---
 
-## Host Configuration
-
-Before running commands, read the host configuration from `kaizen.config.json`:
-```bash
-KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
-HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
-KAIZEN_CLI=$(jq -r '.host.caseCli // ""' kaizen.config.json)
-ISSUE_BACKEND=$(jq -r '.issues.backend // "github"' kaizen.config.json)
-```
-Use `$KAIZEN_REPO` in kaizen issue operations, `$HOST_REPO` in host project operations.
-If `$KAIZEN_CLI` is empty, the host has no case system — use plain `git worktree add` for workspace isolation.
-
-**Issue backend:** When `$ISSUE_BACKEND` is `"github"` (default), use `gh issue` commands directly. When it is `"custom"`, use `npx tsx src/issue-backend.ts` instead of `gh issue` — it routes to the configured backend CLI.
+<!-- Host config: read .claude/kaizen/skill-config-header.md before running commands -->
 
 # /wip — Find In-Progress Work
 

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -13,11 +13,11 @@
 
 import { execSync } from 'node:child_process';
 import { appendFileSync, mkdirSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { type HookInput, readHookInput, writeHookOutput } from './hook-io.js';
 import { stripHeredocBody } from './parse-command.js';
 import {
+  DEFAULT_AUDIT_DIR,
   DEFAULT_STATE_DIR,
   clearStateWithStatusAnyBranch,
   findNewestStateWithStatusAnyBranch,
@@ -39,8 +39,8 @@ interface Impediment {
 
 // ── Audit logging ────────────────────────────────────────────────────
 
-const __hookDirname = dirname(fileURLToPath(import.meta.url));
-const AUDIT_DIR = resolve(__hookDirname, '../../.claude/kaizen/audit');
+// AUDIT_DIR from shared state-utils, with env var override for test isolation (kaizen #429)
+const AUDIT_DIR = process.env.AUDIT_DIR ?? DEFAULT_AUDIT_DIR;
 
 function currentBranch(): string {
   try {

--- a/src/hooks/state-utils.ts
+++ b/src/hooks/state-utils.ts
@@ -19,6 +19,12 @@ import { join } from 'node:path';
 export const DEFAULT_STATE_DIR = '/tmp/.pr-review-state';
 export const DEFAULT_MAX_STATE_AGE = 7200; // 2 hours
 
+// Default audit directory. Override via AUDIT_DIR env var for test isolation (kaizen #429).
+export const DEFAULT_AUDIT_DIR = new URL(
+  '../../.claude/kaizen/audit',
+  import.meta.url,
+).pathname;
+
 export interface StateFile {
   PR_URL: string;
   STATUS: string;


### PR DESCRIPTION
## Summary

- **#429 — Audit log path isolation**: Centralize `AUDIT_DIR`/`AUDIT_LOG` in shared `state-utils` (shell + TS) with env var overrides. Tests no longer pollute the repo's audit log.
- **#430 — Skill config header DRY**: Extract duplicated 13-line "Host Configuration" block from 8 SKILL.md files into shared `.claude/kaizen/skill-config-header.md`. Skills now reference it via a one-line HTML comment.
- **Hook shared libs**: New `lib/input-utils.sh` (input parsing) and `lib/hook-output.sh` (deny/block JSON). 4 hooks updated to use them.
- **Stop hook debugging**: Added diagnostic hook to capture CWD during session stop, to trace the persistent "not found" errors.
- **E2E test**: 20-assertion integration test for audit log path isolation.

Closes #429, closes #430

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm test` — 314/314 TS tests pass
- [x] `bash .claude/hooks/tests/test-pr-kaizen-clear.sh` — 88/88 pass
- [x] `bash .claude/hooks/tests/test-squash-merge-safety.sh` — 7/7 pass
- [x] `bash .claude/hooks/tests/test-block-git-rebase.sh` — 18/18 pass
- [x] `bash .claude/hooks/tests/test-integration-audit-isolation.sh` — 20/20 pass
- [x] `npm run test:hooks` — 959/962 pass (3 pre-existing failures in case-exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)