### PR TITLE
fix: stop swallowing stderr in TS trampoline hooks

### DIFF
--- a/.claude/hooks/kaizen-bump-plugin-version-ts.sh
+++ b/.claude/hooks/kaizen-bump-plugin-version-ts.sh
@@ -3,4 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/bump-plugin-version.ts" 2>/dev/null
+exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/bump-plugin-version.ts"

--- a/.claude/hooks/kaizen-check-dirty-files-ts.sh
+++ b/.claude/hooks/kaizen-check-dirty-files-ts.sh
@@ -3,4 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/check-dirty-files.ts" 2>/dev/null
+exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/check-dirty-files.ts"

--- a/.claude/hooks/kaizen-enforce-pr-reflect-ts.sh
+++ b/.claude/hooks/kaizen-enforce-pr-reflect-ts.sh
@@ -3,4 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/enforce-pr-reflect.ts" 2>/dev/null
+exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/enforce-pr-reflect.ts"

--- a/.claude/hooks/kaizen-enforce-pr-review-ts.sh
+++ b/.claude/hooks/kaizen-enforce-pr-review-ts.sh
@@ -3,4 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/enforce-pr-review.ts" 2>/dev/null
+exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/enforce-pr-review.ts"

--- a/.claude/hooks/kaizen-post-merge-clear-ts.sh
+++ b/.claude/hooks/kaizen-post-merge-clear-ts.sh
@@ -3,4 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/post-merge-clear.ts" 2>/dev/null
+exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/post-merge-clear.ts"

--- a/.claude/hooks/kaizen-pr-quality-checks-ts.sh
+++ b/.claude/hooks/kaizen-pr-quality-checks-ts.sh
@@ -5,4 +5,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/pr-quality-checks.ts" 2>/dev/null
+exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/pr-quality-checks.ts"

--- a/.claude/hooks/kaizen-session-cleanup-ts.sh
+++ b/.claude/hooks/kaizen-session-cleanup-ts.sh
@@ -3,4 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/session-cleanup.ts" 2>/dev/null
+exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/session-cleanup.ts"

--- a/.claude/hooks/pr-review-loop-ts.sh
+++ b/.claude/hooks/pr-review-loop-ts.sh
@@ -3,4 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/$(basename "${BASH_SOURCE[0]}" .sh | sed 's/-ts$//' ).ts" 2>/dev/null
+exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/$(basename "${BASH_SOURCE[0]}" .sh | sed 's/-ts$//' ).ts"


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from all 10 TS hook trampoline scripts (8 files + 2 symlinks)
- TypeScript compilation errors, runtime exceptions, and npx failures are now visible on stderr instead of silently discarded
- Previously, a crashing hook would appear to "pass" (exit 0 from failed exec) — enforcement gates could be silently bypassed

Fixes #821

jolly-marsupial/run-21

## Test plan

- [x] All 1665 tests pass
- [x] Symlinks (`kaizen-reflect-ts.sh`, `pr-kaizen-clear-ts.sh`) preserved correctly — they point to the fixed `pr-review-loop-ts.sh`
- [x] Verified no other `2>/dev/null` patterns in trampoline scripts remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)