### PR TITLE
fix: enforce minimum labels in kaizen-file-issue skill (#835)

### DIFF
--- a/.claude/skills/kaizen-file-issue/SKILL.md
+++ b/.claude/skills/kaizen-file-issue/SKILL.md
@@ -93,6 +93,17 @@ Use the three-way routing from `/kaizen-reflect`:
 
 **Area labels** (pick one): `area/hooks`, `area/skills`, `area/cases`, `area/deploy`, `area/testing`, `area/container`, `area/worktree`, `area/observability`, `area/auto-dent`
 
+
+### Step 4b: Validate minimum labels
+
+Before filing, verify the issue will have **at minimum** these labels:
+- `kaizen` (always required)
+- One `area/*` label (e.g. `area/hooks`, `area/skills`, `area/testing`)
+
+If a level was determined, also include the `level-N` label. Issues filed without labels are invisible to `/kaizen-pick`, `/kaizen-audit-issues`, and filtered views — #757 sat unlabeled for 24+ hours as an installation blocker because it had no labels.
+
+**Hard rule:** Never pass an empty `--label` argument to `gh issue create`. If you cannot determine the area, default to the most likely area based on the incident description, or ask the user.
+
 ### Step 5: File the issue
 
 ```bash
@@ -141,6 +152,7 @@ Before filing, verify the issue body passes these checks:
 - [ ] **Title** starts with `[L1]`, `[L2]`, or `[L3]`
 - [ ] **No solution collapse** — the body doesn't prescribe "add hook X" or "change prompt Y"
 - [ ] **Duplicate search was done** — confirmed no existing issue covers this
+- [ ] **Labels present** — issue has at least `kaizen` + one `area/*` label. Never file without labels.
 
 ## Example Output
 


### PR DESCRIPTION
## Summary

- Adds Step 4b (Validate minimum labels) to `/kaizen-file-issue` requiring `kaizen` + one `area/*` label before filing
- Adds label presence check to the Issue Body Quality Checklist
- Prevents unlabeled issues from going invisible in filtered views, `/kaizen-pick`, and `/kaizen-audit-issues`

## Context

Issue #757 (critical installation blocker) sat unlabeled for 24+ hours because it was filed without any labels. This L1 prompt improvement ensures the skill always validates label presence before calling `gh issue create`.

Closes #835

Run tag: jolly-marsupial/run-31

## Test plan

- [ ] L1 skill prompt change — verified by reading the updated SKILL.md
- [ ] Build passes (`npm run build`)
- [ ] No code changes, only SKILL.md prompt improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)