### PR TITLE
Canonize review finding contract and align review-gate lifecycle tests

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -93,6 +93,10 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 - PR sections: `update-pr-section --name "Validation" --text "..."`
 - Iteration: `store-iteration`, `retrieve-iteration`
 
+`store-review-finding` canonical payload:
+`{"dimension":"correctness","verdict":"pass|fail","summary":"...","findings":[{"requirement":"...","status":"DONE|PARTIAL|MISSING","detail":"..."}]}`
+Legacy fields are normalized (`status/result`, `item/description`, missing `findings`).
+
 Store plans immediately after creating them. Review findings are stored per-round per-dimension (e.g., `review/r5/correctness`). Use `list-review-rounds` to count rounds mechanistically. For low-level section/attachment operations, use `cli-section-editor.ts`.
 
 **PR review dimensions**: When running `/kaizen-review-pr`, bundle dimensions by shared data needs (use the briefing from `npx tsx src/cli-dimensions.ts briefing --lines N`). Don't spawn one agent per dimension — batch dims with identical `needs` into single agents.

--- a/.claude/hooks/tests/harness.py
+++ b/.claude/hooks/tests/harness.py
@@ -352,6 +352,15 @@ class PRReviewState:
     def state_count(self) -> int:
         return len(list(self.state_dir.iterdir()))
 
+    def create_review_sentinel(self, pr_url: str, round_num: int | str):
+        """Create the review sentinel written by store-review-summary/store-review-batch.
+
+        Format: <STATE_DIR>/<owner_repo_pr>.reviewed-r<round>
+        """
+        state_key = pr_url.replace("https://github.com/", "").replace("/pull/", "_").replace("/", "_")
+        sentinel = self.state_dir / f"{state_key}.reviewed-r{round_num}"
+        sentinel.write_text("reviewed_at=test\n")
+
 
 # Mock git/gh helpers
 

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -256,7 +256,10 @@ class TestPRLifecycle:
         r = review_harness.run_hook("kaizen-enforce-pr-review-ts.sh", PreToolUseInput.bash("gh pr diff 55"))
         assert r.allows(), "Should allow gh pr diff"
 
-        # Phase 3: gh pr diff → review passed
+        # Phase 3: Review outcome persisted (store-review-summary/store-review-batch sentinel)
+        state.create_review_sentinel(self.PR_URL, 1)
+
+        # gh pr diff → review passed
         r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "passed"
@@ -271,6 +274,22 @@ class TestPRLifecycle:
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "needs_review", "Push after passed should re-engage gate"
         assert s["ROUND"] == "2", "Round should be incremented after push"
+
+    def test_diff_requires_review_sentinel(self, review_harness, state):
+        """gh pr diff alone must not clear gate; sentinel is required (#920)."""
+        state.create_state(self.PR_URL, round_num=1, status="needs_review", branch="wt/test-branch")
+
+        # No sentinel yet -> stays blocked
+        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
+        s = state.read_state(self.PR_URL)
+        assert s["STATUS"] == "needs_review"
+        assert "No review findings stored" in r.stdout
+
+        # Sentinel present -> clears
+        state.create_review_sentinel(self.PR_URL, 1)
+        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
+        s = state.read_state(self.PR_URL)
+        assert s["STATUS"] == "passed"
 
     def test_merge_cleans_up(self, review_harness, state):
         state.create_state(self.PR_URL, round_num=2, status="needs_review", branch="wt/test-branch")

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -4,6 +4,9 @@
  *
  * Reviews:
  *   npx tsx src/cli-structured-data.ts store-review-finding --pr 903 --repo R --round 5 --dimension correctness --file findings.md
+ *   # Preferred payload:
+ *   # {"dimension":"correctness","verdict":"pass|fail","summary":"...","findings":[{"requirement":"...","status":"DONE|PARTIAL|MISSING","detail":"..."}]}
+ *   # Legacy payloads are normalized (status/result aliases, item/description fields, missing findings).
  *   npx tsx src/cli-structured-data.ts store-review-summary --pr 903 --repo R --round 5 --text "PASSED — 5 rounds"
  *   npx tsx src/cli-structured-data.ts list-review-rounds --pr 903 --repo R
  *   npx tsx src/cli-structured-data.ts list-review-dims --pr 903 --repo R --round 5
