### PR TITLE
feat: add mid-batch reflection summary to progress issue (#571)

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -11,6 +11,7 @@ import {
   formatWatchdogResult,
   buildBatchReflection,
   formatBatchReflection,
+  formatBatchReflectionComment,
   buildReflectionTemplateVars,
   DEFAULT_WATCHDOG_THRESHOLD_SEC,
   type BatchInfo,
@@ -624,6 +625,84 @@ describe('formatBatchReflection', () => {
     const reflection = buildBatchReflection(batch);
     const output = formatBatchReflection(reflection);
     expect(output).toContain('No significant patterns');
+  });
+});
+
+describe('formatBatchReflectionComment', () => {
+  it('formats reflection as a GitHub-friendly markdown comment', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        run: 5,
+        run_history: [
+          makeRunMetrics({ run: 1, cost_usd: 2.0, prs: ['https://github.com/Garsson-io/kaizen/pull/100'], issues_closed: ['#10'] }),
+          makeRunMetrics({ run: 2, cost_usd: 3.0, prs: ['https://github.com/Garsson-io/kaizen/pull/101'], issues_closed: ['#11'] }),
+          makeRunMetrics({ run: 3, cost_usd: 1.5, prs: [], exit_code: 1, issues_closed: [] }),
+          makeRunMetrics({ run: 4, cost_usd: 2.0, prs: ['https://github.com/Garsson-io/kaizen/pull/102'], issues_closed: ['#12'] }),
+          makeRunMetrics({ run: 5, cost_usd: 2.5, prs: ['https://github.com/Garsson-io/kaizen/pull/103'], issues_closed: [] }),
+        ],
+      }),
+    });
+    const reflection = buildBatchReflection(batch);
+    const comment = formatBatchReflectionComment(reflection);
+
+    expect(comment).toContain('### Mid-Batch Reflection (after run 5)');
+    expect(comment).toContain('| **Success rate** |');
+    expect(comment).toContain('80%');
+    expect(comment).toContain('| **Total cost** |');
+    expect(comment).toContain('$11.00');
+    expect(comment).toContain('| **PRs created** | 4 |');
+    expect(comment).toContain('| **Issues closed** | 3 |');
+    expect(comment).toContain('| **Avg cost/run** | $2.20 |');
+    expect(comment).toContain('**Insights:**');
+  });
+
+  it('shows no patterns message when insights are empty', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        run: 1,
+        run_history: [
+          makeRunMetrics({ run: 1, cost_usd: 2.0, prs: ['https://github.com/Garsson-io/kaizen/pull/100'] }),
+        ],
+      }),
+    });
+    const reflection = buildBatchReflection(batch);
+    const comment = formatBatchReflectionComment(reflection);
+
+    expect(comment).toContain('### Mid-Batch Reflection (after run 1)');
+    expect(comment).toContain('No significant patterns detected yet');
+  });
+
+  it('includes avg cost/PR when there are PRs', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        run: 3,
+        run_history: [
+          makeRunMetrics({ run: 1, cost_usd: 2.0, prs: ['https://github.com/Garsson-io/kaizen/pull/100'] }),
+          makeRunMetrics({ run: 2, cost_usd: 4.0, prs: ['https://github.com/Garsson-io/kaizen/pull/101'] }),
+          makeRunMetrics({ run: 3, cost_usd: 3.0, prs: [], exit_code: 1 }),
+        ],
+      }),
+    });
+    const reflection = buildBatchReflection(batch);
+    const comment = formatBatchReflectionComment(reflection);
+
+    expect(comment).toContain('| **Avg cost/PR** | $4.50 |');
+  });
+
+  it('shows N/A for avg cost/PR when no PRs', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        run: 2,
+        run_history: [
+          makeRunMetrics({ run: 1, cost_usd: 2.0, prs: [], exit_code: 1 }),
+          makeRunMetrics({ run: 2, cost_usd: 3.0, prs: [], exit_code: 1 }),
+        ],
+      }),
+    });
+    const reflection = buildBatchReflection(batch);
+    const comment = formatBatchReflectionComment(reflection);
+
+    expect(comment).toContain('| **Avg cost/PR** | N/A |');
   });
 });
 

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -8,6 +8,8 @@
  *   score [batch-id]    Score batches — efficiency, success rate, cost-per-PR
  *   score --post-hoc    Include live merge status checks
  *   cleanup [batch-id]  Close superseded PRs whose issues are already resolved from GitHub
