### PR TITLE
fix(hooks): compound command false positive + hook sync CI check

### DIFF
--- a/.claude/hooks/tests/validate-hook-integrity.sh
+++ b/.claude/hooks/tests/validate-hook-integrity.sh
@@ -144,6 +144,37 @@ if [ -d "$HOOKS_DIR" ]; then
 fi
 
 echo ""
+echo "--- Sync: settings.json <-> plugin.json hook parity (kaizen #793) ---"
+# Both files should declare the same set of hooks (normalized).
+# settings.json uses ./ prefix, plugin.json uses ${CLAUDE_PLUGIN_ROOT}/.
+SETTINGS_JSON="$PROJECT_ROOT/.claude/settings.json"
+PLUGIN_JSON="$PROJECT_ROOT/.claude-plugin/plugin.json"
+if [ -f "$SETTINGS_JSON" ] && [ -f "$PLUGIN_JSON" ]; then
+  # Extract and normalize: strip prefix to get relative path
+  settings_hooks=$(jq -r '.. | .command? // empty' "$SETTINGS_JSON" | sed 's|^\./||' | sort -u)
+  plugin_hooks=$(jq -r '.. | .command? // empty' "$PLUGIN_JSON" | sed 's|${CLAUDE_PLUGIN_ROOT}/||; s|^\./||' | sort -u)
+
+  only_settings=$(comm -23 <(echo "$settings_hooks") <(echo "$plugin_hooks"))
+  only_plugin=$(comm -13 <(echo "$settings_hooks") <(echo "$plugin_hooks"))
+
+  if [ -n "$only_settings" ]; then
+    echo "::error::[sync] Hooks in settings.json but NOT in plugin.json:"
+    echo "$only_settings"
+    ((ERRORS++))
+  fi
+  if [ -n "$only_plugin" ]; then
+    echo "::error::[sync] Hooks in plugin.json but NOT in settings.json:"
+    echo "$only_plugin"
+    ((ERRORS++))
+  fi
+  if [ -z "$only_settings" ] && [ -z "$only_plugin" ]; then
+    echo "  OK: settings.json and plugin.json hooks are in sync"
+  fi
+else
+  echo "  Skipped: one or both config files not found"
+fi
+
+echo ""
 echo "Checked $CHECKED hook commands, $ERRORS errors."
 
 if [ "$ERRORS" -gt 0 ]; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,6 +69,11 @@
             "type": "command",
             "command": "./.claude/hooks/kaizen-block-git-rebase.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "./.claude/hooks/kaizen-search-before-file.sh",
+            "timeout": 10
           }
         ]
       },

--- a/src/hooks/bash-ts-parity.test.ts
+++ b/src/hooks/bash-ts-parity.test.ts
@@ -38,6 +38,10 @@ const EXCLUSIONS: Record<string, string> = {
   // TS splits extractPrUrl from reconstructPrUrl; bash inlines the grep
   extractPrUrl:
     'ts-only: extracted helper, bash inlines grep in reconstruct_pr_url',
+
+  // TS internal utility for splitting compound commands; bash uses IFS/sed inline
+  splitCommandSegments:
+    'ts-only: internal helper, bash splits on operators inline',
 };
 
 /** Extract function names from a bash script (matches `function_name() {`). */

--- a/src/hooks/check-dirty-files.test.ts
+++ b/src/hooks/check-dirty-files.test.ts
@@ -3,6 +3,7 @@ import {
   checkDirtyFiles,
   detectTrigger,
   formatFileList,
+  hasCommitBeforePush,
   parseDirtyFiles,
 } from './check-dirty-files.js';
 
@@ -22,6 +23,41 @@ describe('detectTrigger', () => {
   it('returns none for other commands', () => {
     expect(detectTrigger('npm test')).toBe('none');
     expect(detectTrigger('git diff')).toBe('none');
+  });
+
+  it('returns none when git commit precedes git push in compound command (kaizen #721)', () => {
+    expect(detectTrigger('git add -A && git commit -m "fix" && git push')).toBe('none');
+    expect(detectTrigger('git commit -m "msg" && git push origin main')).toBe('none');
+  });
+
+  it('still detects standalone git push', () => {
+    expect(detectTrigger('git push origin feature')).toBe('git_push');
+    expect(detectTrigger('git push')).toBe('git_push');
+  });
+
+  it('still detects git push after non-commit commands', () => {
+    expect(detectTrigger('npm test && git push')).toBe('git_push');
+    expect(detectTrigger('echo done && git push origin main')).toBe('git_push');
+  });
+});
+
+describe('hasCommitBeforePush', () => {
+  it('detects commit before push in compound command', () => {
+    expect(hasCommitBeforePush('git commit -m "fix" && git push')).toBe(true);
+    expect(hasCommitBeforePush('git add -A && git commit -m "msg" && git push origin main')).toBe(true);
+  });
+
+  it('returns false for push without preceding commit', () => {
+    expect(hasCommitBeforePush('git push origin main')).toBe(false);
+    expect(hasCommitBeforePush('npm test && git push')).toBe(false);
+  });
+
+  it('returns false when push comes before commit', () => {
+    expect(hasCommitBeforePush('git push && git commit -m "fix"')).toBe(false);
+  });
+
+  it('handles git -C path variants', () => {
+    expect(hasCommitBeforePush('git -C /foo commit -m "x" && git -C /foo push')).toBe(true);
   });
 });
 
