### PR TITLE
feat: add mode diversity metric to batch scoring (#623)

### DIFF
--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -4,6 +4,7 @@ import {
   scoreRunResult,
   scoreBatch,
   scoreModeBreakdown,
+  computeModeDiversity,
   formatRunScoreLine,
   formatBatchScoreTable,
   formatModeBreakdown,
@@ -364,6 +365,7 @@ describe('formatBatchScoreTable', () => {
         { mode: 'explore', runs: 1, successes: 0, success_rate: 0, cost_usd: 1, prs: 0, avg_cost: 1, efficiency: 0, lines_deleted: 0, issues_pruned: 0 },
       ],
       cost_anomaly_count: 0,
+      mode_diversity: 0,
     };
     const table = formatBatchScoreTable(score);
     expect(table).toContain('| **Runs** | 3 (2 successful) |');
@@ -396,6 +398,7 @@ describe('formatBatchScoreTable', () => {
       runs: [],
       mode_breakdown: [],
       cost_anomaly_count: 0,
+      mode_diversity: 0,
     };
     const table = formatBatchScoreTable(score);
     expect(table).toContain('| **Avg cost/success** | N/A |');
@@ -419,6 +422,7 @@ describe('formatBatchScoreTable', () => {
       runs: [],
       mode_breakdown: [],
       cost_anomaly_count: 0,
+      mode_diversity: 0,
       post_hoc: {
         prs: [
           { url: 'https://github.com/org/repo/pull/1', status: 'merged' },
@@ -455,6 +459,7 @@ describe('formatBatchScoreTable', () => {
       runs: [],
       mode_breakdown: [],
       cost_anomaly_count: 0,
+      mode_diversity: 0,
     };
     const table = formatBatchScoreTable(score);
     expect(table).not.toContain('merge rate');
@@ -604,6 +609,98 @@ describe('scoreBatch mode_breakdown integration', () => {
     const score = scoreBatch(history);
     const table = formatBatchScoreTable(score);
     expect(table).not.toContain('Per-mode effectiveness');
+  });
+});
+
+describe('computeModeDiversity', () => {
+  function makeRunScore(mode: string): RunScore {
+    return {
+      run: 1,
+      mode,
+      success: true,
+      cost_usd: 1.0,
+      duration_seconds: 60,
+      pr_count: 1,
+      issues_closed_count: 0,
+      cost_vs_avg: null,
+      lines_deleted: 0,
+      issues_pruned: 0,
+    };
+  }
+
+  it('returns 0 for empty runs', () => {
+    expect(computeModeDiversity([])).toBe(0);
+  });
+
+  it('returns 0 for single mode', () => {
+    const runs = [makeRunScore('exploit'), makeRunScore('exploit'), makeRunScore('exploit')];
+    expect(computeModeDiversity(runs)).toBe(0);
+  });
+
+  it('returns 1 for perfectly even distribution', () => {
+    const runs = [
+      makeRunScore('exploit'),
+      makeRunScore('explore'),
+      makeRunScore('reflect'),
+      makeRunScore('subtract'),
+    ];
+    expect(computeModeDiversity(runs)).toBeCloseTo(1.0, 5);
+  });
+
+  it('returns value between 0 and 1 for uneven distribution', () => {
+    const runs = [
+      makeRunScore('exploit'),
+      makeRunScore('exploit'),
+      makeRunScore('exploit'),
+      makeRunScore('explore'),
+    ];
+    const diversity = computeModeDiversity(runs);
+    expect(diversity).toBeGreaterThan(0);
+    expect(diversity).toBeLessThan(1);
+  });
+
+  it('higher diversity for more even distributions', () => {
+    // Uneven: 7 exploit, 1 explore
+    const uneven = [
+      ...Array(7).fill(null).map(() => makeRunScore('exploit')),
+      makeRunScore('explore'),
+    ];
+    // Even: 4 exploit, 4 explore
+    const even = [
+      ...Array(4).fill(null).map(() => makeRunScore('exploit')),
+      ...Array(4).fill(null).map(() => makeRunScore('explore')),
+    ];
+    expect(computeModeDiversity(even)).toBeGreaterThan(computeModeDiversity(uneven));
+  });
+});
+
+describe('scoreBatch mode_diversity integration', () => {
+  it('includes mode_diversity in batch score', () => {
+    const history: RunMetrics[] = [
+      makeRunMetrics({ run: 1, mode: 'exploit' }),
+      makeRunMetrics({ run: 2, mode: 'explore', prs: [], exit_code: 1 }),
+    ];
+    const score = scoreBatch(history);
+    expect(score.mode_diversity).toBeCloseTo(1.0, 5);
+  });
+
+  it('mode_diversity is 0 for single-mode batch', () => {
+    const history: RunMetrics[] = [
+      makeRunMetrics({ run: 1, mode: 'exploit' }),
+      makeRunMetrics({ run: 2, mode: 'exploit' }),
+    ];
+    const score = scoreBatch(history);
+    expect(score.mode_diversity).toBe(0);
+  });
+
+  it('shows mode diversity in batch score table', () => {
+    const history: RunMetrics[] = [
+      makeRunMetrics({ run: 1, mode: 'exploit' }),
+      makeRunMetrics({ run: 2, mode: 'explore', prs: [], exit_code: 1 }),
+    ];
+    const score = scoreBatch(history);
+    const table = formatBatchScoreTable(score);
+    expect(table).toContain('Mode diversity');
   });
 });
 
@@ -849,6 +946,7 @@ describe('cost_vs_avg in scoring', () => {
       runs: [],
       mode_breakdown: [],
       cost_anomaly_count: 2,
+      mode_diversity: 0,
     };
     const table = formatBatchScoreTable(score);
     expect(table).toContain('| **Cost anomalies** | 2 runs >= 2x avg |');
@@ -871,6 +969,7 @@ describe('cost_vs_avg in scoring', () => {
       runs: [],
       mode_breakdown: [],
       cost_anomaly_count: 0,
+      mode_diversity: 0,
     };
     const table = formatBatchScoreTable(score);
     expect(table).not.toContain('Cost anomalies');

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -71,6 +71,8 @@ export interface BatchScore {
   mode_breakdown: ModeStats[];
   /** Number of runs flagged as cost anomalies (>= 2x rolling avg) */
   cost_anomaly_count: number;
+  /** Mode diversity score: 0 = all runs in one mode, 1 = perfectly even distribution */
+  mode_diversity: number;
   /** Post-hoc merge results (populated by postHocScoreBatch) */
   post_hoc?: PostHocBatchResult;
 }
@@ -238,6 +240,7 @@ export function scoreBatch(runHistory: RunMetrics[]): BatchScore {
     runs,
     mode_breakdown: scoreModeBreakdown(runs),
     cost_anomaly_count: costAnomalyCount,
+    mode_diversity: computeModeDiversity(runs),
   };
 }
 
@@ -335,6 +338,7 @@ export function formatBatchScoreTable(score: BatchScore): string {
   ];
   if (modeStr) {
     lines.push(`| **Modes** | ${modeStr} |`);
+    lines.push(`| **Mode diversity** | ${(score.mode_diversity * 100).toFixed(0)}% |`);
   }
   if (score.cost_anomaly_count > 0) {
     lines.push(`| **Cost anomalies** | ${score.cost_anomaly_count} runs >= 2x avg |`);
@@ -421,6 +425,39 @@ export function scoreModeBreakdown(runs: RunScore[]): ModeStats[] {
   // Sort by number of runs descending (most-used mode first)
   stats.sort((a, b) => b.runs - a.runs);
   return stats;
+}
+
+/**
+ * Compute mode diversity using normalized Shannon entropy.
+ *
+ * Returns a value in [0, 1]:
+ *   0 = all runs used a single mode (no diversity)
+ *   1 = runs are perfectly evenly distributed across modes
+ *
+ * With only one distinct mode, returns 0.
+ */
+export function computeModeDiversity(runs: RunScore[]): number {
+  if (runs.length === 0) return 0;
+
+  const counts = new Map<string, number>();
+  for (const r of runs) {
+    counts.set(r.mode, (counts.get(r.mode) || 0) + 1);
+  }
+
+  const numModes = counts.size;
+  if (numModes <= 1) return 0;
+
+  // Shannon entropy: H = -sum(p * ln(p))
+  const total = runs.length;
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const p = count / total;
+    if (p > 0) entropy -= p * Math.log(p);
+  }
+
+  // Normalize by max entropy (ln(numModes)) to get [0, 1]
+  const maxEntropy = Math.log(numModes);
+  return maxEntropy > 0 ? entropy / maxEntropy : 0;
 }
 
 /** Format per-mode breakdown as a markdown table. */


### PR DESCRIPTION
## Summary

- Adds `computeModeDiversity()` using normalized Shannon entropy (0=single mode, 1=perfectly even)
- Adds `mode_diversity` field to `BatchScore` interface
- Displays as percentage in batch score table
- Gives observability into the strategic diversity principle from #616

## Test plan

- [x] Unit tests for `computeModeDiversity` (5 tests: empty, single mode, even, uneven, comparison)
- [x] Integration tests for `scoreBatch` and `formatBatchScoreTable` (3 tests)
- [x] All existing tests updated with new field (no regressions)
- [x] Full test suite passes (1011 tests)
- [x] TypeScript build passes

Closes #623

Run tag: batch-260323-0003-072b/run-46

Generated with [Claude Code](https://claude.com/claude-code)