+ *   reflect [batch-id]  Cross-run pattern analysis (#551)
+ *   reflect --post [batch-id]  Post reflection summary to progress issue (#571)
  *   watchdog [--threshold N]  Check active batches for stale heartbeats, halt if stuck
  *
  * Usage:
@@ -479,6 +481,85 @@ export function buildBatchReflection(batch: BatchInfo): BatchReflection {
 }
 
 /**
+ * Format a batch reflection as a GitHub issue comment (markdown).
+ * Designed to be posted to the batch progress issue every 5 runs.
+ */
+export function formatBatchReflectionComment(reflection: BatchReflection): string {
+  const lines: string[] = [
+    `### Mid-Batch Reflection (after run ${reflection.runCount})`,
+    '',
+    '| Metric | Value |',
+    '|--------|-------|',
+    `| **Success rate** | ${(reflection.successRate * 100).toFixed(0)}% (${Math.round(reflection.successRate * reflection.runCount)}/${reflection.runCount} runs) |`,
+    `| **Total cost** | $${reflection.totalCost.toFixed(2)} |`,
+    `| **Avg cost/run** | $${reflection.runCount > 0 ? (reflection.totalCost / reflection.runCount).toFixed(2) : '0.00'} |`,
+    `| **PRs created** | ${reflection.totalPrs} |`,
+    `| **Issues closed** | ${reflection.issuesClosedCount} |`,
+    `| **Avg cost/PR** | ${reflection.avgCostPerPr > 0 ? '$' + reflection.avgCostPerPr.toFixed(2) : 'N/A'} |`,
+    '',
+  ];
+
+  if (reflection.insights.length > 0) {
+    lines.push('**Insights:**');
+    for (const insight of reflection.insights) {
+      const icon = insight.type === 'success_pattern' ? ':white_check_mark:' :
+                   insight.type === 'failure_pattern' ? ':warning:' :
+                   insight.type === 'efficiency' ? ':chart_with_upwards_trend:' : ':bulb:';
+      lines.push(`- ${icon} ${insight.message}`);
+    }
+  } else {
+    lines.push('_No significant patterns detected yet._');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Post a mid-batch reflection summary to the batch progress issue.
+ * Non-fatal: returns false if posting fails.
+ */
+export function postBatchReflectionToProgressIssue(
+  batch: BatchInfo,
+): boolean {
+  const state = batch.state;
+  const progressIssue = state.progress_issue;
+  const repo = state.kaizen_repo || state.host_repo;
+
+  if (!progressIssue || !repo) {
+    console.log('  [reflect] no progress issue or repo configured — skipping post');
+    return false;
+  }
+
+  const m = progressIssue.match(/issues\/(\d+)/);
+  if (!m) {
+    console.log('  [reflect] could not parse issue number from progress_issue');
+    return false;
+  }
+  const issueNum = m[1];
+
+  const history = state.run_history || [];
+  if (history.length === 0) {
+    console.log('  [reflect] no run history to reflect on');
+    return false;
+  }
+
+  const reflection = buildBatchReflection(batch);
+  const comment = formatBatchReflectionComment(reflection);
+
+  try {
+    execSync(
+      `gh issue comment ${issueNum} --repo ${repo} --body ${JSON.stringify(comment)}`,
+      { encoding: 'utf8', timeout: 30_000 },
+    );
+    console.log(`  [reflect] posted mid-batch reflection to progress issue #${issueNum}`);
+    return true;
+  } catch (e: any) {
+    console.log(`  [reflect] warning: failed to post reflection — ${e.message?.split('\n')[0] || 'failed'}`);
+    return false;
+  }
+}
+
+/**
  * Format a batch reflection for human-readable display.
  */
 export function formatBatchReflection(reflection: BatchReflection): string {
@@ -541,6 +622,7 @@ Usage:
   auto-dent-ctl.ts score --post-hoc [batch-id]  Include live PR merge status checks
   auto-dent-ctl.ts cleanup [batch-id]  Close superseded PRs whose issues are already resolved
   auto-dent-ctl.ts reflect [batch-id]  Cross-run pattern analysis and learning (#551)
+  auto-dent-ctl.ts reflect --post [batch-id]  Post reflection summary to progress issue (#571)
   auto-dent-ctl.ts reflect --prompt [batch-id]  Output rendered prompt for Claude reflection
   auto-dent-ctl.ts watchdog [--threshold N]  Check heartbeats, halt stale batches (default: 600s)`);
     process.exit(0);
@@ -720,7 +802,8 @@ Usage:
 
     case 'reflect': {
       const showPrompt = args.includes('--prompt');
-      const reflectArgs = args.slice(1).filter((a) => a !== '--prompt');
+      const postToIssue = args.includes('--post');
+      const reflectArgs = args.slice(1).filter((a) => a !== '--prompt' && a !== '--post');
       const targetId = reflectArgs[0];
       const batches = discoverBatches(logsDir);
 
@@ -762,6 +845,11 @@ Usage:
         } else {
           console.log(formatBatchReflection(reflection));
         }
+
+        if (postToIssue) {
+          postBatchReflectionToProgressIssue(batch);
+        }
+
         console.log('');
       }
       break;

--- a/scripts/auto-dent.sh
+++ b/scripts/auto-dent.sh
@@ -355,11 +355,11 @@ while true; do
     npx tsx "$CTL_SCRIPT" cleanup "$BATCH_ID" 2>/dev/null || echo ">>> Cleanup skipped (non-fatal)."
   fi
 
-  # Cross-run reflection every 5 runs (issue #551)
+  # Cross-run reflection every 5 runs (issue #551, #571)
   if [[ "$NEXT_RUN" -gt 1 ]] && (( (NEXT_RUN - 1) % 5 == 0 )); then
     echo ">>> Running cross-run reflection (every 5 runs)..."
-    if npx tsx "$CTL_SCRIPT" reflect "$BATCH_ID" 2>/dev/null; then
-      echo ">>> Reflection complete."
+    if npx tsx "$CTL_SCRIPT" reflect --post "$BATCH_ID" 2>/dev/null; then
+      echo ">>> Reflection complete (posted to progress issue)."
     else
       echo ">>> Reflection skipped (non-fatal)."
     fi


### PR DESCRIPTION
## Summary

- Adds `formatBatchReflectionComment()` that renders batch reflection data as a GitHub-friendly markdown table with success rate, cost metrics, and pattern insights
- Adds `postBatchReflectionToProgressIssue()` that posts the reflection comment to the batch progress issue
- Adds `--post` flag to the `reflect` subcommand in auto-dent-ctl
- Updates the trampoline to use `reflect --post` every 5 runs so mid-batch summaries appear on the progress issue automatically
- 4 new tests covering the comment formatting

Closes #571

Run tag: batch-260323-0003-072b/run-21

## Test plan
- [x] All 45 existing + new tests pass
- [x] TypeScript build passes
- [ ] On next batch run, verify reflection comment appears on progress issue after run 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)