### PR TITLE
fix(observability): correct run.start timestamp and mode-aware outcome (#656, #657)

### DIFF
--- a/scripts/auto-dent-events.test.ts
+++ b/scripts/auto-dent-events.test.ts
@@ -220,6 +220,81 @@ describe('EventEmitter', () => {
     }
   });
 
+  it('emitAt uses the provided timestamp instead of now', () => {
+    const pastDate = new Date('2026-01-15T10:30:00.000Z');
+    emitter.emitAt(pastDate, {
+      type: 'run.start',
+      run_id: 'batch-test/run-1',
+      batch_id: 'batch-test',
+      run_num: 1,
+      mode: 'exploit',
+      mode_reason: 'schedule',
+      prompt_template: 'test.md',
+      prompt_hash: 'abc',
+      start_epoch: 1736935800,
+    });
+
+    const events = readEvents(emitter.getFilePath());
+    expect(events).toHaveLength(1);
+    expect(events[0].timestamp).toBe('2026-01-15T10:30:00.000Z');
+    expect((events[0].event as any).start_epoch).toBe(1736935800);
+  });
+
+  it('emits run.complete with empty_success outcome', () => {
+    emitter.emit({
+      type: 'run.complete',
+      run_id: 'batch-test/run-1',
+      batch_id: 'batch-test',
+      run_num: 1,
+      duration_ms: 120000,
+      exit_code: 0,
+      cost_usd: 1.0,
+      tool_calls: 30,
+      prs_created: 0,
+      issues_filed: 0,
+      issues_closed: 0,
+      stop_requested: false,
+      lifecycle_violations: 0,
+      outcome: 'empty_success',
+      mode: 'exploit',
+    });
+
+    const events = readEvents(emitter.getFilePath());
+    expect(events[0].event).toMatchObject({
+      type: 'run.complete',
+      outcome: 'empty_success',
+      mode: 'exploit',
+    });
+  });
+
+  it('emits run.complete with mode field for explore runs', () => {
+    emitter.emit({
+      type: 'run.complete',
+      run_id: 'batch-test/run-2',
+      batch_id: 'batch-test',
+      run_num: 2,
+      duration_ms: 180000,
+      exit_code: 0,
+      cost_usd: 2.0,
+      tool_calls: 50,
+      prs_created: 0,
+      issues_filed: 3,
+      issues_closed: 0,
+      stop_requested: false,
+      lifecycle_violations: 0,
+      outcome: 'success',
+      mode: 'explore',
+    });
+
+    const events = readEvents(emitter.getFilePath());
+    expect(events[0].event).toMatchObject({
+      type: 'run.complete',
+      outcome: 'success',
+      mode: 'explore',
+      issues_filed: 3,
+    });
+  });
+
   it('silently handles write errors without throwing', () => {
     // Point at a non-existent deep path — appendFileSync will fail
     const badEmitter = new EventEmitter('/nonexistent/deeply/nested/path');

--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -29,6 +29,8 @@ export interface RunStartEvent {
   mode_reason: string;
   prompt_template: string;
   prompt_hash: string;
+  /** Epoch seconds when the run actually started (before runClaude) */
+  start_epoch?: number;
 }
 
 export interface RunIssuePickedEvent {
@@ -64,7 +66,9 @@ export interface RunCompleteEvent {
   stop_requested: boolean;
   failure_class?: string;
   lifecycle_violations: number;
-  outcome: 'success' | 'failure' | 'stop';
+  outcome: 'success' | 'empty_success' | 'failure' | 'stop';
+  /** Cognitive mode used, for context in analysis */
+  mode?: string;
 }
 
 export interface BatchReflectEvent {
@@ -106,8 +110,13 @@ export class EventEmitter {
   }
 
   emit(event: AutoDentEvent): void {
+    this.emitAt(new Date(), event);
+  }
+
+  /** Emit an event with an explicit timestamp (for events that must be backdated). */
+  emitAt(when: Date, event: AutoDentEvent): void {
     const envelope: EventEnvelope = {
-      timestamp: new Date().toISOString(),
+      timestamp: when.toISOString(),
       event,
     };
     try {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -1413,11 +1413,11 @@ async function main(): Promise<void> {
   console.log(`Tag: ${runTag}`);
   console.log(`Log: ${logFile}`);
 
-  // Structured telemetry (#647) — emitter created early, start event emitted after runClaude
-  // (selectMode/buildPromptWithMetadata have side effects, so we use runClaude's returned metadata)
+  // Structured telemetry (#647) — emitter created early
   const events = new EventEmitter(logDir);
 
   const runStartEpoch = Math.floor(Date.now() / 1000);
+  const runStartDate = new Date();
   const { exitCode, duration, result, mode: runMode, modeReason: runModeReason, promptMeta } = await runClaude(
     state,
     runNum,
@@ -1426,8 +1426,10 @@ async function main(): Promise<void> {
     stateFile,
   );
 
-  // Emit run.start telemetry using actual metadata from runClaude (#647)
-  events.emit({
+  // Emit run.start telemetry with correct pre-run timestamp (#656)
+  // Uses emitAt() to backdate the envelope timestamp to when the run actually started,
+  // and includes start_epoch for explicit duration calculations.
+  events.emitAt(runStartDate, {
     type: 'run.start',
     run_id: makeRunId(state.batch_id, runNum),
     batch_id: state.batch_id,
@@ -1436,6 +1438,7 @@ async function main(): Promise<void> {
     mode_reason: runModeReason,
     prompt_template: promptMeta.template,
     prompt_hash: promptMeta.hash,
+    start_epoch: runStartEpoch,
   });
 
   // Append metadata to log
@@ -1534,10 +1537,29 @@ async function main(): Promise<void> {
     }
   }
 
-  // Emit run.complete telemetry event (#647)
+  // Emit run.complete telemetry event (#647, #657)
+  // Uses mode-aware success: explore/reflect runs that file issues count as success,
+  // not just runs that produce PRs.
   {
+    const runMetricsForOutcome: RunMetrics = {
+      run: runNum,
+      start_epoch: runStartEpoch,
+      duration_seconds: duration,
+      exit_code: exitCode,
+      cost_usd: result.cost,
+      tool_calls: result.toolCalls,
+      prs: result.prs,
+      issues_filed: result.issuesFiled,
+      issues_closed: result.issuesClosed,
+      cases: result.cases,
+      stop_requested: result.stopRequested,
+      mode: runMode,
+      lines_deleted: result.linesDeleted,
+      issues_pruned: result.issuesPruned,
+    };
     const outcome = result.stopRequested ? 'stop' as const
-      : (exitCode === 0 && result.prs.length > 0) ? 'success' as const
+      : (exitCode === 0 && modeSuccess(runMode, runMetricsForOutcome) > 0) ? 'success' as const
+      : (exitCode === 0) ? 'empty_success' as const
       : 'failure' as const;
     events.emit({
       type: 'run.complete',
@@ -1555,6 +1577,7 @@ async function main(): Promise<void> {
       failure_class: result.failureClass,
       lifecycle_violations: lifecycleViolationCount,
       outcome,
+      mode: runMode,
     });
   }
 

--- a/scripts/batch-summary.test.ts
+++ b/scripts/batch-summary.test.ts
@@ -103,6 +103,20 @@ describe('summarizeEvents', () => {
     expect(summary.failure_classes).toEqual({ 'hook-timeout': 2 });
   });
 
+  it('counts empty_success outcomes separately from success and failure', () => {
+    const events = [
+      makeCompleteEvent({ run_num: 1, outcome: 'success' }),
+      makeCompleteEvent({ run_num: 2, outcome: 'empty_success' }),
+      makeCompleteEvent({ run_num: 3, outcome: 'empty_success' }),
+      makeCompleteEvent({ run_num: 4, outcome: 'failure' }),
+    ];
+
+    const summary = summarizeEvents(events);
+    expect(summary.successful_runs).toBe(1);
+    expect(summary.empty_success_runs).toBe(2);
+    expect(summary.failed_runs).toBe(1);
+  });
+
   it('deduplicates issues and PRs', () => {
     const events: EventEnvelope[] = [
       makeEnvelope({ type: 'run.issue_picked', run_id: 'b/run-1', batch_id: 'b', run_num: 1, issue: '#10', title: 'A' }),

--- a/scripts/batch-summary.ts
+++ b/scripts/batch-summary.ts
@@ -21,6 +21,7 @@ export interface BatchSummary {
   batch_id: string;
   total_runs: number;
   successful_runs: number;
+  empty_success_runs: number;
   failed_runs: number;
   stopped_runs: number;
   total_duration_minutes: number;
@@ -87,6 +88,7 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
   const totalViolations = completeEvents.reduce((sum, e) => sum + e.event.lifecycle_violations, 0);
 
   const successCount = completeEvents.filter(e => e.event.outcome === 'success').length;
+  const emptySuccessCount = completeEvents.filter(e => e.event.outcome === 'empty_success').length;
   const failCount = completeEvents.filter(e => e.event.outcome === 'failure').length;
   const stopCount = completeEvents.filter(e => e.event.outcome === 'stop').length;
 
@@ -124,6 +126,7 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
     batch_id: batchId,
     total_runs: completeEvents.length,
     successful_runs: successCount,
+    empty_success_runs: emptySuccessCount,
     failed_runs: failCount,
     stopped_runs: stopCount,
     total_duration_minutes: totalDurationMinutes,
@@ -164,6 +167,7 @@ export function formatPlainLanguage(summary: BatchSummary): string {
   // Outcome breakdown
   const parts: string[] = [];
   if (summary.successful_runs > 0) parts.push(`${summary.successful_runs} successful`);
+  if (summary.empty_success_runs > 0) parts.push(`${summary.empty_success_runs} empty`);
   if (summary.failed_runs > 0) parts.push(`${summary.failed_runs} failed`);
   if (summary.stopped_runs > 0) parts.push(`${summary.stopped_runs} stopped`);
   if (parts.length > 0) {


### PR DESCRIPTION
## Summary

- **#656 fix**: `run.start` event now has correct pre-run timestamp via `emitAt()` + explicit `start_epoch` field, instead of being emitted post-run with wrong envelope timestamp
- **#657 fix**: `run.complete` outcome now uses `modeSuccess()` for mode-aware success detection — explore/reflect runs that file issues are correctly counted as success, not failure
- Adds `empty_success` outcome type to distinguish exit-0-no-artifacts from crashes
- Adds `mode` field to `run.complete` events for analysis context
- Updates `BatchSummary` to track `empty_success_runs` separately

## Test plan

- [x] 4 new tests: `emitAt` backdating, `empty_success` outcome, mode field in complete events, batch summary counting
- [x] All 1196 tests pass
- [x] TypeScript build clean

Run tag: batch-260323-0003-072b/run-65

Closes #656
Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)