### PR TITLE
feat: add exploration and subtraction prompt templates for cognitive modes

### DIFF
--- a/prompts/explore-gaps.md
+++ b/prompts/explore-gaps.md
@@ -1,0 +1,49 @@
+You are running an EXPLORATION run inside an auto-dent batch (run {{run_context}}).
+Your job is NOT to fix issues. Your job is to DISCOVER problems and FILE issues.
+
+Run tag: {{run_tag}}
+
+## Batch Context
+
+Batch: {{batch_id}}
+Guidance: {{guidance}}
+
+{{#issues_closed}}
+Issues already addressed in previous runs (do not rework): {{issues_closed}}
+{{/issues_closed}}
+
+{{#prs}}
+PRs already created in this batch (avoid overlapping work): {{prs}}
+{{/prs}}
+
+## Exploration Tasks
+
+Pick the highest-value exploration from this list:
+
+1. **Tooling gaps**: What tools or skills are missing from the kaizen system?
+   Run `gh issue list --repo {{kaizen_repo}} --state open --label kaizen` and look for
+   patterns that suggest missing capabilities.
+
+2. **Testing gaps**: What's untested? Look for files with no corresponding test file.
+   Check `scripts/` and `src/hooks/` for uncovered code.
+
+3. **Horizon blind spots**: Which horizons have no recent activity?
+   Check `docs/horizons/README.md` and compare against recent issues/PRs.
+
+4. **External ecosystem**: Use WebSearch to find relevant repos, techniques, or tools
+   that could benefit the kaizen system. Look for agent frameworks, batch automation
+   patterns, or autonomous development approaches.
+
+5. **Issue backlog analysis**: Read the oldest 20 open issues. Are any obsolete?
+   Are there clusters that suggest an unnamed problem dimension?
+
+## Output
+
+For each discovery:
+1. File a GitHub issue in {{kaizen_repo}} with clear title and context
+2. Label it `source:auto-dent-explore` and `kaizen`
+3. Reference this exploration run in the issue body
+
+Post a summary of all discoveries to the batch progress issue.
+
+AUTO_DENT_PHASE: REFLECT | issues_filed=<N> | lessons=<what you discovered>

--- a/prompts/subtract-prune.md
+++ b/prompts/subtract-prune.md
@@ -1,0 +1,55 @@
+You are running a SUBTRACTION run inside an auto-dent batch (run {{run_context}}).
+Your job is NOT to add features. Your job is to REMOVE, CONSOLIDATE, and SIMPLIFY.
+
+Run tag: {{run_tag}}
+
+## Batch Context
+
+Batch: {{batch_id}}
+Guidance: {{guidance}}
+
+{{#issues_closed}}
+Issues already addressed in previous runs (do not rework): {{issues_closed}}
+{{/issues_closed}}
+
+{{#prs}}
+PRs already created in this batch (avoid overlapping work): {{prs}}
+{{/prs}}
+
+## Merge & Labeling Policy
+
+After creating a PR, you MUST queue it for auto-merge:
+  gh pr merge <url> --repo {{kaizen_repo}} --squash --delete-branch --auto
+
+## Subtraction Tasks
+
+Pick the highest-value subtraction from this list:
+
+1. **Obsolete issues**: Read the 20 oldest open issues.
+   `gh issue list --repo {{kaizen_repo}} --state open --sort created --json number,title,createdAt --limit 20`
+   Close any that are obsolete with `gh issue close <num> --reason not-planned --comment "Obsolete: <reason>"`.
+
+2. **Duplicate issues**: Search for issues with overlapping titles or descriptions.
+   Close duplicates with `gh issue close <num> --reason not-planned --comment "Duplicate of #X"`.
+
+3. **Dead code**: Search for functions with no callers, files not imported anywhere.
+   `grep -r "function " scripts/ src/ | ...` then check for references.
+   Remove dead code in a PR with clear commit messages.
+
+4. **Unused hooks**: Check `.claude/settings-fragment.json` for hooks that never trigger
+   because their regex conditions can't match any real tool output.
+
+5. **Overlapping skills**: Review `.claude/kaizen/skills/` for skills that do
+   similar things and could be consolidated.
+
+## Chesterton's Fence
+
+Before deleting anything, check the issue or PR that created it.
+Every deletion must explain WHY in the commit message or close comment.
+If you can't determine why something exists, leave it alone.
+
+## Progress Markers
+
+AUTO_DENT_PHASE: PICK | issue=<what you're pruning>
+AUTO_DENT_PHASE: PR | url=<PR URL if code was removed>
+AUTO_DENT_PHASE: REFLECT | issues_filed=<N> | lessons=<what you removed and why>


### PR DESCRIPTION
## Summary

- Adds `prompts/explore-gaps.md` — discovery-focused runs that file issues for tooling gaps, testing gaps, horizon blind spots, and external ecosystem patterns
- Adds `prompts/subtract-prune.md` — deletion-focused runs that close obsolete/duplicate issues, remove dead code, and consolidate overlapping features
- Both use consistent `{{variable}}` syntax matching existing templates
- Includes Chesterton's fence guidance in subtraction template
- `reflect-batch.md` already existed, completing the full set of non-exploitation templates

Closes #564

Run tag: batch-260323-0003-072b/run-22

## Test plan

- [x] Templates use only variables available in `buildTemplateVars()` 
- [x] Variable syntax consistent with deep-dive-default.md and other templates
- [x] Conditional sections use `{{#var}}...{{/var}}` syntax
- [x] No code changes — prompt-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)