### PR TITLE
fix: prevent false auto-dent stop from mid-sentence signal match

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -225,13 +225,6 @@ describe('checkStopSignal', () => {
     );
   });
 
-  it('detects legacy OVERNIGHT_STOP signal', () => {
-    const result = makeRunResult();
-    checkStopSignal('OVERNIGHT_STOP: all done', result);
-    expect(result.stopRequested).toBe(true);
-    expect(result.stopReason).toBe('all done');
-  });
-
   it('does not trigger on text without stop signal', () => {
     const result = makeRunResult();
     checkStopSignal('Just regular output about AUTO_DENT features', result);
@@ -242,6 +235,31 @@ describe('checkStopSignal', () => {
     const result = makeRunResult();
     checkStopSignal('AUTO_DENT_STOP:   spaces around reason   ', result);
     expect(result.stopReason).toBe('spaces around reason');
+  });
+
+  it('does not false-trigger on mid-sentence stop signal mention', () => {
+    const result = makeRunResult();
+    checkStopSignal(
+      'The agent uses AUTO_DENT_STOP: <reason> to signal completion',
+      result,
+    );
+    expect(result.stopRequested).toBe(false);
+  });
+
+  it('does not match removed OVERNIGHT_STOP legacy signal', () => {
+    const result = makeRunResult();
+    checkStopSignal('OVERNIGHT_STOP: all done', result);
+    expect(result.stopRequested).toBe(false);
+  });
+
+  it('detects stop signal on its own line amid other text', () => {
+    const result = makeRunResult();
+    checkStopSignal(
+      'Some preamble\nAUTO_DENT_STOP: backlog exhausted\nSome epilogue',
+      result,
+    );
+    expect(result.stopRequested).toBe(true);
+    expect(result.stopReason).toBe('backlog exhausted');
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -237,16 +237,12 @@ export function extractArtifacts(text: string, result: RunResult): void {
 }
 
 export function checkStopSignal(text: string, result: RunResult): void {
-  const match = text.match(/AUTO_DENT_STOP:\s*(.+)/);
+  // Require signal at start of a line to avoid false positives from
+  // conversational text that mentions the signal (see batch-260322-2148-5c83).
+  const match = text.match(/^AUTO_DENT_STOP:\s*(.+)/m);
   if (match) {
     result.stopRequested = true;
     result.stopReason = match[1].trim();
-  }
-  // Also support legacy signal for backwards compat
-  const legacyMatch = text.match(/OVERNIGHT_STOP:\s*(.+)/);
-  if (legacyMatch) {
-    result.stopRequested = true;
-    result.stopReason = legacyMatch[1].trim();
   }
 }
 


### PR DESCRIPTION
## Summary

- Auto-dent batch `batch-260322-2148-5c83` stopped after run #1 due to a false stop signal
- The agent wrote `"Now update the old OVERNIGHT_STOP: reference in the doc:"` and the regex matched mid-sentence
- Anchor `AUTO_DENT_STOP` regex to start-of-line (`^` with `m` flag)
- Remove legacy `OVERNIGHT_STOP` support entirely — it caused this bug and nothing emits it anymore

## Test plan

- [x] Added regression test: mid-sentence mention does not trigger stop
- [x] Added test: `OVERNIGHT_STOP` no longer matches at all
- [x] Added test: signal on its own line (amid other text) still works
- [x] All 44 tests pass

Closes #497

Generated with [Claude Code](https://claude.com/claude-code)