### PR TITLE
fix: atomic state file writes with crash-recovery fallback

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
-import { writeFileSync, unlinkSync, mkdtempSync } from 'fs';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { writeFileSync, unlinkSync, mkdtempSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -29,6 +29,8 @@ import {
   weightedModeSelect,
   computeModeDistribution,
   formatBatchFooter,
+  readState,
+  writeState,
   color,
   type BatchState,
   type CleanupResult,
@@ -2290,5 +2292,86 @@ describe('buildPromptWithMetadata', () => {
     const meta = buildPromptWithMetadata(state, 3);
     const prompt = buildPrompt(state, 3);
     expect(meta.prompt).toBe(prompt);
+  });
+});
+
+describe('atomic state I/O', () => {
+  let dir: string;
+  let stateFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'state-io-'));
+    stateFile = join(dir, 'state.json');
+  });
+
+  it('writeState creates atomic temp-then-rename', () => {
+    const state = makeBatchState({ run: 3 });
+    writeState(stateFile, state);
+
+    const read = JSON.parse(readFileSync(stateFile, 'utf8'));
+    expect(read.run).toBe(3);
+    // No lingering .tmp file
+    expect(existsSync(stateFile + '.tmp')).toBe(false);
+  });
+
+  it('writeState creates backup of previous state', () => {
+    const state1 = makeBatchState({ run: 1 });
+    writeState(stateFile, state1);
+
+    const state2 = makeBatchState({ run: 2 });
+    writeState(stateFile, state2);
+
+    // Backup should contain state1
+    const bak = JSON.parse(readFileSync(stateFile + '.bak', 'utf8'));
+    expect(bak.run).toBe(1);
+    // Primary should contain state2
+    const primary = JSON.parse(readFileSync(stateFile, 'utf8'));
+    expect(primary.run).toBe(2);
+  });
+
+  it('readState reads normal state file', () => {
+    const state = makeBatchState({ run: 5 });
+    writeState(stateFile, state);
+
+    const read = readState(stateFile);
+    expect(read.run).toBe(5);
+  });
+
+  it('readState falls back to .bak correctly after two writes', () => {
+    const state1 = makeBatchState({ run: 1 });
+    writeState(stateFile, state1);
+
+    const state2 = makeBatchState({ run: 2 });
+    writeState(stateFile, state2);
+
+    // Corrupt primary
+    writeFileSync(stateFile, 'not-json!!!');
+
+    const read = readState(stateFile);
+    expect(read.run).toBe(1); // Falls back to backup (state before run=2)
+  });
+
+  it('readState throws when both primary and backup are missing', () => {
+    expect(() => readState(stateFile)).toThrow('corrupt and no backup');
+  });
+
+  it('readState throws when primary is corrupt and no backup exists', () => {
+    writeFileSync(stateFile, '{bad json');
+    expect(() => readState(stateFile)).toThrow('corrupt and no backup');
+  });
+
+  it('writeState round-trip preserves all BatchState fields', () => {
+    const state = makeBatchState({
+      run: 10,
+      prs: ['https://example.com/pr/1'],
+      issues_filed: ['#100'],
+      stop_reason: 'budget exhausted',
+    });
+    writeState(stateFile, state);
+    const read = readState(stateFile);
+    expect(read.run).toBe(10);
+    expect(read.prs).toEqual(['https://example.com/pr/1']);
+    expect(read.issues_filed).toEqual(['#100']);
+    expect(read.stop_reason).toBe('budget exhausted');
   });
 });

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -22,7 +22,7 @@
 
 import { spawn, execSync } from 'child_process';
 import { createHash } from 'crypto';
-import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, renameSync, copyFileSync } from 'fs';
 import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
