### PR TITLE
feat: detect fixable-filed impediments with advisory warning

### DIFF
--- a/src/hooks/pr-kaizen-clear.test.ts
+++ b/src/hooks/pr-kaizen-clear.test.ts
@@ -39,6 +39,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import {
   classifyReflectionQuality,
+  detectFixableFiledImpediments,
   formatReflectionComment,
   matchesWaiverBlocklist,
   processHookInput,
@@ -846,5 +847,147 @@ describe('processHookInput: quality advisory (kaizen #446)', () => {
     });
     expect(result).toContain('PR kaizen gate cleared');
     expect(result).not.toContain('Reflection quality: LOW');
+  });
+});
+
+// ── Fixable-filed advisory tests (kaizen #401) ─────────────────────
+
+describe('detectFixableFiledImpediments', () => {
+  it('returns advisory for "hand-rolled" in description', () => {
+    const items = [
+      { impediment: 'Hand-rolled JSON parser', disposition: 'filed', ref: '#10' },
+    ];
+    const advisories = detectFixableFiledImpediments(items);
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain('hand-rolled');
+    expect(advisories[0]).toContain('fixed-in-pr');
+  });
+
+  it('returns advisory for "could use" in description', () => {
+    const items = [
+      { impediment: 'Could use a helper function here', disposition: 'filed', ref: '#11' },
+    ];
+    const advisories = detectFixableFiledImpediments(items);
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain('could use');
+  });
+
+  it('returns advisory for "hack" in description', () => {
+    const items = [
+      { impediment: 'This is a hack to work around the API', disposition: 'filed', ref: '#12' },
+    ];
+    const advisories = detectFixableFiledImpediments(items);
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain('hack');
+  });
+
+  it('returns advisory for "hardcoded" in description', () => {
+    const items = [
+      { finding: 'Hardcoded timeout value', disposition: 'filed', ref: '#13' },
+    ];
+    const advisories = detectFixableFiledImpediments(items);
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain('hardcoded');
+  });
+
+  it('returns advisory for "TODO" in description (case-insensitive)', () => {
+    const items = [
+      { impediment: 'TODO: clean up error handling', disposition: 'filed', ref: '#14' },
+    ];
+    const advisories = detectFixableFiledImpediments(items);
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain('todo');
+  });
+
+  it('returns empty array for legitimate filed items without fixable patterns', () => {
+    const items = [
+      { impediment: 'CI pipeline flaky on ARM builds', disposition: 'filed', ref: '#20' },
+      { impediment: 'Upstream library missing feature X', disposition: 'filed', ref: '#21' },
+    ];
+    const advisories = detectFixableFiledImpediments(items);
+    expect(advisories).toHaveLength(0);
+  });
+
+  it('ignores non-filed dispositions even with fixable patterns', () => {
+    const items = [
+      { impediment: 'Hand-rolled parser', disposition: 'fixed-in-pr' },
+      { impediment: 'Could use a helper', disposition: 'incident', ref: '#30' },
+      { finding: 'Hack in code', type: 'positive', disposition: 'no-action', reason: 'validated existing pattern' },
+    ];
+    const advisories = detectFixableFiledImpediments(items);
+    expect(advisories).toHaveLength(0);
+  });
+
+  it('returns multiple advisories for multiple fixable filed items', () => {
+    const items = [
+      { impediment: 'Hand-rolled validation', disposition: 'filed', ref: '#40' },
+      { impediment: 'Workaround for missing API', disposition: 'filed', ref: '#41' },
+    ];
+    const advisories = detectFixableFiledImpediments(items);
+    expect(advisories).toHaveLength(2);
+  });
+});
+
+describe('processHookInput: fixable-filed advisory (kaizen #401)', () => {
+  let unitStateDir: string;
+
+  beforeEach(() => {
+    unitStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kaizen-clear-fix-'));
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf-8',
+    }).trim();
+    fs.writeFileSync(
+      path.join(unitStateDir, 'pr-kaizen-Garsson-io_kaizen_88'),
+      `PR_URL=https://github.com/Garsson-io/kaizen/pull/88\nSTATUS=needs_pr_kaizen\nBRANCH=${branch}\n`,
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(unitStateDir, { recursive: true, force: true });
+  });
+
+  it('shows advisory but still clears gate when fixable filed detected', () => {
+    const postComment = vi.fn();
+    const input = {
+      tool_name: 'Bash',
+      tool_input: {
+        command: `echo 'KAIZEN_IMPEDIMENTS: [{"impediment":"Hand-rolled JSON parser","disposition":"filed","ref":"#10"}]'`,
+      },
+      tool_response: {
+        stdout:
+          'KAIZEN_IMPEDIMENTS: [{"impediment":"Hand-rolled JSON parser","disposition":"filed","ref":"#10"}]',
+        exit_code: 0,
+      },
+    };
+
+    const result = processHookInput(input, {
+      stateDir: unitStateDir,
+      postComment,
+    });
+    expect(result).toContain('PR kaizen gate cleared');
+    expect(result).toContain('hand-rolled');
+    expect(result).toContain('fixed-in-pr');
+  });
+
+  it('does not show advisory for legitimate filed items', () => {
+    const postComment = vi.fn();
+    const input = {
+      tool_name: 'Bash',
+      tool_input: {
+        command: `echo 'KAIZEN_IMPEDIMENTS: [{"impediment":"CI flaky on ARM","disposition":"filed","ref":"#20"}]'`,
+      },
+      tool_response: {
+        stdout:
+          'KAIZEN_IMPEDIMENTS: [{"impediment":"CI flaky on ARM","disposition":"filed","ref":"#20"}]',
+        exit_code: 0,
+      },
+    };
+
+    const result = processHookInput(input, {
+      stateDir: unitStateDir,
+      postComment,
+    });
+    expect(result).toContain('PR kaizen gate cleared');
+    expect(result).not.toContain('Advisory');
   });
 });

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -173,6 +173,44 @@ function validateImpediments(items: Impediment[]): string[] {
   return errors;
 }
 
