### PR TITLE
feat: add ANSI colors and batch scoreboard to auto-dent terminal output

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -20,6 +20,8 @@ import {
   extractLinkedIssue,
   formatPlanAsMarkdown,
   selectMode,
+  formatBatchFooter,
+  color,
   type BatchState,
   type CleanupResult,
   type RunResult,
@@ -593,58 +595,87 @@ describe('parsePhaseMarkers', () => {
 describe('formatPhaseMarker', () => {
   it('formats PICK with issue and title', () => {
     const result = formatPhaseMarker({ phase: 'PICK', fields: { issue: '#472', title: 'improve hook test DRY' } });
-    expect(result).toBe('[PICK] #472 improve hook test DRY');
+    expect(result).toContain('[PICK]');
+    expect(result).toContain('#472');
+    expect(result).toContain('improve hook test DRY');
   });
 
   it('formats EVALUATE with verdict and reason', () => {
     const result = formatPhaseMarker({ phase: 'EVALUATE', fields: { verdict: 'proceed', reason: 'clear spec' } });
-    expect(result).toBe('[EVALUATE] proceed (clear spec)');
+    expect(result).toContain('[EVALUATE]');
+    expect(result).toContain('proceed');
+    expect(result).toContain('(clear spec)');
   });
 
   it('formats IMPLEMENT with case and branch', () => {
     const result = formatPhaseMarker({ phase: 'IMPLEMENT', fields: { case: '260323-1200-k472', branch: 'case/260323-1200-k472' } });
-    expect(result).toBe('[IMPLEMENT] case:260323-1200-k472 branch:case/260323-1200-k472');
+    expect(result).toContain('[IMPLEMENT]');
+    expect(result).toContain('case:260323-1200-k472');
+    expect(result).toContain('branch:case/260323-1200-k472');
   });
 
   it('formats TEST with result and count', () => {
     const result = formatPhaseMarker({ phase: 'TEST', fields: { result: 'pass', count: '15' } });
-    expect(result).toBe('[TEST] pass 15 tests');
+    expect(result).toContain('[TEST]');
+    expect(result).toContain('pass');
+    expect(result).toContain('15 tests');
   });
 
   it('formats PR with url', () => {
     const result = formatPhaseMarker({ phase: 'PR', fields: { url: 'https://github.com/Garsson-io/kaizen/pull/500' } });
-    expect(result).toBe('[PR] https://github.com/Garsson-io/kaizen/pull/500');
+    expect(result).toContain('[PR]');
+    expect(result).toContain('https://github.com/Garsson-io/kaizen/pull/500');
   });
 
   it('formats MERGE with url and status', () => {
     const result = formatPhaseMarker({ phase: 'MERGE', fields: { url: 'https://github.com/Garsson-io/kaizen/pull/500', status: 'queued' } });
-    expect(result).toBe('[MERGE] https://github.com/Garsson-io/kaizen/pull/500 queued');
+    expect(result).toContain('[MERGE]');
+    expect(result).toContain('https://github.com/Garsson-io/kaizen/pull/500');
+    expect(result).toContain('queued');
   });
 
   it('formats REFLECT with issues_filed and lessons', () => {
     const result = formatPhaseMarker({ phase: 'REFLECT', fields: { issues_filed: '2', lessons: 'shared helpers reduce boilerplate' } });
-    expect(result).toBe('[REFLECT] 2 issues filed shared helpers reduce boilerplate');
+    expect(result).toContain('[REFLECT]');
+    expect(result).toContain('2 issues filed');
+    expect(result).toContain('shared helpers reduce boilerplate');
   });
 
   it('formats phase with no fields', () => {
     const result = formatPhaseMarker({ phase: 'REFLECT', fields: {} });
-    expect(result).toBe('[REFLECT]');
+    expect(result).toContain('[REFLECT]');
   });
 
   it('truncates very long output', () => {
     const longTitle = 'A'.repeat(200);
     const result = formatPhaseMarker({ phase: 'PICK', fields: { issue: '#1', title: longTitle } });
-    expect(result.length).toBeLessThanOrEqual(120);
+    // Allow for icon prefix (2 chars + space) in length check
+    expect(result.length).toBeLessThanOrEqual(125);
   });
 
   it('formats DECOMPOSE with epic and issues_created', () => {
     const result = formatPhaseMarker({ phase: 'DECOMPOSE', fields: { epic: '#506', issues_created: '#560,#561,#562' } });
-    expect(result).toBe('[DECOMPOSE] epic:#506 created:#560,#561,#562');
+    expect(result).toContain('[DECOMPOSE]');
+    expect(result).toContain('epic:#506');
+    expect(result).toContain('created:#560,#561,#562');
   });
 
   it('formats DECOMPOSE with epic only', () => {
     const result = formatPhaseMarker({ phase: 'DECOMPOSE', fields: { epic: '#548' } });
-    expect(result).toBe('[DECOMPOSE] epic:#548');
+    expect(result).toContain('[DECOMPOSE]');
+    expect(result).toContain('epic:#548');
+  });
+
+  it('includes phase icon prefix', () => {
+    const result = formatPhaseMarker({ phase: 'PICK', fields: {} });
+    // Should contain the ◉ icon
+    expect(result).toContain('\u25c9');
+  });
+
+  it('uses stop icon for STOP phase', () => {
+    const result = formatPhaseMarker({ phase: 'STOP', fields: { reason: 'done' } });
+    // Should contain the ● icon for STOP
+    expect(result).toContain('\u25cf');
   });
 });
 
@@ -1506,5 +1537,56 @@ describe('selectMode', () => {
     // Run 0 should not trigger contemplate even though 0 % 15 !== 14
     const { mode } = selectMode(makeBatchState(), 0);
     expect(mode).toBe('exploit');
+  });
+});
+
+describe('formatBatchFooter', () => {
+  it('shows run count and PR count', () => {
+    const state = makeBatchState({
+      run: 5,
+      prs: ['https://github.com/org/repo/pull/1', 'https://github.com/org/repo/pull/2'],
+      run_history: [
+        { run: 1, start_epoch: 0, duration_seconds: 60, exit_code: 0, cost_usd: 1.5, tool_calls: 10, prs: ['https://github.com/org/repo/pull/1'], issues_filed: [], issues_closed: [], cases: [], stop_requested: false },
+        { run: 2, start_epoch: 0, duration_seconds: 90, exit_code: 0, cost_usd: 2.0, tool_calls: 15, prs: ['https://github.com/org/repo/pull/2'], issues_filed: [], issues_closed: [], cases: [], stop_requested: false },
+      ],
+    });
+    const output = formatBatchFooter(state);
+    expect(output).toContain('Run 5');
+    expect(output).toContain('PRs: 2');
+    expect(output).toContain('$3.50');
+  });
+
+  it('shows 0% success when no PRs', () => {
+    const state = makeBatchState({ run: 1, prs: [], run_history: [] });
+    const output = formatBatchFooter(state);
+    expect(output).toContain('PRs: 0');
+    expect(output).toContain('0% success');
+  });
+
+  it('calculates success rate from run history', () => {
+    const state = makeBatchState({
+      run: 3,
+      prs: ['pr1', 'pr2'],
+      run_history: [
+        { run: 1, start_epoch: 0, duration_seconds: 60, exit_code: 0, cost_usd: 1.0, tool_calls: 10, prs: ['pr1'], issues_filed: [], issues_closed: [], cases: [], stop_requested: false },
+        { run: 2, start_epoch: 0, duration_seconds: 60, exit_code: 1, cost_usd: 1.0, tool_calls: 10, prs: [], issues_filed: [], issues_closed: [], cases: [], stop_requested: false },
+        { run: 3, start_epoch: 0, duration_seconds: 60, exit_code: 0, cost_usd: 1.0, tool_calls: 10, prs: ['pr2'], issues_filed: [], issues_closed: [], cases: [], stop_requested: false },
+      ],
+    });
+    const output = formatBatchFooter(state);
+    expect(output).toContain('100% success');
+  });
+});
+
+describe('color helpers', () => {
+  it('returns plain text in non-TTY environment', () => {
+    // Tests run in non-TTY, so color should be disabled
+    expect(color.green('hello')).toBe('hello');
+    expect(color.red('error')).toBe('error');
+    expect(color.bold('bold')).toBe('bold');
+    expect(color.dim('dim')).toBe('dim');
+    expect(color.cyan('cyan')).toBe('cyan');
+    expect(color.yellow('yellow')).toBe('yellow');
+    expect(color.magenta('magenta')).toBe('magenta');
   });
 });

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -23,6 +23,37 @@ import { dirname, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, postHocScoreBatch, formatPostHocLine } from './auto-dent-score.js';
 import { claimNextItem } from './auto-dent-plan.js';
 
+// ANSI color helpers (graceful degradation when NO_COLOR is set or not a TTY)
+
+const colorEnabled = process.stdout.isTTY && !process.env.NO_COLOR;
+
+function ansi(code: string, text: string): string {
+  return colorEnabled ? `\x1b[${code}m${text}\x1b[0m` : text;
+}
+
+export const color = {
+  green: (t: string) => ansi('32', t),
+  yellow: (t: string) => ansi('33', t),
+  red: (t: string) => ansi('31', t),
+  dim: (t: string) => ansi('90', t),
+  cyan: (t: string) => ansi('36', t),
+  bold: (t: string) => ansi('1', t),
+  magenta: (t: string) => ansi('35', t),
+};
+
+// Phase status icons with color
+const PHASE_STYLE: Record<string, (t: string) => string> = {
+  PICK: color.cyan,
+  EVALUATE: color.yellow,
+  IMPLEMENT: color.magenta,
+  TEST: color.green,
+  PR: color.green,
+  MERGE: color.green,
+  DECOMPOSE: color.cyan,
+  REFLECT: color.yellow,
+  STOP: color.red,
+};
+
 // Types
 
 export interface BatchState {
@@ -490,7 +521,9 @@ export function parsePhaseMarkers(text: string): PhaseMarker[] {
 }
 
 export function formatPhaseMarker(marker: PhaseMarker): string {
-  const parts = [`[${marker.phase}]`];
+  const styleFn = PHASE_STYLE[marker.phase] || color.dim;
+  const icon = marker.phase === 'STOP' ? '\u25cf' : '\u25c9';
+  const parts = [styleFn(`${icon} [${marker.phase}]`)];
 
   // Show the most informative fields for each phase
   const { fields } = marker;
@@ -663,7 +696,7 @@ export function processStreamMessage(
     case 'system':
       if (msg.subtype === 'init') {
         console.log(
-          `  [${elapsed}]  Session ${(msg.session_id || '').slice(0, 8)}... | model: ${msg.model || 'default'}`,
+          `  ${color.dim(`[${elapsed}]`)}  ${color.bold('Session')} ${(msg.session_id || '').slice(0, 8)}... | model: ${msg.model || 'default'}`,
         );
       }
       break;
@@ -674,7 +707,7 @@ export function processStreamMessage(
           if (block.type === 'tool_use') {
             result.toolCalls++;
             const toolDesc = formatToolUse(block.name, block.input);
-            console.log(`  [${elapsed}]  ${toolDesc}`);
+            console.log(`  ${color.dim(`[${elapsed}]`)}  ${toolDesc}`);
             if (ctx) ctx.lastActivity = toolDesc;
           }
           if (block.type === 'text' && block.text) {
@@ -700,9 +733,14 @@ export function processStreamMessage(
         extractArtifacts(msg.result, result);
         checkStopSignal(msg.result, result);
       }
-      console.log(
-        `  [${elapsed}]  ${msg.subtype === 'success' ? 'done' : `error: ${msg.subtype}`} | $${result.cost?.toFixed(2) || '?'} | ${result.toolCalls} tool calls`,
-      );
+      {
+        const statusText = msg.subtype === 'success'
+          ? color.green('done')
+          : color.red(`error: ${msg.subtype}`);
+        console.log(
+          `  ${color.dim(`[${elapsed}]`)}  ${statusText} | $${result.cost?.toFixed(2) || '?'} | ${result.toolCalls} tool calls`,
+        );
+      }
       break;
   }
 }
@@ -1340,34 +1378,64 @@ async function runClaude(
 
 // Display
 
+/**
+ * Format a batch scoreboard footer showing cumulative stats.
+ * Shown after each run so the operator can see batch health at a glance.
+ */
+export function formatBatchFooter(state: BatchState): string {
+  const history = state.run_history || [];
+  const totalCost = history.reduce((s, r) => s + r.cost_usd, 0);
+  const totalPRs = state.prs.length;
+  const mergedCount = history.filter(
+    (r) => r.prs.length > 0 && r.exit_code === 0,
+  ).length;
+  const mergeRate =
+    totalPRs > 0 ? Math.round((mergedCount / totalPRs) * 100) : 0;
+
+  const bar = '\u2501'.repeat(54);
+  const line = [
+    `  Run ${state.run}`,
+    `PRs: ${totalPRs}`,
+    `$${totalCost.toFixed(2)}`,
+    `${mergeRate}% success`,
+  ].join(' \u2502 ');
+
+  return [
+    `  ${color.dim(bar)}`,
+    `  ${color.bold(line)}`,
+    `  ${color.dim(bar)}`,
+  ].join('\n');
+}
+
 function printRunSummary(
   runNum: number,
   exitCode: number,
   duration: number,
   result: RunResult,
 ): void {
-  const status = exitCode === 0 ? 'success' : `failed (exit ${exitCode})`;
+  const status =
+    exitCode === 0 ? color.green('success') : color.red(`failed (exit ${exitCode})`);
 
   console.log('');
   console.log(
-    `  \u250c\u2500 Run #${runNum} Summary \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`,
+    `  ${color.bold(`\u250c\u2500 Run #${runNum} Summary`)} ${'─'.repeat(30)}`,
   );
   console.log(`  \u2502 Status:   ${status}`);
   console.log(`  \u2502 Duration: ${duration}s`);
   console.log(`  \u2502 Cost:     $${result.cost.toFixed(2)}`);
   console.log(`  \u2502 Tools:    ${result.toolCalls} calls`);
 
-  for (const pr of result.prs) console.log(`  \u2502 PR:       ${pr}`);
+  for (const pr of result.prs) console.log(`  \u2502 ${color.green('PR:')}       ${pr}`);
   for (const issue of result.issuesFiled)
-    console.log(`  \u2502 Issue:    ${issue}`);
+    console.log(`  \u2502 ${color.cyan('Issue:')}    ${issue}`);
   if (result.issuesClosed.length > 0)
     console.log(`  \u2502 Closed:   ${result.issuesClosed.join(' ')}`);
   for (const c of result.cases) console.log(`  \u2502 Case:     ${c}`);
   if (result.stopRequested)
-    console.log(`  \u2502 STOP:     ${result.stopReason}`);
+    console.log(`  \u2502 ${color.red('STOP:')}     ${result.stopReason}`);
 
   console.log(
-    `  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`,
+    `  \u2514${'─'.repeat(54)}`,
   );
   console.log('');
 }
@@ -1426,6 +1494,19 @@ async function main(): Promise<void> {
   );
 
   printRunSummary(runNum, exitCode, duration, result);
+
+  // Batch scoreboard (cumulative stats across all runs)
+  {
+    const previewState = readState(stateFile);
+    // Include this run's PRs for an accurate footer
+    for (const pr of result.prs) {
+      if (!previewState.prs.includes(pr)) previewState.prs.push(pr);
+    }
+    previewState.run = runNum;
+    if (!previewState.run_history) previewState.run_history = [];
+    console.log(formatBatchFooter(previewState));
+    console.log('');
+  }
 
   // Post-run hygiene
   const progressIssue = ensureBatchProgressIssue(state, stateFile);


### PR DESCRIPTION
## Summary

- Add ANSI color helpers with `NO_COLOR`/non-TTY graceful degradation
- Color-code phase markers by type (cyan=PICK, yellow=EVALUATE, magenta=IMPLEMENT, green=TEST/PR/MERGE, red=STOP)
- Add phase icon prefix (◉ for phases, ● for STOP)
- Color timestamps, session init, and result status lines
- Add `formatBatchFooter()` showing cumulative stats (run count, PRs, cost, success rate) after each run
- Color run summary box (status, PRs, issues, STOP)

Closes #570

## Test plan

- [x] All 160 existing tests pass with updated assertions (toContain for ANSI-safe matching)
- [x] New tests for `formatBatchFooter` (3 tests) and `color` helpers (1 test)
- [x] Harness tests (56) pass unchanged
- [x] Colors disabled in non-TTY (test environment) — verified by color helper tests

Run tag: batch-260323-0003-072b/run-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)