### PR TITLE
feat: port overnight-dent batch runner as auto-dent (#493)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .worktree-context.json
 .claude/worktrees/
 store/
+logs/

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -1,0 +1,236 @@
+#!/usr/bin/env npx tsx
+/**
+ * auto-dent-ctl — Control running auto-dent batches.
+ *
+ * Subcommands:
+ *   status              List active batches with last-worked-on info
+ *   halt [batch-id]     Halt a specific batch (or all active batches)
+ *
+ * Usage:
+ *   npx tsx scripts/auto-dent-ctl.ts status
+ *   npx tsx scripts/auto-dent-ctl.ts halt
+ *   npx tsx scripts/auto-dent-ctl.ts halt batch-260321-0136-a1b2
+ */
+
+import { readdirSync, readFileSync, existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import type { BatchState } from './auto-dent-run.js';
+
+function getRepoRoot(): string {
+  try {
+    const gitCommonDir = execSync(
+      'git rev-parse --path-format=absolute --git-common-dir',
+      { encoding: 'utf8' },
+    ).trim();
+    return gitCommonDir.replace(/\/\.git$/, '');
+  } catch {
+    return process.cwd();
+  }
+}
+
+function getLogsDir(): string {
+  return join(getRepoRoot(), 'logs', 'auto-dent');
+}
+
+export interface BatchInfo {
+  batchId: string;
+  dir: string;
+  state: BatchState;
+  active: boolean;
+  halted: boolean;
+}
+
+export function discoverBatches(logsDir: string): BatchInfo[] {
+  if (!existsSync(logsDir)) return [];
+
+  const batches: BatchInfo[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(logsDir);
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    const dir = join(logsDir, entry);
+    const stateFile = join(dir, 'state.json');
+    if (!existsSync(stateFile)) continue;
+
+    try {
+      const state: BatchState = JSON.parse(readFileSync(stateFile, 'utf8'));
+      const haltFile = join(dir, 'HALT');
+      batches.push({
+        batchId: state.batch_id || entry,
+        dir,
+        state,
+        active: !state.batch_end && !state.stop_reason,
+        halted: existsSync(haltFile),
+      });
+    } catch {
+      // Corrupt state file — skip
+    }
+  }
+
+  return batches;
+}
+
+export function formatBatchStatus(batch: BatchInfo): string {
+  const s = batch.state;
+  const status = batch.halted
+    ? 'HALT REQUESTED'
+    : batch.active
+      ? 'RUNNING'
+      : s.stop_reason || 'STOPPED';
+
+  const elapsed = Math.floor(
+    ((s.batch_end || Date.now() / 1000) - s.batch_start) / 1,
+  );
+  const hours = Math.floor(elapsed / 3600);
+  const mins = Math.floor((elapsed % 3600) / 60);
+
+  const lines = [
+    `  Batch:     ${batch.batchId}`,
+    `  Status:    ${status}`,
+    `  Guidance:  ${s.guidance}`,
+    `  Runs:      ${s.run}${s.max_runs > 0 ? ` / ${s.max_runs}` : ''}`,
+    `  Duration:  ${hours}h ${mins}m`,
+    `  PRs:       ${s.prs.length > 0 ? s.prs.join(' ') : 'none'}`,
+  ];
+
+  if (s.last_issue) lines.push(`  Last issue:    ${s.last_issue}`);
+  if (s.last_pr) lines.push(`  Last PR:       ${s.last_pr}`);
+  if (s.last_case) lines.push(`  Last case:     ${s.last_case}`);
+  if (s.last_branch) lines.push(`  Last branch:   ${s.last_branch}`);
+  if (s.last_worktree) lines.push(`  Last worktree: ${s.last_worktree}`);
+
+  return lines.join('\n');
+}
+
+export function formatLastState(state: BatchState): string {
+  const lines: string[] = [];
+  lines.push('╔══════════════════════════════════════════════════════════╗');
+  lines.push('║             auto-dent — Last Worked On                  ║');
+  lines.push('╠══════════════════════════════════════════════════════════╣');
+  lines.push(`║ Batch:       ${state.batch_id}`);
+  lines.push(`║ Run:         ${state.run}`);
+  if (state.last_issue) lines.push(`║ Last issue:    ${state.last_issue}`);
+  if (state.last_pr) lines.push(`║ Last PR:       ${state.last_pr}`);
+  if (state.last_case) lines.push(`║ Last case:     ${state.last_case}`);
+  if (state.last_branch) lines.push(`║ Last branch:   ${state.last_branch}`);
+  if (state.last_worktree)
+    lines.push(`║ Last worktree: ${state.last_worktree}`);
+  if (!state.last_issue && !state.last_pr && !state.last_case) {
+    lines.push('║ (no artifacts tracked yet)');
+  }
+  lines.push('╚══════════════════════════════════════════════════════════╝');
+  return lines.join('\n');
+}
+
+export function haltBatch(batchDir: string): void {
+  const haltFile = join(batchDir, 'HALT');
+  writeFileSync(haltFile, `halted at ${new Date().toISOString()}\n`);
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const subcommand = args[0];
+
+  if (!subcommand || subcommand === '--help') {
+    console.log(`auto-dent-ctl — Control running auto-dent batches
+
+Usage:
+  auto-dent-ctl.ts status              List batches with last-worked-on info
+  auto-dent-ctl.ts halt [batch-id]     Halt specific batch (or all active)
+  auto-dent-ctl.ts halt-state <file>   Print last-state from a state.json file`);
+    process.exit(0);
+  }
+
+  const logsDir = getLogsDir();
+
+  switch (subcommand) {
+    case 'status': {
+      const batches = discoverBatches(logsDir);
+      if (batches.length === 0) {
+        console.log('No auto-dent batches found.');
+        process.exit(0);
+      }
+
+      const active = batches.filter((b) => b.active);
+      const stopped = batches.filter((b) => !b.active);
+
+      if (active.length > 0) {
+        console.log(`\n=== Active Batches (${active.length}) ===\n`);
+        for (const b of active) {
+          console.log(formatBatchStatus(b));
+          console.log('');
+        }
+      }
+
+      if (stopped.length > 0) {
+        console.log(`=== Stopped Batches (${stopped.length}) ===\n`);
+        for (const b of stopped) {
+          console.log(formatBatchStatus(b));
+          console.log('');
+        }
+      }
+      break;
+    }
+
+    case 'halt': {
+      const targetId = args[1];
+      const batches = discoverBatches(logsDir);
+      const active = batches.filter((b) => b.active && !b.halted);
+
+      if (targetId) {
+        const match = active.find((b) => b.batchId === targetId);
+        if (!match) {
+          console.error(`No active batch found with ID: ${targetId}`);
+          const available = active.map((b) => b.batchId);
+          if (available.length > 0) {
+            console.error(`Active batches: ${available.join(', ')}`);
+          }
+          process.exit(1);
+        }
+        haltBatch(match.dir);
+        console.log(`Halt requested for: ${match.batchId}`);
+        console.log(formatLastState(match.state));
+      } else {
+        if (active.length === 0) {
+          console.log('No active batches to halt.');
+          process.exit(0);
+        }
+        for (const b of active) {
+          haltBatch(b.dir);
+          console.log(`Halt requested for: ${b.batchId}`);
+          console.log(formatLastState(b.state));
+          console.log('');
+        }
+      }
+      break;
+    }
+
+    case 'halt-state': {
+      const stateFile = args[1];
+      if (!stateFile || !existsSync(stateFile)) {
+        console.error('Usage: auto-dent-ctl.ts halt-state <state-file>');
+        process.exit(1);
+      }
+      const state: BatchState = JSON.parse(readFileSync(stateFile, 'utf8'));
+      console.log(formatLastState(state));
+      break;
+    }
+
+    default:
+      console.error(`Unknown subcommand: ${subcommand}`);
+      process.exit(1);
+  }
+}
+
+const isDirectRun =
+  process.argv[1]?.endsWith('auto-dent-ctl.ts') ||
+  process.argv[1]?.endsWith('auto-dent-ctl.js');
+
+if (isDirectRun) {
+  main();
+}

--- a/scripts/auto-dent-run.sh
+++ b/scripts/auto-dent-run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# auto-dent-run — Thin wrapper for trampoline compatibility.
+#
+# The trampoline (auto-dent.sh) calls this script by path.
+# This delegates to the TypeScript runner which has real-time
+# stream-json observability.
+#
+# Usage: auto-dent-run.sh <state-file>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec npx tsx "$SCRIPT_DIR/auto-dent-run.ts" "$@"

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -1,0 +1,788 @@
+#!/usr/bin/env npx tsx
+/**
+ * auto-dent-run — Execute a single make-a-dent run with real-time observability.
+ *
+ * Called by the trampoline (auto-dent.sh). Re-read from disk each
+ * iteration, so merged improvements take effect on the next run.
+ *
+ * Usage: npx tsx scripts/auto-dent-run.ts <state-file>
+ *
+ * Reads batch config and cross-run state from state.json.
+ * Spawns claude with --output-format stream-json for real-time milestones.
+ * Writes results back after the run completes.
+ *
+ * Stop mechanism: if Claude outputs "AUTO_DENT_STOP: <reason>" in its
+ * response, this sets stop_reason in state.json so the trampoline stops.
+ */
+
+import { spawn, execSync } from 'child_process';
+import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
+import { createInterface } from 'readline';
+import { dirname, resolve } from 'path';
+
+// Types
+
+export interface BatchState {
+  batch_id: string;
+  batch_start: number;
+  batch_end?: number;
+  guidance: string;
+  max_runs: number;
+  cooldown: number;
+  budget: string;
+  max_failures: number;
+  kaizen_repo: string;
+  host_repo: string;
+  run: number;
+  prs: string[];
+  issues_filed: string[];
+  issues_closed: string[];
+  cases: string[];
+  consecutive_failures: number;
+  current_cooldown: number;
+  stop_reason: string;
+  last_issue: string;
+  last_pr: string;
+  last_case: string;
+  last_branch: string;
+  last_worktree: string;
+  progress_issue?: string;
+  test_task?: boolean;
+  experiment?: boolean;
+}
+
+export interface RunResult {
+  prs: string[];
+  issuesFiled: string[];
+  issuesClosed: string[];
+  cases: string[];
+  cost: number;
+  toolCalls: number;
+  stopRequested: boolean;
+  stopReason?: string;
+}
+
+// State I/O
+
+function readState(stateFile: string): BatchState {
+  return JSON.parse(readFileSync(stateFile, 'utf8'));
+}
+
+function writeState(stateFile: string, state: BatchState): void {
+  writeFileSync(stateFile, JSON.stringify(state, null, 2) + '\n');
+}
+
+// Resolve repo root
+
+function getRepoRoot(): string {
+  try {
+    const gitCommonDir = execSync(
+      'git rev-parse --path-format=absolute --git-common-dir',
+      { encoding: 'utf8' },
+    ).trim();
+    return gitCommonDir.replace(/\/\.git$/, '');
+  } catch {
+    return resolve(dirname(new URL(import.meta.url).pathname), '..');
+  }
+}
+
+// Prompt building
+
+export function buildPrompt(state: BatchState, runNum: number): string {
+  const runTag = `${state.batch_id}/run-${runNum}`;
+  const kaizenRepo = state.kaizen_repo || 'unknown';
+  const hostRepo = state.host_repo || kaizenRepo;
+
+  let prompt: string;
+
+  if (state.test_task) {
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/[-:T]/g, '')
+      .slice(0, 14);
+    prompt = `You are running a synthetic test task for pipeline validation.
+
+Run tag: ${runTag}
+
+## Task
+
+1. Create a new branch from HEAD: \`test-probe-${runTag.replace(/\//g, '-')}\`
+2. Create a file \`test-probe-${timestamp}.md\` with this content:
+   \`\`\`
+   # Test Probe
+   Run tag: ${runTag}
+   Timestamp: ${new Date().toISOString()}
+   \`\`\`
+3. Commit with message: "test: probe ${runTag}"
+4. Create a PR: \`gh pr create --title "test: probe ${runTag}" --body "Synthetic test task for pipeline validation. Run tag: ${runTag}" --repo ${hostRepo}\`
+5. Queue auto-merge: \`gh pr merge <url> --repo ${hostRepo} --squash --delete-branch --auto\`
+
+Do not ask for confirmation. Complete all steps.`;
+  } else {
+    prompt = `Use /kaizen-deep-dive with this guidance: ${state.guidance}`;
+  }
+
+  prompt += `
+
+Run tag: ${runTag}
+Include this run tag in any PR descriptions or commit messages you create.
+
+## Batch Context
+
+You are running inside an auto-dent batch loop (run ${runNum}${state.max_runs > 0 ? ` of ${state.max_runs}` : ''}).
+After this run completes, the loop will start another run with fresh context.
+Run to completion. Do not ask for confirmation — make autonomous decisions.`;
+
+  if (state.issues_closed.length > 0) {
+    prompt += `\n\nIssues already addressed in previous runs (do not rework): ${state.issues_closed.join(' ')}`;
+  }
+
+  if (state.prs.length > 0) {
+    prompt += `\n\nPRs already created in this batch (avoid overlapping work): ${state.prs.join(' ')}`;
+  }
+
+  prompt += `
+
+## Merge & Labeling Policy
+
+After creating a PR, you MUST queue it for auto-merge:
+  gh pr merge <url> --repo ${hostRepo} --squash --delete-branch --auto
+Do NOT leave PRs open for manual review — this is an unattended batch.
+The harness will also attempt auto-merge as a safety net, but do it yourself first.
+
+## Stopping the Loop
+
+If you determine there is no more meaningful work to do matching the guidance
+(backlog exhausted, all relevant issues claimed, or remaining issues are
+blocked/too risky), include this exact marker in your final response:
+
+AUTO_DENT_STOP: <reason>
+
+For example: "AUTO_DENT_STOP: backlog exhausted — no more open issues matching 'hooks reliability'"
+This will gracefully stop the batch loop. Only use this when you've genuinely
+run out of work — not when a single run is complete.
+
+When done, summarize what was accomplished. List all PRs created, issues filed,
+and issues closed with full URLs.`;
+
+  return prompt;
+}
+
+// Stream-JSON parsing
+
+function formatElapsed(startMs: number): string {
+  const elapsed = Math.floor((Date.now() - startMs) / 1000);
+  const m = Math.floor(elapsed / 60);
+  const s = elapsed % 60;
+  return `${m}m${s.toString().padStart(2, '0')}s`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '\u2026' : s;
+}
+
+export function formatToolUse(
+  name: string,
+  input: Record<string, any>,
+): string {
+  switch (name) {
+    case 'Read':
+      return `Read ${truncate(input?.file_path || '?', 60)}`;
+    case 'Edit':
+      return `Edit ${truncate(input?.file_path || '?', 60)}`;
+    case 'Write':
+      return `Write ${truncate(input?.file_path || '?', 60)}`;
+    case 'Bash':
+      return `$ ${truncate(input?.command || input?.description || '?', 70)}`;
+    case 'Grep':
+      return `Grep "${truncate(input?.pattern || '?', 30)}" ${input?.path || ''}`;
+    case 'Glob':
+      return `Glob ${truncate(input?.pattern || '?', 50)}`;
+    case 'Skill':
+      return `Skill /${input?.skill_name || input?.skill || '?'}`;
+    case 'Agent':
+      return `Agent: ${truncate(input?.description || '?', 50)}`;
+    case 'TaskCreate':
+      return `Task+ ${truncate(input?.subject || '?', 50)}`;
+    case 'TaskUpdate':
+      return `Task~ #${input?.taskId || '?'} -> ${input?.status || '?'}`;
+    default:
+      return name;
+  }
+}
+
+export function extractArtifacts(text: string, result: RunResult): void {
+  for (const m of text.matchAll(
+    /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/g,
+  )) {
+    if (!result.prs.includes(m[0])) result.prs.push(m[0]);
+  }
+  for (const m of text.matchAll(
+    /https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+/g,
+  )) {
+    if (!result.issuesFiled.includes(m[0])) result.issuesFiled.push(m[0]);
+  }
+  for (const m of text.matchAll(
+    /(?:closes?|closed|fix(?:es|ed)?|resolves?)\s+(#\d+)/gi,
+  )) {
+    if (!result.issuesClosed.includes(m[1])) result.issuesClosed.push(m[1]);
+  }
+  for (const m of text.matchAll(/kaizen\s+#(\d+)/gi)) {
+    const ref = `#${m[1]}`;
+    if (!result.issuesClosed.includes(ref)) result.issuesClosed.push(ref);
+  }
+  for (const m of text.matchAll(/case[:\s]+(\d{6}-\d{4}-[\w-]+)/g)) {
+    if (!result.cases.includes(m[1])) result.cases.push(m[1]);
+  }
+}
+
+export function checkStopSignal(text: string, result: RunResult): void {
+  const match = text.match(/AUTO_DENT_STOP:\s*(.+)/);
+  if (match) {
+    result.stopRequested = true;
+    result.stopReason = match[1].trim();
+  }
+  // Also support legacy signal for backwards compat
+  const legacyMatch = text.match(/OVERNIGHT_STOP:\s*(.+)/);
+  if (legacyMatch) {
+    result.stopRequested = true;
+    result.stopReason = legacyMatch[1].trim();
+  }
+}
+
+export function processStreamMessage(
+  msg: Record<string, any>,
+  result: RunResult,
+  runStart: number,
+): void {
+  const elapsed = formatElapsed(runStart);
+
+  switch (msg.type) {
+    case 'system':
+      if (msg.subtype === 'init') {
+        console.log(
+          `  [${elapsed}]  Session ${(msg.session_id || '').slice(0, 8)}... | model: ${msg.model || 'default'}`,
+        );
+      }
+      break;
+
+    case 'assistant':
+      if (msg.message?.content) {
+        for (const block of msg.message.content) {
+          if (block.type === 'tool_use') {
+            result.toolCalls++;
+            console.log(
+              `  [${elapsed}]  ${formatToolUse(block.name, block.input)}`,
+            );
+          }
+          if (block.type === 'text' && block.text) {
+            extractArtifacts(block.text, result);
+            checkStopSignal(block.text, result);
+          }
+        }
+      }
+      break;
+
+    case 'result':
+      if (msg.total_cost_usd) {
+        result.cost = msg.total_cost_usd;
+      }
+      if (msg.result) {
+        extractArtifacts(msg.result, result);
+        checkStopSignal(msg.result, result);
+      }
+      console.log(
+        `  [${elapsed}]  ${msg.subtype === 'success' ? 'done' : `error: ${msg.subtype}`} | $${result.cost?.toFixed(2) || '?'} | ${result.toolCalls} tool calls`,
+      );
+      break;
+  }
+}
+
+// Post-run hygiene
+
+function ghExec(cmd: string): string {
+  try {
+    return execSync(cmd, { encoding: 'utf8', timeout: 30_000 }).trim();
+  } catch (e: any) {
+    console.log(
+      `  [hygiene] warning: ${cmd.slice(0, 80)}... -> ${e.message?.split('\n')[0] || 'failed'}`,
+    );
+    return '';
+  }
+}
+
+export type MergeStatus =
+  | 'merged'
+  | 'auto_queued'
+  | 'open'
+  | 'closed'
+  | 'unknown';
+
+export function checkMergeStatus(prUrl: string): MergeStatus {
+  const m = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+  if (!m) return 'unknown';
+  try {
+    const json = ghExec(
+      `gh pr view ${m[2]} --repo ${m[1]} --json state,mergeStateStatus,autoMergeRequest`,
+    );
+    if (!json) return 'unknown';
+    const data = JSON.parse(json);
+    if (data.state === 'MERGED') return 'merged';
+    if (data.state === 'CLOSED') return 'closed';
+    if (data.autoMergeRequest) return 'auto_queued';
+    return 'open';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function labelArtifacts(result: RunResult, label: string): void {
+  for (const pr of result.prs) {
+    const m = pr.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+    if (m) {
+      ghExec(`gh pr edit ${m[2]} --repo ${m[1]} --add-label ${label}`);
+      console.log(`  [hygiene] labeled PR ${pr}`);
+    }
+  }
+  for (const issue of result.issuesFiled) {
+    const m = issue.match(/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/);
+    if (m) {
+      ghExec(`gh issue edit ${m[2]} --repo ${m[1]} --add-label ${label}`);
+      console.log(`  [hygiene] labeled issue ${issue}`);
+    }
+  }
+}
+
+export function queueAutoMerge(result: RunResult, hostRepo: string): void {
+  for (const pr of result.prs) {
+    const m = pr.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+    if (m) {
+      const out = ghExec(
+        `gh pr merge ${m[2]} --repo ${m[1]} --squash --delete-branch --auto`,
+      );
+      if (out) {
+        console.log(`  [hygiene] queued auto-merge for PR ${pr}`);
+      }
+    }
+  }
+}
+
+export function ensureBatchProgressIssue(
+  state: BatchState,
+  stateFile: string,
+): string {
+  if (state.progress_issue) return state.progress_issue;
+
+  const kaizenRepo = state.kaizen_repo;
+  if (!kaizenRepo) return '';
+
+  const title = `[Batch] ${state.batch_id}: ${state.guidance.slice(0, 60)}`;
+  const body = [
+    `## Auto-Dent Batch Progress`,
+    '',
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| **Batch ID** | \`${state.batch_id}\` |`,
+    `| **Guidance** | ${state.guidance} |`,
+    `| **Max runs** | ${state.max_runs || 'unlimited'} |`,
+    `| **Budget/run** | ${state.budget ? '$' + state.budget : 'none'} |`,
+    `| **Started** | ${new Date(state.batch_start * 1000).toISOString()} |`,
+    '',
+    'Run-by-run updates will be posted as comments below.',
+    '',
+    '_This issue is auto-managed by the auto-dent harness._',
+  ].join('\n');
+
+  const url = ghExec(
+    `gh issue create --repo ${kaizenRepo} --title ${JSON.stringify(title)} --label auto-dent,kaizen --body ${JSON.stringify(body)}`,
+  );
+
+  if (url) {
+    console.log(`  [hygiene] created batch progress issue: ${url}`);
+    const freshState = readState(stateFile);
+    freshState.progress_issue = url;
+    writeState(stateFile, freshState);
+    return url;
+  }
+  return '';
+}
+
+export function updateBatchProgressIssue(
+  progressIssue: string,
+  kaizenRepo: string,
+  runNum: number,
+  exitCode: number,
+  duration: number,
+  result: RunResult,
+): void {
+  if (!progressIssue || !kaizenRepo) return;
+
+  const m = progressIssue.match(/issues\/(\d+)/);
+  if (!m) return;
+  const issueNum = m[1];
+
+  const status = exitCode === 0 ? 'success' : `failed (exit ${exitCode})`;
+  const mins = Math.floor(duration / 60);
+  const secs = duration % 60;
+
+  const lines = [
+    `### Run #${runNum} — ${status}`,
+    '',
+    `| Metric | Value |`,
+    `|--------|-------|`,
+    `| **Duration** | ${mins}m ${secs}s |`,
+    `| **Cost** | $${result.cost.toFixed(2)} |`,
+    `| **Tool calls** | ${result.toolCalls} |`,
+  ];
+
+  if (result.prs.length > 0) {
+    lines.push(`| **PRs** | ${result.prs.join(', ')} |`);
+  }
+  if (result.issuesFiled.length > 0) {
+    lines.push(`| **Issues filed** | ${result.issuesFiled.join(', ')} |`);
+  }
+  if (result.issuesClosed.length > 0) {
+    lines.push(`| **Issues closed** | ${result.issuesClosed.join(' ')} |`);
+  }
+  if (result.cases.length > 0) {
+    lines.push(
+      `| **Cases** | ${result.cases.map((c) => '`' + c + '`').join(', ')} |`,
+    );
+  }
+  if (result.stopRequested) {
+    lines.push('', `**STOP requested:** ${result.stopReason}`);
+  }
+
+  const comment = lines.join('\n');
+  ghExec(
+    `gh issue comment ${issueNum} --repo ${kaizenRepo} --body ${JSON.stringify(comment)}`,
+  );
+  console.log(`  [hygiene] updated progress issue with run #${runNum}`);
+}
+
+export function closeBatchProgressIssue(
+  progressIssue: string,
+  kaizenRepo: string,
+  state: BatchState,
+): void {
+  if (!progressIssue || !kaizenRepo) return;
+  const m = progressIssue.match(/issues\/(\d+)/);
+  if (!m) return;
+
+  const elapsed = Math.floor(Date.now() / 1000) - state.batch_start;
+  const hours = Math.floor(elapsed / 3600);
+  const mins = Math.floor((elapsed % 3600) / 60);
+
+  const summary = [
+    `### Batch Complete`,
+    '',
+    `| Metric | Value |`,
+    `|--------|-------|`,
+    `| **Runs** | ${state.run} |`,
+    `| **Duration** | ${hours}h ${mins}m |`,
+    `| **Stop reason** | ${state.stop_reason || 'completed'} |`,
+    `| **PRs** | ${state.prs.length > 0 ? state.prs.join(', ') : 'none'} |`,
+    `| **Issues filed** | ${state.issues_filed.length > 0 ? state.issues_filed.join(', ') : 'none'} |`,
+    `| **Issues closed** | ${state.issues_closed.length > 0 ? state.issues_closed.join(' ') : 'none'} |`,
+  ].join('\n');
+
+  ghExec(
+    `gh issue comment ${m[1]} --repo ${kaizenRepo} --body ${JSON.stringify(summary)}`,
+  );
+  ghExec(`gh issue close ${m[1]} --repo ${kaizenRepo} --reason completed`);
+  console.log(`  [hygiene] closed batch progress issue`);
+}
+
+// Execute Claude
+
+async function runClaude(
+  state: BatchState,
+  runNum: number,
+  logFile: string,
+  repoRoot: string,
+): Promise<{ exitCode: number; duration: number; result: RunResult }> {
+  const result: RunResult = {
+    prs: [],
+    issuesFiled: [],
+    issuesClosed: [],
+    cases: [],
+    cost: 0,
+    toolCalls: 0,
+    stopRequested: false,
+  };
+
+  const prompt = buildPrompt(state, runNum);
+  const nonce = `${new Date()
+    .toISOString()
+    .replace(/[-:T]/g, '')
+    .slice(2, 12)}-${Math.random().toString(16).slice(2, 6)}`;
+
+  const args = [
+    '-w',
+    nonce,
+    '-p',
+    prompt,
+    '--dangerously-skip-permissions',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+  ];
+  if (state.budget) {
+    args.push('--max-budget-usd', state.budget);
+  }
+
+  const runStart = Date.now();
+
+  return new Promise((resolve) => {
+    const child = spawn('claude', args, {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let lastOutputTime = Date.now();
+    const heartbeatInterval = setInterval(() => {
+      const silence = Math.floor((Date.now() - lastOutputTime) / 1000);
+      if (silence >= 55) {
+        console.log(
+          `  [${formatElapsed(runStart)}]  ... working (${result.toolCalls} tool calls so far)`,
+        );
+      }
+    }, 60_000);
+
+    const rl = createInterface({ input: child.stdout! });
+    rl.on('line', (line) => {
+      appendFileSync(logFile, line + '\n');
+      lastOutputTime = Date.now();
+
+      try {
+        const msg = JSON.parse(line);
+        processStreamMessage(msg, result, runStart);
+      } catch {
+        // Non-JSON line
+      }
+    });
+
+    child.stderr?.on('data', (data: Buffer) => {
+      appendFileSync(logFile, data.toString());
+    });
+
+    child.on('close', (code) => {
+      clearInterval(heartbeatInterval);
+      const duration = Math.floor((Date.now() - runStart) / 1000);
+      resolve({ exitCode: code ?? 1, duration, result });
+    });
+
+    child.on('error', (err) => {
+      clearInterval(heartbeatInterval);
+      appendFileSync(logFile, `\nProcess error: ${err.message}\n`);
+      const duration = Math.floor((Date.now() - runStart) / 1000);
+      resolve({ exitCode: 1, duration, result });
+    });
+  });
+}
+
+// Display
+
+function printRunSummary(
+  runNum: number,
+  exitCode: number,
+  duration: number,
+  result: RunResult,
+): void {
+  const status = exitCode === 0 ? 'success' : `failed (exit ${exitCode})`;
+
+  console.log('');
+  console.log(
+    `  \u250c\u2500 Run #${runNum} Summary \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`,
+  );
+  console.log(`  \u2502 Status:   ${status}`);
+  console.log(`  \u2502 Duration: ${duration}s`);
+  console.log(`  \u2502 Cost:     $${result.cost.toFixed(2)}`);
+  console.log(`  \u2502 Tools:    ${result.toolCalls} calls`);
+
+  for (const pr of result.prs) console.log(`  \u2502 PR:       ${pr}`);
+  for (const issue of result.issuesFiled)
+    console.log(`  \u2502 Issue:    ${issue}`);
+  if (result.issuesClosed.length > 0)
+    console.log(`  \u2502 Closed:   ${result.issuesClosed.join(' ')}`);
+  for (const c of result.cases) console.log(`  \u2502 Case:     ${c}`);
+  if (result.stopRequested)
+    console.log(`  \u2502 STOP:     ${result.stopReason}`);
+
+  console.log(
+    `  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`,
+  );
+  console.log('');
+}
+
+// Main
+
+const MIN_RUN_SECONDS = 60;
+
+async function main(): Promise<void> {
+  const stateFile = process.argv[2];
+  if (!stateFile || !existsSync(stateFile)) {
+    console.error('Usage: auto-dent-run.ts <state-file>');
+    if (stateFile) console.error(`State file not found: ${stateFile}`);
+    process.exit(1);
+  }
+
+  const repoRoot = getRepoRoot();
+  const state = readState(stateFile);
+  const logDir = dirname(stateFile);
+  const runNum = state.run + 1;
+  const runTag = `${state.batch_id}/run-${runNum}`;
+
+  const timestamp = new Date().toISOString().replace(/[-:T]/g, '').slice(2, 14);
+  const logFile = `${logDir}/run-${runNum}-${timestamp}.log`;
+
+  console.log(`Tag: ${runTag}`);
+  console.log(`Log: ${logFile}`);
+
+  const { exitCode, duration, result } = await runClaude(
+    state,
+    runNum,
+    logFile,
+    repoRoot,
+  );
+
+  // Append metadata to log
+  appendFileSync(
+    logFile,
+    [
+      '',
+      '--- auto-dent metadata ---',
+      `batch_id=${state.batch_id}`,
+      `run=${runNum}`,
+      `exit_code=${exitCode}`,
+      `duration_seconds=${duration}`,
+      `cost_usd=${result.cost.toFixed(2)}`,
+      `prs=${result.prs.join(' ')}`,
+      `issues_filed=${result.issuesFiled.join(' ')}`,
+      `issues_closed=${result.issuesClosed.join(' ')}`,
+      `cases=${result.cases.join(' ')}`,
+      `stop_requested=${result.stopRequested}`,
+      '',
+    ].join('\n'),
+  );
+
+  printRunSummary(runNum, exitCode, duration, result);
+
+  // Post-run hygiene
+  const progressIssue = ensureBatchProgressIssue(state, stateFile);
+  labelArtifacts(result, 'auto-dent');
+  queueAutoMerge(result, state.host_repo || state.kaizen_repo);
+
+  for (const pr of result.prs) {
+    const status = checkMergeStatus(pr);
+    console.log(`  [merge-tracking] ${pr}: ${status}`);
+    if (state.experiment) {
+      appendFileSync(logFile, `merge_status=${pr} ${status}\n`);
+    }
+  }
+
+  updateBatchProgressIssue(
+    progressIssue,
+    state.kaizen_repo,
+    runNum,
+    exitCode,
+    duration,
+    result,
+  );
+
+  // Update state
+  const freshState = readState(stateFile);
+  freshState.run = runNum;
+
+  for (const pr of result.prs) {
+    if (!freshState.prs.includes(pr)) freshState.prs.push(pr);
+  }
+  for (const issue of result.issuesFiled) {
+    if (!freshState.issues_filed.includes(issue))
+      freshState.issues_filed.push(issue);
+  }
+  for (const closed of result.issuesClosed) {
+    if (!freshState.issues_closed.includes(closed))
+      freshState.issues_closed.push(closed);
+  }
+  for (const caseName of result.cases) {
+    if (!freshState.cases.includes(caseName)) freshState.cases.push(caseName);
+  }
+
+  if (result.prs.length > 0) {
+    freshState.last_pr = result.prs[result.prs.length - 1];
+  }
+  if (result.issuesFiled.length > 0) {
+    freshState.last_issue = result.issuesFiled[result.issuesFiled.length - 1];
+  } else if (result.issuesClosed.length > 0) {
+    freshState.last_issue = result.issuesClosed[result.issuesClosed.length - 1];
+  }
+  if (result.cases.length > 0) {
+    const lastCase = result.cases[result.cases.length - 1];
+    freshState.last_case = lastCase;
+    freshState.last_branch = `case/${lastCase}`;
+    freshState.last_worktree = `.claude/worktrees/${lastCase}`;
+  }
+
+  const hasPrs = result.prs.length > 0;
+  if (exitCode !== 0 && !hasPrs) {
+    freshState.consecutive_failures =
+      (freshState.consecutive_failures || 0) + 1;
+    console.log(
+      `>>> Consecutive failures: ${freshState.consecutive_failures} / ${freshState.max_failures}`,
+    );
+  } else {
+    freshState.consecutive_failures = 0;
+    freshState.current_cooldown = freshState.cooldown;
+  }
+
+  const hasIssues = result.issuesFiled.length > 0;
+  if (duration < MIN_RUN_SECONDS && !hasPrs && !hasIssues) {
+    console.log(
+      `>>> Fast fail detected (${duration}s < ${MIN_RUN_SECONDS}s threshold, no output)`,
+    );
+    freshState.current_cooldown = Math.min(
+      (freshState.current_cooldown || freshState.cooldown) * 2,
+      600,
+    );
+    console.log(`>>> Escalated cooldown to ${freshState.current_cooldown}s`);
+  }
+
+  if (result.stopRequested) {
+    freshState.stop_reason = `agent requested stop: ${result.stopReason}`;
+    console.log(`>>> Claude requested batch stop: ${result.stopReason}`);
+  }
+
+  writeState(stateFile, freshState);
+  process.exit(exitCode);
+}
+
+// Close batch subcommand
+
+function closeBatch(): void {
+  const stateFile = process.argv[3];
+  if (!stateFile || !existsSync(stateFile)) {
+    console.error('Usage: auto-dent-run.ts --close-batch <state-file>');
+    process.exit(1);
+  }
+  const state = readState(stateFile);
+  if (state.progress_issue) {
+    closeBatchProgressIssue(state.progress_issue, state.kaizen_repo, state);
+  }
+}
+
+// Guard: don't run main() when imported for testing
+const isDirectRun =
+  process.argv[1]?.endsWith('auto-dent-run.ts') ||
+  process.argv[1]?.endsWith('auto-dent-run.js');
+
+if (isDirectRun) {
+  if (process.argv[2] === '--close-batch') {
+    closeBatch();
+  } else {
+    main().catch((err) => {
+      console.error('Fatal error:', err);
+      process.exit(1);
+    });
+  }
+}

--- a/scripts/auto-dent.sh
+++ b/scripts/auto-dent.sh
@@ -1,0 +1,438 @@
+#!/bin/bash
+# auto-dent — Autonomous batch kaizen runner (trampoline).
+#
+# Thin outer loop that:
+#   1. Parses args and creates the batch
+#   2. Pulls main between runs (so merged improvements take effect)
+#   3. Delegates each run to auto-dent-run.sh (re-read from disk each time)
+#   4. Prints the batch summary when done
+#
+# All real logic (prompt building, output parsing, stream-json observability)
+# lives in auto-dent-run.sh → auto-dent-run.ts, which self-updates
+# when PRs merge to main.
+#
+# Cross-run state is persisted to $LOG_DIR/state.json — survives crashes,
+# enables future --resume, and provides reporting data.
+#
+# Usage:
+#   ./scripts/auto-dent.sh "focus on hooks reliability"
+#   ./scripts/auto-dent.sh --max-runs 5 --budget 5.00 "improve test coverage"
+#   ./scripts/auto-dent.sh --dry-run "test the prompt"
+#
+# Logs go to logs/auto-dent/<batch-id>/
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Always resolve to the main checkout (not a worktree)
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')"
+if [[ -z "$REPO_ROOT" ]]; then
+  REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+# Read repo from kaizen.config.json
+CONFIG_FILE="$REPO_ROOT/kaizen.config.json"
+if [[ -f "$CONFIG_FILE" ]]; then
+  KAIZEN_REPO=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf8')).kaizen?.repo || '')")
+  HOST_REPO=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf8')).host?.repo || '')")
+else
+  echo "Warning: kaizen.config.json not found at $CONFIG_FILE" >&2
+  KAIZEN_REPO=""
+  HOST_REPO=""
+fi
+
+# Defaults
+MAX_RUNS=0              # 0 = unlimited
+COOLDOWN=30             # seconds between runs
+BUDGET=""               # per-run budget
+MAX_FAILURES=3          # consecutive failures before stopping
+DRY_RUN=false
+TEST_TASK=false
+EXPERIMENT=false
+GUIDANCE=""
+
+usage() {
+  cat <<'EOF'
+auto-dent — Autonomous batch kaizen runner
+
+Usage: auto-dent.sh [options] <guidance>
+       auto-dent.sh --status
+       auto-dent.sh --halt [batch-id]
+
+Options:
+  --max-runs N         Stop after N iterations (default: unlimited)
+  --cooldown N         Seconds between runs (default: 30)
+  --budget N.NN        Max USD per run (passed to claude --max-budget-usd)
+  --max-failures N     Stop after N consecutive failures (default: 3)
+  --dry-run            Show what would run without executing
+  --test-task          Use synthetic fast task instead of /kaizen-deep-dive
+  --experiment         Enable extra pipeline diagnostics
+  --status             Show status of all batches (active and stopped)
+  --halt [batch-id]    Halt a specific batch, or all active batches
+  --help               Show this help
+
+Self-update: between runs, the trampoline pulls main so that merged
+improvements to the runner script take effect on the next iteration.
+
+Halt: Ctrl+C halts from the same terminal. From another terminal:
+  ./scripts/auto-dent.sh --halt              # halt all active
+  ./scripts/auto-dent.sh --halt batch-id     # halt one batch
+
+Examples:
+  ./scripts/auto-dent.sh "focus on hooks reliability"
+  ./scripts/auto-dent.sh --max-runs 5 --budget 5.00 "improve test coverage"
+  ./scripts/auto-dent.sh --max-runs 10 --budget 5.00 "fix area/skills issues"
+EOF
+  exit 0
+}
+
+# Subcommands (handled before main arg parsing)
+CTL_SCRIPT="$SCRIPT_DIR/auto-dent-ctl.ts"
+
+if [[ "${1:-}" = "--status" ]]; then
+  exec npx tsx "$CTL_SCRIPT" status
+fi
+
+if [[ "${1:-}" = "--halt" ]]; then
+  shift
+  exec npx tsx "$CTL_SCRIPT" halt "$@"
+fi
+
+# Arg parsing
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help) usage ;;
+    --max-runs) MAX_RUNS="$2"; shift 2 ;;
+    --cooldown) COOLDOWN="$2"; shift 2 ;;
+    --budget) BUDGET="$2"; shift 2 ;;
+    --max-failures) MAX_FAILURES="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --test-task) TEST_TASK=true; shift ;;
+    --experiment) EXPERIMENT=true; shift ;;
+    -*) echo "Unknown option: $1" >&2; exit 1 ;;
+    *) GUIDANCE="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$GUIDANCE" && "$TEST_TASK" != true ]]; then
+  echo "Error: guidance prompt is required (or use --test-task)" >&2
+  echo "Usage: auto-dent.sh [options] <guidance>" >&2
+  exit 1
+fi
+
+# Default guidance for test-task mode
+if [[ -z "$GUIDANCE" && "$TEST_TASK" = true ]]; then
+  GUIDANCE="synthetic pipeline test"
+fi
+
+# Batch identity
+BATCH_ID="batch-$(date +%y%m%d-%H%M)-$(printf '%04x' $RANDOM)"
+BATCH_START=$(date +%s)
+LOG_DIR="$REPO_ROOT/logs/auto-dent/$BATCH_ID"
+mkdir -p "$LOG_DIR"
+HALT_FILE="$LOG_DIR/HALT"
+
+# Initialize state file
+STATE_FILE="$LOG_DIR/state.json"
+
+# JSON-escape guidance using node
+GUIDANCE_JSON=$(node -e "process.stdout.write(JSON.stringify(process.argv[1]))" "$GUIDANCE")
+BUDGET_JSON=$(if [[ -n "$BUDGET" ]]; then echo "\"$BUDGET\""; else echo "null"; fi)
+KAIZEN_REPO_JSON=$(node -e "process.stdout.write(JSON.stringify(process.argv[1]))" "${KAIZEN_REPO:-}")
+HOST_REPO_JSON=$(node -e "process.stdout.write(JSON.stringify(process.argv[1]))" "${HOST_REPO:-}")
+
+cat > "$STATE_FILE" << STATEOF
+{
+  "batch_id": "$BATCH_ID",
+  "guidance": $GUIDANCE_JSON,
+  "batch_start": $BATCH_START,
+  "max_runs": $MAX_RUNS,
+  "cooldown": $COOLDOWN,
+  "budget": $BUDGET_JSON,
+  "max_failures": $MAX_FAILURES,
+  "kaizen_repo": $KAIZEN_REPO_JSON,
+  "host_repo": $HOST_REPO_JSON,
+  "run": 0,
+  "consecutive_failures": 0,
+  "current_cooldown": $COOLDOWN,
+  "stop_reason": "",
+  "prs": [],
+  "issues_filed": [],
+  "issues_closed": [],
+  "cases": [],
+  "last_issue": "",
+  "last_pr": "",
+  "last_case": "",
+  "last_branch": "",
+  "last_worktree": "",
+  "progress_issue": "",
+  "test_task": $TEST_TASK,
+  "experiment": $EXPERIMENT
+}
+STATEOF
+
+# State helpers (using node)
+read_state() {
+  node -e "
+    const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    const v = s[process.argv[2]];
+    console.log(v === null || v === undefined ? '' : String(v));
+  " "$STATE_FILE" "$1"
+}
+
+update_state() {
+  node -e "
+    const fs = require('fs');
+    const s = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+    s[process.argv[2]] = process.argv[3];
+    fs.writeFileSync(process.argv[1], JSON.stringify(s, null, 2) + '\n');
+  " "$STATE_FILE" "$1" "$2"
+}
+
+# Graceful shutdown
+SHUTTING_DOWN=false
+
+handle_shutdown() {
+  if [[ "$SHUTTING_DOWN" = true ]]; then return; fi
+  SHUTTING_DOWN=true
+  echo ""
+  echo ">>> Received shutdown signal. Finishing current run, then stopping..."
+  update_state stop_reason "signal (SIGTERM/SIGINT)"
+}
+trap handle_shutdown SIGTERM SIGINT
+
+print_last_state() {
+  if [[ -n "$STATE_FILE" && -f "$STATE_FILE" ]]; then
+    npx tsx "$CTL_SCRIPT" halt-state "$STATE_FILE" 2>/dev/null || true
+  fi
+}
+
+check_halt_file() {
+  if [[ -n "$HALT_FILE" && -f "$HALT_FILE" ]]; then
+    echo ">>> Halt file detected: $HALT_FILE"
+    update_state stop_reason "halt file (remote request)"
+    SHUTTING_DOWN=true
+    return 0
+  fi
+  return 1
+}
+
+# Banner
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║                 auto-dent (trampoline)                  ║"
+echo "╠══════════════════════════════════════════════════════════╣"
+echo "║ Batch ID:  $BATCH_ID"
+echo "║ Guidance:  $GUIDANCE"
+echo "║ Max runs:  $([ "$MAX_RUNS" -eq 0 ] && echo "unlimited" || echo "$MAX_RUNS")"
+echo "║ Cooldown:  ${COOLDOWN}s"
+[[ -n "$BUDGET" ]] && echo "║ Budget/run: \$$BUDGET"
+[[ "$TEST_TASK" = true ]] && echo "║ Mode:      TEST TASK (synthetic pipeline probe)"
+[[ "$EXPERIMENT" = true ]] && echo "║ Experiment: enabled (extra diagnostics)"
+echo "║ Max consecutive failures: $MAX_FAILURES"
+[[ -n "$KAIZEN_REPO" ]] && echo "║ Kaizen repo: $KAIZEN_REPO"
+[[ -n "$HOST_REPO" ]] && echo "║ Host repo:   $HOST_REPO"
+echo "║ Logs:      $LOG_DIR"
+echo "║ State:     $STATE_FILE"
+echo "║ Halt:      touch $HALT_FILE  (or --halt from another terminal)"
+echo "║ Self-update: enabled (pulls main between runs)"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+if [[ "$DRY_RUN" = true ]]; then
+  echo "[dry-run] Would execute per run:"
+  echo "  $REPO_ROOT/scripts/auto-dent-run.sh $STATE_FILE"
+  echo ""
+  echo "[dry-run] State file:"
+  cat "$STATE_FILE"
+  exit 0
+fi
+
+# Main loop (trampoline)
+while true; do
+  if [[ "$SHUTTING_DOWN" = true ]]; then break; fi
+  check_halt_file && break
+
+  # Read current state
+  RUN=$(read_state run)
+  CONSEC_FAIL=$(read_state consecutive_failures)
+  CUR_COOLDOWN=$(read_state current_cooldown)
+  STOP_REASON=$(read_state stop_reason)
+  NEXT_RUN=$((RUN + 1))
+
+  # Stop conditions
+  if [[ -n "$STOP_REASON" ]]; then
+    echo ">>> Stopping: $STOP_REASON"
+    break
+  fi
+
+  if [[ "$MAX_RUNS" -gt 0 && "$NEXT_RUN" -gt "$MAX_RUNS" ]]; then
+    update_state stop_reason "max runs reached ($MAX_RUNS)"
+    break
+  fi
+
+  if [[ "$CONSEC_FAIL" -ge "$MAX_FAILURES" ]]; then
+    echo ">>> Stopping: $MAX_FAILURES consecutive failures"
+    update_state stop_reason "$MAX_FAILURES consecutive failures"
+    break
+  fi
+
+  # Self-update: pull main before each run
+  if [[ "$EXPERIMENT" = true ]]; then
+    MAIN_HEAD_BEFORE=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown")
+    echo ">>> [experiment] main HEAD before pull: ${MAIN_HEAD_BEFORE:0:8}"
+  fi
+  echo ">>> Pulling main for self-update..."
+  if git -C "$REPO_ROOT" pull --ff-only origin main 2>/dev/null; then
+    echo ">>> Main updated."
+  else
+    echo ">>> Main already up-to-date (or pull failed, continuing with current)."
+  fi
+  if [[ "$EXPERIMENT" = true ]]; then
+    MAIN_HEAD_AFTER=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown")
+    echo ">>> [experiment] main HEAD after pull: ${MAIN_HEAD_AFTER:0:8}"
+    if [[ "$MAIN_HEAD_BEFORE" != "$MAIN_HEAD_AFTER" ]]; then
+      echo ">>> [experiment] main ADVANCED (PR merged between runs)"
+    else
+      echo ">>> [experiment] main UNCHANGED (no PR merged yet)"
+    fi
+  fi
+
+  # Resolve runner (re-resolve after pull in case it was updated)
+  RUNNER="$REPO_ROOT/scripts/auto-dent-run.sh"
+  if [[ ! -x "$RUNNER" ]]; then
+    echo ">>> ERROR: Runner not found: $RUNNER"
+    update_state stop_reason "runner not found"
+    break
+  fi
+
+  # Execute the runner (re-read from disk each time)
+  echo "━━━ Run #$NEXT_RUN starting at $(date) ━━━"
+  EXIT_CODE=0
+  "$RUNNER" "$STATE_FILE" || EXIT_CODE=$?
+
+  # Runner updates state.json with results. Check for stop signal.
+  STOP_REASON=$(read_state stop_reason)
+  if [[ -n "$STOP_REASON" ]]; then
+    echo ">>> Stopping: $STOP_REASON"
+    break
+  fi
+
+  if [[ "$SHUTTING_DOWN" = true ]]; then break; fi
+
+  # Cross-run progress
+  COMPLETED_RUNS=$(read_state run)
+  CONSEC_FAIL=$(read_state consecutive_failures)
+  CUR_COOLDOWN=$(read_state current_cooldown)
+  PR_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$STATE_FILE','utf8')).prs.length)")
+  CLOSED_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$STATE_FILE','utf8')).issues_closed.length)")
+  ELAPSED=$(( $(date +%s) - BATCH_START ))
+  HOURS=$(( ELAPSED / 3600 ))
+  MINS=$(( (ELAPSED % 3600) / 60 ))
+  RUNS_LABEL="$COMPLETED_RUNS"
+  [[ "$MAX_RUNS" -gt 0 ]] && RUNS_LABEL="$COMPLETED_RUNS/$MAX_RUNS"
+
+  echo "━━━ Batch Progress ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Runs: $RUNS_LABEL completed | $CONSEC_FAIL consecutive failures"
+  echo "  PRs:  $PR_COUNT created | Issues: $CLOSED_COUNT closed"
+  echo "  Time: ${HOURS}h ${MINS}m elapsed"
+  if [[ "$EXPERIMENT" = true ]]; then
+    BATCH_KAIZEN_REPO=$(read_state kaizen_repo)
+    ALL_PRS=$(node -e "JSON.parse(require('fs').readFileSync('$STATE_FILE','utf8')).prs.forEach(p=>console.log(p))")
+    for PR_URL in $ALL_PRS; do
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+      PR_REPO=$(echo "$PR_URL" | grep -oP 'github\.com/\K[^/]+/[^/]+')
+      PR_STATE=$(gh pr view "$PR_NUM" --repo "$PR_REPO" --json state,mergeStateStatus,autoMergeRequest --jq '.state + " | " + .mergeStateStatus + " | auto:" + (if .autoMergeRequest then "yes" else "no" end)' 2>/dev/null || echo "unknown")
+      echo "  [experiment] PR #$PR_NUM: $PR_STATE"
+    done
+  fi
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  # Check max-runs after run
+  if [[ "$MAX_RUNS" -gt 0 && "$COMPLETED_RUNS" -ge "$MAX_RUNS" ]]; then
+    update_state stop_reason "max runs reached ($MAX_RUNS)"
+    break
+  fi
+
+  if [[ "$SHUTTING_DOWN" = true ]]; then break; fi
+  check_halt_file && break
+
+  # Cooldown with halt file polling (check every 3s)
+  echo "Cooling down for ${CUR_COOLDOWN}s before next run... (touch $HALT_FILE to stop)"
+  COOLDOWN_REMAINING=$CUR_COOLDOWN
+  while [[ "$COOLDOWN_REMAINING" -gt 0 ]]; do
+    POLL_INTERVAL=$(( COOLDOWN_REMAINING < 3 ? COOLDOWN_REMAINING : 3 ))
+    sleep "$POLL_INTERVAL" &
+    SLEEP_PID=$!
+    wait $SLEEP_PID 2>/dev/null || true
+    COOLDOWN_REMAINING=$((COOLDOWN_REMAINING - POLL_INTERVAL))
+    if [[ "$SHUTTING_DOWN" = true ]]; then break; fi
+    check_halt_file && break 2
+  done
+done
+
+# Close batch progress issue
+npx tsx "$SCRIPT_DIR/auto-dent-run.ts" --close-batch "$STATE_FILE" 2>/dev/null || true
+
+# Batch summary
+node -e "
+  const fs = require('fs');
+  const s = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+
+  const duration = Math.floor(Date.now() / 1000) - s.batch_start;
+  const hours = Math.floor(duration / 3600);
+  const mins = Math.floor((duration % 3600) / 60);
+
+  console.log('');
+  console.log('╔══════════════════════════════════════════════════════════╗');
+  console.log('║               auto-dent — Batch Summary                 ║');
+  console.log('╠══════════════════════════════════════════════════════════╣');
+  console.log('║ Batch ID:  ' + s.batch_id);
+  console.log('║ Guidance:  ' + s.guidance);
+  console.log('║ Runs:      ' + s.run);
+  console.log('║ Duration:  ' + hours + 'h ' + mins + 'm');
+  console.log('║ Stop:      ' + (s.stop_reason || 'completed'));
+  console.log('╠══════════════════════════════════════════════════════════╣');
+
+  if (s.prs.length > 0) {
+    console.log('║ PRs created:');
+    s.prs.forEach(pr => console.log('║   ' + pr));
+  } else {
+    console.log('║ PRs created: none');
+  }
+
+  if (s.issues_filed.length > 0) {
+    console.log('║ Issues filed:');
+    s.issues_filed.forEach(i => console.log('║   ' + i));
+  }
+
+  if (s.issues_closed.length > 0) {
+    console.log('║ Issues closed: ' + s.issues_closed.join(' '));
+  }
+
+  console.log('╚══════════════════════════════════════════════════════════╝');
+  console.log('');
+
+  // Finalize state
+  if (!s.stop_reason) s.stop_reason = 'completed';
+  s.batch_end = Math.floor(Date.now() / 1000);
+  fs.writeFileSync(process.argv[1], JSON.stringify(s, null, 2) + '\n');
+  console.log('State: ' + process.argv[1]);
+
+  const summaryPath = process.argv[1].replace('state.json', 'batch-summary.txt');
+  const lines = [
+    'batch_id=' + s.batch_id,
+    'guidance=' + s.guidance,
+    'runs=' + s.run,
+    'total_duration_seconds=' + duration,
+    'stop_reason=' + (s.stop_reason || 'completed'),
+    'prs=' + s.prs.join(' '),
+    'issues_filed=' + s.issues_filed.join(' '),
+    'issues_closed=' + s.issues_closed.join(' '),
+    'cases=' + s.cases.join(' '),
+  ].join('\n');
+  fs.writeFileSync(summaryPath, lines + '\n');
+  console.log('Summary: ' + summaryPath);
+" "$STATE_FILE"
+
+# Print last-worked-on state for easy resume
+print_last_state


