### PR TITLE
fix(skills): add dead code deletion prompts to evaluate and implement skills

### DIFF
--- a/.claude/skills/kaizen-evaluate/SKILL.md
+++ b/.claude/skills/kaizen-evaluate/SKILL.md
@@ -183,6 +183,7 @@ Before accepting work, assess whether you have the right tools to do it well. Ba
 | Can we test this E2E? | No harness exists → **building the harness is IN SCOPE, not a follow-up** |
 | What existing patterns in the codebase should we reuse? | None found → grep before writing |
 | What test infrastructure do we need? | Nothing planned → mock helpers, fixtures, shared setup must be scoped |
+| What dead code or legacy paths exist in this area? | Working around dead code instead of deleting it → identify and remove dead code as part of the fix |
 
 **The critical rule:** If the E2E test harness doesn't exist, building it is part of this work. Deferring testability is how we get the 4-PR pattern (#400). "Tests later" = no tests. "Harness in a follow-up" = no harness.
 

--- a/.claude/skills/kaizen-implement/SKILL.md
+++ b/.claude/skills/kaizen-implement/SKILL.md
@@ -90,6 +90,7 @@ Every requirement in the spec was added by someone smart at some point. That doe
 - Is this still needed? Has the problem been partially solved by other work?
 - Who added this requirement? (Check git blame on the spec.) Are they still the right person to validate it?
 - What happens if we just... don't do this part?
+- **Is there dead code related to this issue?** Removing dead code simplifies the fix and prevents it from causing future confusion. Deletion is a feature, not a risk.
 
 **Concrete actions:**
 - Re-read the spec's problem statement. Do the incidents it cites still reproduce?


### PR DESCRIPTION
## Summary

- Adds "What dead code or legacy paths exist in this area?" row to `/kaizen-evaluate` Phase 3.7 Architecture & Tooling Fitness table
- Adds "Is there dead code related to this issue?" prompt to `/kaizen-implement` Question the Requirements section

This prevents agents from working around dead code instead of removing it — a failure mode observed 3 times during #760/#756 evaluation.

Fixes Garsson-io/kaizen#765

Run tag: jolly-marsupial/run-10

## Test plan

- [x] Verify table formatting renders correctly in markdown
- [x] Verify implement skill bullet integrates naturally with existing list

Generated with [Claude Code](https://claude.com/claude-code)