### PR TITLE
fix: mode-appropriate success metrics for adaptive selection (#632)

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -26,6 +26,7 @@ import {
   selectMode,
   checkSignalOverrides,
   computeAdaptiveWeights,
+  modeSuccess,
   weightedModeSelect,
   computeModeDistribution,
   formatBatchFooter,
@@ -2069,13 +2070,13 @@ describe('computeAdaptiveWeights', () => {
     for (let i = 0; i < 7; i++) {
       history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: i < 6 ? ['pr'] : [], cost_usd: 1.0 }));
     }
-    // explore: 3 runs, 0 PRs (low success)
+    // explore: 3 runs, 0 issues filed (low success for explore)
     for (let i = 7; i < 10; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'explore', prs: [], cost_usd: 2.0 }));
+      history.push(makeRunMetrics({ run: i, mode: 'explore', prs: [], issues_filed: [], cost_usd: 2.0 }));
     }
     // reflect and subtract: 1 run each
-    history.push(makeRunMetrics({ run: 10, mode: 'reflect', prs: ['pr'], cost_usd: 1.0 }));
-    history.push(makeRunMetrics({ run: 11, mode: 'subtract', prs: ['pr'], cost_usd: 0.5 }));
+    history.push(makeRunMetrics({ run: 10, mode: 'reflect', issues_filed: ['#1'], cost_usd: 1.0 }));
+    history.push(makeRunMetrics({ run: 11, mode: 'subtract', prs: ['pr'], lines_deleted: 200, cost_usd: 0.5 }));
 
     const weights = computeAdaptiveWeights(history, 10);
     expect(weights).not.toBeNull();
