### PR TITLE
feat(observability): hook telemetry analysis — surface collected hooks.jsonl data

### DIFF
--- a/docs/horizons/observability.md
+++ b/docs/horizons/observability.md
@@ -28,7 +28,7 @@ Without observability:
 
 **L2 (partial).** Auto-dent provides structured telemetry for batch operations: per-run `RunScore` with cost, duration, tool calls, PR count, efficiency metrics, and failure classification. `BatchScore` aggregates across runs. Phase markers (`AUTO_DENT_PHASE`) emit structured progress during runs. Heartbeat monitoring and watchdog detect stalled sessions. Cost anomaly detection flags runs that exceed rolling averages. Post-hoc scoring evaluates PR quality after creation. Structured JSON stream output from each run is parsed and scored.
 
-Gaps: No cross-batch analytics queryable from a single interface. No decision tracing (why the agent chose approach A over B). Interactive session telemetry is minimal (PR create/merge events only — see `src/hooks/session-telemetry.ts`).
+Gaps: No cross-batch analytics queryable from a single interface. No decision tracing (why the agent chose approach A over B). Hook telemetry is now analyzed and surfaced during reflection (per-hook avg/p95/failure rate via `src/hooks/telemetry-analysis.ts`), but cross-session trend analysis and anomaly detection are not yet automated.
 
 ## What Exists
 
@@ -47,6 +47,7 @@ Gaps: No cross-batch analytics queryable from a single interface. No decision tr
 | In-flight PR comment updates | L1 | `scripts/auto-dent-run.ts` |
 | Batch reflection summary | L1 | `scripts/auto-dent-ctl.ts` (`buildBatchReflection`) |
 | Interactive session telemetry | L2 | `src/hooks/session-telemetry.ts` (emits via `kaizen-reflect.ts`) |
+| Hook telemetry analysis | L2 | `src/hooks/telemetry-analysis.ts` (reads hooks.jsonl, computes per-hook stats) |
 
 ## L2→L3: Decision Tracing (next step)
 

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -29,6 +29,7 @@ import {
   countChangedFiles,
   emitSessionEvent,
 } from './session-telemetry.js';