@@ -58,6 +61,7 @@ import {
   retrieveIterationState,
   type ReviewFindingData,
 } from './structured-data.js';
+import { normalizeReviewFindingData } from './review-finding-contract.js';
 
 export type CliArgs = Record<string, string> & { command: string };
 type Handler = (a: CliArgs) => Promise<void>;
@@ -91,6 +95,17 @@ export function resolveRound(a: CliArgs): number {
   return 1;
 }
 
+function writeReviewSentinel(repo: string, pr: string | undefined, round: number): void {
+  try {
+    const stateDir = process.env.STATE_DIR ?? '/tmp/.pr-review-state';
+    const stateKey = `${repo.replace('/', '_')}_${pr ?? ''}`;
+    mkdirSync(stateDir, { recursive: true });
+    appendFileSync(`${stateDir}/${stateKey}.reviewed-r${round}`, `reviewed_at=${new Date().toISOString()}\n`);
+  } catch {
+    // best effort — sentinel is advisory
+  }
+}
+
 // Review handlers
 
 async function handleNextRound(a: CliArgs): Promise<void> {
@@ -104,11 +119,10 @@ async function handleStoreReviewFinding(a: CliArgs): Promise<void> {
   const text = resolveContent(a);
   let finding: ReviewFindingData;
   try {
-    finding = JSON.parse(text);
+    finding = normalizeReviewFindingData(JSON.parse(text), { defaultDimension: dim });
   } catch {
-    finding = { dimension: dim, verdict: 'fail', summary: text.slice(0, 100), findings: [] };
+    finding = normalizeReviewFindingData({ summary: text.slice(0, 100) }, { defaultDimension: dim });
   }
-  if (!finding.dimension || finding.dimension === 'unknown') finding.dimension = dim;
   const url = storeReviewFinding(pr, r, finding);
   console.log(`Review finding stored (round ${r}): ${url}`);
 }
@@ -120,12 +134,7 @@ async function handleStoreReviewBatch(a: CliArgs): Promise<void> {
   const result = storeReviewBatch(pr, r, findings);
   // #966: Write review sentinel so pr-review-loop.ts gate guard passes.
   // Mirrors handleStoreReviewSummary — batch includes summary, so sentinel must be written here too.
-  try {
-    const stateDir = process.env.STATE_DIR ?? '/tmp/.pr-review-state';
-    const stateKey = `${a.repo.replace('/', '_')}_${a.pr ?? ''}`;
-    mkdirSync(stateDir, { recursive: true });
-    appendFileSync(`${stateDir}/${stateKey}.reviewed-r${r}`, `reviewed_at=${new Date().toISOString()}\n`);
-  } catch { /* best effort — sentinel is advisory */ }
+  writeReviewSentinel(a.repo, a.pr, r);
   console.log(`Batch stored: ${result.urls.length} findings + summary (round ${r})`);
   console.log(`Summary: ${result.summaryUrl}`);
 }
@@ -143,12 +152,7 @@ async function handleStoreReviewSummary(a: CliArgs): Promise<void> {
   const r = resolveRound(a);
   const url = storeReviewSummary(prTarget(a.pr, a.repo), r, text || undefined);
   // #920: Write review sentinel so pr-review-loop.ts can verify outcome
-  try {
-    const stateDir = process.env.STATE_DIR ?? '/tmp/.pr-review-state';
-    const stateKey = `${a.repo.replace('/', '_')}_${a.pr ?? ''}`;
-    mkdirSync(stateDir, { recursive: true });
-    appendFileSync(`${stateDir}/${stateKey}.reviewed-r${r}`, `reviewed_at=${new Date().toISOString()}\n`);
-  } catch { /* best effort — sentinel is advisory */ }
+  writeReviewSentinel(a.repo, a.pr, r);
   console.log(`Review summary stored (round ${r}): ${url}`);
 }
 

--- a/src/review-battery.ts
+++ b/src/review-battery.ts
@@ -17,6 +17,12 @@ import { resolve, dirname, basename } from 'node:path';
 import YAML from 'yaml';
 import { resolveProjectRoot } from './lib/resolve-project-root.js';
 import { retrievePlan, issueTarget } from './structured-data.js';
+import {
+  normalizeFindingStatus,
+  deriveVerdictFromFindings,
+  type FindingStatus,
+  type ReviewFinding,
+} from './review-finding-contract.js';
 
 // ── Review Output Schema ────────────────────────────────────────────
 //
@@ -29,22 +35,10 @@ import { retrievePlan, issueTarget } from './structured-data.js';
 // Review prompts are instructed to output a JSON block fenced with
 // ```json ... ``` containing this structure.
 
-/** Status of a single requirement or criterion */
-export type FindingStatus = 'DONE' | 'PARTIAL' | 'MISSING';
-
 /** Prefix for synthetic findings that represent missing input data, not code gaps.
  * Used by review-fix.ts to distinguish fixable code gaps from unfixable data-availability gaps. */
 export const DATA_GAP_PREFIX = '[data-gap]';
-
-/** A single finding from a review dimension */
-export interface ReviewFinding {
-  /** The requirement or criterion being evaluated */
-  requirement: string;
-  /** Whether the requirement is met */
-  status: FindingStatus;
-  /** Explanation of the finding — what's done, what's missing, why */
-  detail: string;
-}
+export type { FindingStatus, ReviewFinding } from './review-finding-contract.js';
 
 /** Output from a single review dimension */
 export interface DimensionReview {
@@ -337,28 +331,19 @@ export function parseReviewOutput(raw: string, dimension: string): DimensionRevi
 
     const findings: ReviewFinding[] = parsed.findings.map((f: any) => ({
       requirement: String(f.requirement ?? f.item ?? ''),
-      status: normalizeStatus(f.status),
+      status: normalizeFindingStatus(f.status),
       detail: String(f.detail ?? f.description ?? ''),
     }));
 
-    const hasFailure = findings.some(f => f.status !== 'DONE');
-
     return {
       dimension: parsed.dimension ?? dimension,
-      verdict: hasFailure ? 'fail' : 'pass',
+      verdict: deriveVerdictFromFindings(findings),
       findings,
       summary: String(parsed.summary ?? ''),
     };
   } catch {
     return null;
   }
-}
-
-function normalizeStatus(s: unknown): FindingStatus {
-  const str = String(s).toUpperCase().trim();
-  if (str === 'DONE' || str === 'PASS' || str === 'COMPLETE' || str === 'ADDRESSED') return 'DONE';
-  if (str === 'PARTIAL' || str === 'PARTIALLY') return 'PARTIAL';
-  return 'MISSING';
 }
 
 // ── Prompt Loading ──────────────────────────────────────────────────

