### PR TITLE
fix: wire markItem into run loop so plan items track outcomes (#638)

### DIFF
--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -8,6 +8,7 @@ import {
   readPlan,
   claimNextItem,
   markItem,
+  resetAssignedItems,
   formatPlanSummary,
   buildPlanPrompt,
   type BatchPlan,
@@ -312,6 +313,121 @@ describe('claimNextItem with decompose items', () => {
     const second = claimNextItem(tmpDir);
     expect(second!.item_type).toBe('decompose');
     expect(second!.parent_epic).toBe('#506');
+  });
+});
+
+describe('resetAssignedItems', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'plan-reset-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resets assigned items to pending', () => {
+    const plan = makePlan();
+    plan.items[0].status = 'assigned';
+    plan.items[1].status = 'assigned';
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const count = resetAssignedItems(tmpDir);
+    expect(count).toBe(2);
+
+    const updated = readPlan(tmpDir);
+    expect(updated!.items[0].status).toBe('pending');
+    expect(updated!.items[1].status).toBe('pending');
+    expect(updated!.items[2].status).toBe('pending');
+  });
+
+  it('does not touch done or skipped items', () => {
+    const plan = makePlan();
+    plan.items[0].status = 'done';
+    plan.items[1].status = 'skipped';
+    plan.items[2].status = 'assigned';
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const count = resetAssignedItems(tmpDir);
+    expect(count).toBe(1);
+
+    const updated = readPlan(tmpDir);
+    expect(updated!.items[0].status).toBe('done');
+    expect(updated!.items[1].status).toBe('skipped');
+    expect(updated!.items[2].status).toBe('pending');
+  });
+
+  it('returns 0 when no assigned items exist', () => {
+    const plan = makePlan();
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const count = resetAssignedItems(tmpDir);
+    expect(count).toBe(0);
+  });
+
+  it('returns 0 when no plan exists', () => {
+    const count = resetAssignedItems(tmpDir);
+    expect(count).toBe(0);
+  });
+});
+
+describe('claim → mark lifecycle', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'plan-lifecycle-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('full lifecycle: claim, mark done, claim next', () => {
+    const plan = makePlan();
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    // Claim first item
+    const first = claimNextItem(tmpDir);
+    expect(first!.issue).toBe('#302');
+    expect(first!.status).toBe('assigned');
+
+    // Mark it done
+    markItem(tmpDir, '#302', 'done');
+    const afterDone = readPlan(tmpDir);
+    expect(afterDone!.items[0].status).toBe('done');
+
+    // Claim next — should get #451
+    const second = claimNextItem(tmpDir);
+    expect(second!.issue).toBe('#451');
+
+    // Mark it skipped
+    markItem(tmpDir, '#451', 'skipped');
+    const afterSkip = readPlan(tmpDir);
+    expect(afterSkip!.items[1].status).toBe('skipped');
+
+    // Claim next — should get #407
+    const third = claimNextItem(tmpDir);
+    expect(third!.issue).toBe('#407');
+  });
+
+  it('interrupted run: claim, crash, reset, re-claim same item', () => {
+    const plan = makePlan();
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    // Claim first item (simulating a run start)
+    claimNextItem(tmpDir);
+    const afterClaim = readPlan(tmpDir);
+    expect(afterClaim!.items[0].status).toBe('assigned');
+
+    // Simulate crash — item stays assigned
+    // On resume, reset assigned items
+    const resetCount = resetAssignedItems(tmpDir);
+    expect(resetCount).toBe(1);
+
+    // Re-claim — should get the same item again
+    const retried = claimNextItem(tmpDir);
+    expect(retried!.issue).toBe('#302');
   });
 });
 

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -273,6 +273,31 @@ export function markItem(
 }
 
 /**
+ * Reset any 'assigned' items back to 'pending'.
+ * Called on batch start/resume to recover from interrupted runs
+ * where items were claimed but never marked done/skipped.
+ */
+export function resetAssignedItems(logDir: string): number {
+  const plan = readPlan(logDir);
+  if (!plan) return 0;
+
+  let resetCount = 0;
+  for (const item of plan.items) {
+    if (item.status === 'assigned') {
+      item.status = 'pending';
+      resetCount++;
+    }
+  }
+
+  if (resetCount > 0) {
+    const planFile = resolve(logDir, 'plan.json');
+    writeFileSync(planFile, JSON.stringify(plan, null, 2) + '\n');
+  }
+
+  return resetCount;
+}
+
+/**
  * Format a plan summary for display.
  */
 export function formatPlanSummary(plan: BatchPlan): string {

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -204,6 +204,31 @@ describe('buildTemplateVars', () => {
     expect(vars.issues_closed).toBe('');
     expect(vars.prs).toBe('');
   });
+
+  it('sets claimed_plan_issue when plan exists with pending items', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'plan-claim-vars-'));
+    const plan = {
+      created_at: '2026-03-23T00:00:00Z',
+      guidance: 'test',
+      items: [
+        { issue: '#302', title: 'Test item', score: 8, approach: 'do it', status: 'pending' },
+      ],
+      wip_excluded: [],
+      epics_scanned: [],
+    };
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const state = makeBatchState();
+    const vars = buildTemplateVars(state, 1, tmpDir);
+    expect(vars.claimed_plan_issue).toBe('#302');
+  });
+
+  it('sets empty claimed_plan_issue when no plan exists', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'no-plan-vars-'));
+    const state = makeBatchState();
+    const vars = buildTemplateVars(state, 1, tmpDir);
+    expect(vars.claimed_plan_issue).toBe('');
+  });
 });
 
 // Reflection feedback loop (#603)
