### PR TITLE
feat: enrich PR merge status with actual GitHub state

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -737,6 +737,8 @@ describe('buildReflectionTemplateVars', () => {
     expect(vars.pr_count).toBe('2');
     expect(vars.run_history_table).toContain('| Run |');
     expect(vars.pr_merge_status).toContain('pull/100');
+    // PR merge status should include status labels
+    expect(vars.pr_merge_status).toMatch(/— \*\*(merged|open|closed)\*\*|— unknown/);
     expect(vars.reflection_insights).toContain('[');
   });
 

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -658,7 +658,17 @@ export function buildReflectionTemplateVars(
     issues_closed_count: String(reflection.issuesClosedCount),
     run_history_table: reflection.runHistoryTable,
     reflection_insights: insightLines.join('\n'),
-    pr_merge_status: state.prs.length > 0 ? state.prs.join('\n') : '',
+    pr_merge_status: state.prs.length > 0
+      ? state.prs.map(url => {
+          const status = checkMergeStatus(url);
+          const label = status === 'merged' ? '**merged**'
+            : status === 'auto_queued' ? '**open** (auto-merge queued)'
+            : status === 'closed' ? '**closed**'
+            : status === 'open' ? '**open**'
+            : 'unknown';
+          return `- ${url} — ${label}`;
+        }).join('\n')
+      : '',
   };
 }
 

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { writeFileSync, unlinkSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -306,6 +306,10 @@ describe('buildTemplateVars with run_history', () => {
     expect(vars.run_count).toBe('2');
     expect(vars.pr_merge_status).toContain('pull/100');
     expect(vars.pr_merge_status).toContain('pull/101');
+    // Each PR line should include a status label (merged, open, closed, or unknown)
+    for (const line of vars.pr_merge_status.split('\n')) {
+      expect(line).toMatch(/— \*\*(merged|open|closed)\*\*|— unknown/);
+    }
   });
 
   it('returns empty strings when no run_history exists', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -270,9 +270,17 @@ export function buildTemplateVars(
     issuesClosedCount = String(batchScore.total_issues_closed);
     runCount = String(batchScore.total_runs);
 
-    // Build PR merge status summary from state.prs
+    // Build PR merge status summary with actual merge state from GitHub
     if (state.prs.length > 0) {
-      prMergeStatus = state.prs.map(url => `- ${url}`).join('\n');
+      prMergeStatus = state.prs.map(url => {
+        const status = checkMergeStatus(url);
+        const label = status === 'merged' ? '**merged**'
+          : status === 'auto_queued' ? '**open** (auto-merge queued)'
+          : status === 'closed' ? '**closed**'
+          : status === 'open' ? '**open**'
+          : 'unknown';
+        return `- ${url} — ${label}`;
+      }).join('\n');
     }
   }
 


### PR DESCRIPTION
## Summary

- Enriches `pr_merge_status` template variable with actual merge state from GitHub API (`merged`, `open`, `auto-merge queued`, `closed`, `unknown`) instead of bare URLs
- Applied to both `buildTemplateVars()` (auto-dent-run.ts) and `buildReflectionTemplateVars()` (auto-dent-ctl.ts)
- Enables reflect-batch and contemplate prompts to accurately answer "cost per merged PR" and assess batch effectiveness

Closes #612
Run tag: batch-260323-0003-072b/run-45

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 971 tests pass (`npm test`)
- [x] Tests verify PR merge status includes status labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)