### PR TITLE
feat(observability): domain distribution in batch-summary via label-enriched events

### DIFF
--- a/scripts/auto-dent-github.ts
+++ b/scripts/auto-dent-github.ts
@@ -24,6 +24,30 @@ export function ghExec(cmd: string): string {
   }
 }
 
+// Issue label lookup
+
+/**
+ * Fetch labels for a GitHub issue by number.
+ * Returns an array of label names, or empty array on failure.
+ * Best-effort: never throws.
+ */
+export function fetchIssueLabels(issueRef: string, repo: string): string[] {
+  // issueRef may be "#123" or "123" or a full URL
+  const numMatch = issueRef.match(/(\d+)/);
+  if (!numMatch) return [];
+  const issueNum = numMatch[1];
+  try {
+    const json = ghExec(
+      `gh issue view ${issueNum} --repo ${repo} --json labels`,
+    );
+    if (!json) return [];
+    const data = JSON.parse(json);
+    return (data.labels || []).map((l: { name: string }) => l.name);
+  } catch {
+    return [];
+  }
+}
+
 // Merge status
 
 export type MergeStatus =

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -39,6 +39,7 @@ export {
   extractLinkedIssue,
   isIssueClosed,
   cleanupSupersededPRs,
+  fetchIssueLabels,
   type MergeStatus,
   type SweepAction,
   type SweepResult,
@@ -81,6 +82,7 @@ import {
   sweepBatchPRs,
   labelArtifacts,
   queueAutoMerge,
+  fetchIssueLabels,
 } from './auto-dent-github.js';
 import {
   color,
@@ -1466,8 +1468,10 @@ async function main(): Promise<void> {
     // Extract picked issue from log phase markers
     try {
       const logContent = readFileSync(logFile, 'utf8');
+      const repo = state.kaizen_repo || state.host_repo || '';
       for (const marker of parsePhaseMarkers(logContent)) {
         if (marker.phase === 'PICK' && marker.fields.issue) {
+          const labels = repo ? fetchIssueLabels(marker.fields.issue, repo) : [];
           events.emit({
             type: 'run.issue_picked',
             run_id: runId,
@@ -1475,6 +1479,7 @@ async function main(): Promise<void> {
             run_num: runNum,
             issue: marker.fields.issue,
             title: marker.fields.title || '',
+            labels,
           });
         }
       }

--- a/scripts/batch-summary.test.ts
+++ b/scripts/batch-summary.test.ts
@@ -123,6 +123,9 @@ describe('summarizeEvents', () => {
     expect(summary.total_runs).toBe(0);
     expect(summary.batch_id).toBe('unknown');
     expect(summary.total_cost_usd).toBe(0);
+    expect(summary.label_distribution).toEqual({});
+    expect(summary.horizon_distribution).toEqual({});
+    expect(summary.area_distribution).toEqual({});
   });
 
   it('computes cost_per_pr correctly', () => {
@@ -148,6 +151,42 @@ describe('summarizeEvents', () => {
     ];
     const summary = summarizeEvents(events);
     expect(summary.total_lifecycle_violations).toBe(4);
+  });
+
+  it('computes label distribution from issue_picked events', () => {
+    const events: EventEnvelope[] = [
+      makeEnvelope({ type: 'run.issue_picked', run_id: 'b/run-1', batch_id: 'b', run_num: 1, issue: '#10', title: 'A', labels: ['kaizen', 'area/hooks', 'horizon/observability'] }),
+      makeEnvelope({ type: 'run.issue_picked', run_id: 'b/run-2', batch_id: 'b', run_num: 2, issue: '#20', title: 'B', labels: ['kaizen', 'area/hooks', 'horizon/resilience'] }),
+      makeEnvelope({ type: 'run.issue_picked', run_id: 'b/run-3', batch_id: 'b', run_num: 3, issue: '#30', title: 'C', labels: ['kaizen', 'area/skills'] }),
+    ];
+
+    const summary = summarizeEvents(events);
+    expect(summary.label_distribution).toEqual({
+      'kaizen': 3,
+      'area/hooks': 2,
+      'area/skills': 1,
+      'horizon/observability': 1,
+      'horizon/resilience': 1,
+    });
+    expect(summary.horizon_distribution).toEqual({
+      'horizon/observability': 1,
+      'horizon/resilience': 1,
+    });
+    expect(summary.area_distribution).toEqual({
+      'area/hooks': 2,
+      'area/skills': 1,
+    });
+  });
+
+  it('handles issue_picked events without labels', () => {
+    const events: EventEnvelope[] = [
+      makeEnvelope({ type: 'run.issue_picked', run_id: 'b/run-1', batch_id: 'b', run_num: 1, issue: '#10', title: 'A' }),
+    ];
+
+    const summary = summarizeEvents(events);
+    expect(summary.label_distribution).toEqual({});
+    expect(summary.horizon_distribution).toEqual({});
+    expect(summary.area_distribution).toEqual({});
   });
 });
 
@@ -210,5 +249,28 @@ describe('formatPlainLanguage', () => {
     const text = formatPlainLanguage(summary);
     expect(text).toContain('30m');
     expect(text).not.toContain('0h');
+  });
+
+  it('shows domain distribution when labels present', () => {
+    const events: EventEnvelope[] = [
+      makeCompleteEvent({ run_num: 1 }),
+      makeEnvelope({ type: 'run.issue_picked', run_id: 'batch-test/run-1', batch_id: 'batch-test', run_num: 1, issue: '#10', title: 'A', labels: ['area/hooks', 'horizon/observability'] }),
+      makeEnvelope({ type: 'run.issue_picked', run_id: 'batch-test/run-1', batch_id: 'batch-test', run_num: 1, issue: '#20', title: 'B', labels: ['area/hooks', 'horizon/resilience'] }),
+    ];
+    const summary = summarizeEvents(events);
+    const text = formatPlainLanguage(summary);
+
+    expect(text).toContain('### Domain Distribution');
+    expect(text).toContain('horizon/observability: 1 issue');
+    expect(text).toContain('horizon/resilience: 1 issue');
+    expect(text).toContain('area/hooks: 2 issues');
+  });
+
+  it('omits domain distribution when no labels', () => {
+    const summary = summarizeEvents([
+      makeCompleteEvent({ run_num: 1 }),
+    ]);
+    const text = formatPlainLanguage(summary);
+    expect(text).not.toContain('### Domain Distribution');
   });
 });

--- a/scripts/batch-summary.ts
+++ b/scripts/batch-summary.ts
@@ -36,6 +36,12 @@ export interface BatchSummary {
   avg_run_duration_minutes: number;
   avg_cost_per_run_usd: number;
   cost_per_pr_usd: number;
+  /** Label frequency across all picked issues — enables domain/horizon distribution analysis */
+  label_distribution: Record<string, number>;
+  /** Horizon labels (horizon/*) grouped for quick visibility */
+  horizon_distribution: Record<string, number>;
+  /** Area labels (area/*) grouped for quick visibility */
+  area_distribution: Record<string, number>;
 }
 
 /**
@@ -94,6 +100,23 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
   const issuesWorked = [...new Set(issueEvents.map(e => e.event.issue))];
   const prsCreated = [...new Set(prEvents.map(e => e.event.pr_url))];
 
+  // Compute label distributions from issue_picked events
+  const labelDistribution: Record<string, number> = {};
+  const horizonDistribution: Record<string, number> = {};
+  const areaDistribution: Record<string, number> = {};
+  for (const e of issueEvents) {
+    const labels = e.event.labels ?? [];
+    for (const label of labels) {
+      labelDistribution[label] = (labelDistribution[label] ?? 0) + 1;
+      if (label.startsWith('horizon/')) {
+        horizonDistribution[label] = (horizonDistribution[label] ?? 0) + 1;
+      }
+      if (label.startsWith('area/')) {
+        areaDistribution[label] = (areaDistribution[label] ?? 0) + 1;
+      }
+    }
+  }
+
   const runCount = completeEvents.length || 1;
   const totalDurationMinutes = Math.round(totalDurationMs / 60000 * 10) / 10;
 
@@ -116,6 +139,9 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
     avg_run_duration_minutes: Math.round(totalDurationMinutes / runCount * 10) / 10,
     avg_cost_per_run_usd: Math.round(totalCost / runCount * 100) / 100,
     cost_per_pr_usd: totalPrs > 0 ? Math.round(totalCost / totalPrs * 100) / 100 : 0,
+    label_distribution: labelDistribution,
+    horizon_distribution: horizonDistribution,
+    area_distribution: areaDistribution,
   };
 }
 
@@ -163,6 +189,26 @@ export function formatPlainLanguage(summary: BatchSummary): string {
     lines.push('### Failure Patterns');
     for (const [cls, count] of failureEntries.sort((a, b) => b[1] - a[1])) {
       lines.push(`- ${cls}: ${count} occurrence${count > 1 ? 's' : ''}`);
+    }
+  }
+
+  // Domain distribution (horizons and areas)
+  const horizonEntries = Object.entries(summary.horizon_distribution);
+  const areaEntries = Object.entries(summary.area_distribution);
+  if (horizonEntries.length > 0 || areaEntries.length > 0) {
+    lines.push('');
+    lines.push('### Domain Distribution');
+    if (horizonEntries.length > 0) {
+      lines.push('**Horizons touched:**');
+      for (const [label, count] of horizonEntries.sort((a, b) => b[1] - a[1])) {
+        lines.push(`- ${label}: ${count} issue${count > 1 ? 's' : ''}`);
+      }
+    }
+    if (areaEntries.length > 0) {
+      lines.push('**Areas touched:**');
+      for (const [label, count] of areaEntries.sort((a, b) => b[1] - a[1])) {
+        lines.push(`- ${label}: ${count} issue${count > 1 ? 's' : ''}`);
+      }
     }
   }
 

--- a/scripts/batch-trends.ts
+++ b/scripts/batch-trends.ts
@@ -31,6 +31,8 @@ export interface BatchDataPoint {
   avg_run_duration_minutes: number;
   total_lifecycle_violations: number;
   failure_classes: Record<string, number>;
+  horizon_distribution: Record<string, number>;
+  area_distribution: Record<string, number>;
 }
 
 export interface TrendReport {
@@ -105,6 +107,8 @@ export function toDataPoint(summary: BatchSummary, timestamp: string): BatchData
     avg_run_duration_minutes: summary.avg_run_duration_minutes,
     total_lifecycle_violations: summary.total_lifecycle_violations,
     failure_classes: summary.failure_classes,
+    horizon_distribution: summary.horizon_distribution,
+    area_distribution: summary.area_distribution,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `fetchIssueLabels()` to look up issue labels from GitHub when emitting `run.issue_picked` events
- Extends `BatchSummary` with `label_distribution`, `horizon_distribution`, and `area_distribution` fields
- Displays Domain Distribution section in batch summary reports showing which horizons and areas were touched
- Propagates distribution data to `BatchDataPoint` in batch-trends for cross-batch analysis

This exercises existing telemetry infrastructure (events.jsonl → batch-summary → batch-trends) to advance observability from L1 to L2. Directly addresses the strategic finding that 11/13 horizons received zero batch activity — now each batch summary shows exactly which horizons and areas were worked on.

**Parent horizon:** #249 (Observability)
**Addresses:** #628 (horizon label desert visibility)

Run tag: batch-260323-0003-072b/run-63

## Test plan

- [x] All 50 existing + new tests pass (batch-summary: 21, batch-trends: 18, events: 11)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] New tests cover: label distribution computation, empty labels, format output with/without distributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)