@@ -2292,6 +2317,30 @@ describe('buildPromptWithMetadata', () => {
     const meta = buildPromptWithMetadata(state, 3);
     const prompt = buildPrompt(state, 3);
     expect(meta.prompt).toBe(prompt);
+  });
+
+  it('propagates claimedPlanIssue from plan', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'meta-plan-'));
+    const plan = {
+      created_at: '2026-03-23T00:00:00Z',
+      guidance: 'test',
+      items: [
+        { issue: '#451', title: 'Hook perf', score: 7, approach: 'instrument', status: 'pending' },
+      ],
+      wip_excluded: [],
+      epics_scanned: [],
+    };
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const state = makeBatchState();
+    const meta = buildPromptWithMetadata(state, 1, tmpDir);
+    expect(meta.claimedPlanIssue).toBe('#451');
+  });
+
+  it('claimedPlanIssue is undefined when no plan exists', () => {
+    const state = makeBatchState();
+    const meta = buildPromptWithMetadata(state, 1);
+    expect(meta.claimedPlanIssue).toBeUndefined();
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -26,7 +26,7 @@ import { readFileSync, writeFileSync, appendFileSync, existsSync, renameSync, co
 import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
-import { claimNextItem } from './auto-dent-plan.js';
+import { claimNextItem, markItem, resetAssignedItems } from './auto-dent-plan.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -293,11 +293,13 @@ export function buildTemplateVars(
 
   // Try to claim next item from plan (if a plan exists)
   let planAssignment = '';
+  let claimedPlanIssue = '';
   let reflectionInsights = '';
   let priorReflections = '';
   if (logDir) {
     const planItem = claimNextItem(logDir);
     if (planItem) {
+      claimedPlanIssue = planItem.issue;
       const lines = [
         `- **Issue:** ${planItem.issue} — ${planItem.title}`,
         `- **Approach:** ${planItem.approach}`,
@@ -384,6 +386,7 @@ export function buildTemplateVars(
     issues_closed: state.issues_closed.join(' '),
     prs: state.prs.join(' '),
     plan_assignment: planAssignment,
+    claimed_plan_issue: claimedPlanIssue,
     reflection_insights: reflectionInsights,
     run_history_table: runHistoryTable,
     total_cost: totalCost,
@@ -676,6 +679,8 @@ export interface PromptMetadata {
   template: string;
   /** SHA-256 hash of the raw template content (first 12 chars), or "none" for inline */
   hash: string;
+  /** Issue ref of the plan item claimed for this run (e.g., "#302"), if any */
+  claimedPlanIssue?: string;
 }
 
 export function buildPrompt(state: BatchState, runNum: number, logDir?: string): string {
@@ -684,6 +689,7 @@ export function buildPrompt(state: BatchState, runNum: number, logDir?: string):
 
 export function buildPromptWithMetadata(state: BatchState, runNum: number, logDir?: string): PromptMetadata {
   const vars = buildTemplateVars(state, runNum, logDir);
+  const claimedPlanIssue = vars.claimed_plan_issue || undefined;
 
   const { template: templateFile } = selectMode(state, runNum);
   const templateContent = loadPromptTemplate(templateFile);
@@ -694,6 +700,7 @@ export function buildPromptWithMetadata(state: BatchState, runNum: number, logDi
       prompt: renderTemplate(templateContent, vars),
       template: templateFile,
       hash,
+      claimedPlanIssue,
     };
   }
 
@@ -702,6 +709,7 @@ export function buildPromptWithMetadata(state: BatchState, runNum: number, logDi
     prompt: buildPromptInline(state, runNum),
     template: 'inline',
     hash: 'none',
+    claimedPlanIssue,
   };
 }
 
@@ -1295,6 +1303,12 @@ async function main(): Promise<void> {
   const runNum = state.run + 1;
   const runTag = `${state.batch_id}/run-${runNum}`;
 
+  // On first run or resume, reset any 'assigned' items from interrupted runs
+  const resetCount = resetAssignedItems(logDir);
+  if (resetCount > 0) {
+    console.log(`  [plan] reset ${resetCount} interrupted item(s) from 'assigned' to 'pending'`);
+  }
+
   const timestamp = new Date().toISOString().replace(/[-:T]/g, '').slice(2, 14);
   const logFile = `${logDir}/run-${runNum}-${timestamp}.log`;
 
@@ -1357,6 +1371,14 @@ async function main(): Promise<void> {
     if (!previewState.run_history) previewState.run_history = [];
     console.log(formatBatchFooter(previewState));
     console.log('');
+  }
+
+  // Mark plan item done/skipped based on run outcome
+  if (promptMeta.claimedPlanIssue) {
+    const produced = result.prs.length > 0 || result.issuesFiled.length > 0 || result.issuesClosed.length > 0;
+    const planStatus = produced ? 'done' : 'skipped';
+    markItem(logDir, promptMeta.claimedPlanIssue, planStatus as 'done' | 'skipped');
+    console.log(`  [plan] marked ${promptMeta.claimedPlanIssue} as ${planStatus}`);
   }
 
   // Post-run hygiene


### PR DESCRIPTION
## Summary

- Plan items were claimed (`assigned`) but never marked `done`/`skipped` after runs — making `plan.json` useless for post-hoc analysis
- Adds `claimedPlanIssue` to `PromptMetadata` to track which plan item each run works on
- Calls `markItem('done')` when a run produces PRs/issues, `'skipped'` otherwise
- Adds `resetAssignedItems()` to recover interrupted items on batch resume (crash recovery)
- Full lifecycle tests: claim → mark done, claim → crash → reset → re-claim

Closes #638

Run tag: batch-260323-0003-072b/run-57

## Test plan

- [x] All 263 existing tests pass
- [x] New tests cover: resetAssignedItems, full claim→mark lifecycle, crash recovery, claimedPlanIssue propagation
- [x] TypeScript build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)