### PR TITLE
feat: add reflection history for stateful consecutive reflections

### DIFF
--- a/prompts/contemplate-strategy.md
+++ b/prompts/contemplate-strategy.md
@@ -24,6 +24,12 @@ PRs created so far: {{prs}}
 {{reflection_insights}}
 {{/reflection_insights}}
 
+{{#prior_reflections}}
+## Prior Reflections History
+
+{{prior_reflections}}
+{{/prior_reflections}}
+
 ## Strategic Assessment Tasks
 
 Work through each of these assessments:

--- a/prompts/reflect-batch.md
+++ b/prompts/reflect-batch.md
@@ -25,6 +25,15 @@ performance and produce insights that will help subsequent runs be more effectiv
 {{pr_merge_status}}
 {{/pr_merge_status}}
 
+{{#prior_reflections}}
+## Prior Reflections
+
+Previous reflections in this batch produced the following insights.
+Review whether their recommendations were followed and what changed since.
+
+{{prior_reflections}}
+{{/prior_reflections}}
+
 ## Your Task
 
 Analyze the batch data above and produce a structured reflection. Focus on:
@@ -32,8 +41,9 @@ Analyze the batch data above and produce a structured reflection. Focus on:
 1. **Success patterns** — Which domains/issue types produced merged PRs? What approaches worked?
 2. **Failure patterns** — Were there repeated failures? Which runs had high cost but low output?
 3. **Efficiency** — What's the cost per merged PR? Are there runs that should have stopped earlier?
-4. **Recommendations** — What should future runs focus on or avoid?
-5. **Meta-kaizen** — Are there systemic improvements to the auto-dent harness itself?
+4. **Prior reflection follow-up** — If prior reflections exist, were their recommendations followed? What changed?
+5. **Recommendations** — What should future runs focus on or avoid?
+6. **Meta-kaizen** — Are there systemic improvements to the auto-dent harness itself?
 
 Output your reflection in this format:
 

--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -824,6 +824,31 @@ describe('persistReflectionSummary', () => {
     const count42 = data.avoidIssues.filter((i) => i === '42').length;
     expect(count42).toBe(1);
   });
+
+  it('appends to reflection-history.json for consecutive reflections', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'reflect-history-'));
+    const batch = makeBatchInfo({ dir: tmpDir });
+
+    // First reflection
+    const r1 = buildBatchReflection(batch);
+    r1.insights = [{ type: 'recommendation', message: 'Focus on hooks' }];
+    persistReflectionSummary(batch, r1);
+
+    const historyPath = join(tmpDir, 'reflection-history.json');
+    expect(existsSync(historyPath)).toBe(true);
+    let history = JSON.parse(readFileSync(historyPath, 'utf8'));
+    expect(history).toHaveLength(1);
+    expect(history[0].insights[0].message).toBe('Focus on hooks');
+
+    // Second reflection
+    const r2 = buildBatchReflection(batch);
+    r2.insights = [{ type: 'success_pattern', message: 'Testing works well' }];
+    persistReflectionSummary(batch, r2);
+
+    history = JSON.parse(readFileSync(historyPath, 'utf8'));
+    expect(history).toHaveLength(2);
+    expect(history[1].insights[0].message).toBe('Testing works well');
+  });
 });
 
 // Cross-batch aggregate tests (#586)

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -632,7 +632,19 @@ export function persistReflectionSummary(
 
   try {
     writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + '\n');
-    console.log(`  [reflect] persisted reflection summary to ${summaryPath}`);
+
+    // Append to reflection history so consecutive reflections can see prior conclusions
+    const historyPath = join(batch.dir, 'reflection-history.json');
+    let history: PersistedReflection[] = [];
+    try {
+      if (existsSync(historyPath)) {
+        history = JSON.parse(readFileSync(historyPath, 'utf8'));
+      }
+    } catch { /* start fresh if corrupted */ }
+    history.push(summary);
+    writeFileSync(historyPath, JSON.stringify(history, null, 2) + '\n');
+
+    console.log(`  [reflect] persisted reflection summary to ${summaryPath} (history: ${history.length} entries)`);
     return summaryPath;
   } catch (e: any) {
     console.log(`  [reflect] warning: failed to persist reflection — ${e.message?.split('\n')[0] || 'failed'}`);

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -7,6 +7,7 @@ import {
   buildPromptWithMetadata,
   buildTemplateVars,
   loadReflectionInsights,
+  loadReflectionHistory,
   renderTemplate,
   loadPromptTemplate,
   extractArtifacts,
@@ -282,6 +283,89 @@ describe('buildTemplateVars with reflection insights', () => {
     const state = makeBatchState();
     const vars = buildTemplateVars(state, 3, tmpDir);
     expect(vars.reflection_insights).toBe('');
+  });
+});
+
+describe('loadReflectionHistory', () => {
+  it('returns empty string when no history file exists', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'hist-none-'));
+    expect(loadReflectionHistory(tmpDir)).toBe('');
+  });
+
+  it('returns empty string for empty array', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'hist-empty-'));
+    writeFileSync(join(tmpDir, 'reflection-history.json'), '[]');
+    expect(loadReflectionHistory(tmpDir)).toBe('');
+  });
+
+  it('formats reflection entries with run number, success rate, and insights', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'hist-data-'));
+    const history = [
+      {
+        timestamp: '2026-03-23T01:00:00Z',
+        runCount: 5,
+        successRate: 0.8,
+        avgCostPerPr: 1.50,
+        insights: [
+          { type: 'success_pattern', message: 'Hooks issues merge quickly' },
+          { type: 'recommendation', message: 'Focus on testing gaps' },
+        ],
+        avoidIssues: [],
+      },
+      {
+        timestamp: '2026-03-23T02:00:00Z',
+        runCount: 15,
+        successRate: 0.6,
+        avgCostPerPr: 2.00,
+        insights: [
+          { type: 'failure_pattern', message: 'Large refactors fail' },
+        ],
+        avoidIssues: ['500'],
+      },
+    ];
+    writeFileSync(join(tmpDir, 'reflection-history.json'), JSON.stringify(history));
+
+    const result = loadReflectionHistory(tmpDir);
+    expect(result).toContain('Reflection 1');
+    expect(result).toContain('after run 5');
+    expect(result).toContain('success: 80%');
+    expect(result).toContain('Hooks issues merge quickly');
+    expect(result).toContain('Reflection 2');
+    expect(result).toContain('after run 15');
+    expect(result).toContain('Large refactors fail');
+  });
+
+  it('returns empty string for corrupted file', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'hist-bad-'));
+    writeFileSync(join(tmpDir, 'reflection-history.json'), 'not json');
+    expect(loadReflectionHistory(tmpDir)).toBe('');
+  });
+});
+
+describe('buildTemplateVars includes prior_reflections', () => {
+  it('includes prior_reflections when reflection-history.json exists', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'vars-hist-'));
+    const history = [{
+      timestamp: '2026-03-23T01:00:00Z',
+      runCount: 8,
+      successRate: 0.75,
+      avgCostPerPr: 1.80,
+      insights: [{ type: 'recommendation', message: 'Prioritize testing' }],
+      avoidIssues: [],
+    }];
+    writeFileSync(join(tmpDir, 'reflection-history.json'), JSON.stringify(history));
+
+    const state = makeBatchState();
+    const vars = buildTemplateVars(state, 10, tmpDir);
+    expect(vars.prior_reflections).toContain('Prioritize testing');
+    expect(vars.prior_reflections).toContain('Reflection 1');
+  });
+
+  it('returns empty prior_reflections when no history exists', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'vars-nohist-'));
+    const state = makeBatchState();
+    const vars = buildTemplateVars(state, 3, tmpDir);
+    expect(vars.prior_reflections).toBe('');
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -206,6 +206,28 @@ export function loadReflectionInsights(logDir: string): { text: string; avoidIss
 }
 
 /**
+ * Load reflection history — all prior reflection entries in this batch.
+ * Used to give the reflect-batch prompt visibility into prior reflections.
+ */
+export function loadReflectionHistory(logDir: string): string {
+  const historyPath = resolve(logDir, 'reflection-history.json');
+  try {
+    if (!existsSync(historyPath)) return '';
+    const entries = JSON.parse(readFileSync(historyPath, 'utf8'));
+    if (!Array.isArray(entries) || entries.length === 0) return '';
+
+    return entries.map((entry: any, idx: number) => {
+      const insights = (entry.insights || [])
+        .map((i: any) => `  - **[${i.type}]** ${i.message}`)
+        .join('\n');
+      return `### Reflection ${idx + 1} (after run ${entry.runCount}, success: ${(entry.successRate * 100).toFixed(0)}%, cost/PR: $${entry.avgCostPerPr.toFixed(2)})\n${insights}`;
+    }).join('\n\n');
+  } catch {
+    return '';
+  }
+}
+
+/**
  * Build template variables from batch state and run number.
  * These are substituted into prompt templates via {{variable}} syntax.
  */
