### PR TITLE
fix: add restart notice to kaizen-update skill (#783)

### DIFF
--- a/.claude/skills/kaizen-update/SKILL.md
+++ b/.claude/skills/kaizen-update/SKILL.md
@@ -93,6 +93,17 @@ git log --oneline -10
 
 Report what changed to the user.
 
+
+## Step 7: Restart notice
+
+**IMPORTANT:** Tell the user they must restart Claude Code for skill changes to take effect.
+
+Claude Code loads plugin skills into memory at session start. Updating files on disk does not cause a live reload. After the update completes, output this message:
+
+> **Update complete. Please restart Claude Code** (exit and re-launch) to pick up the new skill versions. Until you restart, skills will continue using the previous version's behavior.
+
+For plugin installs, this is especially important — the plugin cache is read once at startup.
+
 ## Workflow Tasks
 
 Create these tasks at skill start using TaskCreate:
@@ -103,5 +114,6 @@ Create these tasks at skill start using TaskCreate:
 | 2 | Install and re-setup | `npm install`, re-run symlinks/hooks (idempotent) |
 | 3 | Validate update | Run post-update-validate, abort if build/tests fail |
 | 4 | Show changelog | `git log --oneline -10`, report new skills |
+| 5 | Restart notice | Tell user to restart Claude Code for new skills to take effect |
 
 **What comes next:** Nothing — standalone update. See [workflow-tasks.md](../../kaizen/workflow-tasks.md) for full workflow.


### PR DESCRIPTION
## Summary

- Adds Step 7 (restart notice) to `/kaizen-update` SKILL.md instructing users to restart Claude Code after plugin updates
- Claude Code loads plugin skills into memory at session start — updating files on disk doesn't trigger a reload
- Updates workflow tasks table to include the restart step

Fixes #783

Run tag: jolly-marsupial/run-30

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1747 tests pass (`npm test`)
- [x] SKILL.md renders correctly with new Step 7 between Step 6 and Workflow Tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)