### PR TITLE
feat: contemplation feedback loop — strategic insights feed back into batch

### DIFF
--- a/prompts/contemplate-strategy.md
+++ b/prompts/contemplate-strategy.md
@@ -112,6 +112,25 @@ For each finding, take one concrete action:
 - **System problem?** File a kaizen issue
 - **Philosophical gap?** File a `zen-evolution` issue proposing an amendment
 
+## Structured Recommendations
+
+After your assessment, emit recommendations that feed back into subsequent runs.
+Each recommendation MUST be on its own line with this exact prefix:
+
+```
+CONTEMPLATION_REC: <recommendation text>
+```
+
+Examples:
+```
+CONTEMPLATION_REC: Guidance is exhausted for hooks reliability — shift focus to testing gaps and observability
+CONTEMPLATION_REC: Epic #548 (cognitive modes) is stalled — decompose into concrete issues next run
+CONTEMPLATION_REC: Horizon autonomous-kaizen has zero recent activity — prioritize it
+```
+
+These recommendations will be visible to subsequent runs in the batch, steering
+future work based on your strategic assessment. Emit at least one recommendation.
+
 ## Progress Markers
 
 AUTO_DENT_PHASE: PICK | issue=strategic-assessment | title=batch contemplation

--- a/prompts/deep-dive-default.md
+++ b/prompts/deep-dive-default.md
@@ -27,6 +27,16 @@ Prior mid-batch reflection produced these insights. Use them to guide your work:
 Factor these insights into your issue selection and approach.
 {{/reflection_insights}}
 
