### PR TITLE
feat: post-hoc PR merge rate scoring for auto-dent batches (#511)

### DIFF
--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -19,7 +19,7 @@ import { spawn, execSync } from 'child_process';
 import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
 import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
-import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable } from './auto-dent-score.js';
+import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, postHocScoreBatch, formatPostHocLine } from './auto-dent-score.js';
 
 // Types
 
@@ -787,6 +787,21 @@ export function updateBatchProgressIssue(
   console.log(`  [hygiene] updated progress issue with run #${runNum}`);
 }
 
+/**
+ * Run post-hoc scoring: check merge status for all batch PRs.
+ * Returns the post-hoc result which can be attached to a BatchScore.
+ */
+export function runPostHocScoring(
+  allPrUrls: string[],
+  totalCostUsd: number,
+): ReturnType<typeof postHocScoreBatch> {
+  const prStatuses = allPrUrls.map((url) => ({
+    url,
+    status: checkMergeStatus(url),
+  }));
+  return postHocScoreBatch(prStatuses, totalCostUsd);
+}
+
 export function closeBatchProgressIssue(
   progressIssue: string,
   kaizenRepo: string,
@@ -801,6 +816,13 @@ export function closeBatchProgressIssue(
   const mins = Math.floor((elapsed % 3600) / 60);
 
   const batchScore = scoreBatch(state.run_history || []);
+
+  // Post-hoc: check final merge status for all PRs
+  if (state.prs.length > 0) {
+    const postHoc = runPostHocScoring(state.prs, batchScore.total_cost_usd);
+    batchScore.post_hoc = postHoc;
+    console.log(`  [post-hoc] ${formatPostHocLine(postHoc)}`);
+  }
 
   const summary = [
     `### Batch Complete`,
@@ -1226,6 +1248,36 @@ function closeBatch(): void {
   }
 }
 
+// Post-hoc scoring subcommand
+
+function postHocScore(): void {
+  const stateFile = process.argv[3];
+  if (!stateFile || !existsSync(stateFile)) {
+    console.error('Usage: auto-dent-run.ts --post-hoc-score <state-file>');
+    process.exit(1);
+  }
+  const state = readState(stateFile);
+  const batchScore = scoreBatch(state.run_history || []);
+
+  if (state.prs.length === 0) {
+    console.log('No PRs to score.');
+    return;
+  }
+
+  console.log(`Checking merge status for ${state.prs.length} PR(s)...`);
+  const postHoc = runPostHocScoring(state.prs, batchScore.total_cost_usd);
+  batchScore.post_hoc = postHoc;
+
+  console.log('');
+  console.log(formatBatchScoreTable(batchScore));
+  console.log('');
+  for (const pr of postHoc.prs) {
+    console.log(`  ${pr.status.padEnd(12)} ${pr.url}`);
+  }
+  console.log('');
+  console.log(formatPostHocLine(postHoc));
+}
+
 // Guard: don't run main() when imported for testing
 const isDirectRun =
   process.argv[1]?.endsWith('auto-dent-run.ts') ||
@@ -1234,6 +1286,8 @@ const isDirectRun =
 if (isDirectRun) {
   if (process.argv[2] === '--close-batch') {
     closeBatch();
+  } else if (process.argv[2] === '--post-hoc-score') {
+    postHocScore();
   } else {
     main().catch((err) => {
       console.error('Fatal error:', err);

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -5,8 +5,11 @@ import {
   scoreBatch,
   formatRunScoreLine,
   formatBatchScoreTable,
+  postHocScoreBatch,
+  formatPostHocLine,
   type RunScore,
   type BatchScore,
+  type PostHocBatchResult,
 } from './auto-dent-score.js';
 import type { RunMetrics, RunResult } from './auto-dent-run.js';
 
@@ -288,5 +291,157 @@ describe('formatBatchScoreTable', () => {
     const table = formatBatchScoreTable(score);
     expect(table).toContain('| **Avg cost/success** | N/A |');
     expect(table).toContain('| **Efficiency** | N/A |');
+  });
+
+  it('includes post-hoc merge rate when available', () => {
+    const score: BatchScore = {
+      total_runs: 3,
+      successful_runs: 3,
+      success_rate: 1.0,
+      total_cost_usd: 9.0,
+      total_prs: 3,
+      total_issues_closed: 3,
+      total_duration_seconds: 900,
+      avg_cost_per_success: 3.0,
+      avg_duration_seconds: 300,
+      overall_efficiency: 1 / 3,
+      runs: [],
+      post_hoc: {
+        prs: [
+          { url: 'https://github.com/org/repo/pull/1', status: 'merged' },
+          { url: 'https://github.com/org/repo/pull/2', status: 'merged' },
+          { url: 'https://github.com/org/repo/pull/3', status: 'closed' },
+        ],
+        merged_count: 2,
+        pending_count: 0,
+        closed_count: 1,
+        merge_rate: 2 / 3,
+        effective_efficiency: 2 / 9,
+        scored_at: '2026-03-23T00:00:00.000Z',
+      },
+    };
+    const table = formatBatchScoreTable(score);
+    expect(table).toContain('| **PR merge rate** | 67% (2/3) |');
+    expect(table).toContain('| **Effective efficiency** |');
+  });
+
+  it('omits post-hoc rows when not present', () => {
+    const score: BatchScore = {
+      total_runs: 1,
+      successful_runs: 1,
+      success_rate: 1.0,
+      total_cost_usd: 3.0,
+      total_prs: 1,
+      total_issues_closed: 1,
+      total_duration_seconds: 300,
+      avg_cost_per_success: 3.0,
+      avg_duration_seconds: 300,
+      overall_efficiency: 1 / 3,
+      runs: [],
+    };
+    const table = formatBatchScoreTable(score);
+    expect(table).not.toContain('merge rate');
+  });
+});
+
+describe('postHocScoreBatch', () => {
+  it('scores a batch with mixed merge outcomes', () => {
+    const result = postHocScoreBatch(
+      [
+        { url: 'https://github.com/org/repo/pull/1', status: 'merged' },
+        { url: 'https://github.com/org/repo/pull/2', status: 'merged' },
+        { url: 'https://github.com/org/repo/pull/3', status: 'closed' },
+        { url: 'https://github.com/org/repo/pull/4', status: 'open' },
+      ],
+      10.0,
+    );
+
+    expect(result.merged_count).toBe(2);
+    expect(result.closed_count).toBe(1);
+    expect(result.pending_count).toBe(1);
+    expect(result.merge_rate).toBe(0.5);
+    expect(result.effective_efficiency).toBe(0.2);
+    expect(result.prs).toHaveLength(4);
+    expect(result.scored_at).toBeTruthy();
+  });
+
+  it('returns NaN merge rate for empty PR list', () => {
+    const result = postHocScoreBatch([], 5.0);
+    expect(isNaN(result.merge_rate)).toBe(true);
+    expect(result.merged_count).toBe(0);
+    expect(result.pending_count).toBe(0);
+    expect(result.closed_count).toBe(0);
+  });
+
+  it('handles all merged PRs', () => {
+    const result = postHocScoreBatch(
+      [
+        { url: 'https://github.com/org/repo/pull/1', status: 'merged' },
+        { url: 'https://github.com/org/repo/pull/2', status: 'merged' },
+      ],
+      4.0,
+    );
+    expect(result.merge_rate).toBe(1.0);
+    expect(result.effective_efficiency).toBe(0.5);
+    expect(result.pending_count).toBe(0);
+    expect(result.closed_count).toBe(0);
+  });
+
+  it('handles zero cost', () => {
+    const result = postHocScoreBatch(
+      [{ url: 'https://github.com/org/repo/pull/1', status: 'merged' }],
+      0,
+    );
+    expect(result.effective_efficiency).toBe(0);
+    expect(result.merge_rate).toBe(1.0);
+  });
+
+  it('treats auto_queued and unknown as pending', () => {
+    const result = postHocScoreBatch(
+      [
+        { url: 'https://github.com/org/repo/pull/1', status: 'auto_queued' },
+        { url: 'https://github.com/org/repo/pull/2', status: 'unknown' },
+      ],
+      2.0,
+    );
+    expect(result.pending_count).toBe(2);
+    expect(result.merged_count).toBe(0);
+    expect(result.closed_count).toBe(0);
+  });
+});
+
+describe('formatPostHocLine', () => {
+  it('formats a post-hoc result summary', () => {
+    const ph: PostHocBatchResult = {
+      prs: [
+        { url: 'pr1', status: 'merged' },
+        { url: 'pr2', status: 'open' },
+      ],
+      merged_count: 1,
+      pending_count: 1,
+      closed_count: 0,
+      merge_rate: 0.5,
+      effective_efficiency: 0.25,
+      scored_at: '2026-03-23T00:00:00.000Z',
+    };
+    const line = formatPostHocLine(ph);
+    expect(line).toContain('merge rate: 50%');
+    expect(line).toContain('1 merged');
+    expect(line).toContain('1 pending');
+    expect(line).toContain('0 closed');
+  });
+
+  it('shows N/A for empty batch', () => {
+    const ph: PostHocBatchResult = {
+      prs: [],
+      merged_count: 0,
+      pending_count: 0,
+      closed_count: 0,
+      merge_rate: NaN,
+      effective_efficiency: 0,
+      scored_at: '2026-03-23T00:00:00.000Z',
+    };
+    const line = formatPostHocLine(ph);
+    expect(line).toContain('merge rate: N/A');
   });
 });

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -7,7 +7,7 @@
  * See issue #507.
  */
 
-import type { RunMetrics, RunResult } from './auto-dent-run.js';
+import type { RunMetrics, RunResult, MergeStatus } from './auto-dent-run.js';
 
 export interface RunScore {
   /** Whether the run succeeded: exit code 0 AND at least one PR created */
@@ -55,6 +55,32 @@ export interface BatchScore {
   overall_efficiency: number;
   /** Per-run scores */
   runs: RunScore[];
+  /** Post-hoc merge results (populated by postHocScoreBatch) */
+  post_hoc?: PostHocBatchResult;
+}
+
+export interface PostHocPRResult {
+  /** PR URL */
+  url: string;
+  /** Current merge status */
+  status: MergeStatus;
+}
+
+export interface PostHocBatchResult {
+  /** Per-PR merge outcomes */
+  prs: PostHocPRResult[];
+  /** Number of PRs that successfully merged */
+  merged_count: number;
+  /** Number of PRs still open or queued */
+  pending_count: number;
+  /** Number of PRs closed without merging */
+  closed_count: number;
+  /** Merge rate: merged / total (NaN if no PRs) */
+  merge_rate: number;
+  /** Effective efficiency: merged PRs / total cost (0 if no cost) */
+  effective_efficiency: number;
+  /** Timestamp of scoring */
+  scored_at: string;
 }
 
 /** Score a single run from RunMetrics (stored in state.run_history). */
@@ -158,5 +184,58 @@ export function formatBatchScoreTable(score: BatchScore): string {
     `| **Avg cost/success** | ${isNaN(score.avg_cost_per_success) ? 'N/A' : '$' + score.avg_cost_per_success.toFixed(2)} |`,
     `| **Efficiency** | ${score.overall_efficiency > 0 ? score.overall_efficiency.toFixed(2) + ' PR/$' : 'N/A'} |`,
   ];
+  if (score.post_hoc) {
+    const ph = score.post_hoc;
+    lines.push(
+      `| **PR merge rate** | ${isNaN(ph.merge_rate) ? 'N/A' : (ph.merge_rate * 100).toFixed(0) + '%'} (${ph.merged_count}/${ph.prs.length}) |`,
+    );
+    if (ph.effective_efficiency > 0) {
+      lines.push(
+        `| **Effective efficiency** | ${ph.effective_efficiency.toFixed(2)} merged/$  |`,
+      );
+    }
+  }
   return lines.join('\n');
+}
+
+/**
+ * Build post-hoc merge results from PR URLs and their statuses.
+ * The caller is responsible for fetching statuses (e.g. via checkMergeStatus).
+ */
+export function postHocScoreBatch(
+  prStatuses: Array<{ url: string; status: MergeStatus }>,
+  totalCostUsd: number,
+): PostHocBatchResult {
+  const prs: PostHocPRResult[] = prStatuses.map(({ url, status }) => ({
+    url,
+    status,
+  }));
+
+  const merged = prs.filter((p) => p.status === 'merged').length;
+  const closed = prs.filter((p) => p.status === 'closed').length;
+  const pending = prs.length - merged - closed;
+
+  return {
+    prs,
+    merged_count: merged,
+    pending_count: pending,
+    closed_count: closed,
+    merge_rate: prs.length > 0 ? merged / prs.length : NaN,
+    effective_efficiency: totalCostUsd > 0 ? merged / totalCostUsd : 0,
+    scored_at: new Date().toISOString(),
+  };
+}
+
+/** Format post-hoc results as a compact summary line. */
+export function formatPostHocLine(ph: PostHocBatchResult): string {
+  const rate = isNaN(ph.merge_rate)
+    ? 'N/A'
+    : `${(ph.merge_rate * 100).toFixed(0)}%`;
+  const parts = [
+    `merge rate: ${rate}`,
+    `${ph.merged_count} merged`,
+    `${ph.pending_count} pending`,
+    `${ph.closed_count} closed`,
+  ];
+  return parts.join(' | ');
 }


### PR DESCRIPTION
## Summary

- Adds `pr_merge_rate` as a first-class batch metric — the most important quality signal (did PRs merge?) only becomes known post-hoc
- New `postHocScoreBatch()` computes merge rate and effective efficiency (merged PRs per dollar)
- Integrated into batch close flow: merge statuses are checked when closing the progress issue
- New `--post-hoc-score` CLI subcommand for standalone re-scoring of completed batches
- Merge rate + effective efficiency rows added to the batch score markdown table

## Test plan

- [x] All 29 score tests pass including 8 new post-hoc tests
- [x] Full suite: 566 tests pass, clean TypeScript build
- [x] Tests cover: mixed outcomes, empty batches, all-merged, zero cost, pending statuses

Run tag: batch-260323-0003-072b/run-5
Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)