### PR TITLE
fix: bash hook fragility — resilient source guards + CI lints (#480)

### DIFF
--- a/.claude/hooks/kaizen-block-git-rebase.sh
+++ b/.claude/hooks/kaizen-block-git-rebase.sh
@@ -16,9 +16,9 @@
 #   - git rebase --continue (finish in-progress rebase)
 #   - git rebase --skip (skip conflicting commit)
 
-source "$(dirname "$0")/lib/parse-command.sh"
-source "$(dirname "$0")/lib/input-utils.sh"
-source "$(dirname "$0")/lib/hook-output.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
 
 read_hook_input
 get_command

--- a/.claude/hooks/kaizen-bump-plugin-version.sh
+++ b/.claude/hooks/kaizen-bump-plugin-version.sh
@@ -10,7 +10,7 @@
 #
 # Always exits 0 — advisory, never blocks.
 
-source "$(dirname "$0")/lib/parse-command.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')

--- a/.claude/hooks/kaizen-capture-worktree-context.sh
+++ b/.claude/hooks/kaizen-capture-worktree-context.sh
@@ -9,7 +9,7 @@
 #
 # Always exits 0 — advisory, not blocking.
 
-source "$(dirname "$0")/lib/parse-command.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')

--- a/.claude/hooks/kaizen-check-dirty-files.sh
+++ b/.claude/hooks/kaizen-check-dirty-files.sh
@@ -14,7 +14,7 @@
 # Exit 0 = allow
 # JSON with permissionDecision deny = block
 
-source "$(dirname "$0")/lib/parse-command.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')

--- a/.claude/hooks/kaizen-check-practices.sh
+++ b/.claude/hooks/kaizen-check-practices.sh
@@ -8,7 +8,7 @@
 # Runs as PreToolUse hook on Bash tool calls.
 # Always exits 0 (advisory only — never blocks).
 
-source "$(dirname "$0")/lib/parse-command.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')

--- a/.claude/hooks/kaizen-check-test-coverage.sh
+++ b/.claude/hooks/kaizen-check-test-coverage.sh
@@ -7,7 +7,7 @@
 # Runs as PreToolUse hook on Bash tool calls.
 # Always exits 0 (advisory only — never blocks).
 
-source "$(dirname "$0")/lib/parse-command.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')

--- a/.claude/hooks/kaizen-check-verification.sh
+++ b/.claude/hooks/kaizen-check-verification.sh
@@ -8,7 +8,7 @@
 # Runs as PreToolUse hook on Bash tool calls.
 # Always exits 0 (advisory only — never blocks).
 
-source "$(dirname "$0")/lib/parse-command.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')

--- a/.claude/hooks/kaizen-check-wip.sh
+++ b/.claude/hooks/kaizen-check-wip.sh
@@ -37,7 +37,7 @@ if [ -z "$WORKTREES" ]; then
 fi
 
 # Read config for repo name
-source "$(dirname "$0")/lib/read-config.sh"
+source "$(dirname "$0")/lib/read-config.sh" 2>/dev/null || { exit 0; }
 
 # Collect open PRs (fast, cached by gh)
 PR_COUNT=0

--- a/.claude/hooks/kaizen-enforce-case-exists.sh
+++ b/.claude/hooks/kaizen-enforce-case-exists.sh
@@ -15,8 +15,8 @@
 #   1. If $KAIZEN_CASE_CLI is configured, use: $KAIZEN_CASE_CLI case-by-branch <branch>
 #   2. If no case CLI configured, skip enforcement (can't check without a backend)
 
-source "$(dirname "$0")/lib/allowlist.sh"
-source "$(dirname "$0")/lib/read-config.sh"
+source "$(dirname "$0")/lib/allowlist.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/read-config.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')

--- a/.claude/hooks/kaizen-enforce-post-merge-stop.sh
+++ b/.claude/hooks/kaizen-enforce-post-merge-stop.sh
@@ -21,10 +21,10 @@
 # Exit 0 with no output = allow stop
 # Exit 0 with JSON {"decision":"block","reason":"..."} = block stop
 
-source "$(dirname "$0")/lib/state-utils.sh"
-source "$(dirname "$0")/lib/resolve-main-checkout.sh"
-source "$(dirname "$0")/lib/input-utils.sh"
-source "$(dirname "$0")/lib/hook-output.sh"
+source "$(dirname "$0")/lib/state-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/resolve-main-checkout.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
 
 read_hook_input
 

--- a/.claude/hooks/kaizen-enforce-pr-reflect.sh
+++ b/.claude/hooks/kaizen-enforce-pr-reflect.sh
@@ -20,9 +20,9 @@
 #   git diff, git log, git show, git status, git branch, git fetch
 #   ls, cat, stat, find, head, tail, wc, file (read-only)
 
-source "$(dirname "$0")/lib/parse-command.sh"
-source "$(dirname "$0")/lib/state-utils.sh"
-source "$(dirname "$0")/lib/allowlist.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/state-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/allowlist.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -87,7 +87,7 @@ fi
 PR_URL=$(echo "$STATE_INFO" | cut -d'|' -f1)
 
 # Block the command — agent must complete kaizen reflection first
-source "$(dirname "$0")/lib/hook-output.sh"
+source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
 
 IMPEDIMENTS_FORMAT=$(render_prompt "impediments-format.md")
 

--- a/.claude/hooks/kaizen-enforce-pr-review-stop.sh
+++ b/.claude/hooks/kaizen-enforce-pr-review-stop.sh
@@ -20,9 +20,9 @@
 # Exit 0 with no output = allow stop
 # Exit 0 with JSON {"decision":"block","reason":"..."} = block stop
 
-source "$(dirname "$0")/lib/state-utils.sh"
-source "$(dirname "$0")/lib/input-utils.sh"
-source "$(dirname "$0")/lib/hook-output.sh"
+source "$(dirname "$0")/lib/state-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
 
 read_hook_input
 

--- a/.claude/hooks/kaizen-enforce-pr-review-tools.sh
+++ b/.claude/hooks/kaizen-enforce-pr-review-tools.sh
@@ -15,7 +15,7 @@
 # Read-only tools (Read, Glob, Grep) are NOT blocked because they're useful
 # for reviewing code during the review process.
 
-source "$(dirname "$0")/lib/state-utils.sh"
+source "$(dirname "$0")/lib/state-utils.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')

--- a/.claude/hooks/kaizen-enforce-pr-review.sh
+++ b/.claude/hooks/kaizen-enforce-pr-review.sh
@@ -20,9 +20,9 @@
 # The gate opens when the agent runs `gh pr diff` (which sets STATUS=passed
 # in the PostToolUse hook). If the agent pushes fixes, the gate re-engages.
 
-source "$(dirname "$0")/lib/parse-command.sh"
-source "$(dirname "$0")/lib/state-utils.sh"
-source "$(dirname "$0")/lib/allowlist.sh"
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/state-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/allowlist.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')

--- a/.claude/hooks/kaizen-enforce-reflect-stop.sh
+++ b/.claude/hooks/kaizen-enforce-reflect-stop.sh
@@ -19,7 +19,7 @@
 # Exit 0 with no output = allow stop
 # Exit 0 with JSON {"decision":"block","reason":"..."} = block stop
 
-source "$(dirname "$0")/lib/state-utils.sh"
+source "$(dirname "$0")/lib/state-utils.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 
@@ -46,7 +46,7 @@ else
 fi
 
 # Block stop: agent must complete kaizen reflection first.
-source "$(dirname "$0")/lib/hook-output.sh"
+source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
 
 REASON=$(render_prompt "pr-kaizen-block.md" "PR_HEADER=$PR_HEADER")
 

--- a/.claude/hooks/kaizen-enforce-worktree-writes.sh
+++ b/.claude/hooks/kaizen-enforce-worktree-writes.sh
@@ -17,7 +17,7 @@
 #
 # Runs as PreToolUse hook on Edit and Write tool calls.
 
-source "$(dirname "$0")/lib/allowlist.sh"
+source "$(dirname "$0")/lib/allowlist.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')

--- a/.claude/hooks/kaizen-post-merge-clear.sh
+++ b/.claude/hooks/kaizen-post-merge-clear.sh
@@ -14,9 +14,9 @@
 #
 # Always exits 0 — this is a state management hook, not a gate.
 
-source "$(dirname "$0")/lib/state-utils.sh"
-source "$(dirname "$0")/lib/parse-command.sh"
-source "$(dirname "$0")/lib/resolve-main-checkout.sh"
+source "$(dirname "$0")/lib/state-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/resolve-main-checkout.sh" 2>/dev/null || { exit 0; }
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')

--- a/.claude/hooks/kaizen-session-cleanup.sh
+++ b/.claude/hooks/kaizen-session-cleanup.sh
@@ -7,5 +7,5 @@
 
 
 source "$(dirname "$0")/lib/scope-guard.sh"
-source "$(dirname "$0")/lib/state-utils.sh"
+source "$(dirname "$0")/lib/state-utils.sh" 2>/dev/null || { exit 0; }
 cleanup_merged_review_states

--- a/.claude/hooks/tests/test-resilient-source.sh
+++ b/.claude/hooks/tests/test-resilient-source.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# test-resilient-source.sh — Verify resilient source guards on all hooks
+#
+# INVARIANT: Every source call to lib/ (except scope-guard.sh) must have
+# an error guard (|| { exit 0; }) to prevent hook crashes from corrupted
+# libraries. This is the category prevention test for kaizen #386, #371.
+#
+# Also verifies the CI lints in validate-hook-integrity.sh catch violations.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOKS_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+echo "=== Resilient source guard tests ==="
+
+# Phase 1: All hooks have guarded source calls
+echo ""
+echo "--- Phase 1: All lib source calls are guarded ---"
+
+TOTAL_GUARDED=0
+TOTAL_UNGUARDED=0
+for f in "$HOOKS_DIR"/kaizen-*.sh "$HOOKS_DIR"/pr-*.sh; do
+  [ -f "$f" ] || continue
+  name=$(basename "$f")
+
+  # Find unguarded source calls (not scope-guard, no || guard)
+  unguarded=$(grep -c '^source .*/lib/' "$f" | head -1)
+  guarded=$(grep -c '^source .*/lib/.*||' "$f" | head -1)
+  scope=$(grep -c '^source .*/lib/scope-guard' "$f" | head -1)
+
+  # All non-scope-guard sources should have guards
+  expected_guarded=$((unguarded - scope))
+  if [ "$expected_guarded" -gt 0 ] && [ "$guarded" -lt "$expected_guarded" ]; then
+    echo "  FAIL: $name has $((expected_guarded - guarded)) unguarded source call(s)"
+    FAILED_NAMES+=("$name unguarded source")
+    ((FAIL++))
+    ((TOTAL_UNGUARDED += expected_guarded - guarded))
+  elif [ "$expected_guarded" -gt 0 ]; then
+    ((TOTAL_GUARDED += guarded))
+  fi
+done
+
+if [ "$TOTAL_UNGUARDED" -eq 0 ]; then
+  echo "  PASS: all $TOTAL_GUARDED non-scope-guard source calls are guarded"
+  ((PASS++))
+fi
+
+# Phase 2: Resilient source pattern causes fail-open on missing libs
+echo ""
+echo "--- Phase 2: Resilient source guard causes fail-open ---"
+
+# Create a minimal hook that uses the resilient pattern with a missing lib
+FAIL_OPEN_HOOK=$(mktemp)
+cat > "$FAIL_OPEN_HOOK" << 'HOOK'
+#!/bin/bash
+source "/nonexistent/path/to/broken-lib.sh" 2>/dev/null || { exit 0; }
+echo "SHOULD_NOT_REACH"
+exit 1
+HOOK
+chmod +x "$FAIL_OPEN_HOOK"
+
+EXIT_CODE=0
+OUTPUT=$(bash "$FAIL_OPEN_HOOK" 2>/dev/null) || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ] && [ -z "$OUTPUT" ]; then
+  echo "  PASS: resilient guard exits 0 on missing lib (fail-open)"
+  ((PASS++))
+else
+  echo "  FAIL: expected exit 0 with no output, got exit=$EXIT_CODE output='$OUTPUT'"
+  FAILED_NAMES+=("resilient guard fail-open")
+  ((FAIL++))
+fi
+
+# Verify: the guard stops execution before reaching dependent code
+GUARDED_HOOK=$(mktemp)
+cat > "$GUARDED_HOOK" << 'HOOK'
+#!/bin/bash
+source "/nonexistent/lib.sh" 2>/dev/null || { exit 0; }
+echo "DEPENDENT_CODE_REACHED"
+HOOK
+
+OUTPUT=$(bash "$GUARDED_HOOK" 2>/dev/null)
+if [ -z "$OUTPUT" ]; then
+  echo "  PASS: guard prevents reaching dependent code after failed source"
+  ((PASS++))
+else
+  echo "  FAIL: dependent code was reached despite failed source"
+  FAILED_NAMES+=("guard prevents dependent code")
+  ((FAIL++))
+fi
+rm -f "$FAIL_OPEN_HOOK" "$GUARDED_HOOK"
+
+# Phase 3: validate-hook-integrity.sh catches unguarded source
+echo ""
+echo "--- Phase 3: CI lint catches unguarded source ---"
+
+# Create a fake hook with unguarded source
+FAKE_HOOKS_DIR=$(mktemp -d)
+mkdir -p "$FAKE_HOOKS_DIR/.claude/hooks/lib"
+echo '#!/bin/bash' > "$FAKE_HOOKS_DIR/.claude/hooks/lib/test-lib.sh"
+cat > "$FAKE_HOOKS_DIR/.claude/hooks/kaizen-fake-test.sh" << 'HOOK'
+#!/bin/bash
+source "$(dirname "$0")/lib/test-lib.sh"
+exit 0
+HOOK
+chmod +x "$FAKE_HOOKS_DIR/.claude/hooks/kaizen-fake-test.sh"
+
+# Create minimal settings.json
+cat > "$FAKE_HOOKS_DIR/.claude/settings.json" << 'JSON'
+{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"command":"./.claude/hooks/kaizen-fake-test.sh"}]}]}}
+JSON
+
+LINT_OUTPUT=$(bash "$SCRIPT_DIR/validate-hook-integrity.sh" "$FAKE_HOOKS_DIR" 2>&1)
+if echo "$LINT_OUTPUT" | grep -q "Unguarded source"; then
+  echo "  PASS: CI lint detects unguarded source"
+  ((PASS++))
+else
+  echo "  FAIL: CI lint did not detect unguarded source"
+  echo "    output: $LINT_OUTPUT"
+  FAILED_NAMES+=("CI lint unguarded source detection")
+  ((FAIL++))
+fi
+rm -rf "$FAKE_HOOKS_DIR"
+
+# Phase 4: validate-hook-integrity.sh passes with guarded hooks
+echo ""
+echo "--- Phase 4: CI lint passes on current hooks ---"
+
+LINT_OUTPUT=$(bash "$SCRIPT_DIR/validate-hook-integrity.sh" 2>&1)
+LINT_EXIT=$?
+if [ "$LINT_EXIT" -eq 0 ]; then
+  echo "  PASS: all current hooks pass CI lint"
+  ((PASS++))
+else
+  echo "  FAIL: CI lint failed on current hooks"
+  echo "$LINT_OUTPUT" | grep "::error::"
+  FAILED_NAMES+=("CI lint on current hooks")
+  ((FAIL++))
+fi
+
+print_results