+import { analyzeHookTelemetry } from './telemetry-analysis.js';
 
 /** Detect the GitHub repo from the origin remote URL. */
 function detectGhRepo(): string | undefined {
@@ -399,8 +400,14 @@ export function processHookInput(
     ? `\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n${timingReport}\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`
     : '';
 
+  // Analyze collected hook telemetry (kaizen #249 — observability L2)
+  const telemetryReport = analyzeHookTelemetry(options.telemetryDir);
+  const telemetrySection = telemetryReport
+    ? `\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n${telemetryReport}\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`
+    : '';
+
   if (isCreate) {
-    return generateCreateReflection(prUrl, branch, changed, transcriptPath) + timingSection;
+    return generateCreateReflection(prUrl, branch, changed, transcriptPath) + timingSection + telemetrySection;
   }
 
   // Merge path
@@ -422,7 +429,7 @@ export function processHookInput(
     sendTelegramIpc(notifyText);
   }
 
-  return output + timingSection;
+  return output + timingSection + telemetrySection;
 }
 
 /** Main entry point — read stdin, process, write stdout. */

--- a/src/hooks/telemetry-analysis.test.ts
+++ b/src/hooks/telemetry-analysis.test.ts
@@ -1,0 +1,203 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeHookTelemetry,
+  buildReport,
+  computeHookStats,
+  formatReport,
+  parseHooksJsonl,
+  type HookTelemetryRecord,
+} from './telemetry-analysis.js';
+
+const SAMPLE_RECORDS: HookTelemetryRecord[] = [
+  { hook: 'kaizen-enforce-pr-review', timestamp: '2026-03-23T08:35:58.815Z', duration_ms: 63, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-enforce-pr-review', timestamp: '2026-03-23T08:36:00.581Z', duration_ms: 63, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-enforce-pr-review', timestamp: '2026-03-23T08:36:01.763Z', duration_ms: 66, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-enforce-pr-review', timestamp: '2026-03-23T08:36:14.864Z', duration_ms: 60, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-enforce-pr-review', timestamp: '2026-03-23T08:40:00.000Z', duration_ms: 250, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-block-git-rebase', timestamp: '2026-03-23T08:35:58.821Z', duration_ms: 10, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-block-git-rebase', timestamp: '2026-03-23T08:36:00.586Z', duration_ms: 22, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-block-git-rebase', timestamp: '2026-03-23T08:36:01.769Z', duration_ms: 21, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-session-cleanup', timestamp: '2026-03-23T08:35:42.990Z', duration_ms: 33, exit_code: 0, branch: 'main', case_id: '' },
+  { hook: 'kaizen-session-cleanup', timestamp: '2026-03-23T08:42:00.000Z', duration_ms: 40, exit_code: 1, branch: 'main', case_id: '' },
+];
+
+describe('parseHooksJsonl', () => {
+  it('parses valid JSONL lines', () => {
+    const content = [
+      '{"hook":"kaizen-foo","timestamp":"2026-03-23T08:00:00Z","duration_ms":50,"exit_code":0,"branch":"main","case_id":""}',
+      '{"hook":"kaizen-bar","timestamp":"2026-03-23T08:01:00Z","duration_ms":120,"exit_code":1,"branch":"feat","case_id":"abc"}',
+    ].join('\n');
+    const records = parseHooksJsonl(content);
+    expect(records).toHaveLength(2);
+    expect(records[0].hook).toBe('kaizen-foo');
+    expect(records[0].duration_ms).toBe(50);
+    expect(records[1].exit_code).toBe(1);
+    expect(records[1].case_id).toBe('abc');
+  });
+
+  it('skips malformed lines', () => {
+    const content = [
+      '{"hook":"valid","timestamp":"2026-03-23T08:00:00Z","duration_ms":50}',
+      'not json',
+      '{"no_hook_field": true}',
+      '',
+      '{"hook":"also-valid","timestamp":"2026-03-23T08:01:00Z","duration_ms":30}',
+    ].join('\n');
+    const records = parseHooksJsonl(content);
+    expect(records).toHaveLength(2);
+    expect(records[0].hook).toBe('valid');
+    expect(records[1].hook).toBe('also-valid');
+  });
+
+  it('handles empty content', () => {
+    expect(parseHooksJsonl('')).toHaveLength(0);
+    expect(parseHooksJsonl('\n\n\n')).toHaveLength(0);
+  });
+
+  it('defaults exit_code to 0 when missing', () => {
+    const content = '{"hook":"test","timestamp":"2026-03-23T08:00:00Z","duration_ms":10}';
+    const records = parseHooksJsonl(content);
+    expect(records[0].exit_code).toBe(0);
+  });
+});
+
+describe('computeHookStats', () => {
+  it('computes correct statistics per hook', () => {
+    const stats = computeHookStats(SAMPLE_RECORDS);
+    expect(stats.length).toBe(3);
+
+    const prReview = stats.find((s) => s.hook === 'kaizen-enforce-pr-review');
+    expect(prReview).toBeDefined();
+    expect(prReview!.count).toBe(5);
+    expect(prReview!.max_ms).toBe(250);
+    expect(prReview!.failures).toBe(0);
+    expect(prReview!.failure_rate).toBe(0);
+  });
+
+  it('calculates failure rate correctly', () => {
+    const stats = computeHookStats(SAMPLE_RECORDS);
+    const cleanup = stats.find((s) => s.hook === 'kaizen-session-cleanup');
+    expect(cleanup).toBeDefined();
+    expect(cleanup!.count).toBe(2);
+    expect(cleanup!.failures).toBe(1);
+    expect(cleanup!.failure_rate).toBe(0.5);
+  });
+
+  it('sorts by avg_ms descending', () => {
+    const stats = computeHookStats(SAMPLE_RECORDS);
+    for (let i = 1; i < stats.length; i++) {
+      expect(stats[i - 1].avg_ms).toBeGreaterThanOrEqual(stats[i].avg_ms);
+    }
+  });
+
+  it('handles empty input', () => {
+    expect(computeHookStats([])).toHaveLength(0);
+  });
+
+  it('computes p95 for single-record hooks', () => {
+    const stats = computeHookStats([
+      { hook: 'solo', timestamp: '2026-03-23T08:00:00Z', duration_ms: 42, exit_code: 0, branch: '', case_id: '' },
+    ]);
+    expect(stats[0].p95_ms).toBe(42);
+    expect(stats[0].avg_ms).toBe(42);
+  });
+});
+
+describe('buildReport', () => {
+  it('identifies slow hooks based on p95 threshold', () => {
+    const report = buildReport(SAMPLE_RECORDS);
+    expect(report.total_records).toBe(SAMPLE_RECORDS.length);
+    expect(report.time_range).not.toBeNull();
+    expect(report.hooks.length).toBe(3);
+    // kaizen-enforce-pr-review has p95 of 250ms which exceeds 100ms threshold
+    expect(report.slow_hooks.some((h) => h.hook === 'kaizen-enforce-pr-review')).toBe(true);
+  });
+
+  it('identifies high failure rate hooks', () => {
+    // kaizen-session-cleanup has 50% failure rate but only 2 calls (< 5 minimum)
+    const report = buildReport(SAMPLE_RECORDS);
+    expect(report.high_failure_hooks.some((h) => h.hook === 'kaizen-session-cleanup')).toBe(false);
+
+    // Create a hook with enough calls and failures
+    const failRecords: HookTelemetryRecord[] = Array.from({ length: 10 }, (_, i) => ({
+      hook: 'kaizen-flaky',
+      timestamp: `2026-03-23T08:${String(i).padStart(2, '0')}:00Z`,
+      duration_ms: 20,
+      exit_code: i < 2 ? 1 : 0,
+      branch: '',
+      case_id: '',
+    }));
+    const report2 = buildReport(failRecords);
+    expect(report2.high_failure_hooks.some((h) => h.hook === 'kaizen-flaky')).toBe(true);
+  });
+
+  it('calculates event count from timestamp clusters', () => {
+    // Records within 2s of each other form one event
+    const report = buildReport(SAMPLE_RECORDS);
+    // The sample data has clusters at ~08:35:42, ~08:35:58-08:36:02, ~08:36:14, ~08:40:00, ~08:42:00
+    expect(report.avg_overhead_per_event_ms).toBeGreaterThan(0);
+  });
+
+  it('handles empty records', () => {
+    const report = buildReport([]);
+    expect(report.total_records).toBe(0);
+    expect(report.time_range).toBeNull();
+    expect(report.hooks).toHaveLength(0);
+    expect(report.total_overhead_ms).toBe(0);
+    expect(report.avg_overhead_per_event_ms).toBe(0);
+  });
+});
+
+describe('formatReport', () => {
+  it('formats a report with slow hooks', () => {
+    const report = buildReport(SAMPLE_RECORDS);
+    const formatted = formatReport(report);
+    expect(formatted).toContain('HOOK TELEMETRY ANALYSIS');
+    expect(formatted).toContain('kaizen-enforce-pr-review');
+    expect(formatted).toContain('Slow hooks');
+  });
+
+  it('returns empty string for empty report', () => {
+    const report = buildReport([]);
+    expect(formatReport(report)).toBe('');
+  });
+
+  it('shows all-clear message when no issues', () => {
+    const fastRecords: HookTelemetryRecord[] = [
+      { hook: 'fast-hook', timestamp: '2026-03-23T08:00:00Z', duration_ms: 5, exit_code: 0, branch: '', case_id: '' },
+      { hook: 'fast-hook', timestamp: '2026-03-23T08:01:00Z', duration_ms: 8, exit_code: 0, branch: '', case_id: '' },
+    ];
+    const report = buildReport(fastRecords);
+    const formatted = formatReport(report);
+    expect(formatted).toContain('All hooks within performance budgets');
+  });
+});
+
+describe('analyzeHookTelemetry', () => {
+  it('reads hooks.jsonl and produces a report', () => {
+    const dir = `/tmp/.test-ta-${Date.now()}-a`;
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'hooks.jsonl'),
+      SAMPLE_RECORDS.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    );
+    const result = analyzeHookTelemetry(dir);
+    expect(result).toContain('HOOK TELEMETRY ANALYSIS');
+    expect(result).toContain(`${SAMPLE_RECORDS.length} records`);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns empty string when file does not exist', () => {
+    expect(analyzeHookTelemetry('/tmp/.nonexistent-telemetry-dir')).toBe('');
+  });
+
+  it('returns empty string for empty file', () => {
+    const dir = `/tmp/.test-ta-${Date.now()}-b`;
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'hooks.jsonl'), '');
+    expect(analyzeHookTelemetry(dir)).toBe('');
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/hooks/telemetry-analysis.ts
+++ b/src/hooks/telemetry-analysis.ts
@@ -1,0 +1,218 @@
+/**
+ * telemetry-analysis.ts — Analyze collected hook telemetry data.
+ *
+ * Reads the hooks.jsonl file produced by hook-telemetry.sh and computes
+ * per-hook statistics: average duration, p95, failure rate, invocation count.
+ * Identifies slow hooks and performance regressions.
+ *
+ * This closes the observability gap where hook timing data was collected
+ * (via hook-telemetry.sh) but never analyzed or surfaced.
+ *
+ * Part of horizon #249 (Observability), epic #451 (Hook performance).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface HookTelemetryRecord {
+  hook: string;
+  timestamp: string;
+  duration_ms: number;
+  exit_code: number;
+  branch: string;
+  case_id: string;
+}
+
+export interface HookStats {
+  hook: string;
+  count: number;
+  avg_ms: number;
+  p95_ms: number;
+  max_ms: number;
+  failure_rate: number;
+  failures: number;
+}
+
+export interface TelemetryReport {
+  total_records: number;
+  time_range: { first: string; last: string } | null;
+  hooks: HookStats[];
+  slow_hooks: HookStats[];
+  high_failure_hooks: HookStats[];
+  total_overhead_ms: number;
+  avg_overhead_per_event_ms: number;
+}
+
+const SLOW_THRESHOLD_MS = 100;
+const HIGH_FAILURE_RATE = 0.05;
+
+/**
+ * Parse hooks.jsonl file into records. Skips malformed lines.
+ */
+export function parseHooksJsonl(content: string): HookTelemetryRecord[] {
+  const records: HookTelemetryRecord[] = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      if (
+        typeof parsed.hook === 'string' &&
+        typeof parsed.duration_ms === 'number' &&
+        typeof parsed.timestamp === 'string'
+      ) {
+        records.push({
+          hook: parsed.hook,
+          timestamp: parsed.timestamp,
+          duration_ms: parsed.duration_ms,
+          exit_code: typeof parsed.exit_code === 'number' ? parsed.exit_code : 0,
+          branch: typeof parsed.branch === 'string' ? parsed.branch : '',
+          case_id: typeof parsed.case_id === 'string' ? parsed.case_id : '',
+        });
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+  return records;
+}
+
+/**
+ * Compute the p95 value from a sorted array of numbers.
+ */
+function percentile95(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const idx = Math.ceil(sorted.length * 0.95) - 1;
+  return sorted[Math.min(idx, sorted.length - 1)];
+}
+
+/**
+ * Compute per-hook statistics from telemetry records.
+ */
+export function computeHookStats(records: HookTelemetryRecord[]): HookStats[] {
+  const byHook = new Map<string, HookTelemetryRecord[]>();
+  for (const r of records) {
+    const existing = byHook.get(r.hook);
+    if (existing) {
+      existing.push(r);
+    } else {
+      byHook.set(r.hook, [r]);
+    }
+  }
+
+  const stats: HookStats[] = [];
+  for (const [hook, hookRecords] of byHook) {
+    const durations = hookRecords.map((r) => r.duration_ms).sort((a, b) => a - b);
+    const failures = hookRecords.filter((r) => r.exit_code !== 0).length;
+    const total = durations.reduce((sum, d) => sum + d, 0);
+
+    stats.push({
+      hook,
+      count: hookRecords.length,
+      avg_ms: Math.round(total / hookRecords.length),
+      p95_ms: percentile95(durations),
+      max_ms: durations[durations.length - 1],
+      failure_rate: hookRecords.length > 0 ? failures / hookRecords.length : 0,
+      failures,
+    });
+  }
+
+  return stats.sort((a, b) => b.avg_ms - a.avg_ms);
+}
+
+/**
+ * Build a full telemetry report from records.
+ */
+export function buildReport(records: HookTelemetryRecord[]): TelemetryReport {
+  const stats = computeHookStats(records);
+  const slowHooks = stats.filter((s) => s.p95_ms >= SLOW_THRESHOLD_MS);
+  const highFailureHooks = stats.filter((s) => s.failure_rate >= HIGH_FAILURE_RATE && s.count >= 5);
+
+  const totalOverhead = records.reduce((sum, r) => sum + r.duration_ms, 0);
+
+  // Estimate events by counting distinct timestamp clusters (within 2s)
+  const timestamps = records.map((r) => new Date(r.timestamp).getTime()).sort((a, b) => a - b);
+  let eventCount = timestamps.length > 0 ? 1 : 0;
+  for (let i = 1; i < timestamps.length; i++) {
+    if (timestamps[i] - timestamps[i - 1] > 2000) {
+      eventCount++;
+    }
+  }
+
+  const sortedTimestamps = records
+    .map((r) => r.timestamp)
+    .sort();
+
+  return {
+    total_records: records.length,
+    time_range:
+      sortedTimestamps.length > 0
+        ? { first: sortedTimestamps[0], last: sortedTimestamps[sortedTimestamps.length - 1] }
+        : null,
+    hooks: stats,
+    slow_hooks: slowHooks,
+    high_failure_hooks: highFailureHooks,
+    total_overhead_ms: totalOverhead,
+    avg_overhead_per_event_ms: eventCount > 0 ? Math.round(totalOverhead / eventCount) : 0,
+  };
+}
+
+/**
+ * Format a report as a human-readable string for inclusion in reflection prompts.
+ */
+export function formatReport(report: TelemetryReport): string {
+  if (report.total_records === 0) {
+    return '';
+  }
+
+  const lines: string[] = [];
+  lines.push(`HOOK TELEMETRY ANALYSIS (${report.total_records} records)`);
+  if (report.time_range) {
+    lines.push(`Period: ${report.time_range.first} → ${report.time_range.last}`);
+  }
+  lines.push(`Total overhead: ${report.total_overhead_ms}ms | Avg per event: ${report.avg_overhead_per_event_ms}ms`);
+  lines.push('');
+
+  if (report.slow_hooks.length > 0) {
+    lines.push('Slow hooks (p95 ≥ 100ms):');
+    for (const h of report.slow_hooks) {
+      lines.push(`  ${h.hook}  avg=${h.avg_ms}ms  p95=${h.p95_ms}ms  max=${h.max_ms}ms  (${h.count} calls)`);
+    }
+    lines.push('');
+  }
+
+  if (report.high_failure_hooks.length > 0) {
+    lines.push('High failure rate hooks (≥5%):');
+    for (const h of report.high_failure_hooks) {
+      const pct = (h.failure_rate * 100).toFixed(1);
+      lines.push(`  ${h.hook}  ${pct}% failure rate  (${h.failures}/${h.count})`);
+    }
+    lines.push('');
+  }
+
+  if (report.slow_hooks.length === 0 && report.high_failure_hooks.length === 0) {
+    lines.push('All hooks within performance budgets.');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Read hooks.jsonl from the telemetry directory and produce a formatted report.
+ * Returns empty string if no data or errors occur.
+ */
+export function analyzeHookTelemetry(telemetryDir?: string): string {
+  try {
+    const dir = telemetryDir ?? resolve(process.env.CLAUDE_PROJECT_DIR ?? process.cwd(), '.kaizen', 'telemetry');
+    const filePath = resolve(dir, 'hooks.jsonl');
+    if (!existsSync(filePath)) return '';
+    const content = readFileSync(filePath, 'utf-8');
+    const records = parseHooksJsonl(content);
+    if (records.length === 0) return '';
+    const report = buildReport(records);
+    return formatReport(report);
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `telemetry-analysis.ts` that reads the hooks.jsonl file produced by `hook-telemetry.sh` and computes per-hook statistics (avg/p95/max duration, failure rate, slow hook identification)
- Wires the analysis into `kaizen-reflect.ts` so collected telemetry data is surfaced during PR reflections alongside the existing timing sentinel
- Updates the observability horizon doc to reflect L2 advancement
- 19 new tests with full coverage of parsing, stats, report building, and formatting

Closes the feedback loop where hook telemetry was collected but never read back. Part of the "use what was built" strategic recommendation.

Related: horizon #249 (Observability), epic #451 (Hook performance), filed #678 (zen feedback-latency principle)

Run tag: batch-260323-0003-072b/run-72

## Test plan

- [x] 19 new tests pass (parseHooksJsonl, computeHookStats, buildReport, formatReport, analyzeHookTelemetry)
- [x] All 235 existing hook tests pass
- [x] TypeScript builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)