### PR TITLE
fix: CI build step, dirty-files false positive, review-fix async spawn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm run build
       - name: Run shell hook tests
         run: bash .claude/hooks/tests/run-all-tests.sh
       - name: Verify no test side-effects on repo files

--- a/scripts/review-fix.e2e.test.ts
+++ b/scripts/review-fix.e2e.test.ts
@@ -40,7 +40,7 @@ import { describe, it, beforeAll } from 'vitest';
 import { expect } from 'vitest';
 import { mkdirSync, writeFileSync, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { stateKey } from './review-fix.js';
 import { findLatestCheckpoint } from './e2e-test-utils.js';
 
@@ -78,7 +78,7 @@ interface RunResult {
   fromCheckpoint: boolean;
 }
 
-function runFullLoopDryRun(): RunResult {
+async function runFullLoopDryRun(): Promise<RunResult> {
   const timestamp = Date.now();
   const resultFile = join(RESULTS_DIR, `review-fix-smoke-${timestamp}.txt`);
 
@@ -94,26 +94,43 @@ function runFullLoopDryRun(): RunResult {
 
   const start = Date.now();
 
-  const result = spawnSync(
-    'npx', ['tsx', 'scripts/review-fix.ts',
-      '--pr', FIXTURE_PR,
-      '--issue', FIXTURE_ISSUE,
-      '--repo', FIXTURE_REPO,
-      '--dry-run',
-      '--max-rounds', '1',
-    ],
-    {
-      cwd: process.cwd(),
-      encoding: 'utf8',
-      timeout: 720_000, // 12 min — sequential: 10+ dims × ~30-60s each
-      env: { ...process.env, REVIEW_MODEL: process.env.REVIEW_MODEL ?? 'haiku' },
-    },
-  );
+  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
+    const child = spawn(
+      'npx', ['tsx', 'scripts/review-fix.ts',
+        '--pr', FIXTURE_PR,
+        '--issue', FIXTURE_ISSUE,
+        '--repo', FIXTURE_REPO,
+        '--dry-run',
+        '--max-rounds', '1',
+      ],
+      {
+        cwd: process.cwd(),
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, REVIEW_MODEL: process.env.REVIEW_MODEL ?? 'haiku' },
+      },
+    );
+
+    let out = '';
+    let err = '';
+    child.stdout.on('data', (d: Buffer) => { out += d.toString(); });
+    child.stderr.on('data', (d: Buffer) => { err += d.toString(); });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error('review-fix subprocess timed out after 720s'));
+    }, 720_000);
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ stdout: out, stderr: err, exitCode: code ?? -1 });
+    });
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
 
   const durationMs = Date.now() - start;
-  const stdout = result.stdout ?? '';
-  const stderr = result.stderr ?? '';
-  const exitCode = result.status ?? -1;
 
   // Write checkpoint immediately — all assertions below read from this
   const checkpoint = { stdout, stderr, exitCode, durationMs };
