### PR TITLE
fix(hooks): upgrade PRD reflection gate from advisory to blocking (#683)

### DIFF
--- a/src/hooks/pr-kaizen-clear.test.ts
+++ b/src/hooks/pr-kaizen-clear.test.ts
@@ -1018,16 +1018,18 @@ describe('detectPrdWithoutFiledIssues', () => {
   const prdFiles = ['docs/prd-agent-diagnosis.md', 'src/foo.ts'];
   const noPrdFiles = ['src/foo.ts', 'CLAUDE.md'];
 
-  it('returns advisory when PRD present and KAIZEN_NO_ACTION', () => {
+  it('returns blocking message when PRD present and KAIZEN_NO_ACTION', () => {
     const result = detectPrdWithoutFiledIssues(prdFiles, [], true);
+    expect(result).toContain('BLOCKED');
     expect(result).toContain('PRD but filed no actionable issues');
   });
 
-  it('returns advisory when PRD present and zero filed dispositions', () => {
+  it('returns blocking message when PRD present and zero filed dispositions', () => {
     const items = [
       { impediment: 'minor style issue', disposition: 'no-action', type: 'positive', reason: 'cosmetic' },
     ];
     const result = detectPrdWithoutFiledIssues(prdFiles, items, false);
+    expect(result).toContain('BLOCKED');
     expect(result).toContain('PRD but filed no actionable issues');
   });
 
@@ -1045,19 +1047,33 @@ describe('detectPrdWithoutFiledIssues', () => {
   });
 });
 
-describe('processHookInput PRD advisory (kaizen #694)', () => {
-  it('emits advisory when PRD in diff and KAIZEN_NO_ACTION', () => {
+describe('processHookInput PRD blocking gate (kaizen #683, upgraded from #694)', () => {
+  it('blocks gate when PRD in diff and KAIZEN_NO_ACTION', () => {
     const input = noActionInput('docs-only', 'PRD creation only');
     const result = processHookInput(input, {
       stateDir: testStateDir,
       postComment: () => {},
       getPrFiles: () => ['docs/prd-agent-diagnosis.md', 'CLAUDE.md'],
     });
+    expect(result).toContain('BLOCKED');
     expect(result).toContain('PRD but filed no actionable issues');
-    expect(result).toContain('gate cleared');
+    expect(result).not.toContain('gate cleared');
   });
 
-  it('no advisory when PRD in diff but issues were filed', () => {
+  it('blocks gate when PRD in diff with only no-action impediments', () => {
+    const input = impedimentsInput(
+      '[{"impediment":"cosmetic","disposition":"no-action","type":"positive","reason":"style only"}]',
+    );
+    const result = processHookInput(input, {
+      stateDir: testStateDir,
+      postComment: () => {},
+      getPrFiles: () => ['docs/prd-agent-diagnosis.md'],
+    });
+    expect(result).toContain('BLOCKED');
+    expect(result).not.toContain('gate cleared');
+  });
+
+  it('clears gate when PRD in diff and issues were filed', () => {
     const input = impedimentsInput(
       '[{"impediment":"P0 from PRD","disposition":"filed","ref":"#999"}]',
     );
@@ -1066,11 +1082,11 @@ describe('processHookInput PRD advisory (kaizen #694)', () => {
       postComment: () => {},
       getPrFiles: () => ['docs/prd-agent-diagnosis.md'],
     });
-    expect(result).not.toContain('PRD but filed no actionable issues');
+    expect(result).not.toContain('BLOCKED');
     expect(result).toContain('gate cleared');
   });
 
-  it('no advisory when no PRD files in diff', () => {
+  it('clears gate when no PRD files in diff', () => {
     const input = noActionInput('config-only', 'just config');
     const result = processHookInput(input, {
       stateDir: testStateDir,
@@ -1079,5 +1095,19 @@ describe('processHookInput PRD advisory (kaizen #694)', () => {
     });
     expect(result).not.toContain('PRD');
     expect(result).toContain('gate cleared');
+  });
+
+  it('preserves gate state when PRD blocks clearing', () => {
+    const input = noActionInput('docs-only', 'PRD creation only');
+    processHookInput(input, {
+      stateDir: testStateDir,
+      postComment: () => {},
+      getPrFiles: () => ['docs/prd-agent-diagnosis.md'],
+    });
+    const stateContent = fs.readFileSync(
+      path.join(testStateDir, 'pr-kaizen-Garsson-io_kaizen_42'),
+      'utf-8',
+    );
+    expect(stateContent).toContain('needs_pr_kaizen');
   });
 });

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -406,7 +406,7 @@ export function hasPrdFiles(files: string[]): boolean {
   return files.some(f => /^docs\/prd[/-].*\.md$/i.test(f));
 }
 
-/** Advisory when a PRD is created but no issues were filed. */
+/** Block gate clearing when a PRD is created but no issues were filed (kaizen #683). */
 export function detectPrdWithoutFiledIssues(
   files: string[],
   items: Impediment[],
@@ -418,9 +418,9 @@ export function detectPrdWithoutFiledIssues(
   ).length;
   if (!isNoAction && filedCount > 0) return null;
   return (
-    'Advisory: You created a PRD but filed no actionable issues. ' +
-    'PRDs without filed issues are reflection without action. ' +
-    'Did you mean to file P0/P1 items as issues?'
+    'BLOCKED: You created a PRD but filed no actionable issues. ' +
+    'PRDs without filed issues are "reflection without action" (kaizen #683). ' +
+    'File at least one P0/P1 item as a GitHub issue, then resubmit your reflection with it as a "filed" disposition.'
   );
 }
 
@@ -545,16 +545,16 @@ export function processHookInput(
       }
     }
 
-    // PRD-without-issues advisory (kaizen #694)
+    // PRD-without-issues BLOCKING check (kaizen #683, upgraded from #694 advisory)
     const getPrFiles = options.getPrFiles ?? defaultGetPrFiles;
     try {
       const files = getPrFiles(gatePrUrl);
-      const prdAdvisory = detectPrdWithoutFiledIssues(
+      const prdBlock = detectPrdWithoutFiledIssues(
         files,
         validatedItems,
         isNoAction,
       );
-      if (prdAdvisory) output.push(`\n${prdAdvisory}\n`);
+      if (prdBlock) return `\n${prdBlock}\n`;
     } catch {}
 
     clearStateWithStatusAnyBranch(


### PR DESCRIPTION
## Summary

- Upgrades the PRD-without-filed-issues check from advisory (warn but clear gate) to **blocking** (refuse to clear gate until issues are filed)
- Prevents the fractal failure pattern where agents write PRDs about problems but don't file actionable issues (#683)
- Gate clears normally when: no PRD files in diff, or at least one impediment has `disposition: "filed"`

## What changed

- `detectPrdWithoutFiledIssues()` now returns a `BLOCKED:` message instead of `Advisory:`
- `processHookInput()` returns the blocking message and preserves gate state (instead of clearing + appending advisory)
- Updated 5 tests to verify blocking behavior + added 2 new tests (gate state preservation, no-action impediments with PRD)

## Test plan

- [x] All 79 pr-kaizen-clear tests pass
- [x] Full suite: 1338 tests pass, 0 failures
- [x] TypeScript compiles clean

Closes #683

Run tag: worried-fish/run-2

Generated with [Claude Code](https://claude.com/claude-code)