### PR TITLE
fix: remove 38 dead TypeScript exports across 11 files

### DIFF
--- a/src/claude-wt.ts
+++ b/src/claude-wt.ts
@@ -14,7 +14,7 @@ import { analyzeWorktrees, defaultDeps } from "./worktree-du.js";
 
 // ── Arg parsing (exported for tests) ──
 
-export interface ParsedArgs {
+interface ParsedArgs {
   skipPermissions: boolean;
   claudeArgs: string[];
 }

--- a/src/cli-experiment.ts
+++ b/src/cli-experiment.ts
@@ -23,14 +23,14 @@ import { parseExperimentSpec } from './experiment-spec-parser.js';
 
 // --- Types ---
 
-export type ExperimentStatus =
+type ExperimentStatus =
   | 'pending'
   | 'running'
   | 'completed'
   | 'falsified'
   | 'inconclusive';
-export type ExperimentResult = 'supported' | 'falsified' | 'inconclusive';
-export type ExperimentPattern =
+type ExperimentResult = 'supported' | 'falsified' | 'inconclusive';
+type ExperimentPattern =
   | 'a-b-compare'
   | 'probe-and-observe'
   | 'toggle-and-measure';
@@ -49,7 +49,7 @@ export interface ExperimentFrontmatter {
   measurements: ExperimentMeasurement[];
 }
 
-export interface ExperimentMeasurement {
+interface ExperimentMeasurement {
   name: string;
   method: string;
   expected: string;

--- a/src/experiment-spec-parser.ts
+++ b/src/experiment-spec-parser.ts
@@ -6,17 +6,17 @@
 
 // Types
 
-export interface ExperimentVariant {
+interface ExperimentVariant {
   name: string;
   value: string;
 }
 
-export interface ExperimentMetric {
+interface ExperimentMetric {
   type: 'primary' | 'secondary';
   name: string;
 }
 
-export interface ExperimentBudget {
+interface ExperimentBudget {
   runsPerVariant: number | null;
   maxCostPerRun: number | null;
 }

--- a/src/hooks/check-dirty-files.ts
+++ b/src/hooks/check-dirty-files.ts
@@ -56,7 +56,7 @@ export function detectTrigger(cmdLine: string): TriggerType {
   return 'none';
 }
 
-export interface DirtyFileReport {
+interface DirtyFileReport {
   staged: string[];
   modified: string[];
   untracked: string[];

--- a/src/hooks/pr-quality-checks.ts
+++ b/src/hooks/pr-quality-checks.ts
@@ -23,7 +23,7 @@ import {
   stripHeredocBody,
 } from './parse-command.js';
 
-export type CommandType = 'pr_create' | 'pr_merge' | 'git_commit' | 'none';
+type CommandType = 'pr_create' | 'pr_merge' | 'git_commit' | 'none';
 
 export function detectCommandType(cmdLine: string): CommandType {
   if (isGhPrCommand(cmdLine, 'create')) return 'pr_create';
@@ -32,7 +32,7 @@ export function detectCommandType(cmdLine: string): CommandType {
   return 'none';
 }
 
-export interface RunnerOptions {
+interface RunnerOptions {
   exec?: (cmd: string) => string;
   fileExists?: (path: string) => boolean;
   readFile?: (path: string) => string;
@@ -71,7 +71,7 @@ export function getChangedFiles(
 }
 
 // Check 1: Test coverage
-export interface TestCoverageResult {
+interface TestCoverageResult {
   srcCount: number;
   testCount: number;
   uncoveredFiles: string[];
@@ -297,7 +297,7 @@ Full checklist: .claude/kaizen/practices.md`;
 }
 
 // Check 4: Code quality warnings
-export interface CodeQualityResult {
+interface CodeQualityResult {
   warnings: string[];
 }
 
@@ -365,7 +365,7 @@ See: Zen of Kaizen \u2014 "Avoiding overengineering is not a license to undereng
 }
 
 // Main orchestrator
-export interface QualityCheckOutput {
+interface QualityCheckOutput {
   messages: string[];
 }
 

--- a/src/hooks/state-utils.ts
+++ b/src/hooks/state-utils.ts
@@ -17,7 +17,7 @@ import {
 import { join } from 'node:path';
 
 export const DEFAULT_STATE_DIR = process.env.STATE_DIR || '/tmp/.pr-review-state';
-export const DEFAULT_MAX_STATE_AGE = 7200; // 2 hours
+const DEFAULT_MAX_STATE_AGE = 7200; // 2 hours
 
 // Default audit directory. Override via AUDIT_DIR env var for test isolation (kaizen #429).
 export const DEFAULT_AUDIT_DIR = new URL(
@@ -91,7 +91,7 @@ export function writeStateFile(
 /**
  * Check if a state file belongs to the current worktree and is not stale.
  */
-export function isStateForCurrentWorktree(
+function isStateForCurrentWorktree(
   filepath: string,
   now: number,
   currentBranch: string,

--- a/src/hooks/telemetry-analysis.ts
+++ b/src/hooks/telemetry-analysis.ts
@@ -23,7 +23,7 @@ export interface HookTelemetryRecord {
   case_id: string;
 }
 
-export interface HookStats {
+interface HookStats {
   hook: string;
   count: number;
   avg_ms: number;
@@ -33,7 +33,7 @@ export interface HookStats {
   failures: number;
 }
 
-export interface TelemetryReport {
+interface TelemetryReport {
   total_records: number;
   time_range: { first: string; last: string } | null;
   hooks: HookStats[];

--- a/src/hooks/transcript-analysis.ts
+++ b/src/hooks/transcript-analysis.ts
@@ -48,7 +48,7 @@ export interface Signal {
   evidence: string;
 }
 
-export interface TranscriptAnalysis {
+interface TranscriptAnalysis {
   signals: Signal[];
   summary: {
     totalEntries: number;
@@ -177,7 +177,7 @@ export function parseTranscript(content: string): TranscriptEntry[] {
 }
 
 /** Read and parse a transcript file. */
-export function readTranscript(filePath: string): TranscriptEntry[] {
+function readTranscript(filePath: string): TranscriptEntry[] {
   const content = readFileSync(filePath, 'utf-8');
   return parseTranscript(content);
 }

--- a/src/issue-backend.ts
+++ b/src/issue-backend.ts
@@ -45,14 +45,14 @@ export interface Issue {
   closedAt?: string;
 }
 
-export interface CreateIssueOpts {
+interface CreateIssueOpts {
   title: string;
   body: string;
   labels?: string[];
   repo?: string;
 }
 
-export interface ListIssuesOpts {
+interface ListIssuesOpts {
   state?: "open" | "closed" | "all";
   labels?: string[];
   search?: string;
@@ -61,7 +61,7 @@ export interface ListIssuesOpts {
   json?: string[];
 }
 
-export interface EditIssueOpts {
+interface EditIssueOpts {
   number: number;
   addLabels?: string[];
   removeLabels?: string[];
@@ -69,20 +69,20 @@ export interface EditIssueOpts {
   repo?: string;
 }
 
-export interface CommentOpts {
+interface CommentOpts {
   number: number;
   body: string;
   repo?: string;
 }
 
-export interface CreateResult {
+interface CreateResult {
   number: number;
   url: string;
 }
 
 // ── Backend Interface ──
 
-export interface IssueBackend {
+interface IssueBackend {
   readonly name: string;
 
   create(opts: CreateIssueOpts): CreateResult;

--- a/src/kaizen-setup.ts
+++ b/src/kaizen-setup.ts
@@ -52,7 +52,7 @@ export interface ScaffoldResult {
   reason?: string;
 }
 
-export interface VerifyCheck {
+interface VerifyCheck {
   name: string;
   ok: boolean;
   detail?: string;
@@ -141,7 +141,7 @@ Add project-specific enforcement rules here.
   return { step: "scaffold", status: "ok", path };
 }
 
-export interface PluginContractCheck {
+interface PluginContractCheck {
   hookPaths: VerifyCheck[];
   skillDirs: VerifyCheck[];
   matchers: VerifyCheck[];
@@ -276,13 +276,13 @@ export function verifySetup(cwd: string, opts?: { pluginRoot?: string }): Verify
   return { step: "verify", status: failed > 0 ? "failed" : "ok", checks, passed, failed };
 }
 
-export interface ValidateCheck {
+interface ValidateCheck {
   name: string;
   ok: boolean;
   output?: string;
 }
 
-export interface ValidateResult {
+interface ValidateResult {
   step: "post-update-validate";
   status: "ok" | "failed";
   checks: ValidateCheck[];

--- a/src/worktree-du.ts
+++ b/src/worktree-du.ts
@@ -13,7 +13,7 @@ import { resolveProjectPaths, type ProjectPaths } from "./lib/resolve-project-ro
 
 // ── Types ──
 
-export type LockClass = "active" | "stale" | "orphaned" | "none";
+type LockClass = "active" | "stale" | "orphaned" | "none";
 export type MergeStatus = "merged" | "squash-merged" | "at-main" | "unmerged";
 
 export interface LockFile {
@@ -22,7 +22,7 @@ export interface LockFile {
   started_at?: string;
 }
 
-export interface WorktreeInfo {
+interface WorktreeInfo {
   name: string;
   path: string;
   branch: string;
@@ -35,7 +35,7 @@ export interface WorktreeInfo {
   caseInfo: string | null;
 }
 
-export interface AnalyzeSummary {
+interface AnalyzeSummary {
   count: number;
   totalSize: number;
   activeLocks: number;
@@ -44,7 +44,7 @@ export interface AnalyzeSummary {
   dirty: number;
 }
 
-export interface BranchSummary {
+interface BranchSummary {
   total: number;
   merged: number;
   unmerged: number;
@@ -93,7 +93,7 @@ export function defaultDeps(): Deps {
 
 const STALE_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
 
-export function readLockFile(wtPath: string, deps: Deps): LockFile | null {
+function readLockFile(wtPath: string, deps: Deps): LockFile | null {
   const lockPath = join(wtPath, ".worktree-lock.json");
   if (!deps.exists(lockPath)) return null;
   try {
@@ -103,7 +103,7 @@ export function readLockFile(wtPath: string, deps: Deps): LockFile | null {
   }
 }
 
-export function classifyLockFromData(lock: LockFile | null, deps: Deps): LockClass {
+function classifyLockFromData(lock: LockFile | null, deps: Deps): LockClass {
   if (!lock) return "none";
 
   const pid = lock.pid;
@@ -330,7 +330,7 @@ export interface CleanupResult {
   actions: CleanupAction[];
 }
 
-export interface CleanupAction {
+interface CleanupAction {
   type: "skip" | "remove" | "remove-lock" | "fail";
   target: string;
   reason: string;
@@ -569,7 +569,7 @@ function printCleanup(result: CleanupResult, dryRun: boolean) {
 
 // ── CLI ──
 
-export interface CliOptions {
+interface CliOptions {
   mode: "analyze" | "cleanup";
   fast: boolean;
   dryRun: boolean;


### PR DESCRIPTION
## Summary

- Remove `export` keyword from 38 symbols across 11 TypeScript files that are never imported externally
- Verified each symbol via cross-file grep — 3 symbols from the original issue were found to be live and kept exported (`StateFile`, `SessionEvent`, `SessionPrMergedEvent`)
- All symbols remain available locally — only the unnecessary public API surface is removed

Fixes #820

Relates to epic #560 (Subtraction).

Run tag: jolly-marsupial/run-20

## Test plan

- [x] `npm run build` passes (no type errors from removing exports)
- [x] All 1665 tests pass
- [x] Verified each symbol is unused externally before removing export

🤖 Generated with [Claude Code](https://claude.com/claude-code)