+// ── Fixable-filed detection (kaizen #401) ─────────────────────────────
+
+const FIXABLE_PATTERNS = [
+  'hand-rolled',
+  'fragile',
+  'could use',
+  'should use',
+  'acceptable for now',
+  'could be',
+  'should be',
+  'todo',
+  'hack',
+  'workaround',
+  'hardcoded',
+  'hard-coded',
+  'duplicated',
+  'copy-paste',
+];
+
+/** Detect filed impediments that look fixable in the current PR. Advisory only. */
+export function detectFixableFiledImpediments(items: Impediment[]): string[] {
+  const advisories: string[] = [];
+  for (const item of items) {
+    if (item.disposition !== 'filed') continue;
+    const desc = (item.impediment || item.finding || '').toLowerCase();
+    for (const pattern of FIXABLE_PATTERNS) {
+      if (desc.includes(pattern)) {
+        const original = item.impediment || item.finding || '';
+        advisories.push(
+          `Advisory: "${original}" looks fixable in the current PR (matched "${pattern}"). Consider disposition: "fixed-in-pr" instead of filing for later.`,
+        );
+        break;
+      }
+    }
+  }
+  return advisories;
+}
+
 // ── JSON extraction ──────────────────────────────────────────────────
 
 function extractImpedimentsJson(
@@ -450,6 +488,14 @@ export function processHookInput(
         output.push(
           '\nReflection quality: LOW \u2014 no findings filed or fixed-in-pr. Consider whether real friction is being overlooked.\n',
         );
+      }
+    }
+
+    // Fixable-filed advisory (kaizen #401)
+    if (validatedItems.length > 0) {
+      const fixableAdvisories = detectFixableFiledImpediments(validatedItems);
+      if (fixableAdvisories.length > 0) {
+        output.push(`\n${fixableAdvisories.join('\n')}\n`);
       }
     }
 


### PR DESCRIPTION
## Summary

- Add `detectFixableFiledImpediments()` to `pr-kaizen-clear.ts` that checks filed impediments for patterns suggesting they could be fixed in the current PR (hand-rolled, hack, workaround, TODO, hardcoded, copy-paste, etc.)
- Advisory only — emits warning but still clears the gate (false positives are expected)
- 10 new tests covering pattern matching, case-insensitivity, non-filed disposition ignoring, and integration with `processHookInput`

Closes #401

batch-260323-0003-072b/run-8

## Test plan

- [x] `detectFixableFiledImpediments` returns advisory for "hand-rolled" in description
- [x] `detectFixableFiledImpediments` returns advisory for "could use" in description
- [x] `detectFixableFiledImpediments` returns empty array for legitimate filed items
- [x] `detectFixableFiledImpediments` ignores non-filed dispositions
- [x] `processHookInput` shows advisory but still clears gate when fixable filed detected
- [x] `processHookInput` does not show advisory for legitimate filed items
- [x] All 66 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)