### PR TITLE
fix: deduplicate batch progress issues (#726)

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -44,7 +44,10 @@ import {
   type SweepResult,
   type PromptMetadata,
   validateRunLifecycle,
+  findExistingProgressIssue,
+  ensureBatchProgressIssue,
 } from './auto-dent-run.js';
+import * as github from './auto-dent-github.js';
 
 function makeBatchState(overrides: Partial<BatchState> = {}): BatchState {
   return {
@@ -2773,5 +2776,111 @@ describe('module wiring: re-exported symbols used locally must be imported', () 
     }
 
     expect(missing).toEqual([]);
+  });
+});
+
+describe('findExistingProgressIssue', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns URL when GitHub search finds a matching issue', () => {
+    vi.spyOn(github, 'ghExec').mockReturnValue(JSON.stringify([{ url: 'https://github.com/Garsson-io/kaizen/issues/707' }]));
+    const result = findExistingProgressIssue('batch-260323-1405-5400', 'Garsson-io/kaizen');
+    expect(result).toBe('https://github.com/Garsson-io/kaizen/issues/707');
+  });
+
+  it('returns empty string when no matching issue found', () => {
+    vi.spyOn(github, 'ghExec').mockReturnValue('[]');
+    const result = findExistingProgressIssue('batch-nonexistent', 'Garsson-io/kaizen');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when ghExec returns empty string', () => {
+    vi.spyOn(github, 'ghExec').mockReturnValue('');
+    const result = findExistingProgressIssue('batch-123', 'Garsson-io/kaizen');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when ghExec returns invalid JSON', () => {
+    vi.spyOn(github, 'ghExec').mockReturnValue('not-json');
+    const result = findExistingProgressIssue('batch-123', 'Garsson-io/kaizen');
+    expect(result).toBe('');
+  });
+
+  it('passes batch ID in search query', () => {
+    const spy = vi.spyOn(github, 'ghExec').mockReturnValue('[]');
+    findExistingProgressIssue('batch-260323-1405-5400', 'Garsson-io/kaizen');
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toContain('batch-260323-1405-5400');
+    expect(spy.mock.calls[0][0]).toContain('--repo Garsson-io/kaizen');
+    expect(spy.mock.calls[0][0]).toContain('--label auto-dent');
+  });
+});
+
+describe('ensureBatchProgressIssue', () => {
+  let tmpDir: string;
+  let stateFile: string;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    tmpDir = mkdtempSync(join(tmpdir(), 'progress-issue-'));
+    stateFile = join(tmpDir, 'state.json');
+  });
+
+  afterEach(() => {
+    try { unlinkSync(stateFile); } catch {}
+  });
+
+  it('returns cached progress_issue without calling GitHub', () => {
+    const spy = vi.spyOn(github, 'ghExec');
+    const state = makeBatchState({ progress_issue: 'https://github.com/o/r/issues/42' });
+    writeState(stateFile, state);
+    const result = ensureBatchProgressIssue(state, stateFile);
+    expect(result).toBe('https://github.com/o/r/issues/42');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('returns empty string when kaizen_repo is empty', () => {
+    const spy = vi.spyOn(github, 'ghExec');
+    const state = makeBatchState({ kaizen_repo: '' });
+    writeState(stateFile, state);
+    const result = ensureBatchProgressIssue(state, stateFile);
+    expect(result).toBe('');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('reuses existing issue found via search instead of creating duplicate', () => {
+    const existingUrl = 'https://github.com/Garsson-io/kaizen/issues/707';
+    const spy = vi.spyOn(github, 'ghExec')
+      .mockReturnValueOnce(JSON.stringify([{ url: existingUrl }]));
+    const state = makeBatchState({ progress_issue: undefined });
+    writeState(stateFile, state);
+
+    const result = ensureBatchProgressIssue(state, stateFile);
+
+    expect(result).toBe(existingUrl);
+    expect(spy).toHaveBeenCalledOnce(); // only search, no create
+    expect(spy.mock.calls[0][0]).toContain('issue list');
+    const saved = readState(stateFile);
+    expect(saved.progress_issue).toBe(existingUrl);
+  });
+
+  it('creates new issue when search finds nothing', () => {
+    const newUrl = 'https://github.com/Garsson-io/kaizen/issues/800';
+    const spy = vi.spyOn(github, 'ghExec')
+      .mockReturnValueOnce('[]')       // search returns empty
+      .mockReturnValueOnce(newUrl);     // create returns new URL
+    const state = makeBatchState({ progress_issue: undefined });
+    writeState(stateFile, state);
+
+    const result = ensureBatchProgressIssue(state, stateFile);
+
+    expect(result).toBe(newUrl);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[0][0]).toContain('issue list');   // search
+    expect(spy.mock.calls[1][0]).toContain('issue create'); // create
+    const saved = readState(stateFile);
+    expect(saved.progress_issue).toBe(newUrl);
   });
 });

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -930,6 +930,24 @@ export function cleanGuidanceForTitle(guidance: string): string {
 
 // Batch progress issue management
 
+/**
+ * Search GitHub for an existing batch progress issue by batch ID.
+ * Returns the issue URL if found, empty string otherwise.
+ */
+export function findExistingProgressIssue(batchId: string, kaizenRepo: string): string {
+  const result = ghExec(
+    `gh issue list --repo ${kaizenRepo} --label auto-dent --search ${JSON.stringify(batchId)} --json url --limit 1`,
+  );
+  if (!result) return '';
+  try {
+    const issues = JSON.parse(result) as Array<{ url: string }>;
+    if (issues.length > 0) return issues[0].url;
+  } catch {
+    // JSON parse failed — no match
+  }
+  return '';
+}
+
 export function ensureBatchProgressIssue(
   state: BatchState,
   stateFile: string,
@@ -938,6 +956,16 @@ export function ensureBatchProgressIssue(
 
   const kaizenRepo = state.kaizen_repo;
   if (!kaizenRepo) return '';
+
+  // Search for an existing progress issue to avoid duplicates (#726)
+  const existing = findExistingProgressIssue(state.batch_id, kaizenRepo);
+  if (existing) {
+    console.log(`  [hygiene] found existing batch progress issue: ${existing}`);
+    const freshState = readState(stateFile);
+    freshState.progress_issue = existing;
+    writeState(stateFile, freshState);
+    return existing;
+  }
 
   const cleanGuidance = cleanGuidanceForTitle(state.guidance);
   const title = `[Auto-Dent] ${truncateAtWord(cleanGuidance, 70)} (${state.batch_id})`;


### PR DESCRIPTION
## Summary

- `ensureBatchProgressIssue` now searches GitHub for an existing tracking issue (by batch ID + `auto-dent` label) before creating a new one
- Prevents duplicate tracking issues when state is lost or multiple runs race at batch start
- New `findExistingProgressIssue` function handles search + JSON parsing with graceful fallbacks

Fixes #726

Run tag: jolly-marsupial/run-23

## Test plan

- [x] 5 tests for `findExistingProgressIssue` (match found, empty results, empty string, invalid JSON, query validation)
- [x] 4 tests for `ensureBatchProgressIssue` (cached, no repo, reuse existing, create new)
- [x] Full test suite passes (1700 tests)
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)