### PR TITLE
fix(hooks): kaizen-bg clears reflection gate mechanistically (#794)

### DIFF
--- a/.claude/agents/kaizen-bg.md
+++ b/.claude/agents/kaizen-bg.md
@@ -121,18 +121,29 @@ For each impediment:
   Required labels: `kaizen` + level (`level-1`/`level-2`/`level-3`) + area (`area/hooks`, `area/skills`, `area/cases`, `area/deploy`, `area/testing`, `area/container`, `area/worktree`). Add `horizon/{name}` if it maps to a known horizon.
 - **Trivial / not worth filing** → Note the reason
 
-### 6. Report results
-When done, output a structured summary that the main agent can use to clear the kaizen gate:
+### 6. Clear the kaizen gate (MANDATORY final step)
 
-```
-KAIZEN_BG_RESULTS:
-- impediment: "description"
-  disposition: filed | incident | fixed-in-pr
-  ref: "#NNN" (if filed or incident)
-  reason: "why" (if type is positive with no-action)
+As your **final action**, run an echo command with the structured impediments JSON.
+This fires the pr-kaizen-clear hook and clears the gate mechanistically (kaizen #794).
+
+```bash
+echo 'KAIZEN_IMPEDIMENTS:' && cat <<'IMPEDIMENTS'
+[
+  {"impediment": "description", "disposition": "filed", "ref": "#NNN"},
+  {"impediment": "description", "disposition": "incident", "ref": "#NNN"},
+  {"finding": "description", "type": "positive", "disposition": "no-action", "reason": "why"}
+]
+IMPEDIMENTS
 ```
 
-The main agent will use this to construct the KAIZEN_IMPEDIMENTS declaration and clear the gate.
+If no impediments were found:
+```bash
+echo 'KAIZEN_IMPEDIMENTS: [] no friction observed in this session'
+```
+
+**This echo IS the gate-clearing mechanism.** The pr-kaizen-clear PostToolUse hook
+detects KAIZEN_IMPEDIMENTS in your Bash output and clears the gate automatically.
+Do NOT skip this step — without it, the main agent stays gated.
 
 ### 7. Verifiable meta-questions (aggregate health check)
 

--- a/docs/hooks-design.md
+++ b/docs/hooks-design.md
@@ -40,6 +40,46 @@ Gates are the primary control flow mechanism:
 
 This creates a "you must do X before you can do Y" enforcement.
 
+### Kaizen Reflection Flow (kaizen #794)
+
+The reflection gate uses the gate pattern with a subagent for automated issue filing:
+
+```mermaid
+sequenceDiagram
+    participant Agent as Main Agent
+    participant Hook1 as kaizen-reflect.ts<br/>(PostToolUse)
+    participant Gate as State File<br/>(needs_pr_kaizen)
+    participant Hook2 as enforce-pr-reflect.ts<br/>(PreToolUse)
+    participant BG as kaizen-bg<br/>(subagent)
+    participant Hook3 as pr-kaizen-clear.ts<br/>(PostToolUse)
+
+    Agent->>Agent: gh pr create/merge
+    Hook1->>Gate: Write state file
+    Hook1-->>Agent: "Spawn kaizen-bg subagent"
+
+    Note over Agent,Hook2: Agent is now GATED
+
+    Agent->>Agent: Any non-allowlisted command
+    Hook2->>Hook2: Check gate → DENY
+
+    Agent->>BG: Agent tool (foreground for create,<br/>background for merge)
+    BG->>BG: Analyze transcript
+    BG->>BG: Search existing issues
+    BG->>BG: File issues / add incidents
+    BG->>BG: echo 'KAIZEN_IMPEDIMENTS: [...]'
+    Hook3->>Hook3: Validate JSON
+    Hook3->>Gate: Clear state file
+    Hook3-->>BG: "Gate cleared"
+
+    Note over Agent,Hook2: Agent is now UNGATED
+```
+
+Key design decisions:
+- **PR create**: subagent runs in foreground (agent is fully gated, nothing else to do)
+- **PR merge**: subagent runs in background (agent can do allowlisted post-merge steps: main sync, deploy)
+- **kaizen-bg echoes KAIZEN_IMPEDIMENTS directly** — gate clears mechanistically without main agent relaying results (kaizen #794)
+- **KAIZEN_BG_RESULTS** accepted as alternate trigger format (fallback)
+
 ## Writing Hooks
 
 ### Language Boundaries

--- a/src/hooks/kaizen-reflect.test.ts
+++ b/src/hooks/kaizen-reflect.test.ts
@@ -65,7 +65,6 @@ describe('processHookInput', () => {
       expect(output).toContain('KAIZEN REFLECTION');
       expect(output).toContain('Post-PR Creation');
       expect(output).toContain('kaizen-bg');
-      expect(output).toContain('run_in_background');
       expect(output).toContain('pull/42');
 
       // State file should be created
@@ -93,7 +92,7 @@ describe('processHookInput', () => {
 
       const output = processHookInput(input, defaultOpts);
       expect(output).toContain('Agent');
-      expect(output).toContain('background');
+      expect(output).toContain('kaizen-bg');
     });
   });
 
@@ -218,10 +217,10 @@ describe('generateCreateReflection', () => {
     expect(output).toContain('file1.ts');
   });
 
-  it('mentions waived disposition elimination (#198)', () => {
+  it('mentions gate clearing mechanism (#794)', () => {
     const output = generateCreateReflection('url', 'branch', 'files');
-    expect(output).toContain('#198');
-    expect(output).toContain('eliminated');
+    expect(output).toContain('#794');
+    expect(output).toContain('gate');
   });
 
   it('includes KAIZEN_NO_ACTION categories', () => {
@@ -234,7 +233,6 @@ describe('generateCreateReflection', () => {
     const output = generateCreateReflection('url', 'branch', 'files');
     expect(output).toContain('Compound improvements');
     expect(output).toContain('type: "positive"');
-    expect(output).toContain('compound improvement unlocked');
   });
 
   it('includes transcript_path when provided', () => {
@@ -268,7 +266,6 @@ describe('generateMergeReflection', () => {
     const output = generateMergeReflection('url', 'branch', 'files', '/main');
     expect(output).toContain('Compound improvements');
     expect(output).toContain('type: "positive"');
-    expect(output).toContain('compound improvement unlocked');
   });
 
   it('includes transcript_path when provided', () => {

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -194,14 +194,14 @@ export function generateCreateReflection(
 ): string {
   return `
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🔄 KAIZEN REFLECTION — Post-PR Creation (background)
+🔄 KAIZEN REFLECTION — Post-PR Creation
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Launch a background kaizen-bg subagent to handle reflection while you continue working.
+You are GATED — spawn a kaizen-bg subagent to handle reflection. It will clear the gate
+automatically by echoing KAIZEN_IMPEDIMENTS as its final step (kaizen #794).
 
 **Use the Agent tool** with these parameters:
 - subagent_type: "kaizen-bg"
-- run_in_background: true
 - prompt: Include this context:
   - Event: PR created
   - PR URL: ${prUrl}
@@ -217,34 +217,20 @@ ${transcriptInstruction(transcriptPath)}
     New issues MUST have labels: kaizen + level-N + area/{subsystem}.
     See docs/issue-taxonomy.md for the full policy.
 
-The kaizen-bg subagent will search for duplicate issues, file incidents, and
-create new kaizen issues as needed. It will report results back to you.
-
-**When the subagent completes**, use its results to clear the gate:
+⛔ You are GATED until the subagent clears the gate. Manual fallback:
 
 \`\`\`bash
 echo 'KAIZEN_IMPEDIMENTS:' && cat <<'IMPEDIMENTS'
 [
   {"impediment": "description", "disposition": "filed", "ref": "#NNN"},
-  {"impediment": "description", "disposition": "incident", "ref": "#NNN"},
-  {"impediment": "description", "disposition": "fixed-in-pr"},
-  {"finding": "description of unlocked improvement", "type": "positive", "disposition": "no-action", "reason": "compound improvement unlocked by this work"}
+  {"impediment": "description", "disposition": "fixed-in-pr"}
 ]
 IMPEDIMENTS
 \`\`\`
 
-If the subagent found no impediments: \`echo 'KAIZEN_IMPEDIMENTS: []'\`
+If no impediments: \`echo 'KAIZEN_IMPEDIMENTS: [] straightforward bug fix'\`
 
-⛔ You are GATED until you submit a valid KAIZEN_IMPEDIMENTS declaration.
-Allowed commands: gh issue/pr, gh api, gh run, git read-only, ls/cat.
-
-⚠️ **"Waived" disposition is eliminated (kaizen #198).** Every impediment must be
-filed (\`disposition: "filed"\`) or fixed in this PR (\`disposition: "fixed-in-pr"\`).
-If something is not real friction, reclassify as \`type: "positive"\` with \`disposition: "no-action"\`.
-When in doubt, file — it takes 2 minutes; implementation is a separate decision.
-
-For trivial changes (typo, formatting, docs-only), you may also use:
-  \`echo 'KAIZEN_NO_ACTION [docs-only]: updated README formatting'\`
+For trivial changes: \`echo 'KAIZEN_NO_ACTION [docs-only]: reason'\`
 Valid categories: docs-only, formatting, typo, config-only, test-only, trivial-refactor
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 `;
@@ -260,11 +246,12 @@ export function generateMergeReflection(
 ): string {
   return `
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🔄 KAIZEN REFLECTION — Post-Merge (background)
+🔄 KAIZEN REFLECTION — Post-Merge
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Launch a background kaizen-bg subagent to handle reflection while you continue
-with post-merge steps (deploy verification, main sync, case closure).
+Spawn a kaizen-bg subagent **in background** to handle reflection while you complete
+post-merge steps. It will clear the gate automatically by echoing KAIZEN_IMPEDIMENTS
+as its final step (kaizen #794).
 
 **Use the Agent tool** with these parameters:
 - subagent_type: "kaizen-bg"
@@ -285,37 +272,23 @@ ${transcriptInstruction(transcriptPath)}
     New issues MUST have labels: kaizen + level-N + area/{subsystem}.
     See docs/issue-taxonomy.md for the full policy.
 
-The kaizen-bg subagent will search for duplicate issues, file incidents, and
-create new kaizen issues as needed. It will report results back to you.
-
-**When the subagent completes**, use its results to clear the gate:
+⛔ You are GATED until the subagent clears the gate. Manual fallback:
 
 \`\`\`bash
 echo 'KAIZEN_IMPEDIMENTS:' && cat <<'IMPEDIMENTS'
 [
   {"impediment": "description", "disposition": "filed", "ref": "#NNN"},
-  {"impediment": "description", "disposition": "incident", "ref": "#NNN"},
-  {"impediment": "description", "disposition": "fixed-in-pr"},
-  {"finding": "description of unlocked improvement", "type": "positive", "disposition": "no-action", "reason": "compound improvement unlocked by this work"}
+  {"impediment": "description", "disposition": "fixed-in-pr"}
 ]
 IMPEDIMENTS
 \`\`\`
 
-If the subagent found no impediments: \`echo 'KAIZEN_IMPEDIMENTS: []'\`
+If no impediments: \`echo 'KAIZEN_IMPEDIMENTS: [] straightforward bug fix'\`
 
-⛔ You are GATED until you submit a valid KAIZEN_IMPEDIMENTS declaration.
-Allowed commands: gh issue/pr, gh api, gh run, git read-only, ls/cat.
-
-⚠️ **"Waived" disposition is eliminated (kaizen #198).** Every impediment must be
-filed (\`disposition: "filed"\`) or fixed in this PR (\`disposition: "fixed-in-pr"\`).
-If something is not real friction, reclassify as \`type: "positive"\` with \`disposition: "no-action"\`.
-When in doubt, file — it takes 2 minutes; implementation is a separate decision.
-
-For trivial changes (typo, formatting, docs-only), you may also use:
-  \`echo 'KAIZEN_NO_ACTION [docs-only]: updated README formatting'\`
+For trivial changes: \`echo 'KAIZEN_NO_ACTION [docs-only]: reason'\`
 Valid categories: docs-only, formatting, typo, config-only, test-only, trivial-refactor
 
-**Also complete post-merge steps** (these are NOT delegated to the subagent):
+**Also complete post-merge steps** (while the subagent runs reflection):
 - Follow Post-Merge deployment procedure in CLAUDE.md
 - Sync main: \`git -C ${mainCheckout} fetch origin main && git -C ${mainCheckout} merge --ff-only origin/main\`
 - Close resolved kaizen issues

--- a/src/hooks/pr-kaizen-clear.test.ts
+++ b/src/hooks/pr-kaizen-clear.test.ts
@@ -41,6 +41,7 @@ import {
   classifyReflectionQuality,
   detectFixableFiledImpediments,
   detectPrdWithoutFiledIssues,
+  extractBgResults,
   formatReflectionComment,
   hasPrdFiles,
   matchesWaiverBlocklist,
@@ -1207,5 +1208,106 @@ describe('pr-kaizen-clear: KAIZEN_UNFINISHED escape', () => {
       postComment: () => {},
     });
     expect(result).toContain('no reason given');
+  });
+});
+
+// ── KAIZEN_BG_RESULTS tests (kaizen #794) ─────────────────────────────
+
+function bgResultsInput(resultsJson: string): object {
+  return {
+    tool_name: 'Bash',
+    tool_input: { command: `echo 'KAIZEN_BG_RESULTS: ${resultsJson}'` },
+    tool_response: {
+      stdout: `KAIZEN_BG_RESULTS: ${resultsJson}`,
+      stderr: '',
+      exit_code: '0',
+    },
+  };
+}
+
+describe('extractBgResults', () => {
+  it('extracts JSON from KAIZEN_BG_RESULTS tag', () => {
+    const json = JSON.stringify([
+      { impediment: 'slow tests', disposition: 'filed', ref: '#100' },
+    ]);
+    const result = extractBgResults(`KAIZEN_BG_RESULTS: ${json}`, '');
+    expect(result.json).toEqual([
+      { impediment: 'slow tests', disposition: 'filed', ref: '#100' },
+    ]);
+  });
+
+  it('returns null when no KAIZEN_BG_RESULTS tag present', () => {
+    const result = extractBgResults('some other output', '');
+    expect(result.json).toBeNull();
+  });
+
+  it('handles empty array with reason', () => {
+    const result = extractBgResults(
+      'KAIZEN_BG_RESULTS: [] no friction observed',
+      '',
+    );
+    expect(result.json).toEqual([]);
+    expect(result.emptyReason).toBe('no friction observed');
+  });
+});
+
+describe('pr-kaizen-clear: KAIZEN_BG_RESULTS trigger', () => {
+  it('clears gate with valid bg results', () => {
+    const json = JSON.stringify([
+      { impediment: 'slow tests', disposition: 'filed', ref: '#100' },
+    ]);
+    const result = processHookInput(bgResultsInput(json), {
+      stateDir: testStateDir,
+      postComment: () => {},
+    });
+    expect(result).toContain('kaizen-bg agent');
+    expect(result).toContain('gate cleared');
+    expect(gateExists()).toBe(false);
+  });
+
+  it('rejects invalid bg results', () => {
+    const json = JSON.stringify([
+      { impediment: 'missing disposition' },
+    ]);
+    const result = processHookInput(bgResultsInput(json), {
+      stateDir: testStateDir,
+      postComment: () => {},
+    });
+    expect(result).toContain('Validation failed');
+    expect(gateExists()).toBe(true);
+  });
+
+  it('clears gate with empty bg results and reason', () => {
+    const result = processHookInput(
+      bgResultsInput('[] no friction observed'),
+      {
+        stateDir: testStateDir,
+        postComment: () => {},
+      },
+    );
+    expect(result).toContain('gate cleared');
+    expect(gateExists()).toBe(false);
+  });
+
+  it('rejects empty bg results without reason', () => {
+    const result = processHookInput(bgResultsInput('[]'), {
+      stateDir: testStateDir,
+      postComment: () => {},
+    });
+    expect(result).toContain('Empty array requires a reason');
+    expect(gateExists()).toBe(true);
+  });
+
+  it('does not trigger when no gate is active', () => {
+    fs.rmSync(testStateDir, { recursive: true, force: true });
+    testStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kaizen-clear-test-'));
+    const json = JSON.stringify([
+      { impediment: 'test', disposition: 'filed', ref: '#1' },
+    ]);
+    const result = processHookInput(bgResultsInput(json), {
+      stateDir: testStateDir,
+      postComment: () => {},
+    });
+    expect(result).toBeNull();
   });
 });

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -281,6 +281,32 @@ function extractImpedimentsJson(
   return { json: null, emptyReason: '' };
 }
 
+// ── KAIZEN_BG_RESULTS extraction (kaizen #794) ──────────────────────
+
+/**
+ * Extract structured impediments from KAIZEN_BG_RESULTS output.
+ *
+ * The kaizen-bg agent outputs results as JSON (same format as KAIZEN_IMPEDIMENTS):
+ *   KAIZEN_BG_RESULTS: [{"impediment": "...", "disposition": "filed", "ref": "#NNN"}]
+ *
+ * This reuses the same JSON extraction logic as KAIZEN_IMPEDIMENTS, just
+ * with a different marker tag. The hook validates and persists identically.
+ */
+export function extractBgResults(
+  stdout: string,
+  cmdLine: string,
+): { json: unknown[] | null; emptyReason: string } {
+  // Rewrite KAIZEN_BG_RESULTS → KAIZEN_IMPEDIMENTS and reuse existing extraction
+  const retagged = (text: string) =>
+    text.replace(/KAIZEN_BG_RESULTS:/g, 'KAIZEN_IMPEDIMENTS:');
+
+  return extractImpedimentsJson(
+    stdout ? retagged(stdout) : '',
+    cmdLine ? retagged(cmdLine) : '',
+    '',
+  );
+}
+
 // ── KAIZEN_NO_ACTION ─────────────────────────────────────────────────
 
 const VALID_NO_ACTION_CATEGORIES = new Set([
@@ -520,6 +546,37 @@ export function processHookInput(
       allPassive = items.every((i) => i.disposition === 'no-action');
       shouldClear = true;
       clearReason = `${items.length} finding(s) addressed`;
+    }
+  }
+
+  // ── Trigger 1b: KAIZEN_BG_RESULTS (kaizen #794) ────────────────
+  // The kaizen-bg background agent outputs structured JSON results. If we
+  // detect them, clear the gate without requiring the main agent to relay.
+  if (
+    !shouldClear &&
+    (/KAIZEN_BG_RESULTS:/.test(cmdLine) || /KAIZEN_BG_RESULTS:/.test(stdout))
+  ) {
+    const { json: bgJson, emptyReason: bgEmptyReason } = extractBgResults(stdout, cmdLine);
+
+    if (bgJson !== null) {
+      if (bgJson.length === 0) {
+        if (!bgEmptyReason) {
+          return "\nKAIZEN_BG_RESULTS: Empty array requires a reason.\n  echo 'KAIZEN_BG_RESULTS: [] straightforward bug fix'\n";
+        }
+        logNoAction('bg-empty-array', bgEmptyReason, gatePrUrl);
+        shouldClear = true;
+        clearReason = `no impediments from kaizen-bg (${bgEmptyReason})`;
+      } else {
+        const bgItems = bgJson as Impediment[];
+        const errors = validateImpediments(bgItems);
+        if (errors.length > 0) {
+          return `\nKAIZEN_BG_RESULTS: Validation failed:\n${errors.join('\n')}\n\nThe background agent produced invalid results. Fix and resubmit.\n`;
+        }
+        validatedItems = bgItems;
+        allPassive = bgItems.every((i) => i.disposition === 'no-action');
+        shouldClear = true;
+        clearReason = `${bgItems.length} finding(s) from kaizen-bg agent`;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **kaizen-bg now clears the reflection gate itself** by echoing `KAIZEN_IMPEDIMENTS` as its final bash command. The pr-kaizen-clear PostToolUse hook fires and clears the gate mechanistically — no main agent relay needed.
- **KAIZEN_BG_RESULTS** accepted as a fallback trigger format (reuses existing JSON extraction)
- **Foreground subagent for PR create** (agent is fully gated anyway), background for PR merge (agent can do allowlisted post-merge steps)
- **Mermaid sequence diagram** added to hooks-design.md documenting the full reflection flow
- **Filed #795** — kaizen-bg should differentiate plugin vs host repo impediments

## What changed

| File | Change |
|------|--------|
| `kaizen-bg.md` | Mandatory final `echo KAIZEN_IMPEDIMENTS` step replaces old YAML report |
| `pr-kaizen-clear.ts` | New `KAIZEN_BG_RESULTS:` trigger + `extractBgResults()` |
| `kaizen-reflect.ts` | Simplified prompts: no manual relay, foreground/background split |
| `hooks-design.md` | Mermaid diagram for reflection gate flow |
| Tests | 7 new tests, 5 updated — all 1577 pass |

## Test plan

- [x] All 1577 tests pass (`npm test`)
- [x] `extractBgResults` unit tests (JSON extraction, empty array, null cases)
- [x] `KAIZEN_BG_RESULTS` integration tests (gate clearing, validation, no-gate)
- [x] Updated kaizen-reflect tests for new prompt text

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)