@@ -221,6 +243,7 @@ export function buildTemplateVars(
   // Try to claim next item from plan (if a plan exists)
   let planAssignment = '';
   let reflectionInsights = '';
+  let priorReflections = '';
   if (logDir) {
     const planItem = claimNextItem(logDir);
     if (planItem) {
@@ -245,6 +268,9 @@ export function buildTemplateVars(
     if (reflection.avoidIssues.length > 0) {
       console.log(`  [reflect] loaded ${reflection.avoidIssues.length} issue(s) to avoid from reflection`);
     }
+
+    // Load reflection history for reflect/contemplate prompts (#611)
+    priorReflections = loadReflectionHistory(logDir);
   }
 
   // Build run history table and batch-level stats for reflect/contemplate prompts
@@ -305,6 +331,7 @@ export function buildTemplateVars(
     issues_closed_count: issuesClosedCount,
     run_count: runCount,
     pr_merge_status: prMergeStatus,
+    prior_reflections: priorReflections,
   };
 }
 


### PR DESCRIPTION
## Summary

- `persistReflectionSummary` now appends to `reflection-history.json` (array) alongside existing `reflection-summary.json`
- New `loadReflectionHistory()` reads history and formats entries with run number, success rate, and insights
- New `{{prior_reflections}}` template variable wired into `buildTemplateVars`
- `reflect-batch.md` and `contemplate-strategy.md` prompts now include "Prior Reflections" section when history exists
- Closes the reflection-on-reflection loop: consecutive reflections can evaluate whether prior recommendations were followed

Closes #611
Run tag: batch-260323-0003-072b/run-45

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 978 tests pass (`npm test`)
- [x] `loadReflectionHistory` tested: empty file, empty array, multi-entry, corrupted file
- [x] `buildTemplateVars` tested: prior_reflections populated when history exists, empty when not
- [x] `persistReflectionSummary` tested: appends to history on consecutive calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)