### PR TITLE
feat: add subtraction metrics (lines_deleted, issues_pruned) to auto-dent scoring

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -62,6 +62,8 @@ function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
     cost: 0,
     toolCalls: 0,
     stopRequested: false,
+    linesDeleted: 0,
+    issuesPruned: 0,
     ...overrides,
   };
 }
@@ -377,6 +379,48 @@ describe('extractArtifacts', () => {
     expect(result.issuesFiled).toHaveLength(0);
     expect(result.issuesClosed).toHaveLength(0);
     expect(result.cases).toHaveLength(0);
+  });
+
+  it('counts issues pruned from gh issue close --reason not-planned', () => {
+    const result = makeRunResult();
+    extractArtifacts(
+      'gh issue close 123 --repo Garsson-io/kaizen --reason not-planned\ngh issue close 456 --repo Garsson-io/kaizen --reason not-planned',
+      result,
+    );
+    expect(result.issuesPruned).toBe(2);
+  });
+
+  it('does not count gh issue close without not-planned as pruned', () => {
+    const result = makeRunResult();
+    extractArtifacts('gh issue close 123 --repo Garsson-io/kaizen', result);
+    expect(result.issuesPruned).toBe(0);
+  });
+
+  it('extracts net lines deleted from git diff stat output', () => {
+    const result = makeRunResult();
+    extractArtifacts(
+      '5 files changed, 10 insertions(+), 60 deletions(-)',
+      result,
+    );
+    expect(result.linesDeleted).toBe(50);
+  });
+
+  it('does not count lines deleted when insertions exceed deletions', () => {
+    const result = makeRunResult();
+    extractArtifacts(
+      '3 files changed, 100 insertions(+), 20 deletions(-)',
+      result,
+    );
+    expect(result.linesDeleted).toBe(0);
+  });
+
+  it('accumulates lines deleted across multiple diff stats', () => {
+    const result = makeRunResult();
+    extractArtifacts(
+      '2 files changed, 5 insertions(+), 25 deletions(-)\n3 files changed, 10 insertions(+), 40 deletions(-)',
+      result,
+    );
+    expect(result.linesDeleted).toBe(50);
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -71,6 +71,10 @@ export interface RunMetrics {
   stop_requested: boolean;
   /** Cognitive mode used for this run (default: "exploit" for backward compat) */
   mode?: string;
+  /** Net lines removed (positive = deletion, 0 for older runs) */
+  lines_deleted?: number;
+  /** Issues closed as obsolete/duplicate (not-planned), not fixed */
+  issues_pruned?: number;
 }
 
 export interface RunResult {
@@ -82,6 +86,10 @@ export interface RunResult {
   toolCalls: number;
   stopRequested: boolean;
   stopReason?: string;
+  /** Net lines removed (positive = deletion) */
+  linesDeleted: number;
+  /** Issues closed as not-planned (pruned, not fixed) */
+  issuesPruned: number;
 }
 
 // State I/O
@@ -478,6 +486,22 @@ export function extractArtifacts(text: string, result: RunResult): void {
   }
   for (const m of text.matchAll(/case[:\s]+(\d{6}-\d{4}-[\w-]+)/g)) {
     if (!result.cases.includes(m[1])) result.cases.push(m[1]);
+  }
+  // Extract issues pruned (closed as not-planned/wontfix/duplicate)
+  for (const _m of text.matchAll(
+    /gh\s+issue\s+close\s+.*--reason\s+not-planned/g,
+  )) {
+    result.issuesPruned++;
+  }
+  // Extract net lines deleted from git diff --stat summaries
+  // Matches patterns like "5 files changed, 10 insertions(+), 50 deletions(-)"
+  for (const m of text.matchAll(
+    /(\d+)\s+insertion[s]?\(\+\).*?(\d+)\s+deletion[s]?\(-\)/g,
+  )) {
+    const insertions = parseInt(m[1], 10);
+    const deletions = parseInt(m[2], 10);
+    const net = deletions - insertions;
+    if (net > 0) result.linesDeleted += net;
   }
 }
 
@@ -1099,6 +1123,8 @@ async function runClaude(
     cost: 0,
     toolCalls: 0,
     stopRequested: false,
+    linesDeleted: 0,
+    issuesPruned: 0,
   };
 
   const ctx: StreamContext = {};
@@ -1403,6 +1429,8 @@ async function main(): Promise<void> {
     cases: result.cases,
     stop_requested: result.stopRequested,
     mode: 'exploit',
+    lines_deleted: result.linesDeleted,
+    issues_pruned: result.issuesPruned,
   };
   if (!freshState.run_history) freshState.run_history = [];
   freshState.run_history.push(runMetrics);

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -39,6 +39,8 @@ function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
     cost: 0,
     toolCalls: 0,
     stopRequested: false,
+    linesDeleted: 0,
+    issuesPruned: 0,
     ...overrides,
   };
 }
