### PR TITLE
fix: cmdValidate mismatch + DRY checkpoint + isolated dim tests

### DIFF
--- a/scripts/e2e-test-utils.test.ts
+++ b/scripts/e2e-test-utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { findLatestCheckpoint } from './e2e-test-utils.js';
+
+describe('findLatestCheckpoint', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'kaizen-e2e-utils-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null for non-existent directory', () => {
+    expect(findLatestCheckpoint('/dev/null/impossible', 'test-')).toBeNull();
+  });
+
+  it('returns null for empty directory', () => {
+    expect(findLatestCheckpoint(tmpDir, 'test-')).toBeNull();
+  });
+
+  it('returns null when no files match prefix', () => {
+    writeFileSync(join(tmpDir, 'other-1234.txt'), 'data');
+    expect(findLatestCheckpoint(tmpDir, 'test-')).toBeNull();
+  });
+
+  it('returns the most recent file by lexicographic sort', () => {
+    writeFileSync(join(tmpDir, 'test-100.txt'), 'old');
+    writeFileSync(join(tmpDir, 'test-200.txt'), 'mid');
+    writeFileSync(join(tmpDir, 'test-300.txt'), 'new');
+    expect(findLatestCheckpoint(tmpDir, 'test-')).toBe(join(tmpDir, 'test-300.txt'));
+  });
+
+  it('ignores non-.txt files', () => {
+    writeFileSync(join(tmpDir, 'test-999.json'), 'not txt');
+    writeFileSync(join(tmpDir, 'test-100.txt'), 'only match');
+    expect(findLatestCheckpoint(tmpDir, 'test-')).toBe(join(tmpDir, 'test-100.txt'));
+  });
+});

--- a/scripts/e2e-test-utils.ts
+++ b/scripts/e2e-test-utils.ts
@@ -1,0 +1,23 @@
+/**
+ * e2e-test-utils.ts — Shared helpers for E2E test files.
+ *
+ * Extracted from review-battery.e2e.test.ts and review-fix.e2e.test.ts
+ * to eliminate duplication (issue #880).
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Find the most recent checkpoint file matching a prefix in the results directory.
+ * Files are named: <prefix><timestamp>.txt — sorted lexicographically (most recent last).
+ * Returns the full path or null if none found.
+ */
+export function findLatestCheckpoint(resultsDir: string, prefix: string): string | null {
+  if (!existsSync(resultsDir)) return null;
+  const files = readdirSync(resultsDir)
+    .filter(f => f.startsWith(prefix) && f.endsWith('.txt'))
+    .sort()
+    .reverse();
+  return files.length > 0 ? join(resultsDir, files[0]) : null;
+}

--- a/scripts/review-battery.e2e.test.ts
+++ b/scripts/review-battery.e2e.test.ts
@@ -52,6 +52,7 @@ import { spawn } from 'node:child_process';
 import { expect } from 'vitest';
 import { spawnReview } from '../src/review-battery.js';
 import type { DimensionReview } from '../src/review-battery.js';
+import { findLatestCheckpoint as findLatestCheckpointShared } from './e2e-test-utils.js';
 
 // ── Results dir ───────────────────────────────────────────────────────
 
