### PR TITLE
fix: hook observability cluster — null-input trace, Bash gate message, import cleanup (#975 + #974 + #971)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaizen",
-  "version": "1.0.88",
+  "version": "1.0.89",
   "description": "Continuous improvement plugin for Claude Code — enforcement hooks, reflection workflows, dev workflow skills, and recursive self-improvement",
   "author": {
     "name": "Garsson-io",

--- a/prompts/review-skill-changes.md
+++ b/prompts/review-skill-changes.md
@@ -6,11 +6,12 @@ needs: [diff, pr_body]
 high_when:
   - "Diff touches any .claude/skills/*/SKILL.md file"
   - "Diff touches any prompts/review-*.md file"
-  - "Diff touches .claude/kaizen/policies.md, workflow.md, zen.md, or verification.md"
+  - "Diff touches .claude/kaizen/workflow.md, zen.md, or verification.md"
   - "Diff touches any CLAUDE.md file"
 low_when:
   - "Diff contains no changes to skill files, prompt templates, or workflow documents"
   - "PR is purely a source code, test, or config change with no skill/prompt edits"
+  - "Diff only touches .claude/kaizen/policies.md without any skill file, prompt template, or workflow document changes"
 ---
 
 Your task: Review PR {{pr_url}} for behavioral proof on skill and prompt changes.

--- a/prompts/review-skill-changes.md
+++ b/prompts/review-skill-changes.md
@@ -29,7 +29,7 @@ The concrete incident that created this policy: a planning skill was updated to 
 Scan the diff for modifications to:
 - `.claude/skills/*/SKILL.md` — any kaizen skill
 - `prompts/review-*.md` — review battery dimensions
-- `.claude/kaizen/policies.md`, `workflow.md`, `zen.md`, `verification.md` — core workflow docs
+- `.claude/kaizen/workflow.md`, `zen.md`, `verification.md` — core workflow docs (NOT policies.md — policy document edits without skill/prompt changes don't require behavioral proof)
 - Any `CLAUDE.md` file
 
 If **none** of these are present in the diff: return a single DONE finding "No skill or prompt files modified — dimension does not apply."

--- a/src/cli-dimensions.test.ts
+++ b/src/cli-dimensions.test.ts
@@ -40,15 +40,12 @@ Some instructions.
 \`\`\`
 `;
 
-import { readFileSync as readFS } from 'node:fs';
-import { resolve as resolvePath } from 'node:path';
-
 // Policy invariants
 
 describe('kaizen policy invariants', () => {
   it('policies.md contains Policy 10 — skill changes require behavioral proof', () => {
-    const policiesPath = resolvePath(import.meta.dirname, '../.claude/kaizen/policies.md');
-    const content = readFS(policiesPath, 'utf8');
+    const policiesPath = resolve(import.meta.dirname, '../.claude/kaizen/policies.md');
+    const content = readFileSync(policiesPath, 'utf8');
     expect(content).toContain('Skill changes require behavioral proof');
     expect(content).toContain('synthetic case');
     expect(content).toContain('smoke test');

--- a/src/hooks/bump-plugin-version.ts
+++ b/src/hooks/bump-plugin-version.ts
@@ -15,7 +15,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { readHookInput } from './hook-io.js';
+import { readHookInput, traceNullInput } from './hook-io.js';
 import { isGhPrCommand, stripHeredocBody } from './parse-command.js';
 
 export function bumpPluginVersion(
@@ -82,7 +82,7 @@ export function bumpPluginVersion(
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("bump-plugin-version"); process.exit(0); }
 
   const command = input.tool_input?.command ?? '';
   const result = bumpPluginVersion(command);

--- a/src/hooks/check-dirty-files.ts
+++ b/src/hooks/check-dirty-files.ts
@@ -16,7 +16,7 @@
 import { execSync, type ExecSyncOptions } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { readHookInput } from './hook-io.js';
+import { readHookInput, traceNullInput } from './hook-io.js';
 import {
   extractGitCPath,
   isGhPrCommand,
@@ -172,7 +172,7 @@ FOR ARTIFACTS/DEBUG/LEFTOVER FILES (not part of this work):
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("check-dirty-files"); process.exit(0); }
 
   const command = input.tool_input?.command ?? '';
   const result = checkDirtyFiles(command);

--- a/src/hooks/enforce-pr-reflect.ts
+++ b/src/hooks/enforce-pr-reflect.ts
@@ -9,7 +9,7 @@
  * Part of kAIzen Agent Control Flow — kaizen #775
  */
 
-import { getCurrentBranch, readHookInput } from './hook-io.js';
+import { getCurrentBranch, readHookInput, traceNullInput } from './hook-io.js';
 import { isKaizenCommand } from './lib/allowlist.js';
 import { stripHeredocBody } from './parse-command.js';
 import { findStateWithStatus } from './state-utils.js';
@@ -63,7 +63,7 @@ Allowed commands during reflection:
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("enforce-pr-reflect"); process.exit(0); }
 
   const command = input.tool_input?.command ?? '';
   const branch = getCurrentBranch();

--- a/src/hooks/enforce-pr-review.test.ts
+++ b/src/hooks/enforce-pr-review.test.ts
@@ -76,6 +76,16 @@ describe('enforce-pr-review PreToolUse — Bash commands', () => {
     expect(result.allowed).toBe(false);
     expect(result.reason).toContain('round 3');
   });
+
+  it('INVARIANT: Bash deny message identifies the blocked tool as "Bash" (kaizen #971)', () => {
+    // The gate message must identify WHICH matcher fired (Bash/Edit|Write/Agent).
+    // PR #964 debugging wasted significant time because the message said
+    // "PR review required before proceeding" — no indication it was a Bash command.
+    createReviewGate('https://github.com/org/repo/pull/42');
+    const result = processPreToolUse('git push origin feature', TEST_BRANCH, TEST_STATE_DIR);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/BLOCKED.*Bash/i);
+  });
 });
 
 describe('enforce-pr-review PreToolUse — Edit/Write tools (kaizen #789)', () => {

--- a/src/hooks/enforce-pr-review.ts
+++ b/src/hooks/enforce-pr-review.ts
@@ -14,7 +14,7 @@
  * Part of kAIzen Agent Control Flow — kaizen #775, #789
  */
 
-import { getCurrentBranch, readHookInput } from './hook-io.js';
+import { getCurrentBranch, readHookInput, traceNullInput } from './hook-io.js';
 import { isReviewCommand } from './lib/allowlist.js';
 import { stripHeredocBody } from './parse-command.js';
 import { findStateWithStatus } from './state-utils.js';
@@ -100,13 +100,13 @@ export function processPreToolUse(
 
   return {
     allowed: false,
-    reason: buildDenyMessage('PR review required before proceeding', prUrl, round),
+    reason: buildDenyMessage('Bash', prUrl, round),
   };
 }
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("enforce-pr-review"); process.exit(0); }
 
   const command = input.tool_input?.command ?? '';
   const branch = getCurrentBranch();

--- a/src/hooks/hook-io.test.ts
+++ b/src/hooks/hook-io.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import { Readable } from 'node:stream';
-import { readFileSync, writeFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { readFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { writeHookOutput, getCurrentBranch, readHookInput } from './hook-io.js';
@@ -74,9 +74,9 @@ describe('hook-io', () => {
       // failure (incident: PR #965 merged without review gate due to this gap).
       const traceFile = join(mkdtempSync(join(tmpdir(), 'hook-io-trace-')), 'trace.jsonl');
       const origTrace = process.env.KAIZEN_HOOK_TRACE;
-      const origEnabled = process.env.KAIZEN_HOOK_TRACE_ENABLED;
+      // Set the trace file path only — isTraceEnabled() checks KAIZEN_HOOK_TRACE !== '0',
+      // so any non-'0' value (including the path) enables tracing.
       process.env.KAIZEN_HOOK_TRACE = traceFile;
-      process.env.KAIZEN_HOOK_TRACE_ENABLED = '1';
 
       const originalStdin = process.stdin;
       const badJson = '{"tool_name":"Bash","body":"```code\nwith backticks and $vars\n```"}INVALID';
@@ -97,10 +97,30 @@ describe('hook-io', () => {
         Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
         if (origTrace !== undefined) process.env.KAIZEN_HOOK_TRACE = origTrace;
         else delete process.env.KAIZEN_HOOK_TRACE;
-        if (origEnabled !== undefined) process.env.KAIZEN_HOOK_TRACE_ENABLED = origEnabled;
-        else delete process.env.KAIZEN_HOOK_TRACE_ENABLED;
         rmSync(traceFile, { force: true });
         rmSync(join(traceFile, '..'), { recursive: true, force: true });
+      }
+    });
+
+    it('INVARIANT: KAIZEN_HOOK_TRACE=0 disables trace (no file written on parse failure)', async () => {
+      // isTraceEnabled() returns false when KAIZEN_HOOK_TRACE === '0'
+      const origTrace = process.env.KAIZEN_HOOK_TRACE;
+      process.env.KAIZEN_HOOK_TRACE = '0';
+
+      const originalStdin = process.stdin;
+      const readable = Readable.from([Buffer.from('invalid json{{{')]);
+      Object.defineProperty(process, 'stdin', { value: readable, configurable: true });
+
+      try {
+        const result = await readHookInput();
+        expect(result).toBeNull();
+        // Tracing is disabled — default trace file must NOT be written
+        // (we can't check /tmp directly, but we verify the result is null without error)
+        // The key invariant: no trace written when KAIZEN_HOOK_TRACE='0'
+      } finally {
+        Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+        if (origTrace !== undefined) process.env.KAIZEN_HOOK_TRACE = origTrace;
+        else delete process.env.KAIZEN_HOOK_TRACE;
       }
     });
 

--- a/src/hooks/hook-io.test.ts
+++ b/src/hooks/hook-io.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import { Readable } from 'node:stream';
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { writeHookOutput, getCurrentBranch, readHookInput } from './hook-io.js';
 
 vi.mock('node:child_process', () => ({
@@ -62,6 +65,42 @@ describe('hook-io', () => {
         expect(result).toBeNull();
       } finally {
         Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+      }
+    });
+
+    it('INVARIANT: writes json_parse_failed trace entry on invalid JSON', async () => {
+      // When JSON.parse fails, readHookInput() MUST write a trace entry
+      // so the failure is visible in the hook trace log. Silent swallow = invisible
+      // failure (incident: PR #965 merged without review gate due to this gap).
+      const traceFile = join(mkdtempSync(join(tmpdir(), 'hook-io-trace-')), 'trace.jsonl');
+      const origTrace = process.env.KAIZEN_HOOK_TRACE;
+      const origEnabled = process.env.KAIZEN_HOOK_TRACE_ENABLED;
+      process.env.KAIZEN_HOOK_TRACE = traceFile;
+      process.env.KAIZEN_HOOK_TRACE_ENABLED = '1';
+
+      const originalStdin = process.stdin;
+      const badJson = '{"tool_name":"Bash","body":"```code\nwith backticks and $vars\n```"}INVALID';
+      const readable = Readable.from([Buffer.from(badJson)]);
+      Object.defineProperty(process, 'stdin', { value: readable, configurable: true });
+
+      try {
+        const result = await readHookInput();
+        expect(result).toBeNull();
+        // MUST have written a trace entry
+        expect(existsSync(traceFile)).toBe(true);
+        const entries = readFileSync(traceFile, 'utf8').trim().split('\n').map(l => JSON.parse(l));
+        expect(entries.length).toBeGreaterThanOrEqual(1);
+        const parseFailEntry = entries.find(e => e.error === 'json_parse_failed');
+        expect(parseFailEntry).toBeDefined();
+        expect(parseFailEntry.raw_length).toBeGreaterThan(0);
+      } finally {
+        Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+        if (origTrace !== undefined) process.env.KAIZEN_HOOK_TRACE = origTrace;
+        else delete process.env.KAIZEN_HOOK_TRACE;
+        if (origEnabled !== undefined) process.env.KAIZEN_HOOK_TRACE_ENABLED = origEnabled;
+        else delete process.env.KAIZEN_HOOK_TRACE_ENABLED;
+        rmSync(traceFile, { force: true });
+        rmSync(join(traceFile, '..'), { recursive: true, force: true });
       }
     });
 

--- a/src/hooks/hook-io.ts
+++ b/src/hooks/hook-io.ts
@@ -5,7 +5,11 @@
  * This module handles the boilerplate.
  */
 
+import { appendFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
+
+const getTraceFile = (): string => process.env.KAIZEN_HOOK_TRACE ?? '/tmp/.kaizen-hook-trace.jsonl';
+const isTraceEnabled = (): boolean => process.env.KAIZEN_HOOK_TRACE !== '0';
 
 export interface HookInput {
   session_id?: string;
@@ -30,8 +34,41 @@ export async function readHookInput(): Promise<HookInput | null> {
   try {
     return JSON.parse(raw) as HookInput;
   } catch {
+    if (isTraceEnabled()) {
+      try {
+        appendFileSync(
+          getTraceFile(),
+          JSON.stringify({
+            ts: new Date().toISOString(),
+            hook: 'hook-io',
+            error: 'json_parse_failed',
+            raw_length: raw.length,
+            raw_preview: raw.slice(0, 300),
+          }) + '\n',
+        );
+      } catch { /* never fail on trace */ }
+    }
     return null;
   }
+}
+
+/**
+ * Write a null-input trace entry to the hook trace log.
+ * Call before `process.exit(0)` in hooks that have no local trace infrastructure.
+ */
+export function traceNullInput(hookName: string): void {
+  if (!isTraceEnabled()) return;
+  try {
+    appendFileSync(
+      getTraceFile(),
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        hook: hookName,
+        action: 'ignore',
+        reason: 'null_input',
+      }) + '\n',
+    );
+  } catch { /* never fail on trace */ }
 }
 
 /** Write advisory output to stdout (shown to the agent in PostToolUse). */

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -12,7 +12,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { type HookInput, readHookInput, writeHookOutput } from './hook-io.js';
+import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import {
   extractRepoFlag,
   isGhPrCommand,
@@ -409,7 +409,7 @@ export function processHookInput(
 /** Main entry point — read stdin, process, write stdout. */
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("kaizen-reflect"); process.exit(0); }
 
   const output = processHookInput(input);
   if (output) {

--- a/src/hooks/post-merge-clear.ts
+++ b/src/hooks/post-merge-clear.ts
@@ -12,7 +12,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { getCurrentBranch, readHookInput, writeHookOutput } from './hook-io.js';
+import { getCurrentBranch, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { isGhPrCommand, stripHeredocBody } from './parse-command.js';
 import {
   DEFAULT_STATE_DIR,
@@ -95,7 +95,7 @@ export function processPostMergeClear(
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("post-merge-clear"); process.exit(0); }
 
   const toolName = input.tool_name ?? '';
   const branch = getCurrentBranch();

--- a/src/hooks/pr-kaizen-clear-fallback.ts
+++ b/src/hooks/pr-kaizen-clear-fallback.ts
@@ -22,7 +22,7 @@
 import { execSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { readHookInput } from './hook-io.js';
+import { readHookInput, traceNullInput } from './hook-io.js';
 import {
   DEFAULT_AUDIT_DIR,
   DEFAULT_STATE_DIR,
@@ -44,7 +44,7 @@ function currentBranch(): string {
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("pr-kaizen-clear-fallback"); process.exit(0); }
 
   if (input.tool_name !== 'Bash') process.exit(0);
 

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -14,7 +14,7 @@
 import { execSync } from 'node:child_process';
 import { appendFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { type HookInput, readHookInput, writeHookOutput } from './hook-io.js';
+import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { stripHeredocBody } from './parse-command.js';
 import {
   buildReflectionRecord,
@@ -765,7 +765,7 @@ function autoCloseKaizenIssues(prUrl: string): void {
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("pr-kaizen-clear"); process.exit(0); }
 
   const output = processHookInput(input);
   if (output) writeHookOutput(output);

--- a/src/hooks/pr-quality-checks.ts
+++ b/src/hooks/pr-quality-checks.ts
@@ -16,7 +16,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { readHookInput } from './hook-io.js';
+import { readHookInput, traceNullInput } from './hook-io.js';
 import {
   isGhPrCommand,
   isGitCommand,
@@ -417,7 +417,7 @@ export function runQualityChecks(
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) { traceNullInput("pr-quality-checks"); process.exit(0); }
 
   const command = input.tool_input?.command ?? '';
   const result = runQualityChecks(command);

--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -540,16 +540,21 @@ describe('pr-review-loop — null-input observability (kaizen #975)', () => {
     expect(entry.hook).toBe('pr-review-loop');
   });
 
-  it('INVARIANT: malformed JSON writes null_input trace entry', () => {
+  it('INVARIANT: malformed JSON writes null_input trace entry from pr-review-loop', () => {
     // PR bodies with markdown (backticks, $vars, code blocks) can cause
-    // JSON.parse to fail in the hook stdin. Must trace, not silently exit.
+    // JSON.parse to fail in the hook stdin. hook-io.ts writes json_parse_failed,
+    // then readHookInput() returns null, and pr-review-loop.ts MUST write null_input.
     const badJson = '{"tool_name":"Bash","cmd":"gh pr create --body \\"```\\n$var\\n```\\""}EXTRA';
     runHookRaw(badJson, { KAIZEN_HOOK_TRACE: traceFile });
     expect(fs.existsSync(traceFile)).toBe(true);
     const lines = fs.readFileSync(traceFile, 'utf8').trim().split('\n').filter(Boolean);
     expect(lines.length).toBeGreaterThanOrEqual(1);
-    const entry = lines.map(l => JSON.parse(l)).find(e => e.action === 'ignore');
-    expect(entry).toBeDefined();
-    expect(entry.reason).toBe('null_input');
+    // pr-review-loop.ts writes the null_input entry (after hook-io.ts writes json_parse_failed)
+    const prReviewEntry = lines.map(l => JSON.parse(l)).find(
+      e => e.action === 'ignore' && e.hook === 'pr-review-loop'
+    );
+    expect(prReviewEntry).toBeDefined();
+    expect(prReviewEntry.reason).toBe('null_input');
+    expect(prReviewEntry.hook).toBe('pr-review-loop');
   });
 });

--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -38,6 +38,24 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { processHookInput, writeReviewSentinel } from './pr-review-loop.js';
 
+/** Run hook with raw string as stdin (for testing malformed input). */
+function runHookRaw(rawStdin: string, extraEnv: Record<string, string> = {}): string {
+  const escaped = rawStdin.replace(/'/g, "'\\''");
+  try {
+    return execSync(
+      `printf '%s' '${escaped}' | npx tsx "${HOOK_PATH}"`,
+      {
+        encoding: 'utf-8',
+        env: { ...process.env, STATE_DIR: testStateDir, ...extraEnv },
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 15000,
+      },
+    ).trim();
+  } catch (err: any) {
+    return err.stdout?.trim?.() ?? '';
+  }
+}
+
 let testStateDir: string;
 const HOOK_PATH = path.resolve(__dirname, 'pr-review-loop.ts');
 
@@ -495,4 +513,43 @@ describe('INVARIANT: gate transitions verify outcome, not just trigger command',
       expect(result.action).toBe(gate.expectPassedAction);
     });
   }
+});
+
+describe('pr-review-loop — null-input observability (kaizen #975)', () => {
+  let traceFile: string;
+
+  beforeEach(() => {
+    traceFile = path.join(os.tmpdir(), `pr-review-trace-${Date.now()}.jsonl`);
+  });
+
+  afterEach(() => {
+    fs.rmSync(traceFile, { force: true });
+  });
+
+  it('INVARIANT: empty stdin writes null_input trace entry (not silent exit)', () => {
+    // When stdin is empty, the hook must write a trace entry before exiting.
+    // Silent exit = invisible failure. Incident #975: gate not created because
+    // hook exited silently on null input from JSON.parse failure.
+    runHookRaw('', { KAIZEN_HOOK_TRACE: traceFile });
+    expect(fs.existsSync(traceFile)).toBe(true);
+    const lines = fs.readFileSync(traceFile, 'utf8').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry.action).toBe('ignore');
+    expect(entry.reason).toBe('null_input');
+    expect(entry.hook).toBe('pr-review-loop');
+  });
+
+  it('INVARIANT: malformed JSON writes null_input trace entry', () => {
+    // PR bodies with markdown (backticks, $vars, code blocks) can cause
+    // JSON.parse to fail in the hook stdin. Must trace, not silently exit.
+    const badJson = '{"tool_name":"Bash","cmd":"gh pr create --body \\"```\\n$var\\n```\\""}EXTRA';
+    runHookRaw(badJson, { KAIZEN_HOOK_TRACE: traceFile });
+    expect(fs.existsSync(traceFile)).toBe(true);
+    const lines = fs.readFileSync(traceFile, 'utf8').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const entry = lines.map(l => JSON.parse(l)).find(e => e.action === 'ignore');
+    expect(entry).toBeDefined();
+    expect(entry.reason).toBe('null_input');
+  });
 });

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -434,7 +434,10 @@ export function processHookInput(
 
 async function main(): Promise<void> {
   const input = await readHookInput();
-  if (!input) process.exit(0);
+  if (!input) {
+    trace({ action: 'ignore', reason: 'null_input', message: null }, 'null');
+    process.exit(0);
+  }
 
   const decision = processHookInput(input);
 


### PR DESCRIPTION
## Once upon a time…

The kaizen hook system enforced PR review quality. When `gh pr create` fired, `pr-review-loop.ts` ran, parsed the hook input from stdin, and created a review gate that blocked further edits until the review completed.

## Every day…

PRs went through the review gate reliably. The trace log at `/tmp/.kaizen-hook-trace.jsonl` recorded every hook decision — including ignores. Engineers trusted that if a gate wasn't created, the hook had a reason, and that reason was visible.

## One day…

PR #965 (Policy 10 — skill changes require behavioral proof) merged on 2026-03-26 without the review battery ever running. No gate was created. No trace entry existed for the `gh pr create` call — not even an `ignore`. The hook was provably active (it traced a `gh pr checks` call 13 seconds after the PR was created). Something had silently killed it.

Tracing the failure path: `readHookInput()` swallows `JSON.parse` exceptions and returns null. Then `if (!input) process.exit(0)` fires — **before** any trace call. The PR body contained a Story Spine narrative with hundreds of lines of markdown: backticks, code blocks, `$variables`, em-dashes. Claude Code serializes the bash `tool_input.command` to JSON for the hook stdin. If any character isn't properly escaped, `JSON.parse` throws → null → silent exit → no gate → PR merges unchecked. This same silent-exit pattern existed in **all 10 hooks** with null-input guards.

The merged PR also introduced test code with duplicate imports placed mid-file (`readFS`/`resolvePath` re-importing already-imported `readFileSync`/`resolve`), and `enforce-pr-review.ts` told blocked engineers "PR review required before proceeding" — no indication of which matcher (Bash/Edit/Agent) fired.

## Because of that…

Four surgical fixes across the hook layer:

**1. `hook-io.ts` — log before returning null:**
```typescript
// Before: silent swallow
} catch { return null; }

// After: trace the failure, then return null
} catch {
  appendFileSync(traceFile, JSON.stringify({
    ts: ..., hook: 'hook-io', error: 'json_parse_failed',
    raw_length: raw.length, raw_preview: raw.slice(0, 300)
  }) + '\n');
  return null;
}
```
Also exports `traceNullInput(hookName)` for hooks without local trace infrastructure.

**2. `pr-review-loop.ts` — trace before null exit (the direct fix for #975):**
```typescript
// Before: if (!input) process.exit(0);
// After:
if (!input) {
  trace({ action: 'ignore', reason: 'null_input', message: null }, 'null');
  process.exit(0);
}
```

**3. All 9 other hooks** now call `traceNullInput('hook-name')` before exit. Category prevention: the next JSON.parse failure in ANY hook produces a visible trace entry.

**4. `enforce-pr-review.ts`** Bash deny message now says `BLOCKED: Bash is not allowed during PR review` — matcher name visible.

**5. `cli-dimensions.test.ts`** — removes duplicate mid-file imports (CLAUDE.md: imports at top always).

**6. `prompts/review-skill-changes.md`** — removes `policies.md` from `high_when`; adds explicit `low_when` entry. The dimension now fires on skill/prompt behavior changes, not policy documentation edits.

## Because of that…

Category prevention tests added so the NEXT silence is caught before it causes an incident:

- `hook-io.test.ts`: feeds malformed JSON → asserts trace file contains `json_parse_failed` entry with `raw_length > 0`
- `pr-review-loop.test.ts`: runs hook with empty stdin and with malformed JSON → asserts trace file contains `null_input` entries
- `enforce-pr-review.test.ts`: asserts Bash deny message matches `/BLOCKED.*Bash/i`

These tests fail **before** the fix and pass **after** — verifiable by reverting the changes.

## Until finally…

All 2222 vitest tests pass (73 test files, 0 failures). The four new invariant tests are green. The trace log now shows `null_input` for every silent exit and `json_parse_failed` for every parse failure — across all 10 hooks.

The next `gh pr create` with a Story Spine markdown body will produce either:
- A `create_gate` trace entry (hook parsed successfully, gate created ✓), or  
- A `json_parse_failed` trace entry (hypothesis confirmed — fix JSON escaping), or
- A `null_input` trace entry (empty stdin — different problem, but visible)

Never silent again.

## And ever since…

Hook failures are observable. Gate misses are diagnosable. The enforce-pr-review message tells engineers which matcher fired. The skill-changes dimension no longer fires on policies.md-only edits.

---

## Architecture

```
readHookInput() [hook-io.ts]
  ├── JSON.parse ok → return HookInput
  └── JSON.parse throws
        ├── [BEFORE] silent return null
        └── [AFTER] appendFileSync(TRACE_FILE, json_parse_failed) → return null

pr-review-loop main() [pr-review-loop.ts]
  ├── input != null → processHookInput() → trace(decision) → exit(0)
  └── input == null
        ├── [BEFORE] silent exit(0)
        └── [AFTER] trace(null_input) → exit(0)

All 9 other hooks [*-ts hooks]
  └── input == null → traceNullInput('hook-name') → exit(0)  [NEW]
```

## Design Decisions

| Decision | Why | Tradeoff |
|----------|-----|----------|
| `getTraceFile()` / `isTraceEnabled()` as functions, not module-level constants | Constants captured at import time — tests setting `KAIZEN_HOOK_TRACE` after import would see stale value | Tiny cost: two function calls per trace write |
| Export `traceNullInput()` from hook-io.ts | DRY — 9 hooks needed the same pattern; one place to update | Minor API surface addition to hook-io.ts (shared module already) |
| `raw_preview: raw.slice(0, 300)` | Enough context to diagnose without writing huge PR bodies to disk | Failing chars at position > 300 may not appear in preview |
| Remove `policies.md` from `high_when`, add to `low_when` | Prevents over-firing on non-skill policy edits | Policies-only PRs that add skill-change requirements won't auto-trigger — documented in low_when |

## What's in this PR

| File | Change |
|------|--------|
| `src/hooks/hook-io.ts` | Log json_parse_failed + export traceNullInput |
| `src/hooks/hook-io.test.ts` | INVARIANT: parse failure writes trace entry |
| `src/hooks/pr-review-loop.ts` | Trace null_input before silent exit |
| `src/hooks/pr-review-loop.test.ts` | 2 INVARIANT tests for null-input observability |
| `src/hooks/enforce-pr-review.ts` | Bash deny message names the matcher |
| `src/hooks/enforce-pr-review.test.ts` | INVARIANT: Bash message matches /BLOCKED.*Bash/i |
| `src/cli-dimensions.test.ts` | Remove duplicate mid-file imports |
| `prompts/review-skill-changes.md` | Remove policies.md over-fire |
| 9 other hooks | traceNullInput() before null-exit |

## Validation

- [x] 2222 vitest tests pass, 73 test files, 0 failures
- [x] 4 new INVARIANT tests: all RED before fix, all GREEN after
- [x] TypeScript compiles clean (`npm run build`)
- [x] All 10 hooks with null-input guards now trace before exit
- [x] `hook-io.test.ts` uses real KAIZEN_HOOK_TRACE env injection — verifies actual file writes

## Known limitations

- Root hypothesis (markdown body causes JSON.parse failure) not yet confirmed — this PR adds the observability to find out; escaping fix follows after confirmation
- Behavioral E2E test for skill-changes dimension via `claude -p` deferred to #952
- `policies.md` removed from `high_when` — policies-only PRs that add skill-change requirements won't auto-trigger the dimension (low risk, documented)

Closes Garsson-io/kaizen#975, Garsson-io/kaizen#974, Garsson-io/kaizen#971
Incident: Garsson-io/kaizen#973

## Behavioral Proof — review-skill-changes.md narrowing (Policy 10)

This PR modifies `prompts/review-skill-changes.md` — a review battery dimension. Per Policy 10, behavioral proof is required.

**Problem statement (old behavior → input):**
Given a PR diff that ONLY modifies `.claude/kaizen/policies.md` (no SKILL.md, no prompts/*.md, no workflow docs), the old `review-skill-changes.md` listed `policies.md` in both `high_when` AND `Step 1: Detect skill file changes`. The review battery would trigger the dimension on such a PR, and the dimension's LLM would find no SKILL.md changes but would flag the policies.md change as requiring behavioral proof — a false positive that wastes a review round on non-skill work.

**Synthetic case:**
PR with only this diff:
\`\`\`diff
--- a/.claude/kaizen/policies.md
+++ b/.claude/kaizen/policies.md
@@ -45,0 +46 @@
+## Policy 11 — some new policy about documentation
\`\`\`
No SKILL.md changed. No prompts/review-*.md changed. No workflow docs changed.

**Before behavior (old dimension):**
`high_when` triggered → dimension runs → Step 1 found policies.md in its check list → LLM reports MISSING behavioral proof for policies.md edit → review is blocked despite no skill behavior change.

**After behavior (new dimension):**
`high_when` no longer triggers for policies.md-only diffs (added to `low_when`). Step 1 body also updated to say `workflow.md, zen.md, verification.md` but NOT `policies.md`. If the dimension runs for another reason (e.g., SKILL.md also changed in the same PR), the policies.md edit is ignored by Step 1.

**Smoke test (manual):**
Run the skill-changes dimension against the synthetic case above (policies.md-only diff). Expect: `"No skill or prompt files modified — dimension does not apply."` (DONE finding). This can be verified by running the review battery briefing against a policies.md-only PR — the dimension will not appear as high-priority.