@@ -117,6 +119,22 @@ describe('scoreRunMetrics', () => {
     );
     expect(score.issues_filed_count).toBe(2);
   });
+
+  it('propagates lines_deleted from RunMetrics', () => {
+    const score = scoreRunMetrics(makeRunMetrics({ lines_deleted: 42 }));
+    expect(score.lines_deleted).toBe(42);
+  });
+
+  it('propagates issues_pruned from RunMetrics', () => {
+    const score = scoreRunMetrics(makeRunMetrics({ issues_pruned: 3 }));
+    expect(score.issues_pruned).toBe(3);
+  });
+
+  it('defaults lines_deleted and issues_pruned to 0 when absent', () => {
+    const score = scoreRunMetrics(makeRunMetrics());
+    expect(score.lines_deleted).toBe(0);
+    expect(score.issues_pruned).toBe(0);
+  });
 });
 
 describe('scoreRunResult', () => {
@@ -157,6 +175,13 @@ describe('scoreRunResult', () => {
   it('accepts explicit mode parameter', () => {
     const score = scoreRunResult(makeRunResult(), 0, 100, 'reflect');
     expect(score.mode).toBe('reflect');
+  });
+
+  it('propagates linesDeleted and issuesPruned from RunResult', () => {
+    const result = makeRunResult({ linesDeleted: 100, issuesPruned: 2 });
+    const score = scoreRunResult(result, 0, 100);
+    expect(score.lines_deleted).toBe(100);
+    expect(score.issues_pruned).toBe(2);
   });
 });
 
@@ -214,6 +239,18 @@ describe('scoreBatch', () => {
     expect(isNaN(score.avg_cost_per_success)).toBe(true);
   });
 
+  it('aggregates subtraction metrics across runs', () => {
+    const history: RunMetrics[] = [
+      makeRunMetrics({ run: 1, lines_deleted: 50, issues_pruned: 1 }),
+      makeRunMetrics({ run: 2, lines_deleted: 30, issues_pruned: 2 }),
+      makeRunMetrics({ run: 3, exit_code: 1, prs: [] }),
+    ];
+
+    const score = scoreBatch(history);
+    expect(score.total_lines_deleted).toBe(80);
+    expect(score.total_issues_pruned).toBe(3);
+  });
+
   it('provides per-run scores', () => {
     const history: RunMetrics[] = [
       makeRunMetrics({ run: 1 }),
@@ -241,6 +278,8 @@ describe('formatRunScoreLine', () => {
       cost_per_pr: 2.5,
       stop_requested: false,
       mode: 'exploit',
+      lines_deleted: 0,
+      issues_pruned: 0,
     };
     const line = formatRunScoreLine(score);
     expect(line).toContain('pass');
@@ -250,6 +289,27 @@ describe('formatRunScoreLine', () => {
     expect(line).toContain('1 PRs');
     expect(line).toContain('300s');
     expect(line).toContain('0.40 PR/$');
+  });
+
+  it('shows subtraction metrics when non-zero', () => {
+    const score: RunScore = {
+      success: true,
+      cost_usd: 1.0,
+      tool_calls: 10,
+      pr_count: 1,
+      issues_closed_count: 0,
+      issues_filed_count: 0,
+      duration_seconds: 100,
+      efficiency: 1.0,
+      cost_per_pr: 1.0,
+      stop_requested: false,
+      mode: 'subtract',
+      lines_deleted: 200,
+      issues_pruned: 3,
+    };
+    const line = formatRunScoreLine(score);
+    expect(line).toContain('-200 lines');
+    expect(line).toContain('3 pruned');
   });
 
   it('formats a failed run score without efficiency', () => {
@@ -265,6 +325,8 @@ describe('formatRunScoreLine', () => {
       cost_per_pr: Infinity,
       stop_requested: false,
       mode: 'explore',
+      lines_deleted: 0,
+      issues_pruned: 0,
     };
     const line = formatRunScoreLine(score);
     expect(line).toContain('fail');
@@ -283,13 +345,15 @@ describe('formatBatchScoreTable', () => {
       total_prs: 3,
       total_issues_closed: 5,
       total_duration_seconds: 650,
+      total_lines_deleted: 120,
+      total_issues_pruned: 2,
       avg_cost_per_success: 3.0,
       avg_duration_seconds: 216.67,
       overall_efficiency: 0.5,
       runs: [
-        { success: true, cost_usd: 2, tool_calls: 10, pr_count: 1, issues_closed_count: 1, issues_filed_count: 0, duration_seconds: 200, efficiency: 0.5, cost_per_pr: 2, stop_requested: false, mode: 'exploit' },
-        { success: true, cost_usd: 3, tool_calls: 15, pr_count: 2, issues_closed_count: 3, issues_filed_count: 0, duration_seconds: 400, efficiency: 0.67, cost_per_pr: 1.5, stop_requested: false, mode: 'exploit' },
-        { success: false, cost_usd: 1, tool_calls: 5, pr_count: 0, issues_closed_count: 1, issues_filed_count: 0, duration_seconds: 50, efficiency: 0, cost_per_pr: Infinity, stop_requested: false, mode: 'explore' },
+        { success: true, cost_usd: 2, tool_calls: 10, pr_count: 1, issues_closed_count: 1, issues_filed_count: 0, duration_seconds: 200, efficiency: 0.5, cost_per_pr: 2, stop_requested: false, mode: 'exploit', lines_deleted: 80, issues_pruned: 1 },
+        { success: true, cost_usd: 3, tool_calls: 15, pr_count: 2, issues_closed_count: 3, issues_filed_count: 0, duration_seconds: 400, efficiency: 0.67, cost_per_pr: 1.5, stop_requested: false, mode: 'exploit', lines_deleted: 40, issues_pruned: 1 },
+        { success: false, cost_usd: 1, tool_calls: 5, pr_count: 0, issues_closed_count: 1, issues_filed_count: 0, duration_seconds: 50, efficiency: 0, cost_per_pr: Infinity, stop_requested: false, mode: 'explore', lines_deleted: 0, issues_pruned: 0 },
       ],
     };
     const table = formatBatchScoreTable(score);
@@ -298,6 +362,8 @@ describe('formatBatchScoreTable', () => {
     expect(table).toContain('| **Total cost** | $6.00 |');
     expect(table).toContain('| **Total PRs** | 3 |');
     expect(table).toContain('| **Issues closed** | 5 |');
+    expect(table).toContain('| **Lines deleted** | 120 |');
+    expect(table).toContain('| **Issues pruned** | 2 |');
     expect(table).toContain('| **Avg cost/success** | $3.00 |');
     expect(table).toContain('| **Efficiency** | 0.50 PR/$ |');
     expect(table).toContain('| **Modes** | exploit:2, explore:1 |');
@@ -311,6 +377,8 @@ describe('formatBatchScoreTable', () => {
       total_cost_usd: 1.0,
       total_prs: 0,
       total_issues_closed: 0,
+      total_lines_deleted: 0,
+      total_issues_pruned: 0,
       total_duration_seconds: 50,
       avg_cost_per_success: NaN,
       avg_duration_seconds: 50,
@@ -331,6 +399,8 @@ describe('formatBatchScoreTable', () => {
       total_prs: 3,
       total_issues_closed: 3,
       total_duration_seconds: 900,
+      total_lines_deleted: 0,
+      total_issues_pruned: 0,
       avg_cost_per_success: 3.0,
       avg_duration_seconds: 300,
       overall_efficiency: 1 / 3,
@@ -363,6 +433,8 @@ describe('formatBatchScoreTable', () => {
       total_prs: 1,
       total_issues_closed: 1,
       total_duration_seconds: 300,
+      total_lines_deleted: 0,
+      total_issues_pruned: 0,
       avg_cost_per_success: 3.0,
       avg_duration_seconds: 300,
       overall_efficiency: 1 / 3,

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -32,6 +32,10 @@ export interface RunScore {
   stop_requested: boolean;
   /** Cognitive mode used for this run */
   mode: string;
+  /** Net lines removed (positive = deletion) */
+  lines_deleted: number;
+  /** Issues closed as not-planned (pruned, not fixed) */
+  issues_pruned: number;
 }
 
 export interface BatchScore {
@@ -49,6 +53,10 @@ export interface BatchScore {
   total_issues_closed: number;
   /** Total duration in seconds */
   total_duration_seconds: number;
+  /** Total net lines deleted across all runs */
+  total_lines_deleted: number;
+  /** Total issues pruned across all runs */
+  total_issues_pruned: number;
   /** Average cost per successful run (NaN if no successes) */
   avg_cost_per_success: number;
   /** Average duration per run */
@@ -101,6 +109,8 @@ export function scoreRunMetrics(metrics: RunMetrics): RunScore {
     cost_per_pr: prCount > 0 ? cost / prCount : Infinity,
     stop_requested: metrics.stop_requested,
     mode: metrics.mode ?? 'exploit',
+    lines_deleted: metrics.lines_deleted ?? 0,
+    issues_pruned: metrics.issues_pruned ?? 0,
   };
 }
 
@@ -125,6 +135,8 @@ export function scoreRunResult(
     cost_per_pr: prCount > 0 ? cost / prCount : Infinity,
     stop_requested: result.stopRequested,
     mode,
+    lines_deleted: result.linesDeleted,
+    issues_pruned: result.issuesPruned,
   };
 }
 
@@ -140,6 +152,14 @@ export function scoreBatch(runHistory: RunMetrics[]): BatchScore {
     0,
   );
   const totalDuration = runs.reduce((s, r) => s + r.duration_seconds, 0);
+  const totalLinesDeleted = runs.reduce(
+    (s, r) => s + r.lines_deleted,
+    0,
+  );
+  const totalIssuesPruned = runs.reduce(
+    (s, r) => s + r.issues_pruned,
+    0,
+  );
 
   return {
     total_runs: runs.length,
@@ -149,6 +169,8 @@ export function scoreBatch(runHistory: RunMetrics[]): BatchScore {
     total_prs: totalPrs,
     total_issues_closed: totalIssuesClosed,
     total_duration_seconds: totalDuration,
+    total_lines_deleted: totalLinesDeleted,
+    total_issues_pruned: totalIssuesPruned,
     avg_cost_per_success:
       successfulRuns.length > 0
         ? totalCost / successfulRuns.length
@@ -174,6 +196,12 @@ export function formatRunScoreLine(score: RunScore): string {
   if (score.efficiency > 0) {
     parts.push(`${score.efficiency.toFixed(2)} PR/$`);
   }
+  if (score.lines_deleted > 0) {
+    parts.push(`-${score.lines_deleted} lines`);
+  }
+  if (score.issues_pruned > 0) {
+    parts.push(`${score.issues_pruned} pruned`);
+  }
   return parts.join(' | ');
 }
 
@@ -196,6 +224,8 @@ export function formatBatchScoreTable(score: BatchScore): string {
     `| **Total cost** | $${score.total_cost_usd.toFixed(2)} |`,
     `| **Total PRs** | ${score.total_prs} |`,
     `| **Issues closed** | ${score.total_issues_closed} |`,
+    `| **Lines deleted** | ${score.total_lines_deleted} |`,
+    `| **Issues pruned** | ${score.total_issues_pruned} |`,
     `| **Avg cost/success** | ${isNaN(score.avg_cost_per_success) ? 'N/A' : '$' + score.avg_cost_per_success.toFixed(2)} |`,
     `| **Efficiency** | ${score.overall_efficiency > 0 ? score.overall_efficiency.toFixed(2) + ' PR/$' : 'N/A'} |`,
   ];


### PR DESCRIPTION
## Summary

- Adds `lines_deleted` and `issues_pruned` fields to `RunMetrics`, `RunResult`, and `RunScore` interfaces
- Extracts `issues_pruned` from `gh issue close --reason not-planned` patterns in run output
- Extracts net `lines_deleted` from git diff `--stat` summaries (only counts when deletions exceed insertions)
- Aggregates `total_lines_deleted` and `total_issues_pruned` in `BatchScore`
- Shows subtraction metrics in `formatRunScoreLine` (e.g., `-200 lines | 3 pruned`) and `formatBatchScoreTable`
- Backward compatible: defaults to 0 for older runs without these fields

Closes #568

Run tag: batch-260323-0003-072b/run-22

## Test plan

- [x] All 175 existing + new tests pass in auto-dent-score.test.ts and auto-dent-run.test.ts
- [x] auto-dent-ctl.test.ts passes (45 tests)
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)