@@ -2112,6 +2113,68 @@ describe('computeAdaptiveWeights', () => {
     expect(weights!.explore).toBeGreaterThan(0);
     expect(weights!.reflect).toBeGreaterThan(0);
     expect(weights!.subtract).toBeGreaterThan(0);
+  });
+
+  it('uses issues_filed for explore mode success (not PRs)', () => {
+    const history: RunMetrics[] = [];
+    // exploit: 7 runs, all with PRs
+    for (let i = 0; i < 7; i++) {
+      history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr'], cost_usd: 1.0 }));
+    }
+    // explore: 5 runs, 0 PRs but filed issues
+    for (let i = 7; i < 12; i++) {
+      history.push(makeRunMetrics({ run: i, mode: 'explore', prs: [], issues_filed: ['#1', '#2'], cost_usd: 1.5 }));
+    }
+
+    const weights = computeAdaptiveWeights(history, 10);
+    expect(weights).not.toBeNull();
+    // explore should get meaningful weight since it filed issues
+    expect(weights!.explore).toBeGreaterThan(0.01);
+  });
+
+  it('uses lines_deleted for subtract mode success', () => {
+    const history: RunMetrics[] = [];
+    for (let i = 0; i < 10; i++) {
+      history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr'], cost_usd: 1.0 }));
+    }
+    // subtract: 3 runs, 0 PRs but deleted lines
+    for (let i = 10; i < 13; i++) {
+      history.push(makeRunMetrics({ run: i, mode: 'subtract', prs: [], lines_deleted: 300, issues_pruned: 2, cost_usd: 0.8 }));
+    }
+
+    const weights = computeAdaptiveWeights(history, 10);
+    expect(weights).not.toBeNull();
+    // subtract should get meaningful weight since it deleted lines
+    expect(weights!.subtract).toBeGreaterThan(0.01);
+  });
+});
+
+describe('modeSuccess', () => {
+  it('exploit uses PRs', () => {
+    expect(modeSuccess('exploit', makeRunMetrics({ prs: ['pr1', 'pr2'] }))).toBe(2);
+    expect(modeSuccess('exploit', makeRunMetrics({ prs: [] }))).toBe(0);
+  });
+
+  it('explore uses issues_filed', () => {
+    expect(modeSuccess('explore', makeRunMetrics({ issues_filed: ['#1', '#2', '#3'] }))).toBe(3);
+    expect(modeSuccess('explore', makeRunMetrics({ prs: ['pr1'], issues_filed: [] }))).toBe(0);
+  });
+
+  it('reflect uses issues_filed', () => {
+    expect(modeSuccess('reflect', makeRunMetrics({ issues_filed: ['#1'] }))).toBe(1);
+  });
+
+  it('subtract uses lines_deleted and issues_pruned', () => {
+    expect(modeSuccess('subtract', makeRunMetrics({ lines_deleted: 200, issues_pruned: 1 }))).toBe(3);
+    expect(modeSuccess('subtract', makeRunMetrics({ lines_deleted: 0, issues_pruned: 0 }))).toBe(0);
+  });
+
+  it('contemplate always returns 1', () => {
+    expect(modeSuccess('contemplate', makeRunMetrics({ prs: [], issues_filed: [] }))).toBe(1);
+  });
+
+  it('unknown modes fall back to PRs', () => {
+    expect(modeSuccess('unknown', makeRunMetrics({ prs: ['pr1'] }))).toBe(1);
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -519,11 +519,40 @@ export function checkSignalOverrides(state: BatchState): ModeSelection | null {
 }
 
 /**
+ * Compute mode-appropriate success metric for a run.
+ * Each mode has its own definition of "success":
+ *   - exploit: PRs produced
+ *   - explore: issues filed (its purpose is discovery, not PRs)
+ *   - reflect: issues filed (insights that become actionable issues)
+ *   - subtract: lines deleted + issues pruned (reduction, not addition)
+ *   - contemplate: fixed baseline (strategic value not measurable per-run)
+ */
+export function modeSuccess(mode: string, metrics: RunMetrics): number {
+  switch (mode) {
+    case 'exploit':
+      return metrics.prs.length;
+    case 'explore':
+      return metrics.issues_filed.length;
+    case 'reflect':
+      return metrics.issues_filed.length;
+    case 'subtract':
+      return (metrics.lines_deleted ?? 0) / 100 + (metrics.issues_pruned ?? 0);
+    case 'contemplate':
+      return 1; // strategic value, always counts as success
+    default:
+      return metrics.prs.length;
+  }
+}
+
+/**
  * Compute adaptive mode weights from run history.
  *
- * For each mode, computes an effectiveness score based on:
- *   - Success rate (PRs produced per run)
- *   - Cost efficiency (PRs per dollar)
+ * For each mode, computes an effectiveness score based on mode-appropriate
+ * success metrics (not just PRs). Each mode is measured by its own output:
+ *   - exploit → PRs/run, PRs/$
+ *   - explore/reflect → issues/run, issues/$
+ *   - subtract → (lines_deleted/100 + issues_pruned)/run
+ *   - contemplate → fixed baseline
  *
  * Returns weights normalized so they sum to 1.0, or null if insufficient data.
  * Requires at least `minRuns` total runs with mode data to activate.
@@ -555,7 +584,7 @@ export function computeAdaptiveWeights(
     subtract: 0.1,
   };
 
-  // Compute raw effectiveness scores
+  // Compute raw effectiveness scores using mode-appropriate metrics
   const scores: Record<string, number> = {};
   for (const mode of schedulableModes) {
     const runs = byMode.get(mode) || [];
@@ -565,10 +594,10 @@ export function computeAdaptiveWeights(
       continue;
     }
 
-    const totalPrs = runs.reduce((s, r) => s + r.prs.length, 0);
+    const totalSuccess = runs.reduce((s, r) => s + modeSuccess(mode, r), 0);
     const totalCostVal = runs.reduce((s, r) => s + r.cost_usd, 0);
-    const successRate = totalPrs / runs.length; // PRs per run
-    const efficiency = totalCostVal > 0 ? totalPrs / totalCostVal : 0; // PRs per dollar
+    const successRate = totalSuccess / runs.length;
+    const efficiency = totalCostVal > 0 ? totalSuccess / totalCostVal : 0;
 
     // Blend success rate and efficiency, then scale by base weight
     // This preserves the general shape (exploit dominant) while rewarding performance


### PR DESCRIPTION
## Summary

- Adds `modeSuccess()` function that returns mode-appropriate success metrics instead of PR count for all modes
- exploit: PRs produced (unchanged)
- explore/reflect: issues filed (these modes discover work, not ship PRs)
- subtract: lines_deleted/100 + issues_pruned (reduction metrics)
- contemplate: fixed baseline of 1 (strategic value not measurable per-run)
- Updates `computeAdaptiveWeights()` to use `modeSuccess()` instead of raw PR count
- Updates existing tests and adds 8 new tests covering `modeSuccess` and the corrected adaptive behavior

Closes #632

Run tag: batch-260323-0003-072b/run-58

## Test plan

- [x] All 245 tests pass
- [x] `modeSuccess` tests for all 5 modes + unknown fallback
- [x] Adaptive weights test: explore with issues_filed gets meaningful weight
- [x] Adaptive weights test: subtract with lines_deleted gets meaningful weight
- [x] Existing tests updated to reflect mode-appropriate metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)