### PR TITLE
fix(hooks): benchmark all hooks, not just kaizen-* prefixed ones (#811)

### DIFF
--- a/.claude/hooks/lib/hook-timing-sentinel.sh
+++ b/.claude/hooks/lib/hook-timing-sentinel.sh
@@ -41,17 +41,6 @@ _time_hook() {
   echo $(( end - start ))
 }
 
-# Get the list of hook scripts from settings.json.
-# Returns unique hook paths, one per line.
-_list_hooks_from_settings() {
-  local settings_file
-  local hook_dir
-  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-  settings_file="$(cd "$hook_dir/../.." && pwd)/.claude/settings.json"
-  [ -f "$settings_file" ] || return 1
-  jq -r '.. | .command? // empty' "$settings_file" 2>/dev/null | sort -u
-}
-
 # Run the full hook benchmark. Outputs a formatted report if any hook
 # exceeds the warning threshold. Outputs nothing if all hooks are fast.
 #
@@ -67,7 +56,7 @@ run_hook_benchmark() {
   local project_root
   project_root="$(cd "$hook_dir/../.." && pwd)"
 
-  for hook_path in "$hook_dir"/kaizen-*.sh; do
+  for hook_path in "$hook_dir"/*.sh; do
     [ -f "$hook_path" ] && [ -x "$hook_path" ] && hooks+=("$hook_path")
   done
 


### PR DESCRIPTION
## Summary

- Changed glob in `hook-timing-sentinel.sh` from `kaizen-*.sh` to `*.sh` so `pr-review-loop-ts.sh` and `pr-kaizen-clear-ts.sh` are included in performance benchmarks
- Removed dead `_list_hooks_from_settings()` function (never called, misleading)

Net: -11 lines

Fixes #811

Run tag: jolly-marsupial/run-12

## Test plan

- [x] All 1640 existing tests pass
- [x] No other code references the removed function
- [x] New glob matches all 21 hook scripts in `.claude/hooks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)