### PR TITLE
fix: wire cleanup_merged_review_states into SessionStart hook

### DIFF
--- a/.claude/hooks/kaizen-session-cleanup.sh
+++ b/.claude/hooks/kaizen-session-cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Part of kAIzen Agent Control Flow — see .claude/kaizen/README.md
+# kaizen-session-cleanup.sh — SessionStart hook
+# Runs cleanup_merged_review_states() to clear stale merged/closed PR state files.
+# Moved out of find_needs_review_state() hot path in kaizen #452 — was adding ~400ms
+# per PreToolUse call due to gh pr view HTTP roundtrip.
+
+source "$(dirname "$0")/lib/state-utils.sh"
+cleanup_merged_review_states

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,11 @@
             "type": "command",
             "command": "./.claude/hooks/kaizen-check-wip.sh",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "./.claude/hooks/kaizen-session-cleanup.sh",
+            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## Summary

- PR #456 moved `gh pr view` out of the `find_needs_review_state()` hot path (saving ~400ms per PreToolUse) into a new `cleanup_merged_review_states()` function
- But that function was **never wired into any hook** — merged/closed PR state files were never cleaned up until the 2-hour staleness timeout
- This adds a small SessionStart hook that calls it once per session

## What was wrong

`find_needs_review_state()` used to call `gh pr view` on every match to auto-clear merged PRs. PR #456 correctly moved this to a batch function, but forgot to call it from anywhere. Dead code.

## Test plan

- [x] `npm test` — 400 passed, 2 skipped
- [x] `test-state-utils.sh` — 58 passed, 0 failed (existing tests for the function itself)
- [x] Hook runs cleanly with empty state dir
- [x] settings.json validates as JSON

Generated with [Claude Code](https://claude.com/claude-code)