### PR TITLE
feat: wire lifecycle validation into production runs (#639)

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -41,6 +41,7 @@ import {
   type SweepAction,
   type SweepResult,
   type PromptMetadata,
+  validateRunLifecycle,
 } from './auto-dent-run.js';
 
 function makeBatchState(overrides: Partial<BatchState> = {}): BatchState {
@@ -2450,5 +2451,102 @@ describe('atomic state I/O', () => {
     expect(read.prs).toEqual(['https://example.com/pr/1']);
     expect(read.issues_filed).toEqual(['#100']);
     expect(read.stop_reason).toBe('budget exhausted');
+  });
+});
+
+describe('validateRunLifecycle', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'lifecycle-test-'));
+  });
+
+  it('returns valid for correct phase ordering', () => {
+    const logFile = join(tmpDir, 'valid.log');
+    writeFileSync(logFile, [
+      'AUTO_DENT_PHASE: PICK | issue=#1 | title=test',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed | reason=ok',
+      'AUTO_DENT_PHASE: IMPLEMENT | case=test-case',
+      'AUTO_DENT_PHASE: TEST | result=pass | count=5',
+      'AUTO_DENT_PHASE: PR | url=https://example.com/pr/1',
+      'AUTO_DENT_PHASE: MERGE | url=https://example.com/pr/1 | status=queued',
+      'AUTO_DENT_PHASE: REFLECT | issues_filed=0',
+    ].join('\n'));
+
+    const result = validateRunLifecycle(logFile);
+    expect(result.valid).toBe(true);
+    expect(result.violations).toEqual([]);
+    expect(result.phasesMissing).toEqual([]);
+    expect(result.phasesPresent).toEqual(['PICK', 'EVALUATE', 'IMPLEMENT', 'TEST', 'PR', 'MERGE', 'REFLECT']);
+  });
+
+  it('detects ordering violations', () => {
+    const logFile = join(tmpDir, 'violation.log');
+    writeFileSync(logFile, [
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: TEST | result=pass',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed',
+    ].join('\n'));
+
+    const result = validateRunLifecycle(logFile);
+    expect(result.valid).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toEqual({ phase: 'EVALUATE', after: 'TEST' });
+  });
+
+  it('ignores floating phases (DECOMPOSE, STOP)', () => {
+    const logFile = join(tmpDir, 'floating.log');
+    writeFileSync(logFile, [
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed',
+      'AUTO_DENT_PHASE: DECOMPOSE | epic=#100',
+      'AUTO_DENT_PHASE: STOP | reason=done',
+    ].join('\n'));
+
+    const result = validateRunLifecycle(logFile);
+    expect(result.valid).toBe(true);
+    expect(result.phasesPresent).toContain('DECOMPOSE');
+    expect(result.phasesPresent).toContain('STOP');
+  });
+
+  it('reports missing phases', () => {
+    const logFile = join(tmpDir, 'missing.log');
+    writeFileSync(logFile, [
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: PR | url=https://example.com/pr/1',
+    ].join('\n'));
+
+    const result = validateRunLifecycle(logFile);
+    expect(result.valid).toBe(true);
+    expect(result.phasesMissing).toContain('EVALUATE');
+    expect(result.phasesMissing).toContain('REFLECT');
+  });
+
+  it('handles log with no phases', () => {
+    const logFile = join(tmpDir, 'empty.log');
+    writeFileSync(logFile, 'just some log output\nno phases here\n');
+
+    const result = validateRunLifecycle(logFile);
+    expect(result.valid).toBe(true);
+    expect(result.phasesPresent).toEqual([]);
+    expect(result.phasesMissing).toEqual(['PICK', 'EVALUATE', 'IMPLEMENT', 'TEST', 'PR', 'MERGE', 'REFLECT']);
+  });
+
+  it('handles phases mixed with JSON stream messages', () => {
+    const logFile = join(tmpDir, 'mixed.log');
+    writeFileSync(logFile, [
+      '{"type":"system","subtype":"init"}',
+      '{"type":"content_block_delta","delta":{"text":"AUTO_DENT_PHASE: PICK | issue=#1"}}',
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      '{"type":"content_block_delta","delta":{"text":"working..."}}',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed',
+      'AUTO_DENT_PHASE: IMPLEMENT | case=test',
+    ].join('\n'));
+
+    const result = validateRunLifecycle(logFile);
+    expect(result.valid).toBe(true);
+    expect(result.phasesPresent).toContain('PICK');
+    expect(result.phasesPresent).toContain('EVALUATE');
+    expect(result.phasesPresent).toContain('IMPLEMENT');
   });
 });

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -72,6 +72,7 @@ import {
 import {
   color,
   processStreamMessage,
+  parsePhaseMarkers,
   postInFlightUpdate,
   formatHeartbeat,
   IN_FLIGHT_UPDATE_INTERVAL_MS,
@@ -139,6 +140,8 @@ export interface RunMetrics {
   prompt_hash?: string;
   /** Structured failure classification (populated post-run) */
   failure_class?: string;
+  /** Number of lifecycle ordering violations detected post-run */
+  lifecycle_violations?: number;
 }
 
 export interface RunResult {
@@ -1297,6 +1300,45 @@ function printRunSummary(
   console.log('');
 }
 
+// Lifecycle validation
+
+const LIFECYCLE_ORDER = ['PICK', 'EVALUATE', 'IMPLEMENT', 'TEST', 'PR', 'MERGE', 'REFLECT'];
+const FLOATING_PHASES = new Set(['DECOMPOSE', 'STOP']);
+
+export interface LifecycleValidation {
+  valid: boolean;
+  phasesPresent: string[];
+  phasesMissing: string[];
+  violations: Array<{ phase: string; after: string }>;
+}
+
+/**
+ * Validate lifecycle phase ordering from a run log file.
+ * Reads the log, extracts AUTO_DENT_PHASE markers, and checks ordering.
+ * Advisory only — violations are logged but don't block the batch.
+ */
+export function validateRunLifecycle(logFile: string): LifecycleValidation {
+  const logContent = readFileSync(logFile, 'utf8');
+  const markers = parsePhaseMarkers(logContent);
+  const phasesPresent = markers.map(m => m.phase);
+  const orderedPhases = phasesPresent.filter(p => !FLOATING_PHASES.has(p));
+  const violations: Array<{ phase: string; after: string }> = [];
+
+  for (let i = 1; i < orderedPhases.length; i++) {
+    const prevIdx = LIFECYCLE_ORDER.indexOf(orderedPhases[i - 1]);
+    const currIdx = LIFECYCLE_ORDER.indexOf(orderedPhases[i]);
+    if (prevIdx === -1 || currIdx === -1) continue;
+    if (currIdx < prevIdx) {
+      violations.push({ phase: orderedPhases[i], after: orderedPhases[i - 1] });
+    }
+  }
+
+  const presentSet = new Set(phasesPresent);
+  const phasesMissing = LIFECYCLE_ORDER.filter(p => !presentSet.has(p));
+
+  return { valid: violations.length === 0, phasesPresent, phasesMissing, violations };
+}
+
 // Main
 
 const MIN_RUN_SECONDS = 60;
@@ -1359,6 +1401,33 @@ async function main(): Promise<void> {
   );
 
   printRunSummary(runNum, exitCode, duration, result);
+
+  // Lifecycle validation (#639) — advisory, not blocking
+  let lifecycleViolationCount = 0;
+  try {
+    const lifecycle = validateRunLifecycle(logFile);
+    lifecycleViolationCount = lifecycle.violations.length;
+    if (!lifecycle.valid) {
+      const details = lifecycle.violations
+        .map(v => `${v.phase} appeared after ${v.after}`)
+        .join(', ');
+      console.log(
+        `  ${color.yellow('[lifecycle]')} ${lifecycle.violations.length} violation(s): ${details}`,
+      );
+      appendFileSync(logFile, `\nlifecycle_violations=${lifecycle.violations.length}: ${details}\n`);
+    } else {
+      console.log(
+        `  ${color.dim('[lifecycle]')} valid (${lifecycle.phasesPresent.join(' -> ')})`,
+      );
+    }
+    if (lifecycle.phasesMissing.length > 0) {
+      console.log(
+        `  ${color.dim('[lifecycle]')} missing phases: ${lifecycle.phasesMissing.join(', ')}`,
+      );
+    }
+  } catch {
+    // Log file unreadable — skip lifecycle check
+  }
 
   // Cost anomaly detection (#585)
   {
@@ -1451,6 +1520,7 @@ async function main(): Promise<void> {
     issues_pruned: result.issuesPruned,
     prompt_template: promptMeta.template,
     prompt_hash: promptMeta.hash,
+    lifecycle_violations: lifecycleViolationCount,
   };
   // Classify failure from metrics (log-based classification could be added later)
   runMetrics.failure_class = classifyFailure(runMetrics);


### PR DESCRIPTION
## Summary

- Adds `validateRunLifecycle()` that reads a run log file, extracts `AUTO_DENT_PHASE` markers via `parsePhaseMarkers`, and checks lifecycle ordering
- Wires validation into `main()` after each run — logs violations and missing phases to console and log file
- Adds `lifecycle_violations` field to `RunMetrics` for batch-level trend analysis
- Advisory only: violations are logged but never block the batch

Closes #639

Run tag: batch-260323-0003-072b/run-58

## Test plan

- [x] All 237 tests pass (231 existing + 6 new)
- [x] Test: valid phase ordering returns `valid: true`
- [x] Test: out-of-order phases detected as violations
- [x] Test: floating phases (DECOMPOSE, STOP) ignored in ordering checks
- [x] Test: missing phases reported correctly
- [x] Test: empty log with no phases handled gracefully
- [x] Test: phases mixed with JSON stream messages parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)