### PR TITLE
feat(reflection): add compound improvement prompt to reflection templates

### DIFF
--- a/.claude/agents/kaizen-bg.md
+++ b/.claude/agents/kaizen-bg.md
@@ -71,7 +71,7 @@ Read the transcript file using the Read tool. It is a JSONL file where each line
 - Read the PR description: `gh pr view {PR_URL}`
 - Check git log for recent commits on this branch
 
-### 3. Identify impediments — combine transcript signals with PR context
+### 3. Identify impediments AND compound improvements — combine transcript signals with PR context
 
 **Transcript signals are objective evidence.** The main agent's self-reported impediments are subjective. When they conflict, trust the transcript.
 
@@ -82,6 +82,8 @@ For each piece of friction:
 - Was this impediment reported by the main agent, or only visible in the transcript?
 
 **Pay special attention to impediments the main agent did NOT report.** These are the highest-value findings — they reveal blind spots in the reflection process itself.
+
+**Compound improvements (kaizen #264):** Also identify what future improvements this work makes easier or possible. What's now cheaper to build because of this foundation? Record these as `type: "positive"` findings with `disposition: "no-action"`. This captures the compounding value of work — not just what was fixed, but what was unlocked.
 
 ### 4. Search for duplicates THOROUGHLY
 For EACH impediment, search existing kaizen issues with multiple query strategies:

--- a/src/hooks/kaizen-reflect.test.ts
+++ b/src/hooks/kaizen-reflect.test.ts
@@ -230,6 +230,13 @@ describe('generateCreateReflection', () => {
     expect(output).toContain('trivial-refactor');
   });
 
+  it('includes compound improvement prompt (#264)', () => {
+    const output = generateCreateReflection('url', 'branch', 'files');
+    expect(output).toContain('Compound improvements');
+    expect(output).toContain('type: "positive"');
+    expect(output).toContain('compound improvement unlocked');
+  });
+
   it('includes transcript_path when provided', () => {
     const output = generateCreateReflection(
       'url',
@@ -255,6 +262,13 @@ describe('generateMergeReflection', () => {
     expect(output).toContain('post-merge steps');
     expect(output).toContain('Sync main');
     expect(output).toContain('/main');
+  });
+
+  it('includes compound improvement prompt (#264)', () => {
+    const output = generateMergeReflection('url', 'branch', 'files', '/main');
+    expect(output).toContain('Compound improvements');
+    expect(output).toContain('type: "positive"');
+    expect(output).toContain('compound improvement unlocked');
   });
 
   it('includes transcript_path when provided', () => {

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -204,6 +204,9 @@ Launch a background kaizen-bg subagent to handle reflection while you continue w
   - Changed files: ${changed}
 ${transcriptInstruction(transcriptPath)}
   - List any impediments/friction you encountered during this work
+  - **Compound improvements (kaizen #264):** Also identify what future improvements
+    this work makes easier or possible. What's now cheaper to build because of this
+    foundation? Record these as type: "positive" findings.
   - IMPORTANT: For each impediment, search existing kaizen issues FIRST.
     Recording an incident on an existing issue is MORE VALUABLE than filing new.
     New issues MUST have labels: kaizen + level-N + area/{subsystem}.
@@ -219,7 +222,8 @@ echo 'KAIZEN_IMPEDIMENTS:' && cat <<'IMPEDIMENTS'
 [
   {"impediment": "description", "disposition": "filed", "ref": "#NNN"},
   {"impediment": "description", "disposition": "incident", "ref": "#NNN"},
-  {"impediment": "description", "disposition": "fixed-in-pr"}
+  {"impediment": "description", "disposition": "fixed-in-pr"},
+  {"finding": "description of unlocked improvement", "type": "positive", "disposition": "no-action", "reason": "compound improvement unlocked by this work"}
 ]
 IMPEDIMENTS
 \`\`\`
@@ -267,6 +271,9 @@ with post-merge steps (deploy verification, main sync, case closure).
   - Changed files: ${changed}
 ${transcriptInstruction(transcriptPath)}
   - List any impediments/friction you encountered during this work
+  - **Compound improvements (kaizen #264):** Also identify what future improvements
+    this work makes easier or possible. What's now cheaper to build because of this
+    foundation? Record these as type: "positive" findings.
   - Ask it to also check if any open kaizen issues are now resolved by this merge
   - IMPORTANT: For each impediment, search existing kaizen issues FIRST.
     Recording an incident on an existing issue is MORE VALUABLE than filing new.
@@ -283,7 +290,8 @@ echo 'KAIZEN_IMPEDIMENTS:' && cat <<'IMPEDIMENTS'
 [
   {"impediment": "description", "disposition": "filed", "ref": "#NNN"},
   {"impediment": "description", "disposition": "incident", "ref": "#NNN"},
-  {"impediment": "description", "disposition": "fixed-in-pr"}
+  {"impediment": "description", "disposition": "fixed-in-pr"},
+  {"finding": "description of unlocked improvement", "type": "positive", "disposition": "no-action", "reason": "compound improvement unlocked by this work"}
 ]
 IMPEDIMENTS
 \`\`\`


### PR DESCRIPTION
## Summary
- Adds forward-looking "compound improvements" question to both PR create and merge reflection prompts in `kaizen-reflect.ts`
- Agents are now prompted to identify what future improvements their work makes easier/possible, using `type: "positive"` findings with example format
- Updates `kaizen-bg.md` agent to include compound improvement analysis in its reflection workflow
- Adds tests verifying both create and merge reflection prompts include compound improvement content

Closes #264

## Context
The reflection template previously only asked backward-looking questions ("what impediments?"). This adds the forward-looking dimension: "what compound improvements does this work unlock?" — capturing the compounding value of work, not just what was fixed.

## Test plan
- [x] All 23 kaizen-reflect tests pass (including 2 new compound improvement tests)
- [x] Full test suite passes (1200 tests)

Run tag: batch-260323-0003-072b/run-66

🤖 Generated with [Claude Code](https://claude.com/claude-code)