--- a/src/review-finding-contract.test.ts
+++ b/src/review-finding-contract.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeFindingStatus,
+  deriveVerdictFromFindings,
+  normalizeReviewFindingData,
+  makeReviewFindingMeta,
+  extractReviewFindingMeta,
+} from './review-finding-contract.js';
+
+describe('review-finding-contract', () => {
+  it('normalizes canonical and alias statuses', () => {
+    expect(normalizeFindingStatus('DONE')).toBe('DONE');
+    expect(normalizeFindingStatus('pass')).toBe('DONE');
+    expect(normalizeFindingStatus('COMPLETE')).toBe('DONE');
+    expect(normalizeFindingStatus('PARTIALLY')).toBe('PARTIAL');
+    expect(normalizeFindingStatus('NOT_ADDRESSED')).toBe('MISSING');
+  });
+
+  it('derives verdict from findings', () => {
+    expect(deriveVerdictFromFindings([{ status: 'DONE' }, { status: 'DONE' }])).toBe('pass');
+    expect(deriveVerdictFromFindings([{ status: 'DONE' }, { status: 'PARTIAL' }])).toBe('fail');
+    expect(deriveVerdictFromFindings([{ status: 'MISSING' }])).toBe('fail');
+  });
+
+  it('normalizes legacy payloads with default dimension', () => {
+    const finding = normalizeReviewFindingData(
+      { status: 'pass', text: 'legacy', findings: [{ item: 'R1', status: 'COMPLETE', description: 'ok' }] },
+      { defaultDimension: 'self-review' },
+    );
+    expect(finding.dimension).toBe('self-review');
+    expect(finding.verdict).toBe('pass');
+    expect(finding.findings[0]).toEqual({ requirement: 'R1', status: 'DONE', detail: 'ok' });
+  });
+
+  it('writes and reads review meta consistently', () => {
+    const meta = makeReviewFindingMeta(2, {
+      dimension: 'correctness',
+      verdict: 'fail',
+      summary: 'gap',
+      findings: [
+        { requirement: 'R1', status: 'DONE', detail: 'ok' },
+        { requirement: 'R2', status: 'MISSING', detail: 'missing' },
+      ],
+    });
+    const content = `<!-- meta:${JSON.stringify(meta)} -->\n### correctness — FAIL`;
+    expect(extractReviewFindingMeta(content)).toEqual(meta);
+  });
+});

