### PR TITLE
feat(skills): discipline checks for issue-filing, spec critique, dual failure modes

### DIFF
--- a/.claude/skills/kaizen-evaluate/SKILL.md
+++ b/.claude/skills/kaizen-evaluate/SKILL.md
@@ -227,6 +227,20 @@ Read the spec with the incidents in hand. Evaluate:
 - **Is the most important question buried?** Specs sometimes bury the pivotal decision as an "open question" instead of resolving it first.
 - **Is there a simpler framing?** Sometimes the spec is solving the wrong problem at the right scope, or the right problem at the wrong scope.
 
+#### Solution evaluation — is this the right fix? (kaizen #714)
+
+Scope evaluation asks "should we do this?" Solution evaluation asks "is this the right thing to do?" Both are required. Before accepting a spec's proposed solution, answer:
+
+1. **What failure mode does this spec address? Is that the right failure mode?** The spec may describe a symptom while the root cause is elsewhere.
+2. **Is the proposed mechanism the simplest one that addresses it? What alternatives exist?** A lint hook, a test, a SKILL.md update, and an architectural change all address "bad code gets committed" — but at very different costs.
+3. **Would a simpler fix (one level lower: L3→L2→L1) address the same failure mode?** Don't build L2 enforcement when L1 instructions would suffice. Don't build L3 architecture when L2 hooks would work.
+4. **Is this failure mode expected to recur? If not, is prevention worth the overhead?** A one-time incident doesn't necessarily justify a permanent mechanism.
+5. **What is the cost of the proposed mechanism?** Maintenance burden, false positives, performance impact, cognitive load on agents. Every mechanism has ongoing cost.
+
+**If any answer raises doubt, surface it before implementing.** Do not ship a correct implementation of the wrong spec. The goal is to catch #685-style mistakes (perfect implementation, wrong solution) before they consume implementation time.
+
+**Red flag:** The spec's solution section reads like a task list ("add hook X, modify file Y, create test Z") instead of describing the desired outcome. That's a sign the solution was the first idea, not the best one.
+
 **If this case is one phase of a larger spec**, also assess the spec's progressive detail:
 - Is the current phase detailed enough to implement without guessing?
 - Are distant phases over-specified with solution details that will be wrong by the time we get there?

--- a/.claude/skills/kaizen-implement/SKILL.md
+++ b/.claude/skills/kaizen-implement/SKILL.md
@@ -105,6 +105,8 @@ This step is about **accuracy** — is the spec still true? — not about **scop
 
 If re-examination reveals something significant has changed (e.g., half the spec was already built by another PR, or a key assumption is wrong), **don't unilaterally skip it**. Flag it to the admin: "The spec assumed X but Y is now true — should we adjust scope?" That's an accept-case decision, not an implementation decision.
 