@@ -97,6 +133,13 @@ describe('checkDirtyFiles', () => {
     });
     expect(result.action).toBe('warn');
     expect(result.message).toContain('merging a PR');
+  });
+
+  it('allows compound commit+push even when dirty (kaizen #721)', () => {
+    const result = checkDirtyFiles('git add -A && git commit -m "fix" && git push', {
+      gitRunner: mockGit(' M src/hooks/test.ts'),
+    });
+    expect(result.action).toBe('allow');
   });
 
   it('skips during merge resolution (kaizen #775)', () => {

--- a/src/hooks/check-dirty-files.ts
+++ b/src/hooks/check-dirty-files.ts
@@ -21,6 +21,7 @@ import {
   extractGitCPath,
   isGhPrCommand,
   isGitCommand,
+  splitCommandSegments,
   stripHeredocBody,
 } from './parse-command.js';
 
@@ -28,9 +29,29 @@ const EXEC_OPTS: ExecSyncOptions = { encoding: 'utf-8' as const, stdio: ['pipe',
 
 type TriggerType = 'pr_create' | 'git_push' | 'pr_merge' | 'none';
 
+/**
+ * Check if a compound command has `git commit` before `git push`.
+ * When the user runs `git add -A && git commit -m '...' && git push`,
+ * dirty files will be committed before push runs — so the dirty-files
+ * check would be a false positive (kaizen #721).
+ */
+export function hasCommitBeforePush(cmdLine: string): boolean {
+  const segments = splitCommandSegments(cmdLine);
+  let foundCommit = false;
+  for (const seg of segments) {
+    if (/^git\s+(-C\s+\S+\s+)?commit\b/.test(seg)) foundCommit = true;
+    if (/^git\s+(-C\s+\S+\s+)?push\b/.test(seg) && foundCommit) return true;
+  }
+  return false;
+}
+
 export function detectTrigger(cmdLine: string): TriggerType {
   if (isGhPrCommand(cmdLine, 'create')) return 'pr_create';
-  if (isGitCommand(cmdLine, 'push')) return 'git_push';
+  if (isGitCommand(cmdLine, 'push')) {
+    // Skip false positive when commit precedes push in compound command (kaizen #721)
+    if (hasCommitBeforePush(cmdLine)) return 'none';
+    return 'git_push';
+  }
   if (isGhPrCommand(cmdLine, 'merge')) return 'pr_merge';
   return 'none';
 }

--- a/src/hooks/parse-command.ts
+++ b/src/hooks/parse-command.ts
@@ -28,7 +28,7 @@ export function stripHeredocBody(command: string): string {
  * Split a command line by pipe/chain operators (|, &&, ||, ;)
  * and return individual segments trimmed.
  */
-function splitCommandSegments(cmdLine: string): string[] {
+export function splitCommandSegments(cmdLine: string): string[] {
   return cmdLine
     .split(/[|;&]{1,2}/)
     .map((s) => s.trim())


### PR DESCRIPTION
## Summary

- **#721**: Fixed dirty-files hook false positive when `git commit && git push` is used as a compound command. The hook previously fired on `push` before `commit` had executed. Added `hasCommitBeforePush()` to detect and skip this case.
- **#793**: Added settings.json <-> plugin.json hook parity check to `validate-hook-integrity.sh`. Immediately caught that `kaizen-search-before-file.sh` was in plugin.json but missing from settings.json — fixed the drift.

## Changes

| File | What |
|------|------|
| `src/hooks/check-dirty-files.ts` | Added `hasCommitBeforePush()`, integrated into `detectTrigger()` |
| `src/hooks/parse-command.ts` | Exported `splitCommandSegments` for reuse |
| `src/hooks/check-dirty-files.test.ts` | 8 new tests for compound command detection |
| `src/hooks/bash-ts-parity.test.ts` | Added `splitCommandSegments` to exclusions |
| `.claude/hooks/tests/validate-hook-integrity.sh` | Added settings/plugin sync check |
| `.claude/settings.json` | Added missing `kaizen-search-before-file.sh` |

## Test plan

- [x] All 1585 TS tests pass
- [x] All 565 shell hook tests pass
- [x] `validate-hook-integrity.sh` reports 0 errors (50 hooks, all in sync)
- [x] New tests cover: compound commands, standalone push, non-commit prefix, git -C variants

Run tag: jolly-marsupial/run-1
Fixes #721
Fixes #793

Generated with [Claude Code](https://claude.com/claude-code)