### PR DESCRIPTION
## Summary

Ports the autonomous batch kaizen runner from nanoclaw to kaizen as **auto-dent** — a config-driven batch harness for running `/kaizen-deep-dive` unattended.

### Files

| File | Lines | Role |
|------|-------|------|
| `scripts/auto-dent.sh` | 438 | Trampoline — outer loop, self-update, halt, progress |
| `scripts/auto-dent-run.ts` | 788 | Runner — stream-json observability, prompt building, state management |
| `scripts/auto-dent-run.sh` | 13 | Thin bash→TS bridge |
| `scripts/auto-dent-ctl.ts` | 236 | Control — `--status`, `--halt` subcommands |

### Key changes from nanoclaw version

- **Config-driven:** Reads `kaizen_repo`/`host_repo` from `kaizen.config.json`
- **Skill:** Uses `/kaizen-deep-dive` (not `/make-a-dent`)
- **Stop signal:** `AUTO_DENT_STOP` (with `OVERNIGHT_STOP` backwards compat)
- **Labels:** `auto-dent` (not `overnight-dent`)
- **Logs:** `logs/auto-dent/` (gitignored)

### Usage

```bash
./scripts/auto-dent.sh "focus on hooks reliability"
./scripts/auto-dent.sh --max-runs 5 --budget 5.00 "improve test coverage"
./scripts/auto-dent.sh --dry-run "test the prompt"
./scripts/auto-dent.sh --status
./scripts/auto-dent.sh --halt
```

Closes #493

## Test plan

- [x] `--help` shows usage
- [x] `--dry-run` creates state file with correct config values
- [x] `--status` discovers and displays batches
- [x] TS runner compiles and exports `buildPrompt` correctly
- [x] Prompt contains `/kaizen-deep-dive`, `AUTO_DENT_STOP`, config-driven repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)