### PR TITLE
feat: add lifecycle validation and scenario builders to auto-dent harness

### DIFF
--- a/scripts/auto-dent-harness.test.ts
+++ b/scripts/auto-dent-harness.test.ts
@@ -21,6 +21,11 @@ import {
   msg,
   expectPhase,
   phaseCount,
+  validateLifecycle,
+  expectValidLifecycle,
+  expectPhaseOrder,
+  expectResult,
+  scenarios,
   SMOKE_TEST_PROMPT,
 } from './auto-dent-harness.js';
 
@@ -165,6 +170,208 @@ describe('synthetic: DECOMPOSE phase marker', () => {
     expect(phaseCount(capture, 'PICK')).toBe(1);
     expect(phaseCount(capture, 'PR')).toBe(1);
     expect(capture.result.prs).toContain('https://github.com/Garsson-io/kaizen/pull/999');
+  });
+});
+
+// Lifecycle validation tests
+
+describe('lifecycle: validateLifecycle', () => {
+  it('valid lifecycle with standard ordering', () => {
+    const capture = runStream(scenarios.successfulRun());
+    const validation = validateLifecycle(capture);
+
+    expect(validation.valid).toBe(true);
+    expect(validation.violations).toHaveLength(0);
+    expect(validation.phasesPresent).toContain('PICK');
+    expect(validation.phasesPresent).toContain('PR');
+  });
+
+  it('detects reversed phase ordering', () => {
+    const capture = runStream([
+      msg.init(),
+      msg.phase('IMPLEMENT', { case: 'test', branch: 'test' }),
+      msg.phase('PICK', { issue: '#100', title: 'wrong order' }),
+      msg.done(0.5),
+    ]);
+
+    const validation = validateLifecycle(capture);
+    expect(validation.valid).toBe(false);
+    expect(validation.violations.length).toBeGreaterThan(0);
+    expect(validation.violations[0].phase).toBe('PICK');
+    expect(validation.violations[0].after).toBe('IMPLEMENT');
+  });
+
+  it('floating phases (DECOMPOSE, STOP) do not cause violations', () => {
+    const capture = runStream([
+      msg.init(),
+      msg.phase('PICK', { issue: '#100', title: 'test' }),
+      msg.phase('DECOMPOSE', { epic: '#100', issues_created: '#101' }),
+      msg.phase('EVALUATE', { verdict: 'proceed', reason: 'ok' }),
+      msg.phase('STOP', { reason: 'done' }),
+      msg.done(0.5),
+    ]);
+
+    const validation = validateLifecycle(capture);
+    expect(validation.valid).toBe(true);
+  });
+
+  it('reports missing standard phases', () => {
+    const capture = runStream([
+      msg.init(),
+      msg.phase('PICK', { issue: '#100', title: 'test' }),
+      msg.phase('PR', { url: 'https://github.com/Garsson-io/kaizen/pull/1' }),
+      msg.done(1.0),
+    ]);
+
+    const validation = validateLifecycle(capture);
+    expect(validation.phasesMissing).toContain('EVALUATE');
+    expect(validation.phasesMissing).toContain('IMPLEMENT');
+    expect(validation.phasesMissing).toContain('TEST');
+    expect(validation.phasesMissing).not.toContain('PICK');
+    expect(validation.phasesMissing).not.toContain('PR');
+  });
+
+  it('empty stream is valid (no ordering violations possible)', () => {
+    const capture = runStream([msg.init(), msg.done(0)]);
+    const validation = validateLifecycle(capture);
+    expect(validation.valid).toBe(true);
+    expect(validation.phasesPresent).toHaveLength(0);
+  });
+});
+
+describe('lifecycle: expectValidLifecycle', () => {
+  it('passes for valid lifecycle', () => {
+    const capture = runStream(scenarios.successfulRun());
+    expect(() => expectValidLifecycle(capture)).not.toThrow();
+  });
+
+  it('throws descriptive error for invalid lifecycle', () => {
+    const capture = runStream([
+      msg.init(),
+      msg.phase('TEST', { result: 'pass', count: '1' }),
+      msg.phase('EVALUATE', { verdict: 'proceed', reason: 'too late' }),
+      msg.done(0.5),
+    ]);
+
+    expect(() => expectValidLifecycle(capture)).toThrow(/EVALUATE.*after.*TEST/);
+  });
+});
+
+describe('lifecycle: expectPhaseOrder', () => {
+  it('passes when phases appear in expected relative order', () => {
+    const capture = runStream(scenarios.successfulRun());
+    expect(() => expectPhaseOrder(capture, ['PICK', 'EVALUATE', 'TEST', 'PR'])).not.toThrow();
+  });
+
+  it('allows gaps between expected phases', () => {
+    const capture = runStream(scenarios.successfulRun());
+    expect(() => expectPhaseOrder(capture, ['PICK', 'PR'])).not.toThrow();
+  });
+
+  it('throws when phase is missing', () => {
+    const capture = runStream(scenarios.skippedRun());
+    expect(() => expectPhaseOrder(capture, ['PICK', 'IMPLEMENT'])).toThrow(/IMPLEMENT.*not found/);
+  });
+
+  it('throws when phases are reversed', () => {
+    const capture = runStream([
+      msg.init(),
+      msg.phase('PR', { url: 'https://github.com/Garsson-io/kaizen/pull/1' }),
+      msg.phase('PICK', { issue: '#1', title: 'late pick' }),
+      msg.done(0.5),
+    ]);
+
+    expect(() => expectPhaseOrder(capture, ['PICK', 'PR'])).toThrow(/appeared before/);
+  });
+});
+
+// Result assertion tests
+
+describe('result: expectResult', () => {
+  it('passes when all expectations are met', () => {
+    const capture = runStream(scenarios.successfulRun({ cost: 1.5 }));
+    expect(() => expectResult(capture, {
+      minPrs: 1,
+      maxCost: 5.0,
+      stopRequested: false,
+    })).not.toThrow();
+  });
+
+  it('fails when PR count is below minimum', () => {
+    const capture = runStream(scenarios.skippedRun());
+    expect(() => expectResult(capture, { minPrs: 1 })).toThrow(/PRs.*expected >= 1.*got 0/);
+  });
+
+  it('fails when cost exceeds maximum', () => {
+    const capture = runStream(scenarios.successfulRun({ cost: 10.0 }));
+    expect(() => expectResult(capture, { maxCost: 5.0 })).toThrow(/Cost.*expected <= \$5/);
+  });
+
+  it('fails when stopRequested does not match', () => {
+    const capture = runStream(scenarios.stopRun());
+    expect(() => expectResult(capture, { stopRequested: false })).toThrow(/stopRequested.*expected false/);
+  });
+
+  it('reports multiple failures at once', () => {
+    const capture = runStream(scenarios.skippedRun({ cost: 10.0 }));
+    expect(() => expectResult(capture, {
+      minPrs: 1,
+      maxCost: 5.0,
+    })).toThrow(/PRs.*\n.*Cost/);
+  });
+
+  it('checks tool call bounds', () => {
+    const capture = runStream(scenarios.successfulRun());
+    expect(() => expectResult(capture, { minToolCalls: 1 })).not.toThrow();
+    expect(() => expectResult(capture, { maxToolCalls: 0 })).toThrow(/Tool calls/);
+  });
+});
+
+// Scenario builder tests
+
+describe('scenarios: pre-built sequences', () => {
+  it('successfulRun produces valid lifecycle with PR', () => {
+    const capture = runStream(scenarios.successfulRun());
+    expectValidLifecycle(capture);
+    expect(capture.result.prs.length).toBeGreaterThanOrEqual(1);
+    expect(capture.result.cost).toBeGreaterThan(0);
+    expect(capture.result.toolCalls).toBeGreaterThan(0);
+  });
+
+  it('successfulRun accepts custom options', () => {
+    const capture = runStream(scenarios.successfulRun({
+      issue: '#42',
+      prUrl: 'https://github.com/Garsson-io/kaizen/pull/42',
+      cost: 3.0,
+    }));
+    expectPhase(capture, 'PICK', '#42');
+    expect(capture.result.prs).toContain('https://github.com/Garsson-io/kaizen/pull/42');
+    expect(capture.result.cost).toBe(3.0);
+  });
+
+  it('skippedRun produces valid lifecycle with no PRs', () => {
+    const capture = runStream(scenarios.skippedRun());
+    expectValidLifecycle(capture);
+    expect(capture.result.prs).toHaveLength(0);
+  });
+
+  it('decomposeRun includes DECOMPOSE phase and PR', () => {
+    const capture = runStream(scenarios.decomposeRun());
+    expectValidLifecycle(capture);
+    expectPhase(capture, 'DECOMPOSE');
+    expect(capture.result.prs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stopRun signals stop', () => {
+    const capture = runStream(scenarios.stopRun());
+    expect(capture.result.stopRequested).toBe(true);
+    expectPhase(capture, 'STOP');
+  });
+
+  it('errorRun has TEST fail phase and no PRs', () => {
+    const capture = runStream(scenarios.errorRun());
+    expectPhase(capture, 'TEST', 'fail');
+    expect(capture.result.prs).toHaveLength(0);
   });
 });
 

--- a/scripts/auto-dent-harness.ts
+++ b/scripts/auto-dent-harness.ts
@@ -320,6 +320,267 @@ export function phaseCount(capture: StreamCapture, phase: string): number {
   return capture.phases.filter(p => p.phase === phase).length;
 }
 
+// Lifecycle validation
+
+/**
+ * Expected phase ordering for auto-dent runs.
+ * Phases must appear in this relative order (gaps are OK, reversals are not).
+ * DECOMPOSE and STOP can appear at any point after EVALUATE.
+ */
+const LIFECYCLE_ORDER = ['PICK', 'EVALUATE', 'IMPLEMENT', 'TEST', 'PR', 'MERGE', 'REFLECT'];
+
+/** Phases that can appear at any position (after at least PICK) */
+const FLOATING_PHASES = new Set(['DECOMPOSE', 'STOP']);
+
+export interface LifecycleViolation {
+  /** The phase that appeared out of order */
+  phase: string;
+  /** The phase it appeared after (that should have come later) */
+  after: string;
+  /** 0-based indices within the captured phases array */
+  phaseIndex: number;
+  afterIndex: number;
+}
+
+export interface LifecycleValidation {
+  /** Whether all phases appeared in valid order */
+  valid: boolean;
+  /** Phases present in the capture, in order */
+  phasesPresent: string[];
+  /** Standard lifecycle phases that were missing */
+  phasesMissing: string[];
+  /** Ordering violations (if any) */
+  violations: LifecycleViolation[];
+}
+
+/**
+ * Validate that phases in a StreamCapture follow the expected lifecycle order.
+ * Floating phases (DECOMPOSE, STOP) are excluded from ordering checks.
+ */
+export function validateLifecycle(capture: StreamCapture): LifecycleValidation {
+  const phasesPresent = capture.phases.map(p => p.phase);
+  const orderedPhases = phasesPresent.filter(p => !FLOATING_PHASES.has(p));
+  const violations: LifecycleViolation[] = [];
+
+  for (let i = 1; i < orderedPhases.length; i++) {
+    const prevIdx = LIFECYCLE_ORDER.indexOf(orderedPhases[i - 1]);
+    const currIdx = LIFECYCLE_ORDER.indexOf(orderedPhases[i]);
+    if (prevIdx === -1 || currIdx === -1) continue; // Unknown phase, skip
+    if (currIdx < prevIdx) {
+      violations.push({
+        phase: orderedPhases[i],
+        after: orderedPhases[i - 1],
+        phaseIndex: i,
+        afterIndex: i - 1,
+      });
+    }
+  }
+
+  const presentSet = new Set(phasesPresent);
+  const phasesMissing = LIFECYCLE_ORDER.filter(p => !presentSet.has(p));
+
+  return {
+    valid: violations.length === 0,
+    phasesPresent,
+    phasesMissing,
+    violations,
+  };
+}
+
+/**
+ * Assert that phases follow valid lifecycle ordering. Throws on violations.
+ */
+export function expectValidLifecycle(capture: StreamCapture): void {
+  const validation = validateLifecycle(capture);
+  if (!validation.valid) {
+    const details = validation.violations.map(v =>
+      `  ${v.phase} appeared after ${v.after} (expected ${v.after} to come later)`
+    ).join('\n');
+    throw new Error(
+      `Lifecycle ordering violations:\n${details}\nPhases: ${validation.phasesPresent.join(' -> ')}`,
+    );
+  }
+}
+
+/**
+ * Assert that specific phases appear in the expected relative order.
+ * Only checks the listed phases — other phases may appear between them.
+ */
+export function expectPhaseOrder(capture: StreamCapture, expectedOrder: string[]): void {
+  const phasesPresent = capture.phases.map(p => p.phase);
+
+  // Find first occurrence of each expected phase
+  const positions: Array<{ phase: string; pos: number }> = [];
+  for (const phase of expectedOrder) {
+    const pos = phasesPresent.indexOf(phase);
+    if (pos === -1) {
+      throw new Error(
+        `Expected phase [${phase}] not found in output.\nPhases present: ${phasesPresent.join(', ')}`,
+      );
+    }
+    positions.push({ phase, pos });
+  }
+
+  for (let i = 1; i < positions.length; i++) {
+    if (positions[i].pos < positions[i - 1].pos) {
+      throw new Error(
+        `Phase [${positions[i].phase}] (pos ${positions[i].pos}) appeared before [${positions[i - 1].phase}] (pos ${positions[i - 1].pos}).\nExpected order: ${expectedOrder.join(' -> ')}\nActual: ${phasesPresent.join(' -> ')}`,
+      );
+    }
+  }
+}
+
+// Result assertions
+
+export interface ResultExpectation {
+  /** Minimum number of PRs created */
+  minPrs?: number;
+  /** Maximum number of PRs created */
+  maxPrs?: number;
+  /** Minimum number of issues filed */
+  minIssuesFiled?: number;
+  /** Minimum number of issues closed */
+  minIssuesClosed?: number;
+  /** Maximum cost in USD */
+  maxCost?: number;
+  /** Minimum cost in USD */
+  minCost?: number;
+  /** Whether a stop was requested */
+  stopRequested?: boolean;
+  /** Minimum number of tool calls */
+  minToolCalls?: number;
+  /** Maximum number of tool calls */
+  maxToolCalls?: number;
+}
+
+/**
+ * Assert properties of the accumulated RunResult.
+ * Only checks fields that are specified in the expectation.
+ */
+export function expectResult(capture: StreamCapture, expected: ResultExpectation): void {
+  const r = capture.result;
+  const failures: string[] = [];
+
+  if (expected.minPrs !== undefined && r.prs.length < expected.minPrs) {
+    failures.push(`PRs: expected >= ${expected.minPrs}, got ${r.prs.length}`);
+  }
+  if (expected.maxPrs !== undefined && r.prs.length > expected.maxPrs) {
+    failures.push(`PRs: expected <= ${expected.maxPrs}, got ${r.prs.length}`);
+  }
+  if (expected.minIssuesFiled !== undefined && r.issuesFiled.length < expected.minIssuesFiled) {
+    failures.push(`Issues filed: expected >= ${expected.minIssuesFiled}, got ${r.issuesFiled.length}`);
+  }
+  if (expected.minIssuesClosed !== undefined && r.issuesClosed.length < expected.minIssuesClosed) {
+    failures.push(`Issues closed: expected >= ${expected.minIssuesClosed}, got ${r.issuesClosed.length}`);
+  }
+  if (expected.maxCost !== undefined && r.cost > expected.maxCost) {
+    failures.push(`Cost: expected <= $${expected.maxCost}, got $${r.cost}`);
+  }
+  if (expected.minCost !== undefined && r.cost < expected.minCost) {
+    failures.push(`Cost: expected >= $${expected.minCost}, got $${r.cost}`);
+  }
+  if (expected.stopRequested !== undefined && r.stopRequested !== expected.stopRequested) {
+    failures.push(`stopRequested: expected ${expected.stopRequested}, got ${r.stopRequested}`);
+  }
+  if (expected.minToolCalls !== undefined && r.toolCalls < expected.minToolCalls) {
+    failures.push(`Tool calls: expected >= ${expected.minToolCalls}, got ${r.toolCalls}`);
+  }
+  if (expected.maxToolCalls !== undefined && r.toolCalls > expected.maxToolCalls) {
+    failures.push(`Tool calls: expected <= ${expected.maxToolCalls}, got ${r.toolCalls}`);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Result assertion failures:\n  ${failures.join('\n  ')}`);
+  }
+}
+
+// Scenario builders — pre-built realistic message sequences
+
+export const scenarios = {
+  /** A successful run that picks an issue, implements, tests, creates a PR, and merges */
+  successfulRun: (opts: {
+    issue?: string;
+    title?: string;
+    prUrl?: string;
+    cost?: number;
+  } = {}) => [
+    msg.init(),
+    msg.phase('PICK', { issue: opts.issue ?? '#100', title: opts.title ?? 'test issue' }),
+    msg.phase('EVALUATE', { verdict: 'proceed', reason: 'clear scope' }),
+    msg.tool('Read', { file_path: '/src/example.ts' }),
+    msg.tool('Edit', { file_path: '/src/example.ts', old_string: 'old', new_string: 'new' }),
+    msg.phase('IMPLEMENT', { case: '260323-test', branch: 'feat/test' }),
+    msg.tool('Bash', { command: 'npm test' }),
+    msg.phase('TEST', { result: 'pass', count: '5' }),
+    msg.text(`Created PR: ${opts.prUrl ?? 'https://github.com/Garsson-io/kaizen/pull/999'}`),
+    msg.phase('PR', { url: opts.prUrl ?? 'https://github.com/Garsson-io/kaizen/pull/999' }),
+    msg.phase('MERGE', { url: opts.prUrl ?? 'https://github.com/Garsson-io/kaizen/pull/999', status: 'queued' }),
+    msg.phase('REFLECT', { issues_filed: '0', lessons: 'clean implementation' }),
+    msg.done(opts.cost ?? 1.5),
+  ],
+
+  /** A run that skips an issue after evaluation */
+  skippedRun: (opts: {
+    issue?: string;
+    reason?: string;
+    cost?: number;
+  } = {}) => [
+    msg.init(),
+    msg.phase('PICK', { issue: opts.issue ?? '#200', title: 'complex issue' }),
+    msg.phase('EVALUATE', { verdict: 'skip', reason: opts.reason ?? 'too risky for auto-dent' }),
+    msg.phase('REFLECT', { issues_filed: '0', lessons: 'skipped after evaluation' }),
+    msg.done(opts.cost ?? 0.2),
+  ],
+
+  /** A run that decomposes an epic into sub-issues */
+  decomposeRun: (opts: {
+    epic?: string;
+    issuesCreated?: string;
+    prUrl?: string;
+    cost?: number;
+  } = {}) => [
+    msg.init(),
+    msg.phase('PICK', { issue: opts.epic ?? '#500', title: 'epic decomposition' }),
+    msg.phase('EVALUATE', { verdict: 'proceed', reason: 'epic needs decomposition' }),
+    msg.phase('DECOMPOSE', { epic: opts.epic ?? '#500', issues_created: opts.issuesCreated ?? '#501,#502,#503' }),
+    msg.tool('Read', { file_path: '/docs/spec.md' }),
+    msg.tool('Edit', { file_path: '/src/impl.ts', old_string: 'old', new_string: 'new' }),
+    msg.phase('IMPLEMENT', { case: '260323-decompose', branch: 'feat/decompose' }),
+    msg.phase('TEST', { result: 'pass', count: '3' }),
+    msg.text(`Created PR: ${opts.prUrl ?? 'https://github.com/Garsson-io/kaizen/pull/998'}`),
+    msg.phase('PR', { url: opts.prUrl ?? 'https://github.com/Garsson-io/kaizen/pull/998' }),
+    msg.phase('REFLECT', { issues_filed: '3', lessons: 'decomposed epic into actionable work' }),
+    msg.done(opts.cost ?? 2.0),
+  ],
+
+  /** A run that exhausts the backlog and signals STOP */
+  stopRun: (opts: {
+    reason?: string;
+    cost?: number;
+  } = {}) => [
+    msg.init(),
+    msg.phase('PICK', { issue: 'none', title: 'backlog scan' }),
+    msg.phase('EVALUATE', { verdict: 'skip', reason: 'no matching issues' }),
+    msg.phase('STOP', { reason: opts.reason ?? 'backlog exhausted' }),
+    msg.done(opts.cost ?? 0.3),
+  ],
+
+  /** A run that errors out mid-implementation */
+  errorRun: (opts: {
+    issue?: string;
+    cost?: number;
+  } = {}) => [
+    msg.init(),
+    msg.phase('PICK', { issue: opts.issue ?? '#300', title: 'failing issue' }),
+    msg.phase('EVALUATE', { verdict: 'proceed', reason: 'seems straightforward' }),
+    msg.tool('Read', { file_path: '/src/broken.ts' }),
+    msg.phase('IMPLEMENT', { case: '260323-error', branch: 'feat/error' }),
+    msg.tool('Bash', { command: 'npm test' }),
+    msg.phase('TEST', { result: 'fail', count: '3' }),
+    msg.error(opts.cost ?? 0.8),
+  ],
+};
+
 // Smoke test prompt — designed to be fast, cheap, and exercise the protocol
 
 export const SMOKE_TEST_PROMPT = `You are running a pipeline smoke test. This must complete quickly.


### PR DESCRIPTION
## Summary

- Adds **lifecycle validation** to the auto-dent harness: `validateLifecycle()`, `expectValidLifecycle()`, `expectPhaseOrder()` — verify that phase markers follow the expected ordering (PICK->EVALUATE->IMPLEMENT->TEST->PR->MERGE->REFLECT), with floating phases (DECOMPOSE, STOP) exempt
- Adds **result assertion helpers**: `expectResult()` for asserting RunResult properties (PRs, cost, tool calls, stop status) with multi-failure reporting
- Adds **scenario builders**: pre-built message sequences for 5 common run types (successful, skipped, decompose, stop, error) — reduces test boilerplate
- 21 new tests covering lifecycle validation, result assertions, and all scenario types

## Motivation

The harness had message builders and phase counting but lacked:
1. Lifecycle ordering validation (can't detect reversed phases)
2. Structured result assertions (had to manually check each field)
3. Reusable test scenarios (each test built messages from scratch)

These additions make the harness a complete test framework for auto-dent pipeline development.

## Test plan

- [x] All 127 harness tests pass (21 new + 106 existing)
- [x] Full test suite passes (1050 tests, 0 failures)
- [x] npm run build succeeds

Run tag: batch-260323-0003-072b/run-48

Generated with [Claude Code](https://claude.com/claude-code)