--- a/src/review-finding-contract.ts
+++ b/src/review-finding-contract.ts
@@ -1,0 +1,170 @@
+/**
+ * review-finding-contract.ts — Canonical contract for review findings.
+ *
+ * Single source of truth for:
+ * - finding status normalization
+ * - verdict derivation
+ * - finding stats
+ * - review finding metadata shape
+ */
+
+export type FindingStatus = 'DONE' | 'PARTIAL' | 'MISSING';
+
+export interface ReviewFinding {
+  requirement: string;
+  status: FindingStatus;
+  detail: string;
+  analysis?: string;
+}
+
+export interface ReviewFindingData {
+  dimension: string;
+  verdict: 'pass' | 'fail';
+  summary: string;
+  findings: ReviewFinding[];
+  round?: number;
+  durationSec?: number;
+  costUsd?: number;
+}
+
+export interface FindingStats {
+  done: number;
+  partial: number;
+  missing: number;
+}
+
+export interface ReviewFindingMeta extends FindingStats {
+  round: number;
+  dimension: string;
+  verdict: 'pass' | 'fail';
+  duration_sec?: number;
+  cost_usd?: number;
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function firstString(raw: Record<string, unknown>, keys: string[], fallback = ''): string {
+  for (const key of keys) {
+    const value = raw[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return fallback;
+}
+
+export function normalizeFindingStatus(value: unknown): FindingStatus {
+  const raw = asString(value).toUpperCase().trim();
+  if (raw === 'DONE' || raw === 'PASS' || raw === 'PASSED' || raw === 'OK' || raw === 'SUCCESS' || raw === 'COMPLETE' || raw === 'ADDRESSED') return 'DONE';
+  if (raw === 'PARTIAL' || raw === 'PARTIALLY' || raw === 'IN_PROGRESS' || raw === 'WARNING' || raw === 'WARN') return 'PARTIAL';
+  return 'MISSING';
+}
+
+export function summarizeFindingStatuses(findings: Array<{ status: FindingStatus }>): FindingStats {
+  const stats: FindingStats = { done: 0, partial: 0, missing: 0 };
+  for (const f of findings) {
+    if (f.status === 'DONE') stats.done += 1;
+    else if (f.status === 'PARTIAL') stats.partial += 1;
+    else stats.missing += 1;
+  }
+  return stats;
+}
+
+export function deriveVerdictFromFindings(findings: Array<{ status: FindingStatus }>): 'pass' | 'fail' {
+  const stats = summarizeFindingStatuses(findings);
+  return stats.partial > 0 || stats.missing > 0 ? 'fail' : 'pass';
+}
+
+function normalizeVerdict(value: unknown): 'pass' | 'fail' | undefined {
+  const raw = asString(value).toLowerCase().trim();
+  if (raw === 'pass' || raw === 'passed' || raw === 'ok' || raw === 'success') return 'pass';
+  if (raw === 'fail' || raw === 'failed' || raw === 'error') return 'fail';
+  return undefined;
+}
+
+/**
+ * Defensive coercion for CLI/API payloads. Supports legacy shapes (status-only,
+ * missing findings) so storage/formatting never throw.
+ */
+export function normalizeReviewFindingData(
+  input: unknown,
+  opts?: { defaultDimension?: string },
+): ReviewFindingData {
+  const raw = (input && typeof input === 'object') ? input as Record<string, unknown> : {};
+  const rawFindings = Array.isArray(raw.findings) ? raw.findings : [];
+  const findings: ReviewFinding[] = rawFindings.map((item, i) => {
+    const row = (item && typeof item === 'object') ? item as Record<string, unknown> : {};
+    const analysis = asString(row.analysis).trim();
+    return {
+      requirement: firstString(row, ['requirement', 'title', 'item'], `Finding ${i + 1}`),
+      status: normalizeFindingStatus(row.status ?? row.verdict),
+      detail: firstString(row, ['detail', 'summary', 'description'], ''),
+      ...(analysis ? { analysis } : {}),
+    };
+  });
+
+  const verdictFromInput = normalizeVerdict(raw.verdict ?? raw.status ?? raw.result);
+  const derivedVerdict = deriveVerdictFromFindings(findings);
+  const verdict = verdictFromInput ?? (findings.length > 0 ? derivedVerdict : 'fail');
+  const summary = firstString(raw, ['summary', 'text', 'message'], verdict === 'pass' ? 'No issues found.' : 'Findings require follow-up.');
+
+  return {
+    dimension: firstString(raw, ['dimension'], opts?.defaultDimension ?? 'unknown'),
+    verdict,
+    summary,
+    findings,
+    round: asNumber(raw.round),
+    durationSec: asNumber(raw.durationSec ?? raw.duration_sec),
+    costUsd: asNumber(raw.costUsd ?? raw.cost_usd),
+  };
+}
+
+export function makeReviewFindingMeta(round: number, finding: ReviewFindingData): ReviewFindingMeta {
+  const stats = summarizeFindingStatuses(finding.findings);
+  return {
+    round,
+    dimension: finding.dimension,
+    verdict: finding.verdict,
+    done: stats.done,
+    partial: stats.partial,
+    missing: stats.missing,
+    ...(finding.durationSec != null ? { duration_sec: finding.durationSec } : {}),
+    ...(finding.costUsd != null ? { cost_usd: finding.costUsd } : {}),
+  };
+}
+
+export function parseReviewFindingMeta(value: unknown): ReviewFindingMeta | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  const round = asNumber(raw.round);
+  const dimension = asString(raw.dimension);
+  const verdict = normalizeVerdict(raw.verdict);
+  const done = asNumber(raw.done);
+  const partial = asNumber(raw.partial);
+  const missing = asNumber(raw.missing);
+  if (round == null || !dimension || !verdict || done == null || partial == null || missing == null) return null;
+  return {
+    round,
+    dimension,
+    verdict,
+    done,
+    partial,
+    missing,
+    ...(asNumber(raw.duration_sec) != null ? { duration_sec: asNumber(raw.duration_sec)! } : {}),
+    ...(asNumber(raw.cost_usd) != null ? { cost_usd: asNumber(raw.cost_usd)! } : {}),
+  };
+}
+
+export function extractReviewFindingMeta(content: string): ReviewFindingMeta | null {
+  const match = content.match(/<!-- meta:(\{.*?\}) -->/);
+  if (!match) return null;
+  try {
+    return parseReviewFindingMeta(JSON.parse(match[1]));
+  } catch {
+    return null;
+  }
+}

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -22,6 +22,7 @@ import {
   storeIterationState,
   retrieveIterationState,
   updatePrSection,
+  normalizeReviewFindingData,
   type ReviewFindingData,
 } from './structured-data.js';
 
@@ -97,6 +98,34 @@ describe('storeReviewFinding — format and storage', () => {
     const bodyArg = args.find(a => a.startsWith('body='))!;
     expect(bodyArg).toContain('Round 2 | 120s | $0.150');
   });
+
+  it('accepts legacy status-only payload without findings', () => {
+    ghReturns('');
+    ghReturns('https://...');
+    storeReviewFinding(pr, 1, {
+      // legacy shape from older callers
+      dimension: 'self-review',
+      status: 'pass',
+      summary: 'Looks good',
+    } as any);
+    const args = mockGh.mock.calls[1][1] as string[];
+    const bodyArg = args.find(a => a.startsWith('body='))!;
+    expect(bodyArg).toContain('### self-review — PASS');
+    expect(bodyArg).toContain('**0 findings**: 0 DONE, 0 PARTIAL, 0 MISSING');
+  });
+
+  it('defaults missing verdict/findings to safe fail shape', () => {
+    ghReturns('');
+    ghReturns('https://...');
+    storeReviewFinding(pr, 1, {
+      dimension: 'self-review',
+      summary: 'brief note only',
+    } as any);
+    const args = mockGh.mock.calls[1][1] as string[];
+    const bodyArg = args.find(a => a.startsWith('body='))!;
+    expect(bodyArg).toContain('### self-review — FAIL');
+    expect(bodyArg).toContain('> brief note only');
+  });
 });
 
 describe('parseFindingMeta', () => {
@@ -111,6 +140,33 @@ describe('parseFindingMeta', () => {
 
   it('returns null for content without meta', () => {
     expect(parseFindingMeta('just plain text')).toBeNull();
+  });
+});
+
+describe('normalizeReviewFindingData', () => {
+  it('maps legacy status/result fields and defaults safely', () => {
+    const normalized = normalizeReviewFindingData({
+      dimension: 'self-review',
+      status: 'pass',
+      text: 'legacy message',
+    } as any);
+    expect(normalized.dimension).toBe('self-review');
+    expect(normalized.verdict).toBe('pass');
+    expect(normalized.summary).toBe('legacy message');
+    expect(normalized.findings).toEqual([]);
+  });
+
+  it('normalizes finding item statuses and computes derived verdict', () => {
+    const normalized = normalizeReviewFindingData({
+      dimension: 'correctness',
+      findings: [
+        { requirement: 'A', status: 'done' },
+        { requirement: 'B', verdict: 'fail' },
+      ],
+    } as any);
+    expect(normalized.findings[0].status).toBe('DONE');
+    expect(normalized.findings[1].status).toBe('MISSING');
+    expect(normalized.verdict).toBe('fail');
   });
 });
 

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -25,6 +25,14 @@ import {
   type AttachmentTarget,
   type SectionTarget,
 } from './section-editor.js';
+import {
+  normalizeReviewFindingData as normalizeReviewFindingDataContract,
+  makeReviewFindingMeta,
+  extractReviewFindingMeta,
+  type ReviewFinding,
+  type ReviewFindingData,
+  type ReviewFindingMeta,
+} from './review-finding-contract.js';
 
 // ── Target helpers ──────────────────────────────────────────────────
 
@@ -88,29 +96,17 @@ export function extractPlanText(text: string): string | undefined {
 
 // ── Reviews ─────────────────────────────────────────────────────────
 
-export interface ReviewFinding {
-  requirement: string;
-  status: 'DONE' | 'PARTIAL' | 'MISSING';
-  /** Short label for the table row */
-  detail: string;
-  /** Full analysis text — file references, code snippets, fix suggestions. Shown below the table for non-DONE findings. */
-  analysis?: string;
-}
-
-export interface ReviewFindingData {
-  dimension: string;
-  verdict: 'pass' | 'fail';
-  summary: string;
-  findings: ReviewFinding[];
-  /** Review round number (shown in header) */
-  round?: number;
-  /** Wall-clock duration in seconds */
-  durationSec?: number;
-  /** Cost in USD */
-  costUsd?: number;
-}
+export type { ReviewFinding, ReviewFindingData } from './review-finding-contract.js';
 
 const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MISSING: '❌' };
+
+/**
+ * Defensive coercion for CLI/API payloads. Supports legacy shapes (status-only,
+ * missing findings) so storage/formatting never throw.
+ */
+export function normalizeReviewFindingData(input: unknown): ReviewFindingData {
+  return normalizeReviewFindingDataContract(input);
+}
 
 /**
  * Format a dimension's findings as a structured attachment.
@@ -124,15 +120,8 @@ const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MI
  *   | 1 | ✅ DONE | ... | ... |
  */
 function formatFinding(round: number, finding: ReviewFindingData): string {
-  const done = finding.findings.filter(f => f.status === 'DONE').length;
-  const partial = finding.findings.filter(f => f.status === 'PARTIAL').length;
-  const missing = finding.findings.filter(f => f.status === 'MISSING').length;
-
-  const meta = JSON.stringify({
-    round, dimension: finding.dimension, verdict: finding.verdict, done, partial, missing,
-    ...(finding.durationSec != null ? { duration_sec: finding.durationSec } : {}),
-    ...(finding.costUsd != null ? { cost_usd: finding.costUsd } : {}),
-  });
+  const meta = makeReviewFindingMeta(round, finding);
+  const { done, partial, missing } = meta;
 
   const statsLine = [
     `Round ${round}`,
@@ -141,7 +130,7 @@ function formatFinding(round: number, finding: ReviewFindingData): string {
   ].filter(Boolean).join(' | ');
 
   const lines: string[] = [
-    `<!-- meta:${meta} -->`,
+    `<!-- meta:${JSON.stringify(meta)} -->`,
     `### ${finding.dimension} — ${finding.verdict.toUpperCase()}`,
     `*${statsLine}*`,
     '',
@@ -159,11 +148,13 @@ function formatFinding(round: number, finding: ReviewFindingData): string {
   lines.push('', `**${finding.findings.length} findings**: ${done} DONE, ${partial} PARTIAL, ${missing} MISSING`);
 
   // Expanded details for non-DONE findings
-  const nonDone = finding.findings.filter(f => f.status !== 'DONE');
+  const nonDone = finding.findings
+    .map((f, index) => ({ finding: f, index }))
+    .filter(({ finding: f }) => f.status !== 'DONE');
   if (nonDone.length > 0) {
     lines.push('', '---', '');
-    for (const f of nonDone) {
-      const idx = finding.findings.indexOf(f) + 1;
+    for (const { finding: f, index } of nonDone) {
+      const idx = index + 1;
       const icon = STATUS_ICON[f.status] ?? '❓';
       lines.push(`#### ${idx}. ${icon} ${f.requirement}`, '');
       lines.push(f.detail);
@@ -181,9 +172,10 @@ function formatFinding(round: number, finding: ReviewFindingData): string {
  * Parse the machine-readable meta from a stored finding attachment.
  */
 export function parseFindingMeta(content: string): { round: number; dimension: string; verdict: string; done: number; partial: number; missing: number } | null {
-  const match = content.match(/<!-- meta:(\{.*?\}) -->/);
-  if (!match) return null;
-  try { return JSON.parse(match[1]); } catch { return null; }
+  const meta = extractReviewFindingMeta(content);
+  if (!meta) return null;
+  const { round, dimension, verdict, done, partial, missing } = meta as ReviewFindingMeta;
+  return { round, dimension, verdict, done, partial, missing };
 }
 
 /**
@@ -195,7 +187,8 @@ export function storeReviewFinding(
   round: number,
   finding: ReviewFindingData,
 ): string {
-  return writeAttachment(target, `review/r${round}/${finding.dimension}`, formatFinding(round, finding));
+  const normalized = normalizeReviewFindingData(finding);
+  return writeAttachment(target, `review/r${round}/${normalized.dimension}`, formatFinding(round, normalized));
 }
 
 /**


### PR DESCRIPTION
## Once upon a time
Kaizen review data flowed through multiple paths with slightly different contracts. `structured-data.ts` and `review-battery.ts` each normalized statuses and derived verdicts independently, while CLI handlers duplicated sentinel writes.

## Every day
The review gate in `pr-review-loop.ts` expects a persisted review outcome artifact (the `.reviewed-rN` sentinel) before clearing `needs_review`. The skill flow (`/kaizen-review-pr`) stores findings + summary, then the gate clears.

## One day
We hit two concrete failures in this area:
1. `store-review-finding` crashed on legacy/partial payloads (`findings` undefined, `verdict` undefined).
2. Python lifecycle integration tests still modeled pre-#920 behavior (`gh pr diff` alone => `passed`) and failed against current hook semantics.

## Because of that
I canonized the review-finding contract into one module and moved all callers onto it:
- Added `src/review-finding-contract.ts` as the single source of truth for:
  - status normalization
  - verdict derivation
  - finding stats
  - review meta build/parse
  - defensive payload normalization (legacy/current)
- Migrated `structured-data.ts` and `review-battery.ts` to the shared contract.
- DRYed sentinel writes in `cli-structured-data.ts` via one helper.

## Because of that
I aligned integration tests with intended runtime behavior and added a missing invariant:
- Python harness now supports creating review sentinels.
- PR lifecycle test writes sentinel before expecting `needs_review -> passed` on `gh pr diff`.
- Added explicit test that verifies:
  - no sentinel => gate stays `needs_review`
  - sentinel present => gate transitions to `passed`

## Until finally
The contract is now explicit and tested, and the previously failing hook suite is green.

- `npm run -s test:hooks` => `392 passed, 0 failed`
- `npx vitest run src/review-finding-contract.test.ts src/structured-data.test.ts src/cli-structured-data.test.ts src/review-battery.test.ts` => `207 passed`

## And ever since
Review-finding ingestion is resilient to legacy payloads, review verdict semantics are consistent across modules, and lifecycle tests now assert the real gate policy instead of a bypassable variant.

## Architecture

```text
CLI/store-review-* -> review-finding-contract (normalize + verdict + meta)
                    -> structured-data attachment write/read

review-battery parse -> review-finding-contract (same status/verdict semantics)

pr-review-loop gate clear depends on review sentinel (.reviewed-rN)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Canonical contract in `src/review-finding-contract.ts` | Eliminate drift in status/verdict/meta semantics across modules | One more shared module to maintain |
| Keep sentinel requirement in gate | Prevent "manual diff" from clearing review gate without persisted findings | Requires test/harness to model sentinel explicitly |
| Fix integration test instead of gate logic | Hook behavior matches #920 and current skill contract | Older tests needed migration |

## What's In This PR

| File | Purpose |
|---|---|
| `src/review-finding-contract.ts` | Canonical review-finding schema/normalization/verdict/meta helpers |
| `src/review-finding-contract.test.ts` | Direct contract tests |
| `src/structured-data.ts` | Uses canonical contract for normalization/meta parsing |
| `src/review-battery.ts` | Uses canonical status+verdict semantics |
| `src/cli-structured-data.ts` | DRY sentinel writes + canonical payload normalization |
| `src/structured-data.test.ts` | Regression tests for legacy/partial payloads |
| `.claude/hooks/tests/harness.py` | Adds review sentinel helper |
| `.claude/hooks/tests/test_hooks.py` | Lifecycle test aligned to sentinel-gated transition + new invariant test |
| `.agents/AGENTS.md` | Canonical `store-review-finding` payload documented |

## Validation

- [x] `npm run -s build`
- [x] `npx vitest run src/review-finding-contract.test.ts src/structured-data.test.ts src/cli-structured-data.test.ts src/review-battery.test.ts`
- [x] `pytest .claude/hooks/tests/test_hooks.py::TestPRLifecycle -q`
- [x] `npm run -s test:hooks`

## Known Limitations

- This does not add a live `claude -p` E2E assertion that exercises sentinel write/read through a full external session boundary. Current coverage is strong at hook+integration level, but a live-path smoke test remains valuable for operational confidence.