@@ -162,12 +162,32 @@ export interface RunResult {
 
 // State I/O
 
-function readState(stateFile: string): BatchState {
-  return JSON.parse(readFileSync(stateFile, 'utf8'));
+export function readState(stateFile: string): BatchState {
+  try {
+    return JSON.parse(readFileSync(stateFile, 'utf8'));
+  } catch {
+    // Primary file corrupt/missing — try backup
+    const bak = stateFile + '.bak';
+    if (existsSync(bak)) {
+      console.error(`[state-io] Primary state corrupt, falling back to ${bak}`);
+      return JSON.parse(readFileSync(bak, 'utf8'));
+    }
+    throw new Error(`State file corrupt and no backup available: ${stateFile}`);
+  }
 }
 
-function writeState(stateFile: string, state: BatchState): void {
-  writeFileSync(stateFile, JSON.stringify(state, null, 2) + '\n');
+export function writeState(stateFile: string, state: BatchState): void {
+  const tmp = stateFile + '.tmp';
+  const content = JSON.stringify(state, null, 2) + '\n';
+  // Validate we can round-trip before writing
+  JSON.parse(content);
+  // Backup current state before overwriting
+  if (existsSync(stateFile)) {
+    copyFileSync(stateFile, stateFile + '.bak');
+  }
+  // Atomic write: write to temp, then rename
+  writeFileSync(tmp, content);
+  renameSync(tmp, stateFile);
 }
 
 // Resolve repo root

--- a/scripts/auto-dent.sh
+++ b/scripts/auto-dent.sh
@@ -234,9 +234,23 @@ read_state() {
 update_state() {
   node -e "
     const fs = require('fs');
-    const s = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
-    s[process.argv[2]] = process.argv[3];
-    fs.writeFileSync(process.argv[1], JSON.stringify(s, null, 2) + '\n');
+    const path = process.argv[1];
+    const key = process.argv[2];
+    const val = process.argv[3];
+    // Validate key is a simple identifier (no injection)
+    if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) {
+      console.error('[state-io] Invalid state key: ' + key);
+      process.exit(1);
+    }
+    const s = JSON.parse(fs.readFileSync(path, 'utf8'));
+    s[key] = val;
+    const content = JSON.stringify(s, null, 2) + '\n';
+    // Validate round-trip
+    JSON.parse(content);
+    // Backup + atomic write
+    if (fs.existsSync(path)) fs.copyFileSync(path, path + '.bak');
+    fs.writeFileSync(path + '.tmp', content);
+    fs.renameSync(path + '.tmp', path);
   " "$STATE_FILE" "$1" "$2"
 }
 
@@ -542,7 +556,10 @@ node -e "
   // Finalize state
   if (!s.stop_reason) s.stop_reason = 'completed';
   s.batch_end = Math.floor(Date.now() / 1000);
-  fs.writeFileSync(process.argv[1], JSON.stringify(s, null, 2) + '\n');
+  var content = JSON.stringify(s, null, 2) + '\n';
+  if (fs.existsSync(process.argv[1])) fs.copyFileSync(process.argv[1], process.argv[1] + '.bak');
+  fs.writeFileSync(process.argv[1] + '.tmp', content);
+  fs.renameSync(process.argv[1] + '.tmp', process.argv[1]);
   console.log('State: ' + process.argv[1]);
 
   const summaryPath = process.argv[1].replace('state.json', 'batch-summary.txt');


### PR DESCRIPTION
## Summary

- Implements atomic write-to-temp-then-rename pattern for all state file writes in both `auto-dent-run.ts` and `auto-dent.sh`
- Adds `.bak` backup creation before each write so `readState` can fall back when primary is corrupt
- Adds key validation in shell `update_state()` to prevent JSON injection
- 7 new tests covering crash-recovery scenarios (corrupt file, missing file, backup fallback, round-trip)

Closes #637

batch-260323-0003-072b/run-56

## Test plan

- [x] All 1097 tests pass
- [x] TypeScript builds cleanly
- [x] New tests cover: atomic write, backup creation, corrupt-file fallback, missing-file error, round-trip preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)