@@ -130,13 +131,7 @@ const SMOKE_BUDGET_USD = 0.30;
  * They contain the full SmokeResult JSON for that run.
  */
 function findLatestCheckpoint(dim: string, tier: 'smoke' | 'replay'): string | null {
-  if (!existsSync(RESULTS_DIR)) return null;
-  const prefix = `${dim}-${tier}-`;
-  const files = readdirSync(RESULTS_DIR)
-    .filter(f => f.startsWith(prefix) && f.endsWith('.txt'))
-    .sort()
-    .reverse(); // most recent first (timestamp in filename)
-  return files.length > 0 ? join(RESULTS_DIR, files[0]) : null;
+  return findLatestCheckpointShared(RESULTS_DIR, `${dim}-${tier}-`);
 }
 
 interface CheckpointData {

--- a/scripts/review-fix.e2e.test.ts
+++ b/scripts/review-fix.e2e.test.ts
@@ -42,6 +42,7 @@ import { mkdirSync, writeFileSync, existsSync, readFileSync, readdirSync } from 
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { stateKey } from './review-fix.js';
+import { findLatestCheckpoint } from './e2e-test-utils.js';
 
 // ── Config ─────────────────────────────────────────────────────────────
 
@@ -65,13 +66,7 @@ const DEV_MODE = !!process.env.CLAUDE_E2E_DEV;
 // ── Helpers ────────────────────────────────────────────────────────────
 
 function findLatestResultFile(): string | null {
-  if (!existsSync(RESULTS_DIR)) return null;
-  const prefix = 'review-fix-smoke-';
-  const files = readdirSync(RESULTS_DIR)
-    .filter(f => f.startsWith(prefix) && f.endsWith('.txt'))
-    .sort()
-    .reverse();
-  return files.length > 0 ? join(RESULTS_DIR, files[0]) : null;
+  return findLatestCheckpoint(RESULTS_DIR, 'review-fix-smoke-');
 }
 
 interface RunResult {

--- a/src/cli-dimensions.test.ts
+++ b/src/cli-dimensions.test.ts
@@ -231,6 +231,17 @@ describe('cli-dimensions with temp fixtures', () => {
     expect(v.results[0].errors).toContain('Missing ```json output format section');
   });
 
+  it('validate catches frontmatter name/filename mismatch', () => {
+    writeFileSync(resolve(tmpDir, 'review-correct-name.md'), '---\nname: wrong-name\ndescription: test\napplies_to: pr\n---\n```json\n{}\n```\n');
+    const v = cmdValidate(tmpDir);
+    expect(v.ok).toBe(false);
+    const entry = v.results.find(r => r.file === 'review-correct-name.md');
+    expect(entry).toBeDefined();
+    expect(entry!.errors.some(e => e.includes('does not match filename stem'))).toBe(true);
+    expect(entry!.errors.some(e => e.includes('"wrong-name"'))).toBe(true);
+    expect(entry!.errors.some(e => e.includes('"correct-name"'))).toBe(true);
+  });
+
   it('validate distinguishes malformed YAML from missing frontmatter', () => {
     // Has --- markers but invalid YAML inside (unquoted colon in value)
     writeFileSync(resolve(tmpDir, 'review-badyaml.md'), '---\nname: bad: yaml\ndescription: test\n---\nBody\n```json\n{}\n```\n');

--- a/src/cli-dimensions.ts
+++ b/src/cli-dimensions.ts
@@ -167,6 +167,9 @@ export function cmdValidate(promptsDir?: string): { results: ValidationResult[];
       if (!fm.name) errors.push('Frontmatter missing "name" field');
       if (!fm.description) errors.push('Frontmatter missing "description" field');
       if (!fm.applies_to) errors.push('Frontmatter missing "applies_to" field');
+      if (fm.name && fm.name !== dimName) {
+        errors.push(`Frontmatter "name" field "${fm.name}" does not match filename stem "${dimName}" (from ${file})`);
+      }
     }
 
     // Check for ```json output format section

--- a/src/review-battery.test.ts
+++ b/src/review-battery.test.ts
@@ -10,7 +10,10 @@
  * They validate that review prompts produce correct findings on known PRs.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   parseReviewOutput,
   formatBatteryReport,
@@ -286,6 +289,52 @@ describe('discoverDimensions', () => {
     // diff-only dimensions grouped together
     expect(briefing).toContain('security');
     expect(briefing).toContain('correctness');
+  });
+});
+
+// Tier 1: Dimension discovery with isolated temp fixtures (issue #879)
+
+describe('discoverDimensions — isolated temp dir', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'kaizen-dims-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty object for empty directory', () => {
+    const dims = discoverDimensions(tmpDir);
+    expect(dims).toEqual({});
+  });
+
+  it('returns empty object for non-existent directory', () => {
+    const dims = discoverDimensions('/dev/null/impossible');
+    expect(dims).toEqual({});
+  });
+
+  it('discovers synthetic dimension files', () => {
+    writeFileSync(join(tmpDir, 'review-alpha.md'), '---\nname: alpha\ndescription: test\napplies_to: pr\n---\n```json\n{}\n```\n');
+    writeFileSync(join(tmpDir, 'review-beta.md'), '---\nname: beta\ndescription: test\napplies_to: both\n---\n```json\n{}\n```\n');
+    writeFileSync(join(tmpDir, 'not-a-dimension.md'), 'ignored');
+
+    const dims = discoverDimensions(tmpDir);
+    expect(Object.keys(dims)).toEqual(['alpha', 'beta']);
+    expect(dims['alpha']).toBe('review-alpha.md');
+    expect(dims['beta']).toBe('review-beta.md');
+  });
+
+  it('loadDimensionMetas reads frontmatter from synthetic files', () => {
+    writeFileSync(join(tmpDir, 'review-gamma.md'), '---\nname: gamma\ndescription: Gamma check\napplies_to: plan\nneeds: [diff, issue]\n---\n```json\n{}\n```\n');
+
+    const metas = loadDimensionMetas(tmpDir);
+    expect(metas).toHaveLength(1);
+    expect(metas[0].name).toBe('gamma');
+    expect(metas[0].description).toBe('Gamma check');
+    expect(metas[0].applies_to).toBe('plan');
+    expect(metas[0].needs).toEqual(['diff', 'issue']);
   });
 });
 


### PR DESCRIPTION
## Summary

- **#887**: `cmdValidate` now checks that frontmatter `name` matches the filename stem (`review-<name>.md` → `<name>`), catching mismatches at validate-time instead of test-time
- **#880**: Extracted duplicated `findLatestCheckpoint` pattern from `review-battery.e2e.test.ts` and `review-fix.e2e.test.ts` into shared `scripts/e2e-test-utils.ts`
- **#879**: Added `discoverDimensions` and `loadDimensionMetas` tests using `mkdtempSync` fixtures — no longer relying on real `prompts/` directory

Fixes #887, fixes #880, fixes #879

## Test plan

- [x] New test: frontmatter name/filename mismatch detected by cmdValidate
- [x] New test: findLatestCheckpoint shared helper (5 cases)
- [x] New test: discoverDimensions with empty dir, nonexistent dir, synthetic files
- [x] New test: loadDimensionMetas reads frontmatter from synthetic files
- [x] Full test suite passes (2027 tests, 0 failures)

Run tag: constant-cardinal/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)