### PR TITLE
fix: rename stale /kaizen refs to /kaizen-reflect

### DIFF
--- a/.agents/kaizen/README.md
+++ b/.agents/kaizen/README.md
@@ -56,7 +56,7 @@ Key architectural points:
 |------|---------|
 | `policies.md` | Kaizen enforcement policies (#11-17) — recursive kaizen, hooks, MCP, security, isolation, testing, language boundaries |
 | `verification.md` | Verification discipline — path tracing, invariant statements, runtime artifact verification, smoke tests |
-| `workflow.md` | Dev work skill chain — trigger→skill routing for `/kaizen-pick` → `/kaizen-evaluate` → `/kaizen-implement` → `/kaizen` |
+| `workflow.md` | Dev work skill chain — trigger→skill routing for `/kaizen-pick` → `/kaizen-evaluate` → `/kaizen-implement` → `/kaizen-reflect` |
 | `practices.md` | Engineering practices checklist — consulted before shipping (advisory) |
 | `zen.md` | The Zen of Kaizen — philosophical principles |
 | `horizon.md` | Horizon tracking dimensions |
@@ -189,7 +189,7 @@ Read-only mounts, mandatory worktree launcher, protected wrappers. Use when huma
 - **Lifecycle:**
   1. `gh pr merge` → `pr-review-loop.sh` writes `needs_post_merge` (direct merge) or `awaiting_merge` (`--auto`)
   2. `gh pr view` confirms MERGED → `post-merge-clear.sh` promotes `awaiting_merge` to `needs_post_merge`
-  3. Agent runs `/kaizen` → `post-merge-clear.sh` clears state
+  3. Agent runs `/kaizen-reflect` → `post-merge-clear.ts` clears state
   4. `stop-gate.ts` blocks Stop while any gate exists (review, reflection, post-merge)
 
 ### Cross-worktree isolation rule

--- a/.agents/kaizen/prompts/post-merge-block.md
+++ b/.agents/kaizen/prompts/post-merge-block.md
@@ -3,12 +3,12 @@ STOP BLOCKED: Post-merge workflow is incomplete.
 {{PR_HEADER}}
 You MUST complete these steps before finishing:
 
-1. Run `/kaizen` — reflect on impediments, what you'd do differently, process friction
-   (One /kaizen invocation clears ALL pending post-merge gates)
+1. Run `/kaizen-reflect` — reflect on impediments, what you'd do differently, process friction
+   (One /kaizen-reflect invocation clears ALL pending post-merge gates)
 2. Mark the case as done (if a case exists for this work)
 3. Sync main: `git -C {{MAIN_CHECKOUT}} fetch origin main && git -C {{MAIN_CHECKOUT}} merge origin/main --no-edit`
 4. Update linked kaizen issue if applicable
 
-IMPORTANT: Use the `/kaizen` skill to clear this gate. Do NOT use `KAIZEN_IMPEDIMENTS` or
+IMPORTANT: Use the `/kaizen-reflect` skill to clear this gate. Do NOT use `KAIZEN_IMPEDIMENTS` or
 `KAIZEN_NO_ACTION` — those clear a DIFFERENT gate (the pr-kaizen reflection gate).
-The post-merge gate is ONLY cleared by invoking `/kaizen`.
+The post-merge gate is ONLY cleared by invoking `/kaizen-reflect`.

--- a/.agents/kaizen/prompts/pr-kaizen-block.md
+++ b/.agents/kaizen/prompts/pr-kaizen-block.md
@@ -13,4 +13,4 @@ Or for no impediments: echo 'KAIZEN_IMPEDIMENTS: [] brief reason'
 This is mandatory — every PR must have a structured reflection.
 
 NOTE: This clears the pr-kaizen gate only. If you also have a post-merge gate,
-you must separately run `/kaizen` to clear that.
+you must separately run `/kaizen-reflect` to clear that.

--- a/src/hooks/lib/gate-manager.ts
+++ b/src/hooks/lib/gate-manager.ts
@@ -91,7 +91,7 @@ export function readAllPendingGates(
       type: 'post_merge',
       prUrl: r.prUrl,
       label: `POST-MERGE SYNC (${r.prUrl})`,
-      detail: '1. Run /kaizen to reflect on this PR\n   2. Then: git fetch origin main && git merge origin/main',
+      detail: '1. Run /kaizen-reflect to reflect on this PR\n   2. Then: git fetch origin main && git merge origin/main',
       action: 'git fetch origin main && git merge origin/main',
       filepath: r.filepath,
     });

