### PR TITLE
fix: auto-dent runStart bug + per-run metrics display

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatBatchStatus,
+  formatLastState,
+  type BatchInfo,
+} from './auto-dent-ctl.js';
+import type { BatchState } from './auto-dent-run.js';
+
+function makeBatchState(overrides: Partial<BatchState> = {}): BatchState {
+  return {
+    batch_id: 'batch-260322-2100-a1b2',
+    batch_start: 1742680800,
+    guidance: 'improve hooks reliability',
+    max_runs: 5,
+    cooldown: 30,
+    budget: '3.00',
+    max_failures: 3,
+    kaizen_repo: 'Garsson-io/kaizen',
+    host_repo: 'Garsson-io/kaizen',
+    run: 0,
+    prs: [],
+    issues_filed: [],
+    issues_closed: [],
+    cases: [],
+    consecutive_failures: 0,
+    current_cooldown: 30,
+    stop_reason: '',
+    last_issue: '',
+    last_pr: '',
+    last_case: '',
+    last_branch: '',
+    last_worktree: '',
+    ...overrides,
+  };
+}
+
+function makeBatchInfo(overrides: Partial<BatchInfo> = {}): BatchInfo {
+  return {
+    batchId: 'batch-260322-2100-a1b2',
+    dir: '/tmp/test',
+    state: makeBatchState(),
+    active: true,
+    halted: false,
+    ...overrides,
+  };
+}
+
+describe('formatBatchStatus', () => {
+  it('shows basic batch info', () => {
+    const info = makeBatchInfo();
+    const output = formatBatchStatus(info);
+    expect(output).toContain('batch-260322-2100-a1b2');
+    expect(output).toContain('RUNNING');
+    expect(output).toContain('improve hooks reliability');
+  });
+
+  it('shows HALT REQUESTED when halted', () => {
+    const info = makeBatchInfo({ halted: true });
+    const output = formatBatchStatus(info);
+    expect(output).toContain('HALT REQUESTED');
+  });
+
+  it('shows stop reason when inactive', () => {
+    const info = makeBatchInfo({
+      active: false,
+      state: makeBatchState({ stop_reason: 'max runs reached' }),
+    });
+    const output = formatBatchStatus(info);
+    expect(output).toContain('max runs reached');
+  });
+
+  it('shows total cost from run_history', () => {
+    const info = makeBatchInfo({
+      state: makeBatchState({
+        run: 2,
+        run_history: [
+          {
+            run: 1,
+            start_epoch: 1742680800,
+            duration_seconds: 300,
+            exit_code: 0,
+            cost_usd: 2.5,
+            tool_calls: 42,
+            prs: [],
+            issues_filed: [],
+            issues_closed: [],
+            cases: [],
+            stop_requested: false,
+          },
+          {
+            run: 2,
+            start_epoch: 1742681400,
+            duration_seconds: 450,
+            exit_code: 0,
+            cost_usd: 3.1,
+            tool_calls: 60,
+            prs: ['https://github.com/Garsson-io/kaizen/pull/500'],
+            issues_filed: [],
+            issues_closed: ['#451'],
+            cases: [],
+            stop_requested: false,
+          },
+        ],
+      }),
+    });
+    const output = formatBatchStatus(info);
+    expect(output).toContain('$5.60');
+  });
+
+  it('shows per-run metrics breakdown when run_history exists', () => {
+    const info = makeBatchInfo({
+      state: makeBatchState({
+        run: 2,
+        run_history: [
+          {
+            run: 1,
+            start_epoch: 1742680800,
+            duration_seconds: 185,
+            exit_code: 0,
+            cost_usd: 2.5,
+            tool_calls: 42,
+            prs: [],
+            issues_filed: [],
+            issues_closed: [],
+            cases: [],
+            stop_requested: false,
+          },
+          {
+            run: 2,
+            start_epoch: 1742681400,
+            duration_seconds: 450,
+            exit_code: 1,
+            cost_usd: 3.1,
+            tool_calls: 60,
+            prs: ['https://github.com/Garsson-io/kaizen/pull/500'],
+            issues_filed: [],
+            issues_closed: ['#451'],
+            cases: [],
+            stop_requested: true,
+          },
+        ],
+      }),
+    });
+    const output = formatBatchStatus(info);
+    expect(output).toContain('#1: 3m5s $2.50 42tc ok');
+    expect(output).toContain('#2: 7m30s $3.10 60tc exit 1');
+    expect(output).toContain('1PR');
+    expect(output).toContain('STOP');
+  });
+
+  it('omits per-run section when no run_history', () => {
+    const info = makeBatchInfo();
+    const output = formatBatchStatus(info);
+    // Per-run lines look like "    #1: 3m5s ..." — indented with run number
+    expect(output).not.toMatch(/^\s+#\d+:/m);
+  });
+
+  it('shows last-worked-on fields when present', () => {
+    const info = makeBatchInfo({
+      state: makeBatchState({
+        last_pr: 'https://github.com/Garsson-io/kaizen/pull/500',
+        last_issue: '#451',
+      }),
+    });
+    const output = formatBatchStatus(info);
+    expect(output).toContain('Last PR:');
+    expect(output).toContain('pull/500');
+    expect(output).toContain('Last issue:');
+    expect(output).toContain('#451');
+  });
+});
+
+describe('formatLastState', () => {
+  it('shows batch and run info', () => {
+    const state = makeBatchState({ run: 3 });
+    const output = formatLastState(state);
+    expect(output).toContain('batch-260322-2100-a1b2');
+    expect(output).toContain('3');
+  });
+
+  it('shows no artifacts message when nothing tracked', () => {
+    const state = makeBatchState();
+    const output = formatLastState(state);
+    expect(output).toContain('no artifacts tracked yet');
+  });
+
+  it('shows last PR when present', () => {
+    const state = makeBatchState({
+      last_pr: 'https://github.com/Garsson-io/kaizen/pull/500',
+    });
+    const output = formatLastState(state);
+    expect(output).toContain('pull/500');
+  });
+});

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -84,7 +84,7 @@ export function formatBatchStatus(batch: BatchInfo): string {
       : s.stop_reason || 'STOPPED';
 
   const elapsed = Math.floor(
-    ((s.batch_end || Date.now() / 1000) - s.batch_start) / 1,
+    (s.batch_end || Date.now() / 1000) - s.batch_start,
   );
   const hours = Math.floor(elapsed / 3600);
   const mins = Math.floor((elapsed % 3600) / 60);
@@ -109,6 +109,21 @@ export function formatBatchStatus(batch: BatchInfo): string {
   if (s.last_case) lines.push(`  Last case:     ${s.last_case}`);
   if (s.last_branch) lines.push(`  Last branch:   ${s.last_branch}`);
   if (s.last_worktree) lines.push(`  Last worktree: ${s.last_worktree}`);
+
+  if (s.run_history && s.run_history.length > 0) {
+    lines.push('  Runs:');
+    for (const r of s.run_history) {
+      const rm = Math.floor(r.duration_seconds / 60);
+      const rs = r.duration_seconds % 60;
+      const status = r.exit_code === 0 ? 'ok' : `exit ${r.exit_code}`;
+      const prCount = r.prs.length;
+      const issueCount =
+        r.issues_filed.length + r.issues_closed.length;
+      lines.push(
+        `    #${r.run}: ${rm}m${rs}s $${r.cost_usd.toFixed(2)} ${r.tool_calls}tc ${status}${prCount > 0 ? ` ${prCount}PR` : ''}${issueCount > 0 ? ` ${issueCount}iss` : ''}${r.stop_requested ? ' STOP' : ''}`,
+      );
+    }
+  }
 
   return lines.join('\n');
 }

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -760,6 +760,7 @@ async function main(): Promise<void> {
   console.log(`Tag: ${runTag}`);
   console.log(`Log: ${logFile}`);
 
+  const runStartEpoch = Math.floor(Date.now() / 1000);
   const { exitCode, duration, result } = await runClaude(
     state,
     runNum,
@@ -819,7 +820,7 @@ async function main(): Promise<void> {
   // Append per-run metrics for batch observability
   const runMetrics: RunMetrics = {
     run: runNum,
-    start_epoch: Math.floor(runStart / 1000),
+    start_epoch: runStartEpoch,
     duration_seconds: duration,
     exit_code: exitCode,
     cost_usd: result.cost,

--- a/scripts/auto-dent.sh
+++ b/scripts/auto-dent.sh
@@ -417,6 +417,21 @@ node -e "
     console.log('║ Issues closed: ' + s.issues_closed.join(' '));
   }
 
+  if (s.run_history && s.run_history.length > 0) {
+    console.log('╠══════════════════════════════════════════════════════════╣');
+    console.log('║ Per-run metrics:');
+    s.run_history.forEach(function(r) {
+      var rm = Math.floor(r.duration_seconds / 60);
+      var rs = r.duration_seconds % 60;
+      var status = r.exit_code === 0 ? 'ok' : 'exit ' + r.exit_code;
+      var prCount = r.prs.length;
+      var line = '║   #' + r.run + ': ' + rm + 'm' + rs + 's $' + (r.cost_usd || 0).toFixed(2) + ' ' + r.tool_calls + 'tc ' + status;
+      if (prCount > 0) line += ' ' + prCount + 'PR';
+      if (r.stop_requested) line += ' STOP';
+      console.log(line);
+    });
+  }
+
   console.log('╚══════════════════════════════════════════════════════════╝');
   console.log('');
 
@@ -432,13 +447,24 @@ node -e "
     'guidance=' + s.guidance,
     'runs=' + s.run,
     'total_duration_seconds=' + duration,
+    'total_cost_usd=' + totalCost.toFixed(2),
     'stop_reason=' + (s.stop_reason || 'completed'),
     'prs=' + s.prs.join(' '),
     'issues_filed=' + s.issues_filed.join(' '),
     'issues_closed=' + s.issues_closed.join(' '),
     'cases=' + s.cases.join(' '),
-  ].join('\n');
-  fs.writeFileSync(summaryPath, lines + '\n');
+  ];
+  if (s.run_history && s.run_history.length > 0) {
+    lines.push('');
+    s.run_history.forEach(function(r) {
+      lines.push('run_' + r.run + '_duration=' + r.duration_seconds);
+      lines.push('run_' + r.run + '_cost=' + (r.cost_usd || 0).toFixed(2));
+      lines.push('run_' + r.run + '_tools=' + r.tool_calls);
+      lines.push('run_' + r.run + '_exit=' + r.exit_code);
+      if (r.prs.length > 0) lines.push('run_' + r.run + '_prs=' + r.prs.join(' '));
+    });
+  }
+  fs.writeFileSync(summaryPath, lines.join('\n') + '\n');
   console.log('Summary: ' + summaryPath);
 " "$STATE_FILE"
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `runStart` variable in `main()` was undefined — it was scoped to `runClaude()`, producing `NaN` for `start_epoch` in every run's `run_history` metrics. Now captured as `runStartEpoch` before calling `runClaude()`.
- **Per-run metrics display**: `auto-dent-ctl status` and the trampoline batch summary now show per-run breakdown (duration, cost, tool calls, exit code, PR count, stop flag).
- **batch-summary.txt**: Now includes per-run metrics for post-hoc analysis.
- **Minor**: Fixed no-op `/ 1` in elapsed time calculation in ctl.
- **Tests**: Added `auto-dent-ctl.test.ts` with 10 tests for `formatBatchStatus` and `formatLastState`.

Run tag: batch-260323-0003-072b/run-3

## Test plan

- [x] All 467 tests pass (`npm test`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] New ctl tests cover per-run metrics display, halt status, stop reason, and last-state formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)