### PR TITLE
fix(auto-dent): one issue per run — stop after first PR

### DIFF
--- a/prompts/deep-dive-default.md
+++ b/prompts/deep-dive-default.md
@@ -77,17 +77,16 @@ moves the strategic layer forward.
 
 ## Stopping the Loop
 
-If you determine there is no more meaningful work to do matching the guidance
-(backlog exhausted, all relevant issues claimed, remaining issues are
-blocked/too risky, AND no epics/PRDs can be decomposed), include this exact
-marker in your final response:
+**One issue per run.** Complete one issue, create one PR, queue it for merge, then stop. The harness will restart with fresh context for the next issue. Do not pick additional issues after your first PR is queued — stopping is correct behavior, not a failure.
+
+The only exception: if your assigned issue is blocked or already resolved, skip it, pick one replacement, and stop after that PR.
+
+If all issues are genuinely exhausted (backlog empty, all remaining issues claimed or blocked, AND no epics/PRDs can be decomposed), include this marker in your final response:
 
 AUTO_DENT_PHASE: STOP | reason=<reason>
 
 For example: "AUTO_DENT_PHASE: STOP | reason=backlog exhausted — no more open issues matching 'hooks reliability'"
-This will gracefully stop the batch loop. Only use this when you've genuinely
-run out of work — not when a single run is complete. Before stopping, check
-whether there are epics or PRDs you could decompose instead.
+Only emit STOP when work is truly gone. Do not emit STOP after a normal single-issue run — just finish and let the harness restart.
 
 When done, summarize what was accomplished. List all PRs created, issues filed,
 and issues closed with full URLs.


### PR DESCRIPTION
## Problem

The prompt template's \"Stopping the Loop\" section said:

> \"Only use this when you've genuinely run out of work — **not when a single run is complete**.\"

This explicitly told agents to keep picking issues after completing one. Run-2 of batch-260323-1405-5400 picked 4 issues in a single run (#684, #700, #694, #703).

## Why it's wrong

In batch mode, the trampoline handles restarts with fresh context. Each run should be atomic: one issue → one PR → stop. The harness then injects updated state (new PRs list, closed issues) into the next run's prompt. Multi-issue runs:
- Balloon context to 826KB+ mid-run → drift risk
- Leave state.json stale if the run crashes partway through
- Undermine the fresh-context benefit of the trampoline design

`/kaizen-deep-dive` already knows when to bundle multiple issues — that's the skill's job, not the batch runner's.

## Fix

Replaced the ambiguous stopping rule with an explicit one-issue-per-run policy. The STOP marker is now reserved for genuine backlog exhaustion only.

## Kaizen
- **Root cause:** Prompt written for standalone `/kaizen-deep-dive` use (where keep-going is correct). Batch mode needs the opposite behavior.
- **Fix level:** L1 — prompt template change
- **Repeat failure?** No — first time this was observed
- **Escalation needed?** Could be L2 (harness enforces one-PR-per-run by killing the agent after first MERGE marker) but L1 is sufficient for now
- **Backlog issue:** N/A — fixed here