--- a/src/hooks/post-merge-clear.test.ts
+++ b/src/hooks/post-merge-clear.test.ts
@@ -42,7 +42,7 @@ describe('processPostMergeClear — Skill trigger', () => {
     expect(existsSync(join(TEST_STATE_DIR, 'post-merge-org_repo_42'))).toBe(false);
   });
 
-  it('clears post-merge gates when /kaizen invoked', () => {
+  it('clears post-merge gates when /kaizen (legacy alias) invoked', () => {
     writeStateFile(TEST_STATE_DIR, 'post-merge-org_repo_42', {
       PR_URL: 'https://github.com/org/repo/pull/42',
       STATUS: 'needs_post_merge',

--- a/src/hooks/post-merge-clear.ts
+++ b/src/hooks/post-merge-clear.ts
@@ -1,10 +1,10 @@
 /**
- * post-merge-clear.ts — Clears post-merge gate when /kaizen is invoked or merge confirmed.
+ * post-merge-clear.ts — Clears post-merge gate when /kaizen-reflect is invoked or merge confirmed.
  *
  * PostToolUse hook on Bash and Skill — always exits 0 (state management, not blocking).
  *
  * Triggers:
- *   1. Skill: /kaizen or /kaizen-reflect invoked → clear all post-merge gates
+ *   1. Skill: /kaizen-reflect invoked → clear all post-merge gates
  *   2. Bash: gh pr view shows MERGED → promote awaiting_merge to needs_post_merge
  *
  * Part of kAIzen Agent Control Flow — kaizen #786
@@ -43,14 +43,14 @@ export function processPostMergeClear(
   currentBranch: string,
   stateDir: string = DEFAULT_STATE_DIR,
 ): string {
-  // Trigger 1: Skill tool — /kaizen or /kaizen-reflect
+  // Trigger 1: Skill tool — /kaizen-reflect
   if (toolName === 'Skill') {
     const skill = toolInput.skill ?? '';
     if (skill === 'kaizen-reflect' || skill === 'kaizen') {
       const cleared = clearAllStatesWithStatus('needs_post_merge', currentBranch, stateDir);
       if (cleared > 0) {
         const mc = resolveMainCheckout();
-        return `\nPost-merge gate cleared (${cleared} PR${cleared !== 1 ? 's' : ''}). The /kaizen reflection satisfies the post-merge workflow requirement.\n\nRemember to also:\n- Mark the case as done (if applicable)\n- Sync main: \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n- Update linked kaizen issue`;
+        return `\nPost-merge gate cleared (${cleared} PR${cleared !== 1 ? 's' : ''}). The /kaizen-reflect reflection satisfies the post-merge workflow requirement.\n\nRemember to also:\n- Mark the case as done (if applicable)\n- Sync main: \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n- Update linked kaizen issue`;
       }
     }
     return '';


### PR DESCRIPTION
## Summary

- Prompt templates, hook comments, and gate messages still referenced `/kaizen` after the skill was renamed to `/kaizen-reflect`
- Agents following these instructions could invoke the wrong skill name, failing to clear the post-merge gate
- Updated all references in prompts, TS hooks, gate-manager, README, and test descriptions

## Files changed

- `.agents/kaizen/prompts/post-merge-block.md` — 4 refs
- `.agents/kaizen/prompts/pr-kaizen-block.md` — 1 ref
- `.agents/kaizen/README.md` — 2 refs (workflow chain + lifecycle)
- `src/hooks/post-merge-clear.ts` — comments + output message
- `src/hooks/lib/gate-manager.ts` — gate detail message
- `src/hooks/post-merge-clear.test.ts` — test description clarified

## Test plan

- [x] `npm run build` — compiles clean
- [x] `vitest run post-merge-clear.test.ts gate-manager.test.ts` — 34/34 pass
- [x] Legacy `skill: 'kaizen'` alias still accepted in code (backward compat kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)