### PR TITLE
perf: early-exit in 3 slow hooks — 25x faster on common commands

### DIFF
--- a/.claude/hooks/kaizen-enforce-pr-reflect.sh
+++ b/.claude/hooks/kaizen-enforce-pr-reflect.sh
@@ -33,15 +33,6 @@ fi
 
 CMD_LINE=$(strip_heredoc_body "$COMMAND")
 
-# Check for active PR kaizen gate
-STATE_INFO=$(find_state_with_status "needs_pr_kaizen")
-if [ $? -ne 0 ] || [ -z "$STATE_INFO" ]; then
-  # No active kaizen gate — allow everything
-  exit 0
-fi
-
-PR_URL=$(echo "$STATE_INFO" | cut -d'|' -f1)
-
 # Check if the command is allowed during kaizen gate.
 # Uses segment splitting (kaizen #172 bug fix) to prevent bypass via pipes/chains.
 # Before: `npm build && echo KAIZEN_IMPEDIMENTS:` passed the gate.
@@ -77,9 +68,21 @@ is_kaizen_command() {
   return 1
 }
 
+# FAST PATH (kaizen #451): Check command relevance BEFORE expensive state
+# iteration. Allowed commands exit immediately — no need to check whether
+# a gate is active, since they'd be allowed through regardless.
 if is_kaizen_command "$CMD_LINE"; then
   exit 0
 fi
+
+# SLOW PATH: Command would be blocked if gate is active. Check state.
+STATE_INFO=$(find_state_with_status "needs_pr_kaizen")
+if [ $? -ne 0 ] || [ -z "$STATE_INFO" ]; then
+  # No active kaizen gate — allow everything
+  exit 0
+fi
+
+PR_URL=$(echo "$STATE_INFO" | cut -d'|' -f1)
 
 # Block the command — agent must complete kaizen reflection first
 source "$(dirname "$0")/lib/hook-output.sh"

--- a/.claude/hooks/kaizen-enforce-pr-review.sh
+++ b/.claude/hooks/kaizen-enforce-pr-review.sh
@@ -50,7 +50,14 @@ is_review_command() {
   return 1
 }
 
-# Check for active review gate
+# FAST PATH (kaizen #451): Check command relevance BEFORE expensive state
+# iteration. Allowed commands exit immediately — no need to check whether
+# a gate is active, since they'd be allowed through regardless.
+if is_review_command "$CMD_LINE"; then
+  exit 0
+fi
+
+# SLOW PATH: Command would be blocked if gate is active. Check state.
 REVIEW_INFO=$(find_needs_review_state)
 if [ $? -ne 0 ] || [ -z "$REVIEW_INFO" ]; then
   # No active review — allow everything
@@ -59,11 +66,6 @@ fi
 
 PR_URL=$(echo "$REVIEW_INFO" | cut -d'|' -f1)
 ROUND=$(echo "$REVIEW_INFO" | cut -d'|' -f2)
-
-# If the command is review-related, allow it through
-if is_review_command "$CMD_LINE"; then
-  exit 0
-fi
 
 # Block the command — agent must review first
 jq -n \

--- a/.claude/hooks/kaizen-pr-reflect-clear.sh
+++ b/.claude/hooks/kaizen-pr-reflect-clear.sh
@@ -80,6 +80,12 @@ fi
 
 CMD_LINE=$(strip_heredoc_body "$COMMAND")
 
+# FAST PATH (kaizen #451): Only commands containing KAIZEN_IMPEDIMENTS or
+# KAIZEN_NO_ACTION can clear the gate. Skip state iteration for everything else.
+if ! echo "$COMMAND" | grep -qE 'KAIZEN_IMPEDIMENTS|KAIZEN_NO_ACTION'; then
+  exit 0
+fi
+
 # Check if there's an active PR kaizen gate to clear (kaizen #239, #327)
 # Use cross-branch lookup — the agent may submit the declaration from a
 # different worktree than where the PR was created.


### PR DESCRIPTION
## Summary

The 3 slowest hooks were iterating state files before checking if the command was even relevant:

| Hook | Before | After | Speedup |
|------|--------|-------|---------|
| enforce-pr-review | 400ms | 13ms | 31x |
| enforce-pr-reflect | 360ms | 16ms | 23x |
| pr-reflect-clear | 520ms | 12ms | 43x |

**Total per-tool-call savings: ~1.3s → ~40ms for allowed commands** (the common case).

## How

Reordered checks: command relevance BEFORE expensive state file iteration. Allowed commands (git log, gh pr diff, etc.) now exit immediately without touching state files.

The pattern:
```
# FAST PATH: allowed commands exit before state iteration
if is_allowed_command "$CMD_LINE"; then exit 0; fi

# SLOW PATH: only potentially-blocked commands check state
STATE=$(find_state_with_status ...)
```

## Test plan

- [x] All 171 existing tests pass (44 enforce-pr-review + 39 enforce-pr-kaizen + 88 pr-kaizen-clear)
- [x] Timed measurement: 13-16ms vs 360-520ms
- [x] Full hook test suite: 958 passed

Fixes Garsson-io/kaizen#451

🤖 Generated with [Claude Code](https://claude.com/claude-code)