### PR TITLE
feat: add signal-driven mode scheduling to auto-dent (#549)

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -20,6 +20,8 @@ import {
   extractLinkedIssue,
   formatPlanAsMarkdown,
   selectMode,
+  checkSignalOverrides,
+  computeModeDistribution,
   formatBatchFooter,
   color,
   type BatchState,
@@ -1540,6 +1542,190 @@ describe('selectMode', () => {
   });
 });
 
+function makeRunMetrics(overrides: Partial<RunMetrics> = {}): RunMetrics {
+  return {
+    run: 1,
+    start_epoch: 0,
+    duration_seconds: 60,
+    exit_code: 0,
+    cost_usd: 1.0,
+    tool_calls: 10,
+    prs: [],
+    issues_filed: [],
+    issues_closed: [],
+    cases: [],
+    stop_requested: false,
+    ...overrides,
+  };
+}
+
+describe('checkSignalOverrides', () => {
+  it('returns null when history is too short', () => {
+    const state = makeBatchState({ run_history: [makeRunMetrics(), makeRunMetrics()] });
+    expect(checkSignalOverrides(state)).toBeNull();
+  });
+
+  it('returns null when no signals fire', () => {
+    const state = makeBatchState({
+      consecutive_failures: 0,
+      run_history: [
+        makeRunMetrics({ prs: ['pr1'], mode: 'exploit' }),
+        makeRunMetrics({ prs: ['pr2'], mode: 'explore' }),
+        makeRunMetrics({ prs: ['pr3'], mode: 'exploit' }),
+      ],
+    });
+    expect(checkSignalOverrides(state)).toBeNull();
+  });
+
+  it('forces reflect on 3+ consecutive failures', () => {
+    const state = makeBatchState({
+      consecutive_failures: 3,
+      run_history: [
+        makeRunMetrics({ exit_code: 1 }),
+        makeRunMetrics({ exit_code: 1 }),
+        makeRunMetrics({ exit_code: 1 }),
+      ],
+    });
+    const result = checkSignalOverrides(state);
+    expect(result).not.toBeNull();
+    expect(result!.mode).toBe('reflect');
+    expect(result!.reason).toBe('signal:consecutive-failures');
+  });
+
+  it('forces explore when no PRs in last 5 runs', () => {
+    const state = makeBatchState({
+      consecutive_failures: 0,
+      run_history: [
+        makeRunMetrics({ prs: [] }),
+        makeRunMetrics({ prs: [] }),
+        makeRunMetrics({ prs: [] }),
+        makeRunMetrics({ prs: [] }),
+        makeRunMetrics({ prs: [] }),
+      ],
+    });
+    const result = checkSignalOverrides(state);
+    expect(result).not.toBeNull();
+    expect(result!.mode).toBe('explore');
+    expect(result!.reason).toBe('signal:no-recent-prs');
+  });
+
+  it('does not force explore when PRs exist in last 5 runs', () => {
+    const state = makeBatchState({
+      consecutive_failures: 0,
+      run_history: [
+        makeRunMetrics({ prs: [], mode: 'exploit' }),
+        makeRunMetrics({ prs: [], mode: 'explore' }),
+        makeRunMetrics({ prs: ['pr1'], mode: 'exploit' }),
+        makeRunMetrics({ prs: [], mode: 'reflect' }),
+        makeRunMetrics({ prs: [], mode: 'exploit' }),
+      ],
+    });
+    expect(checkSignalOverrides(state)).toBeNull();
+  });
+
+  it('breaks mode streak after 4 consecutive same-mode runs', () => {
+    const state = makeBatchState({
+      consecutive_failures: 0,
+      run_history: [
+        makeRunMetrics({ prs: ['pr1'], mode: 'exploit' }),
+        makeRunMetrics({ prs: ['pr2'], mode: 'exploit' }),
+        makeRunMetrics({ prs: ['pr3'], mode: 'exploit' }),
+        makeRunMetrics({ prs: ['pr4'], mode: 'exploit' }),
+      ],
+    });
+    const result = checkSignalOverrides(state);
+    expect(result).not.toBeNull();
+    expect(result!.mode).toBe('explore');
+    expect(result!.reason).toBe('signal:mode-streak-exploit');
+  });
+
+  it('breaks non-exploit mode streak with contemplate', () => {
+    const state = makeBatchState({
+      consecutive_failures: 0,
+      run_history: [
+        makeRunMetrics({ prs: ['pr1'], mode: 'explore' }),
+        makeRunMetrics({ prs: ['pr2'], mode: 'explore' }),
+        makeRunMetrics({ prs: ['pr3'], mode: 'explore' }),
+        makeRunMetrics({ prs: ['pr4'], mode: 'explore' }),
+      ],
+    });
+    const result = checkSignalOverrides(state);
+    expect(result).not.toBeNull();
+    expect(result!.mode).toBe('contemplate');
+    expect(result!.reason).toBe('signal:mode-streak-explore');
+  });
+
+  it('consecutive failures takes priority over no-prs signal', () => {
+    const state = makeBatchState({
+      consecutive_failures: 3,
+      run_history: [
+        makeRunMetrics({ prs: [], exit_code: 1 }),
+        makeRunMetrics({ prs: [], exit_code: 1 }),
+        makeRunMetrics({ prs: [], exit_code: 1 }),
+        makeRunMetrics({ prs: [], exit_code: 1 }),
+        makeRunMetrics({ prs: [], exit_code: 1 }),
+      ],
+    });
+    const result = checkSignalOverrides(state);
+    expect(result!.mode).toBe('reflect');
+  });
+
+  it('signal overrides are used by selectMode', () => {
+    const state = makeBatchState({
+      consecutive_failures: 4,
+      run_history: [
+        makeRunMetrics({ exit_code: 1 }),
+        makeRunMetrics({ exit_code: 1 }),
+        makeRunMetrics({ exit_code: 1 }),
+        makeRunMetrics({ exit_code: 1 }),
+      ],
+    });
+    // Run 1 would normally be exploit, but signal overrides it
+    const { mode, reason } = selectMode(state, 1);
+    expect(mode).toBe('reflect');
+    expect(reason).toBe('signal:consecutive-failures');
+  });
+
+  it('guidance override takes priority over signals', () => {
+    const state = makeBatchState({
+      guidance: 'fix bugs mode:subtract',
+      consecutive_failures: 5,
+      run_history: [
+        makeRunMetrics({ exit_code: 1 }),
+        makeRunMetrics({ exit_code: 1 }),
+        makeRunMetrics({ exit_code: 1 }),
+      ],
+    });
+    const { mode, reason } = selectMode(state, 1);
+    expect(mode).toBe('subtract');
+    expect(reason).toBe('guidance');
+  });
+});
+
+describe('computeModeDistribution', () => {
+  it('counts modes from run history', () => {
+    const history = [
+      makeRunMetrics({ mode: 'exploit' }),
+      makeRunMetrics({ mode: 'exploit' }),
+      makeRunMetrics({ mode: 'explore' }),
+      makeRunMetrics({ mode: 'reflect' }),
+    ];
+    const dist = computeModeDistribution(history);
+    expect(dist).toEqual({ exploit: 2, explore: 1, reflect: 1 });
+  });
+
+  it('defaults missing mode to exploit', () => {
+    const history = [makeRunMetrics({})];
+    // mode is undefined, should default to exploit
+    const dist = computeModeDistribution(history);
+    expect(dist).toEqual({ exploit: 1 });
+  });
+
+  it('returns empty object for empty history', () => {
+    expect(computeModeDistribution([])).toEqual({});
+  });
+});
+
 describe('formatBatchFooter', () => {
   it('shows run count and PR count', () => {
     const state = makeBatchState({
@@ -1575,6 +1761,28 @@ describe('formatBatchFooter', () => {
     });
     const output = formatBatchFooter(state);
     expect(output).toContain('100% success');
+  });
+
+  it('shows mode distribution when modes are present', () => {
+    const state = makeBatchState({
+      run: 3,
+      prs: [],
+      run_history: [
+        makeRunMetrics({ run: 1, mode: 'exploit' }),
+        makeRunMetrics({ run: 2, mode: 'exploit' }),
+        makeRunMetrics({ run: 3, mode: 'explore' }),
+      ],
+    });
+    const output = formatBatchFooter(state);
+    expect(output).toContain('Modes:');
+    expect(output).toContain('exploit:2');
+    expect(output).toContain('explore:1');
+  });
+
+  it('omits mode line when no history', () => {
+    const state = makeBatchState({ run: 0, prs: [], run_history: [] });
+    const output = formatBatchFooter(state);
+    expect(output).not.toContain('Modes:');
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -267,6 +267,8 @@ export function loadPromptTemplate(templateName: string): string | null {
 export interface ModeSelection {
   mode: string;
   template: string;
+  /** Why this mode was selected (signal name or 'schedule') */
+  reason: string;
 }
 
 const MODE_TEMPLATES: Record<string, string> = {
@@ -278,14 +280,68 @@ const MODE_TEMPLATES: Record<string, string> = {
 };
 
 /**
+ * Check signal-driven overrides based on batch state.
+ * Returns a ModeSelection if a signal fires, or null to fall through to the schedule.
+ *
+ * Signals (checked in priority order):
+ *   1. 3+ consecutive failures → reflect (diagnose what's going wrong)
+ *   2. No PRs in last 5 runs with history → explore (backlog may be exhausted)
+ *   3. Same mode 4+ times consecutively → force a different mode
+ */
+export function checkSignalOverrides(state: BatchState): ModeSelection | null {
+  const history = state.run_history || [];
+  if (history.length < 3) return null;
+
+  // Signal 1: consecutive failures → reflect
+  if (state.consecutive_failures >= 3) {
+    return {
+      mode: 'reflect',
+      template: MODE_TEMPLATES.reflect,
+      reason: 'signal:consecutive-failures',
+    };
+  }
+
+  // Signal 2: no PRs in last 5 runs → explore (backlog may be exhausted)
+  if (history.length >= 5) {
+    const recent5 = history.slice(-5);
+    const recentPRs = recent5.reduce((sum, r) => sum + r.prs.length, 0);
+    if (recentPRs === 0) {
+      return {
+        mode: 'explore',
+        template: MODE_TEMPLATES.explore,
+        reason: 'signal:no-recent-prs',
+      };
+    }
+  }
+
+  // Signal 3: same mode 4+ times in a row → break the streak
+  if (history.length >= 4) {
+    const recent4 = history.slice(-4);
+    const modes = recent4.map(r => r.mode || 'exploit');
+    if (modes.every(m => m === modes[0])) {
+      const staleMode = modes[0];
+      // Pick a different mode: if stuck on exploit, explore; otherwise contemplate
+      const breakMode = staleMode === 'exploit' ? 'explore' : 'contemplate';
+      return {
+        mode: breakMode,
+        template: MODE_TEMPLATES[breakMode],
+        reason: `signal:mode-streak-${staleMode}`,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
  * Select the cognitive mode for a given run.
  *
- * Schedule (v2):
- *   Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
- *   Overlay: every 15th run (mod 15 === 14) triggers contemplate instead
- *   ~67% exploitation, ~10% explore, ~7% reflect, ~7% subtract, ~7% contemplate
- *
- * Override: guidance containing "mode:<name>" forces that mode.
+ * Priority (highest first):
+ *   1. Guidance override: "mode:<name>" in guidance forces that mode
+ *   2. Test task: always exploit with test template
+ *   3. Signal-driven: reactive to batch state (failures, stalls, streaks)
+ *   4. Contemplate overlay: every 15th run for strategic assessment
+ *   5. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
  */
 export function selectMode(state: BatchState, runNum: number): ModeSelection {
   // Force mode from guidance (e.g., "mode:explore")
@@ -295,24 +351,42 @@ export function selectMode(state: BatchState, runNum: number): ModeSelection {
     return {
       mode: forced,
       template: MODE_TEMPLATES[forced] || MODE_TEMPLATES.exploit,
+      reason: 'guidance',
     };
   }
 
   // Test task always uses test template
   if (state.test_task) {
-    return { mode: 'exploit', template: 'test-task.md' };
+    return { mode: 'exploit', template: 'test-task.md', reason: 'test-task' };
   }
+
+  // Signal-driven overrides (reactive to batch state)
+  const signalMode = checkSignalOverrides(state);
+  if (signalMode) return signalMode;
 
   // Contemplate overlay: every 15th run pauses for strategic assessment
   if (runNum > 0 && runNum % 15 === 14) {
-    return { mode: 'contemplate', template: MODE_TEMPLATES.contemplate };
+    return { mode: 'contemplate', template: MODE_TEMPLATES.contemplate, reason: 'schedule' };
   }
 
   const slot = runNum % 10;
-  if (slot <= 6) return { mode: 'exploit', template: MODE_TEMPLATES.exploit };
-  if (slot === 7) return { mode: 'explore', template: MODE_TEMPLATES.explore };
-  if (slot === 8) return { mode: 'reflect', template: MODE_TEMPLATES.reflect };
-  return { mode: 'subtract', template: MODE_TEMPLATES.subtract };
+  if (slot <= 6) return { mode: 'exploit', template: MODE_TEMPLATES.exploit, reason: 'schedule' };
+  if (slot === 7) return { mode: 'explore', template: MODE_TEMPLATES.explore, reason: 'schedule' };
+  if (slot === 8) return { mode: 'reflect', template: MODE_TEMPLATES.reflect, reason: 'schedule' };
+  return { mode: 'subtract', template: MODE_TEMPLATES.subtract, reason: 'schedule' };
+}
+
+/**
+ * Compute mode distribution from run history.
+ * Returns a record of mode → count.
+ */
+export function computeModeDistribution(history: RunMetrics[]): Record<string, number> {
+  const dist: Record<string, number> = {};
+  for (const r of history) {
+    const m = r.mode || 'exploit';
+    dist[m] = (dist[m] || 0) + 1;
+  }
+  return dist;
 }
 
 export function buildPrompt(state: BatchState, runNum: number, logDir?: string): string {
@@ -1217,8 +1291,8 @@ async function runClaude(
 
   const logDir = dirname(stateFile);
   const modeSelection = selectMode(state, runNum);
-  if (modeSelection.mode !== 'exploit') {
-    console.log(`  [mode] run #${runNum}: ${modeSelection.mode} (template: ${modeSelection.template})`);
+  if (modeSelection.mode !== 'exploit' || modeSelection.reason !== 'schedule') {
+    console.log(`  [mode] run #${runNum}: ${modeSelection.mode} (${modeSelection.reason}, template: ${modeSelection.template})`);
   }
   const prompt = buildPrompt(state, runNum, logDir);
   const nonce = `${new Date()
@@ -1400,11 +1474,25 @@ export function formatBatchFooter(state: BatchState): string {
     `${mergeRate}% success`,
   ].join(' \u2502 ');
 
-  return [
+  // Mode distribution
+  const modeDist = computeModeDistribution(history);
+  const modeStr = Object.entries(modeDist)
+    .sort((a, b) => b[1] - a[1])
+    .map(([m, c]) => `${m}:${c}`)
+    .join(' ');
+
+  const lines = [
     `  ${color.dim(bar)}`,
     `  ${color.bold(line)}`,
-    `  ${color.dim(bar)}`,
-  ].join('\n');
+  ];
+
+  if (modeStr) {
+    lines.push(`  ${color.dim(`  Modes: ${modeStr}`)}`);
+  }
+
+  lines.push(`  ${color.dim(bar)}`);
+
+  return lines.join('\n');
 }
 
 function printRunSummary(


### PR DESCRIPTION
## Summary

- Adds signal-driven mode selection overrides to `selectMode()` that react to batch state conditions:
  - **3+ consecutive failures** → force `reflect` mode to diagnose issues
  - **No PRs in last 5 runs** → force `explore` mode (backlog may be exhausted)
  - **Same mode 4+ times consecutively** → break the streak with a different mode
- Adds **mode distribution** display to the batch footer (e.g., `Modes: exploit:7 explore:2 reflect:1`)
- Adds `reason` field to `ModeSelection` so the harness logs *why* a mode was selected (schedule vs signal)
- 15 new tests covering all signal conditions, priority ordering, and mode distribution

## Test plan

- [x] All 175 auto-dent-run tests pass (15 new)
- [x] Full test suite passes (913 tests)
- [x] Existing selectMode schedule tests unaffected (signals require specific state to fire)

Run tag: batch-260323-0003-072b/run-34
Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)