+{{#contemplation_recommendations}}
+## Strategic Recommendations (from contemplation)
+
+A prior contemplation run assessed this batch strategically and recommends:
+
+{{contemplation_recommendations}}
+
+Weight these recommendations when choosing what to work on.
+{{/contemplation_recommendations}}
+
 {{#plan_assignment}}
 ## Assigned Work
 

--- a/prompts/explore-gaps.md
+++ b/prompts/explore-gaps.md
@@ -22,6 +22,12 @@ PRs already created in this batch (avoid overlapping work): {{prs}}
 {{reflection_insights}}
 {{/reflection_insights}}
 
+{{#contemplation_recommendations}}
+## Strategic Recommendations (from contemplation)
+
+{{contemplation_recommendations}}
+{{/contemplation_recommendations}}
+
 ## Exploration Tasks
 
 Pick the highest-value exploration from this list:

--- a/prompts/subtract-prune.md
+++ b/prompts/subtract-prune.md
@@ -22,6 +22,12 @@ PRs already created in this batch (avoid overlapping work): {{prs}}
 {{reflection_insights}}
 {{/reflection_insights}}
 
+{{#contemplation_recommendations}}
+## Strategic Recommendations (from contemplation)
+
+{{contemplation_recommendations}}
+{{/contemplation_recommendations}}
+
 ## Merge & Labeling Policy
 
 After creating a PR, you MUST queue it for auto-merge:

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -11,6 +11,7 @@ import {
   renderTemplate,
   loadPromptTemplate,
   extractArtifacts,
+  extractContemplationRecommendations,
   parsePhaseMarkers,
   formatPhaseMarker,
   checkStopSignal,
@@ -435,6 +436,33 @@ describe('buildTemplateVars with run_history', () => {
   });
 });
 
+describe('buildTemplateVars with contemplation_recommendations', () => {
+  it('formats contemplation recommendations as numbered list', () => {
+    const state = makeBatchState({
+      contemplation_recommendations: [
+        'Shift focus to testing gaps',
+        'Epic #548 needs decomposition',
+      ],
+    });
+    const vars = buildTemplateVars(state, 5);
+    expect(vars.contemplation_recommendations).toBe(
+      '1. Shift focus to testing gaps\n2. Epic #548 needs decomposition',
+    );
+  });
+
+  it('returns empty string when no contemplation recommendations', () => {
+    const state = makeBatchState();
+    const vars = buildTemplateVars(state, 1);
+    expect(vars.contemplation_recommendations).toBe('');
+  });
+
+  it('returns empty string for empty array', () => {
+    const state = makeBatchState({ contemplation_recommendations: [] });
+    const vars = buildTemplateVars(state, 1);
+    expect(vars.contemplation_recommendations).toBe('');
+  });
+});
+
 describe('renderTemplate', () => {
   it('substitutes simple variables', () => {
     const result = renderTemplate('Hello {{name}}!', { name: 'world' });
@@ -668,6 +696,42 @@ describe('extractArtifacts', () => {
       result,
     );
     expect(result.linesDeleted).toBe(50);
+  });
+});
+
+describe('extractContemplationRecommendations', () => {
+  it('extracts structured recommendations from contemplate output', () => {
+    const text = [
+      'Some analysis text...',
+      'CONTEMPLATION_REC: Shift focus from hooks to testing gaps',
+      'More analysis...',
+      'CONTEMPLATION_REC: Epic #548 is stalled — decompose next run',
+    ].join('\n');
+    const recs = extractContemplationRecommendations(text);
+    expect(recs).toEqual([
+      'Shift focus from hooks to testing gaps',
+      'Epic #548 is stalled — decompose next run',
+    ]);
+  });
+
+  it('returns empty array when no recommendations present', () => {
+    expect(extractContemplationRecommendations('just regular text')).toEqual([]);
+  });
+
+  it('trims whitespace from recommendations', () => {
+    const recs = extractContemplationRecommendations('CONTEMPLATION_REC:   padded text   ');
+    expect(recs).toEqual(['padded text']);
+  });
+
+  it('ignores empty recommendations', () => {
+    const text = ['CONTEMPLATION_REC:   ', 'CONTEMPLATION_REC: valid'].join('\n');
+    const recs = extractContemplationRecommendations(text);
+    expect(recs).toEqual(['valid']);
+  });
+
+  it('only matches at start of line', () => {
+    const recs = extractContemplationRecommendations('some text CONTEMPLATION_REC: not a rec');
+    expect(recs).toEqual([]);
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -88,6 +88,8 @@ export interface BatchState {
   last_heartbeat?: number;
   max_run_seconds?: number;
   run_history?: RunMetrics[];
+  /** Recommendations from contemplation runs that feed back into subsequent runs */
+  contemplation_recommendations?: string[];
 }
 
 export interface RunMetrics {
@@ -131,6 +133,8 @@ export interface RunResult {
   issuesPruned: number;
   /** Structured failure classification */
   failureClass?: string;
+  /** Contemplation recommendations extracted from contemplate run output */
+  contemplationRecs?: string[];
 }
 
 // State I/O
@@ -317,6 +321,12 @@ export function buildTemplateVars(
     }
   }
 
+  // Format contemplation recommendations for prompt injection
+  const contemplationRecs = (state.contemplation_recommendations || []);
+  const contemplationRecsText = contemplationRecs.length > 0
+    ? contemplationRecs.map((r, i) => `${i + 1}. ${r}`).join('\n')
+    : '';
+
   return {
     guidance: state.guidance,
     run_tag: runTag,
@@ -340,6 +350,7 @@ export function buildTemplateVars(
     pr_merge_status: prMergeStatus,
     prior_reflections: priorReflections,
     failure_class_summary: failureClassSummary,
+    contemplation_recommendations: contemplationRecsText,
   };
 }
 
@@ -906,6 +917,22 @@ export function extractArtifacts(text: string, result: RunResult): void {
   }
 }
 
+/**
+ * Extract structured contemplation recommendations from run output.
+ *
+ * Parses lines matching: CONTEMPLATION_REC: <recommendation text>
+ * These are emitted by contemplate-strategy.md runs to feed back
+ * strategic insights into subsequent batch runs (#631).
+ */
+export function extractContemplationRecommendations(text: string): string[] {
+  const recs: string[] = [];
+  for (const match of text.matchAll(/^CONTEMPLATION_REC:[^\S\n]*(.+)$/gm)) {
+    const rec = match[1].trim();
+    if (rec) recs.push(rec);
+  }
+  return recs;
+}
+
 export function checkStopSignal(text: string, result: RunResult): void {
   // Primary: structured phase marker format (preferred, avoids in-band ambiguity).
   // AUTO_DENT_PHASE: STOP | reason=<text>
@@ -1033,6 +1060,12 @@ export function processStreamMessage(
           if (block.type === 'text' && block.text) {
             extractArtifacts(block.text, result);
             checkStopSignal(block.text, result);
+            // Extract contemplation recommendations (#631)
+            const recs = extractContemplationRecommendations(block.text);
+            if (recs.length > 0) {
+              if (!result.contemplationRecs) result.contemplationRecs = [];
+              result.contemplationRecs.push(...recs);
+            }
             for (const marker of parsePhaseMarkers(block.text)) {
               console.log(`  [${elapsed}]  ${formatPhaseMarker(marker)}`);
               if (ctx) ctx.lastPhase = formatPhaseMarker(marker);
@@ -1052,6 +1085,11 @@ export function processStreamMessage(
       if (msg.result) {
         extractArtifacts(msg.result, result);
         checkStopSignal(msg.result, result);
+        const recs = extractContemplationRecommendations(msg.result);
+        if (recs.length > 0) {
+          if (!result.contemplationRecs) result.contemplationRecs = [];
+          result.contemplationRecs.push(...recs);
+        }
       }
       {
         const statusText = msg.subtype === 'success'
@@ -1940,6 +1978,13 @@ async function main(): Promise<void> {
   }
   for (const caseName of result.cases) {
     if (!freshState.cases.includes(caseName)) freshState.cases.push(caseName);
+  }
+
+  // Store contemplation recommendations in batch state (#631)
+  if (result.contemplationRecs && result.contemplationRecs.length > 0) {
+    if (!freshState.contemplation_recommendations) freshState.contemplation_recommendations = [];
+    freshState.contemplation_recommendations.push(...result.contemplationRecs);
+    console.log(`  [contemplate] ${result.contemplationRecs.length} recommendation(s) stored in batch state`);
   }
 
   if (result.prs.length > 0) {

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -1231,6 +1231,24 @@ describe('classifyFailure', () => {
       'issue blocked by dependency',
     )).toBe('issue_blocked');
   });
+
+  it('classifies contemplate run with no artifacts as success (#631)', () => {
+    expect(classifyFailure(
+      makeRunMetrics({ exit_code: 0, prs: [], issues_filed: [], issues_closed: [], mode: 'contemplate' }),
+    )).toBe('success');
+  });
+
+  it('classifies reflect run with no artifacts as success (#631)', () => {
+    expect(classifyFailure(
+      makeRunMetrics({ exit_code: 0, prs: [], issues_filed: [], issues_closed: [], mode: 'reflect' }),
+    )).toBe('success');
+  });
+
+  it('still classifies non-zero contemplate run as crash', () => {
+    expect(classifyFailure(
+      makeRunMetrics({ exit_code: 1, prs: [], mode: 'contemplate' }),
+    )).toBe('crash');
+  });
 });
 
 describe('failureClassLabel', () => {

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -40,6 +40,8 @@ export function classifyFailure(
   const hasArtifacts = metrics.prs.length > 0 || metrics.issues_filed.length > 0 || metrics.issues_closed.length > 0;
 
   if (metrics.exit_code === 0 && hasArtifacts) return 'success';
+  // Contemplate/reflect runs are strategic — they don't produce PRs by design (#631)
+  if (metrics.exit_code === 0 && !hasArtifacts && (metrics.mode === 'contemplate' || metrics.mode === 'reflect')) return 'success';
   if (metrics.exit_code === 0 && !hasArtifacts) return 'empty_success';
 
   if (logOutput) {


### PR DESCRIPTION
## Summary

- Contemplation runs now emit structured `CONTEMPLATION_REC:` markers that the harness parses and stores in `BatchState.contemplation_recommendations`
- Subsequent runs (exploit, explore, subtract) see these recommendations in their prompts under "Strategic Recommendations (from contemplation)"
- `classifyFailure` no longer penalizes contemplate/reflect runs as `empty_success` — they complete successfully without PRs by design
- Updated `contemplate-strategy.md` to instruct the contemplate agent to emit structured recommendations

## Why

Contemplation output was fire-and-forget — strategic insights were posted as comments on the progress issue but never influenced subsequent runs (#631). The guidance field was immutable, and contemplate runs were scored as failures because they don't produce PRs.

## Test plan

- [x] `extractContemplationRecommendations` — 5 tests covering extraction, empty input, trimming, empty recs, line-start matching
- [x] `buildTemplateVars` — 3 tests for contemplation recommendations formatting
- [x] `classifyFailure` — 3 tests for contemplate/reflect mode success classification
- [x] Full suite: 1084 tests pass

Run tag: batch-260323-0003-072b/run-53
Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)