### PR TITLE
feat(observability): add reflection persistence to searchable JSONL (#272)

### DIFF
--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -17,6 +17,10 @@ import { join } from 'node:path';
 import { type HookInput, readHookInput, writeHookOutput } from './hook-io.js';
 import { stripHeredocBody } from './parse-command.js';
 import {
+  buildReflectionRecord,
+  persistReflection,
+} from './reflection-persistence.js';
+import {
   DEFAULT_AUDIT_DIR,
   DEFAULT_STATE_DIR,
   clearStateWithStatusAnyBranch,
@@ -516,6 +520,25 @@ export function processHookInput(
         isNoAction,
       );
       postComment(gatePrUrl, comment);
+    } catch {}
+
+    // Persist reflection to searchable JSONL (kaizen #272, best-effort)
+    try {
+      const clearType = isNoAction
+        ? 'no-action' as const
+        : validatedItems.length === 0
+          ? 'empty-array' as const
+          : 'impediments' as const;
+      const quality = classifyReflectionQuality(validatedItems);
+      const record = buildReflectionRecord({
+        prUrl: gatePrUrl,
+        branch: currentBranch(),
+        clearType,
+        clearReason,
+        quality,
+        impediments: validatedItems,
+      });
+      persistReflection(record);
     } catch {}
 
     // Auto-close kaizen issues (best-effort)

--- a/src/hooks/reflection-persistence.test.ts
+++ b/src/hooks/reflection-persistence.test.ts
@@ -1,0 +1,143 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildReflectionRecord,
+  persistReflection,
+  type ReflectionImpediment,
+  type ReflectionRecord,
+} from './reflection-persistence.js';
+
+describe('buildReflectionRecord', () => {
+  it('builds record with correct disposition counts', () => {
+    const impediments: ReflectionImpediment[] = [
+      { impediment: 'missing test', disposition: 'filed', ref: '#100' },
+      { impediment: 'typo fix', disposition: 'fixed-in-pr' },
+      { finding: 'good pattern', type: 'positive', disposition: 'no-action', reason: 'validates approach' },
+      { impediment: 'relates to known bug', disposition: 'incident', ref: '#200' },
+    ];
+
+    const record = buildReflectionRecord({
+      prUrl: 'https://github.com/Garsson-io/kaizen/pull/42',
+      branch: 'feat-test',
+      clearType: 'impediments',
+      clearReason: '4 finding(s) addressed',
+      quality: 'high',
+      impediments,
+      now: new Date('2026-03-23T10:00:00Z'),
+    });
+
+    expect(record.timestamp).toBe('2026-03-23T10:00:00.000Z');
+    expect(record.pr_url).toBe('https://github.com/Garsson-io/kaizen/pull/42');
+    expect(record.branch).toBe('feat-test');
+    expect(record.clear_type).toBe('impediments');
+    expect(record.quality).toBe('high');
+    expect(record.counts).toEqual({
+      total: 4,
+      filed: 1,
+      fixed_in_pr: 1,
+      incident: 1,
+      no_action: 1,
+    });
+  });
+
+  it('builds empty record for no-action', () => {
+    const record = buildReflectionRecord({
+      prUrl: 'https://github.com/Garsson-io/kaizen/pull/55',
+      branch: 'docs-update',
+      clearType: 'no-action',
+      clearReason: 'docs-only change',
+      quality: 'empty',
+      impediments: [],
+    });
+
+    expect(record.clear_type).toBe('no-action');
+    expect(record.counts.total).toBe(0);
+    expect(record.counts.filed).toBe(0);
+  });
+
+  it('builds record for empty-array with reason', () => {
+    const record = buildReflectionRecord({
+      prUrl: 'https://github.com/Garsson-io/kaizen/pull/66',
+      branch: 'bugfix',
+      clearType: 'empty-array',
+      clearReason: 'no impediments identified (straightforward fix)',
+      quality: 'empty',
+      impediments: [],
+    });
+
+    expect(record.clear_type).toBe('empty-array');
+    expect(record.clear_reason).toContain('straightforward fix');
+  });
+});
+
+describe('persistReflection', () => {
+  it('writes reflection record to reflections.jsonl', () => {
+    const dir = `/tmp/.test-rp-${Date.now()}-a`;
+    const record = buildReflectionRecord({
+      prUrl: 'https://github.com/Garsson-io/kaizen/pull/77',
+      branch: 'test-branch',
+      clearType: 'impediments',
+      clearReason: '1 finding(s) addressed',
+      quality: 'medium',
+      impediments: [{ impediment: 'test gap', disposition: 'filed', ref: '#300' }],
+      now: new Date('2026-03-23T12:00:00Z'),
+    });
+
+    persistReflection(record, { telemetryDir: dir });
+
+    const filePath = join(dir, 'reflections.jsonl');
+    expect(existsSync(filePath)).toBe(true);
+    const content = readFileSync(filePath, 'utf-8').trim();
+    const parsed = JSON.parse(content) as ReflectionRecord;
+    expect(parsed.pr_url).toBe('https://github.com/Garsson-io/kaizen/pull/77');
+    expect(parsed.quality).toBe('medium');
+    expect(parsed.counts.filed).toBe(1);
+    expect(parsed.impediments).toHaveLength(1);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('appends multiple records', () => {
+    const dir = `/tmp/.test-rp-${Date.now()}-b`;
+    const base = {
+      branch: 'b',
+      clearType: 'impediments' as const,
+      clearReason: 'ok',
+      quality: 'medium' as const,
+      impediments: [],
+    };
+
+    persistReflection(
+      buildReflectionRecord({ ...base, prUrl: 'url1' }),
+      { telemetryDir: dir },
+    );
+    persistReflection(
+      buildReflectionRecord({ ...base, prUrl: 'url2' }),
+      { telemetryDir: dir },
+    );
+
+    const lines = readFileSync(join(dir, 'reflections.jsonl'), 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect((JSON.parse(lines[0]) as ReflectionRecord).pr_url).toBe('url1');
+    expect((JSON.parse(lines[1]) as ReflectionRecord).pr_url).toBe('url2');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('silently handles write errors without throwing', () => {
+    // /dev/null is a file, not a directory — mkdirSync will fail with ENOTDIR.
+    // Never use /proc paths in tests: mkdirSync('/proc/...') hangs on WSL2 (kaizen #681).
+    expect(() =>
+      persistReflection(
+        buildReflectionRecord({
+          prUrl: 'url',
+          branch: 'b',
+          clearType: 'no-action',
+          clearReason: 'test',
+          quality: 'empty',
+          impediments: [],
+        }),
+        { telemetryDir: '/dev/null/impossible' },
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/hooks/reflection-persistence.ts
+++ b/src/hooks/reflection-persistence.ts
@@ -1,0 +1,95 @@
+/**
+ * reflection-persistence.ts — Persist kaizen reflections to searchable JSONL.
+ *
+ * Closes the observability gap where KAIZEN_IMPEDIMENTS data was only in
+ * PR comments and flat audit logs. Stores full structured reflection records
+ * in data/telemetry/reflections.jsonl, enabling:
+ *   - Gap analysis: aggregate by category, find recurring friction
+ *   - Quality trends: track filed vs no-action ratio over time
+ *   - Cross-session learning: future agents can query past reflections
+ *
+ * Part of horizon #249 (Observability), issue #272.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { resolveTelemetryDir } from './session-telemetry.js';
+
+export interface ReflectionImpediment {
+  impediment?: string;
+  finding?: string;
+  type?: string;
+  disposition?: string;
+  ref?: string;
+  reason?: string;
+  impact_minutes?: number;
+}
+
+export interface ReflectionRecord {
+  timestamp: string;
+  pr_url: string;
+  branch: string;
+  clear_type: 'impediments' | 'no-action' | 'empty-array';
+  clear_reason: string;
+  quality: 'high' | 'medium' | 'low' | 'empty';
+  impediments: ReflectionImpediment[];
+  counts: {
+    total: number;
+    filed: number;
+    fixed_in_pr: number;
+    incident: number;
+    no_action: number;
+  };
+}
+
+function countByDisposition(
+  items: ReflectionImpediment[],
+  disposition: string,
+): number {
+  return items.filter((i) => i.disposition === disposition).length;
+}
+
+export function buildReflectionRecord(options: {
+  prUrl: string;
+  branch: string;
+  clearType: 'impediments' | 'no-action' | 'empty-array';
+  clearReason: string;
+  quality: 'high' | 'medium' | 'low' | 'empty';
+  impediments: ReflectionImpediment[];
+  now?: Date;
+}): ReflectionRecord {
+  return {
+    timestamp: (options.now ?? new Date()).toISOString(),
+    pr_url: options.prUrl,
+    branch: options.branch,
+    clear_type: options.clearType,
+    clear_reason: options.clearReason,
+    quality: options.quality,
+    impediments: options.impediments,
+    counts: {
+      total: options.impediments.length,
+      filed: countByDisposition(options.impediments, 'filed'),
+      fixed_in_pr: countByDisposition(options.impediments, 'fixed-in-pr'),
+      incident: countByDisposition(options.impediments, 'incident'),
+      no_action: countByDisposition(options.impediments, 'no-action'),
+    },
+  };
+}
+
+/**
+ * Persist a reflection record to reflections.jsonl.
+ * Best-effort: never throws — telemetry must not break the hook.
+ */
+export function persistReflection(
+  record: ReflectionRecord,
+  options?: { telemetryDir?: string },
+): void {
+  try {
+    const dir = options?.telemetryDir ?? resolveTelemetryDir();
+    mkdirSync(dir, { recursive: true });
+    const filePath = resolve(dir, 'reflections.jsonl');
+    appendFileSync(filePath, JSON.stringify(record) + '\n');
+  } catch {
+    // Best-effort — never break the hook
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `reflection-persistence.ts` — structured JSONL persistence for kaizen reflections
- Adds `reflection-persistence.test.ts` — 6 tests, all passing (110ms)
- Wires persistence into `pr-kaizen-clear.ts` so reflections are saved when the gate clears
- **Fixes the WSL2 /proc hang** from auto-dent run 73: replaced `/proc/invalid/path` with `/dev/null/impossible` in error-handling test

This completes the work that auto-dent batch run 73 attempted but couldn't ship because the `/proc` test hung vitest for 2.5 hours. See #681 for full incident analysis and PRD.

## Test plan

- [x] `npx vitest run src/hooks/reflection-persistence.test.ts` — 6 tests pass in 110ms
- [x] `npx vitest run` — full suite: 35 files, 1268 tests pass
- [x] `npm run build` — TypeScript compiles clean

Refs: #272, #681, #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)