+**Solution fitness check (kaizen #714):** If during re-examination you realize the spec's proposed solution may address the wrong failure mode or use an unnecessarily complex mechanism, halt and surface the concern before implementing. A correct implementation of the wrong spec wastes more time than pausing to validate. See `/kaizen-evaluate` Phase 4 "Solution evaluation" for the 5-question check.
+
 **The spec was written to be complete. Implementation should match the problem.** Not everything in the spec needs to be built right now — but what you do build should be built well. *"Avoiding overengineering is not a license to underengineer."*
 
 ### Surface the encoded hypothesis (kaizen #348)
@@ -413,6 +415,24 @@ After implementation, **reproduce the original problem and verify it's actually 
 
 The flow is usually: `write-prd → accept-case → implement-spec → kaizen`. But it's not always linear — `implement-spec` may loop back to `write-prd` when it discovers the spec needs more detail for the current level, or to `accept-case` when implementation reveals the problem is different than expected.
 
+## Dual Failure Mode Check — MANDATORY for behavioral constraints (kaizen #722)
+
+When implementing a behavioral constraint (prompt change, stop condition, scope rule, enforcement rule), you must name both failure modes before shipping:
+
+1. **If this rule is absent — what goes wrong?** (the original bug that motivated the rule)
+2. **If this rule is present — what valid behavior does it prevent?** (the over-correction risk)
+
+**If you can't answer both, the constraint isn't fully specified.** Going from one failure mode to the other without naming both is a predictable pattern — the agent focuses on eliminating the original problem and doesn't ask "what valid behavior does this rule prevent?"
+
+**Example — PR #718 (the incident that motivated this):** Fixed auto-dent's blind-loop problem with "one issue per run." The constraint was too restrictive — it prevented intentional bundling that `/kaizen-deep-dive` already handles deliberately. Required a second PR (#720) to correct it. Naming both failure modes upfront would have caught the over-correction.
+
+**How to apply:**
+- State both failure modes explicitly in the PR description
+- If the constraint is a prompt/SKILL.md change, include an "Exceptions" or "When this rule does NOT apply" section
+- If you can't identify the over-correction risk, ask: "What is the most sophisticated valid use case this rule would block?"
+
+This check applies to: SKILL.md prompt additions, hook rules, scope constraints, stop conditions, enforcement policies. It does NOT apply to: bug fixes, feature code, test additions, documentation.
+
 ## Anti-patterns
 
 - **Spec-as-checklist.** Grinding through every spec section in order, implementing what it says regardless of whether the world has changed. The spec is a map, not a contract.
@@ -420,6 +440,7 @@ The flow is usually: `write-prd → accept-case → implement-spec → kaizen`. 
 - **Skipping re-examination.** Jumping straight to coding without questioning whether the requirements are still valid. This is how you implement solutions to problems that no longer exist. *"The most dangerous requirement is the one nobody re-examined."*
 - **Gold-plating.** Adding capabilities the spec mentions as "future work" because you're already in the code. Future work is future work. Ship the current step.
 - **Ignoring new information.** Something you discovered during implementation contradicts the spec. Instead of updating the spec and adjusting, you forge ahead with the original plan. *"Specs are hypotheses. Incidents are data."*
+- **Over-correcting constraints.** Shipping a behavioral rule that fixes the original bug but blocks valid behavior. Name both failure modes (absent vs present) before shipping — see Dual Failure Mode Check above.
 - **Big-bang implementation.** "I'll implement the whole spec in one PR." No. Find the smallest valuable step. Ship it. Loop.
 
 ## Recursive Kaizen — Improving the Improvement Process

--- a/.claude/skills/kaizen-reflect/SKILL.md
+++ b/.claude/skills/kaizen-reflect/SKILL.md
@@ -240,6 +240,19 @@ Is the check fully automatable (no judgment needed)?
   YES → Level 2 (hooks) or Level 3 (mechanistic) — why rely on agent memory?
 ```
 
+## Issue-Filing Discipline — describe the failure mode, not the solution (kaizen #713)
+
+Before writing the solution section of any issue, answer these four questions:
+
+1. **What is the failure mode?** Not the specific trigger — the *class* of failure. Example: "tests can hang with no circuit breaker" not "test wrote to `/proc`."
+2. **How often is this expected to recur, and what is the real cost?** If it happened once and cost 5 minutes, the issue may not be worth the filing overhead.
+3. **What is the simplest fix at the right level?** (L1/L2/L3) — consider all three before committing to one.
+4. **Is the solution section describing an outcome, or a specific implementation?** If it prescribes a specific mechanism (e.g., "add a hook that blocks X"), flag it. The issue should describe the *problem and desired outcome*. Leave the mechanism to the implementor.
+
+**Why this matters:** Issues filed in solution mode ("add a hook that blocks X") collapse the solution space. A future implementor reads the spec as a contract and builds exactly what it says — even if the spec is wrong. The filer is in "what would have prevented this?" mode rather than "what failure mode are we addressing?" mode. The first answer is usually too narrow. (See #685 → #712 as a concrete example of this pattern.)
+
+**Red flag:** If your issue title starts with "Add hook that..." or "Create script to..." — you're describing the solution, not the problem. Rewrite the title to name the failure mode.
+
 ## Kaizen Backlog
 
 All improvements that are too large for the current PR go to:
@@ -251,10 +264,10 @@ Issue format:
 - **Title:** `[L{level}] Brief description`
 - **Required labels:** `kaizen` + level (`level-1`/`level-2`/`level-3`) + area (`area/hooks`, `area/skills`, `area/cases`, `area/deploy`, `area/testing`, `area/container`, `area/worktree`) + horizon (recommended)
 - **Body:**
-  - What failed (incident description)
+  - What failed (incident description / failure mode class)
   - Why it failed (root cause)
   - Current level of fix (if any)
-  - Proposed improvement and target level
+  - Desired outcome and target level (not a specific mechanism — see discipline check above)
   - Verification: how to confirm the fix works
 
 **Before filing a new issue:** Search for existing issues first (`gh issue list --repo "$KAIZEN_REPO" --search "<keywords>"`). If a match exists, add an incident comment instead of filing a duplicate. Incidents compound evidence; duplicates fragment it.


### PR DESCRIPTION
## Summary

- **kaizen-reflect**: Add 4-question issue-filing discipline check (#713) — forces agents to describe the failure mode class, not a specific mechanism, before filing issues
- **kaizen-evaluate**: Add 5-question solution evaluation to Phase 4 spec critique (#714) — catches wrong-solution-right-implementation before work starts
- **kaizen-implement**: Add dual failure mode check for behavioral constraints (#722) — requires naming both what the rule prevents AND what valid behavior it blocks

All three are motivated by the #685→#712 incident chain where a perfectly implemented lint hook addressed the wrong failure mode and had to be reverted.

Fixes Garsson-io/kaizen#713
Fixes Garsson-io/kaizen#714
Fixes Garsson-io/kaizen#722

## Test plan

- [x] L1 changes only (SKILL.md prompt text) — no code to test
- [x] Verify each addition is placed in the correct section of the respective SKILL.md
- [x] Cross-references between skills are consistent (implement references evaluate's solution evaluation)

## Verification

Changes are prompt-only (Level 1). Effectiveness will be verified by observing future issue-filing and spec evaluation quality in subsequent auto-dent batches.

Run tag: worried-fish/run-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)