--- a/.claude/hooks/tests/validate-hook-integrity.sh
+++ b/.claude/hooks/tests/validate-hook-integrity.sh
@@ -73,6 +73,77 @@ echo "--- plugin.json ---"
 validate_file "$PROJECT_ROOT/.claude-plugin/plugin.json" "plugin.json" "."
 
 echo ""
+echo "--- Lint: heavy subprocesses in accumulating hooks (kaizen #475, #474) ---"
+# Stop and PostToolUse hooks run on EVERY tool call. Heavy commands
+# (vitest, tsc, npm test) in these positions cause OOM cascades.
+# Only check actual hook scripts, not test files.
+HOOKS_DIR="$PROJECT_ROOT/.claude/hooks"
+if [ -d "$HOOKS_DIR" ]; then
+  # Identify Stop and PostToolUse hooks from settings.json
+  STOP_AND_POST_HOOKS=""
+  if [ -f "$PROJECT_ROOT/.claude/settings.json" ]; then
+    STOP_AND_POST_HOOKS=$(jq -r '
+      (.hooks.Stop // [])[] | .command // empty,
+      (.hooks.PostToolUse // [])[] | (.hooks // [])[] | .command // empty
+    ' "$PROJECT_ROOT/.claude/settings.json" 2>/dev/null | sort -u)
+  fi
+
+  for cmd in $STOP_AND_POST_HOOKS; do
+    local_path="$cmd"
+    [[ "$local_path" == ./* ]] && local_path="$PROJECT_ROOT/${local_path#./}"
+    [ -f "$local_path" ] || continue
+
+    # Check for heavy subprocess invocations (not in comments)
+    HEAVY=$(grep -nE '(vitest|jest|tsc |npm test|npm run test|npx tsx.*\.test\.)' "$local_path" \
+      | grep -v '^\s*#' | grep -v 'grep' || true)
+    if [ -n "$HEAVY" ]; then
+      echo "::error::[lint] Heavy subprocess in accumulating hook $cmd:"
+      echo "$HEAVY"
+      ((ERRORS++))
+    fi
+  done
+  echo "  Checked Stop/PostToolUse hooks for heavy subprocesses"
+fi
+
+echo ""
+echo "--- Lint: unparenthesized regex alternation (kaizen #378) ---"
+# Bash regex alternation without parens: [[ $x =~ foo|bar ]] matches
+# "foo" OR (entire-expression "bar"), not "foo" or "bar".
+# Must be: [[ $x =~ (foo|bar) ]]
+if [ -d "$HOOKS_DIR" ]; then
+  for f in "$HOOKS_DIR"/kaizen-*.sh "$HOOKS_DIR"/pr-*.sh; do
+    [ -f "$f" ] || continue
+    # Find [[ ... =~ ... | ... ]] without parens around alternation
+    UNSAFE_REGEX=$(grep -nE '=~\s+[^(]*\|' "$f" \
+      | grep -v '^\s*#' | grep -v '# ' || true)
+    if [ -n "$UNSAFE_REGEX" ]; then
+      echo "::error::[lint] Unparenthesized regex alternation in $(basename "$f"):"
+      echo "$UNSAFE_REGEX"
+      ((ERRORS++))
+    fi
+  done
+  echo "  Checked hooks for unparenthesized regex alternation"
+fi
+
+echo ""
+echo "--- Lint: unguarded source statements (kaizen #386) ---"
+# All source calls to lib/ (except scope-guard.sh) must have error guards
+# to prevent hook crashes from corrupted libraries (#371).
+if [ -d "$HOOKS_DIR" ]; then
+  for f in "$HOOKS_DIR"/kaizen-*.sh "$HOOKS_DIR"/pr-*.sh; do
+    [ -f "$f" ] || continue
+    UNGUARDED=$(grep -nE '^source .*/lib/' "$f" \
+      | grep -v 'scope-guard' | grep -v '||' || true)
+    if [ -n "$UNGUARDED" ]; then
+      echo "::error::[lint] Unguarded source in $(basename "$f") — add '2>/dev/null || { exit 0; }':"
+      echo "$UNGUARDED"
+      ((ERRORS++))
+    fi
+  done
+  echo "  Checked hooks for unguarded source statements"
+fi
+
+echo ""
 echo "Checked $CHECKED hook commands, $ERRORS errors."
 
 if [ "$ERRORS" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Category fix for **bash hook fragility** — prevents two known incident classes (deadlock #371, OOM #474) and adds CI lints to catch dangerous patterns before merge.

### Changes

| Scope | What |
|-------|------|
| 18 hooks | Resilient source guards on all 34 non-scope-guard lib source calls |
| `validate-hook-integrity.sh` | 3 new CI lints: heavy subprocesses, regex alternation, unguarded source |
| `test-resilient-source.sh` | **New** — 5-assertion category prevention test |

### How it works

**Resilient source pattern:**
```bash
# Before (crashes if lib is corrupted):
source "$(dirname "$0")/lib/parse-command.sh"

# After (fails open — safe from deadlock):
source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
```

Scope-guard.sh is NOT guarded (it's the guard itself and must always run).

**Three CI lints in validate-hook-integrity.sh:**
1. Heavy subprocesses (vitest/tsc/npm test) in Stop/PostToolUse hooks → prevents OOM
2. Unparenthesized regex alternation → prevents false match security bypass
3. Unguarded source statements → enforces the resilient pattern on new hooks

### Impact

- **Closes #386** (resilient source for all hooks)
- **Closes #475** (CI lint for heavy subprocesses)
- **Closes #378** (CI lint for regex alternation)
- Prevents recurrence of #371 (session deadlock) and #474 (OOM cascade)

## Test plan

- [x] 628 shell tests (627 pass + 1 pre-existing worktree SHA issue unrelated to this PR)
- [x] All hooks pass `bash -n` syntax check
- [x] `validate-hook-integrity.sh` passes with 0 errors
- [x] New prevention test verifies: guard existence, fail-open behavior, CI lint detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)