### PR TITLE
fix: remove stale NanoClaw references across 6 files

### DIFF
--- a/.claude/hooks/tests/harness.py
+++ b/.claude/hooks/tests/harness.py
@@ -377,7 +377,7 @@ class MockBinDir:
         return f"{self.dir}:{self._original_path}"
 
     def add_git_mock(self, branch: str = "wt/test", status_output: str = "",
-                     diff_output: str = "", remote_url: str = "https://github.com/Garsson-io/nanoclaw.git",
+                     diff_output: str = "", remote_url: str = "https://github.com/Garsson-io/kaizen.git",
                      simulate_main_checkout: bool = False):
         """Create a mock git binary.
 
@@ -466,9 +466,9 @@ EOF
 
     "git_push_simple": "git push",
 
-    "pr_merge_squash": "gh pr merge 47 --repo Garsson-io/nanoclaw --squash --delete-branch",
+    "pr_merge_squash": "gh pr merge 47 --repo Garsson-io/kaizen --squash --delete-branch",
 
-    "pr_diff": "gh pr diff 47 --repo Garsson-io/nanoclaw",
+    "pr_diff": "gh pr diff 47 --repo Garsson-io/kaizen",
 
     "chained_commit_push": 'git add src/index.ts && git commit -m "fix: update routing" && git push origin wt/test',
 

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -86,7 +86,7 @@ class TestDenySchema:
         assert "worktree" in result.stderr.lower(), f"Expected worktree warning on stderr, got: {result.stderr[:200]}"
 
     def test_pr_review_gate_denies_during_review(self, review_harness, state):
-        state.create_state("https://github.com/Garsson-io/nanoclaw/pull/42", round_num=1, status="needs_review", branch="wt/test-branch")
+        state.create_state("https://github.com/Garsson-io/kaizen/pull/42", round_num=1, status="needs_review", branch="wt/test-branch")
 
         # npm test is now allowed as diagnostic (kaizen #775), use npm install instead
         result = review_harness.run_hook("kaizen-enforce-pr-review-ts.sh", PreToolUseInput.bash("npm install lodash"))
@@ -161,7 +161,7 @@ class TestRealWorldCommands:
         """Some gh versions output PR URL to stderr."""
         inp = PostToolUseInput.bash(
             "gh pr create --title test --body test",
-            stderr="https://github.com/Garsson-io/nanoclaw/pull/88",
+            stderr="https://github.com/Garsson-io/kaizen/pull/88",
         )
         result = review_harness.run_hook("pr-review-loop-ts.sh", inp)
         assert "SELF-REVIEW" in result.stdout
@@ -229,7 +229,7 @@ class TestEdgeCases:
 class TestPRLifecycle:
     """INVARIANT: PR review lifecycle transitions correctly across hooks."""
 
-    PR_URL = "https://github.com/Garsson-io/nanoclaw/pull/55"
+    PR_URL = "https://github.com/Garsson-io/kaizen/pull/55"
 
     def test_full_lifecycle(self, review_harness, state):
         """End-to-end: create → gate → diff → open → push → re-gate → merge → cleanup."""
@@ -282,12 +282,12 @@ class TestPRLifecycle:
         assert not state.state_exists(self.PR_URL), "State should be cleaned up after merge"
 
     def test_multi_repo_isolation(self, review_harness, state):
-        url_a = "https://github.com/Garsson-io/nanoclaw/pull/60"
+        url_a = "https://github.com/Garsson-io/kaizen/pull/60"
         url_b = "https://github.com/Garsson-io/garsson-prints/pull/10"
 
         # Create PRs for both repos
         review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
-            "gh pr create --repo Garsson-io/nanoclaw", stdout=url_a))
+            "gh pr create --repo Garsson-io/kaizen", stdout=url_a))
         review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
             "gh pr create --repo Garsson-io/garsson-prints", stdout=url_b))
 
@@ -328,7 +328,7 @@ class TestParallelExecution:
         mocks.add_git_mock(branch="main", status_output=" M src/dirty.ts")
         harness.set_env("PATH", mocks.path_with_mocks)
         harness.set_env("STATE_DIR", str(state.state_dir))
-        state.create_state("https://github.com/Garsson-io/nanoclaw/pull/42", status="needs_review", branch="main")
+        state.create_state("https://github.com/Garsson-io/kaizen/pull/42", status="needs_review", branch="main")
 
         # gh pr create on main branch with dirty files and active review
         inp = PreToolUseInput.bash("gh pr create --title test --body test")
@@ -345,7 +345,7 @@ class TestParallelExecution:
     def test_both_post_hooks_fire_on_pr_create(self, review_harness, state):
         inp = PostToolUseInput.bash(
             "gh pr create --title test --body test",
-            stdout="https://github.com/Garsson-io/nanoclaw/pull/99")
+            stdout="https://github.com/Garsson-io/kaizen/pull/99")
 
         review_result = review_harness.run_hook("pr-review-loop-ts.sh", inp)
         kaizen_result = review_harness.run_hook("kaizen-reflect-ts.sh", inp)
@@ -363,7 +363,7 @@ class TestPostToolUseFormat:
     def test_no_deny_json_in_post_hooks(self, review_harness, hook):
         inp = PostToolUseInput.bash(
             "gh pr create --title test --body test",
-            stdout="https://github.com/Garsson-io/nanoclaw/pull/70")
+            stdout="https://github.com/Garsson-io/kaizen/pull/70")
 
         result = review_harness.run_hook(hook, inp)
         assert result.exit_code == 0, f"{hook} should always exit 0"

--- a/docs/skill-script-pattern.md
+++ b/docs/skill-script-pattern.md
@@ -127,7 +127,7 @@ describe("kaizen-setup", () => {
 
 ## Reference Implementation
 
-NanoClaw's `/setup` skill demonstrates this pattern:
+Kaizen's `/kaizen-setup` skill demonstrates this pattern:
 - Skill markdown describes the flow and decision points
 - `bash setup.sh` handles bootstrap (Node.js, deps)
 - `npx tsx setup/index.ts --step <name>` handles each mechanical step

--- a/src/analysis/diff-checks.test.ts
+++ b/src/analysis/diff-checks.test.ts
@@ -124,7 +124,7 @@ describe('FM1: detectDryViolations', () => {
 // ============================================================
 
 describe('FM6: detectStaleReferences', () => {
-  // --- Real incident: PR #416, 24 files referenced old nanoclaw names ---
+  // --- Real incident: PR #416, 24 files referenced old product names ---
   it('detects old skill name after rename (PR #416 pattern)', () => {
     const files: DiffFile[] = [
       {
@@ -245,7 +245,7 @@ describe('FM5: detectEnvAssumptions', () => {
       {
         path: 'scripts/worktree-du.sh',
         additions: [
-          'REPO_ROOT="/home/aviadr1/projects/nanoclaw"',
+          'REPO_ROOT="/home/aviadr1/projects/kaizen"',
         ],
         deletions: [],
 

--- a/src/e2e/plugin-lifecycle.test.ts
+++ b/src/e2e/plugin-lifecycle.test.ts
@@ -4,7 +4,7 @@
  * Tests the FULL operation: setup → hook registration → workflow simulation.
  * No LLM needed — hooks are executed directly with simulated Claude Code events.
  *
- * This is the "trigger-to-outcome" test for kaizen itself (cf. NanoClaw issue #173).
+ * This is the "trigger-to-outcome" test for kaizen itself.
  * It verifies that:
  *   1. Setup produces correct configuration
  *   2. All hooks are registered and executable

--- a/src/worktree-du.ts
+++ b/src/worktree-du.ts
@@ -621,7 +621,7 @@ Flags:
   const deps = defaultDeps();
 
   console.log("");
-  console.log(`${BOLD}NanoClaw Worktree DU${NC}${opts.fast ? " (fast)" : ""}`);
+  console.log(`${BOLD}Kaizen Worktree DU${NC}${opts.fast ? " (fast)" : ""}`);
   console.log(`${DIM}${paths.projectRoot}${NC}`);
   console.log("");
 


### PR DESCRIPTION
## Summary

- Replace all remaining `NanoClaw`/`nanoclaw` references with `kaizen` equivalents across 6 files
- User-visible fix: worktree-du header now says "Kaizen Worktree DU" instead of "NanoClaw Worktree DU"
- Test harness URLs updated from `Garsson-io/nanoclaw` to `Garsson-io/kaizen`
- Only `review-criteria.md` retains a historical reference (acceptable context per issue)

Fixes #827

## Test plan

- [x] TypeScript build passes (`npm run build`)
- [x] diff-checks tests pass (47 tests)
- [x] Python hook tests pass (37 tests)
- [x] Grep confirms no remaining nanoclaw references except historical one

jolly-marsupial/run-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)