@@ -245,7 +262,7 @@ describe('Tier 2 — full loop smoke (CLAUDE_E2E=1 to enable)', () => {
   it(
     `review-fix --dry-run: full pipe for PR #836 (schema + state + findings)`,
     { timeout: 780_000 }, // 13 min — sequential: 10+ dims × ~30-60s each
-    () => {
+    async () => {
       if (!TIER2 && !DEV_MODE) {
         console.log('  [skip] set CLAUDE_E2E=1 to run full loop smoke (~$0.30-0.50, ~2-4min)');
         console.log('         or CLAUDE_E2E_DEV=1 to load latest checkpoint (free)');
@@ -256,7 +273,7 @@ describe('Tier 2 — full loop smoke (CLAUDE_E2E=1 to enable)', () => {
         return;
       }
 
-      const run = runFullLoopDryRun();
+      const run = await runFullLoopDryRun();
 
       // Assertions — each includes the result file path for self-diagnosis
       assertExitedCleanly(run);

--- a/src/hooks/check-dirty-files.test.ts
+++ b/src/hooks/check-dirty-files.test.ts
@@ -82,6 +82,21 @@ describe('parseDirtyFiles', () => {
     const report = parseDirtyFiles('');
     expect(report.total).toBe(0);
   });
+
+  it('classifies MM (staged+modified) as staged (kaizen #871)', () => {
+    const output = 'MM .claude-plugin/plugin.json';
+    const report = parseDirtyFiles(output);
+    expect(report.staged).toHaveLength(1);
+    expect(report.modified).toHaveLength(0);
+    expect(report.total).toBe(1);
+  });
+
+  it('classifies AM (added+modified) as staged', () => {
+    const output = 'AM new-file.ts';
+    const report = parseDirtyFiles(output);
+    expect(report.staged).toHaveLength(1);
+    expect(report.modified).toHaveLength(0);
+  });
 });
 
 describe('formatFileList', () => {
@@ -140,6 +155,27 @@ describe('checkDirtyFiles', () => {
     });
     expect(result.action).toBe('warn');
     expect(result.message).toContain('merging a PR');
+  });
+
+  it('calls update-index --refresh before status --porcelain (kaizen #871)', () => {
+    const calls: string[] = [];
+    const trackingGit = (args: string) => {
+      calls.push(args);
+      if (args.includes('rev-parse --git-dir')) return '/fake/.git';
+      if (args.includes('status --porcelain')) return ' M dirty.ts';
+      return '';
+    };
+    const mockedExistsSync = vi.mocked(existsSync);
+    mockedExistsSync.mockImplementation(() => false);
+
+    checkDirtyFiles('gh pr create --title "test"', { gitRunner: trackingGit });
+
+    const refreshIdx = calls.findIndex(c => c.includes('update-index'));
+    const statusIdx = calls.findIndex(c => c.includes('status --porcelain'));
+    expect(refreshIdx).toBeGreaterThanOrEqual(0);
+    expect(statusIdx).toBeGreaterThan(refreshIdx);
+
+    mockedExistsSync.mockRestore();
   });
 
   it('allows compound commit+push even when dirty (kaizen #721)', () => {

--- a/src/hooks/check-dirty-files.ts
+++ b/src/hooks/check-dirty-files.ts
@@ -72,9 +72,12 @@ export function parseDirtyFiles(porcelainOutput: string): DirtyFileReport {
   for (const line of lines) {
     if (/^\?\?/.test(line)) {
       untracked.push(line);
+    } else if (/^[MARCD][MARCD]/.test(line)) {
+      // Both staged and modified (e.g. MM) — count as staged (the primary state)
+      staged.push(line);
     } else if (/^[MARCD] /.test(line)) {
       staged.push(line);
-    } else if (/^ ?M/.test(line)) {
+    } else if (/^ [M]/.test(line)) {
       modified.push(line);
     }
   }
@@ -124,6 +127,11 @@ export function checkDirtyFiles(
   // Handle git -C <path> push (cross-worktree — kaizen #232)
   const targetDir = extractGitCPath(cmdLine);
   const gitPrefix = targetDir ? `-C ${targetDir}` : '';
+
+  // Refresh the index to clear stale stat info — prevents false positives
+  // when a file was modified and restored (content matches HEAD but stat differs).
+  // Observed: MM status for .claude-plugin/plugin.json with no actual changes (kaizen #871).
+  git(`${gitPrefix} update-index -q --refresh`);
 
   const porcelain = git(`${gitPrefix} status --porcelain`);
   if (!porcelain) return { action: 'allow' };


### PR DESCRIPTION
## Summary

Three annoying bug fixes bundled together:

- **CI: shell-tests needs build step (#886)** — bash hooks that delegate to `node dist/...` fail in CI because `dist/` isn't built. Added `setup-node`, `npm ci`, `npm run build` to the `shell-tests` job.
- **Dirty-files false positive (#871)** — `MM` status for `.claude-plugin/plugin.json` with no actual changes. Root cause: stale git index stat info. Fix: call `git update-index -q --refresh` before `git status --porcelain`. Also fixed `parseDirtyFiles` to properly classify `MM`/`AM` as staged rather than modified.
- **review-fix spawnSync blocking (#878)** — E2E test used `spawnSync` with 12-min timeout, blocking the vitest runner thread. Converted to async `spawn` matching `review-battery.e2e.test.ts` pattern.

Closes #886, closes #871, closes #878

## Test plan

- [x] All 2030 existing tests pass
- [x] New tests for `MM`/`AM` classification in `parseDirtyFiles`
- [x] New test verifying `update-index --refresh` runs before `status --porcelain`
- [x] review-fix E2E tier 0 tests pass with async conversion

Run tag: constant-cardinal/run-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)