### PR TITLE
docs: codify memory-is-insufficient rule and review-rounds behavior

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -107,9 +107,11 @@ Store plans immediately after creating them. Review findings are stored per-roun
 - **Workflow changes** → update the relevant SKILL.md
 Memory-only retention means the next session on a different machine repeats the same mistake.
 
-### Hook behavior notes
+### Branch & PR hygiene
 
-- **Review round bumps on push are intended, not a bug.** `pr-review-loop` sets `needs_review` for a new round after every `git push` — including pushes to branches whose prior PR was merged. Rationale: new code deserves a fresh review; the previous round's pass is stale. Do not file this as a hook bug.
+- **Never push new commits to a branch whose PR has already been merged.** Commits pushed to a merged branch get orphaned or confuse the review loop. Always create a new branch (via `EnterWorktree` or `git checkout -b`) for follow-up work.
+- **If you accidentally pushed to a merged branch, detect and recover.** Check `gh pr list --head <branch>` and `gh pr view <last-pr> --json state`. If the last PR on the branch is `MERGED`, create a fresh branch from `main` (or from the merge commit), cherry-pick or re-apply your new commits there, and open a new PR from the new branch.
+- **Review round bumps on push are intended.** Within a single open PR, `pr-review-loop` correctly sets `needs_review` for a new round after every `git push`. Each push is new code and deserves fresh review; the previous round's pass is stale. This is not a bug — complete the new review round before proceeding.
 
 ## Configuration
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -101,6 +101,16 @@ Store plans immediately after creating them. Review findings are stored per-roun
 
 **PR review dimensions**: When running `/kaizen-review-pr`, bundle dimensions by shared data needs (use the briefing from `npx tsx src/cli-dimensions.ts briefing --lines N`). Don't spawn one agent per dimension — batch dims with identical `needs` into single agents.
 
+**Codify learnings publicly, not just in memory**: Local auto-memory (`~/.claude/projects/.../memory/`) is per-machine and does NOT sync across devices. When an admin corrects you or teaches a rule, memory is the FIRST step, never the only step. You MUST also codify the learning in at least one visible artifact:
+- **Durable rules** → add to this file (`.agents/AGENTS.md`) or a dedicated policy doc under `.agents/kaizen/`
+- **Actionable bugs / follow-ups** → file a GitHub issue
+- **Workflow changes** → update the relevant SKILL.md
+Memory-only retention means the next session on a different machine repeats the same mistake.
+
+### Hook behavior notes
+
+- **Review round bumps on push are intended, not a bug.** `pr-review-loop` sets `needs_review` for a new round after every `git push` — including pushes to branches whose prior PR was merged. Rationale: new code deserves a fresh review; the previous round's pass is stale. Do not file this as a hook bug.
+
 ## Configuration
 
 All skills and hooks read `kaizen.config.json` from the host project root:

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -109,9 +109,14 @@ Memory-only retention means the next session on a different machine repeats the 
 
 ### Branch & PR hygiene
 
-- **Never push new commits to a branch whose PR has already been merged.** Commits pushed to a merged branch get orphaned or confuse the review loop. Always create a new branch (via `EnterWorktree` or `git checkout -b`) for follow-up work.
-- **If you accidentally pushed to a merged branch, detect and recover.** Check `gh pr list --head <branch>` and `gh pr view <last-pr> --json state`. If the last PR on the branch is `MERGED`, create a fresh branch from `main` (or from the merge commit), cherry-pick or re-apply your new commits there, and open a new PR from the new branch.
-- **Review round bumps on push are intended.** Within a single open PR, `pr-review-loop` correctly sets `needs_review` for a new round after every `git push`. Each push is new code and deserves fresh review; the previous round's pass is stale. This is not a bug — complete the new review round before proceeding.
+- **Never push new commits to a branch whose most recent PR was already merged with no subsequent open PR.** Commits pushed to such a branch can get orphaned and the review-loop state file points at the merged PR, not the new work. Always create a new branch (via `EnterWorktree` or `git checkout -b`) for follow-up work.
+- **Detect merged-branch state before pushing.** Run:
+  ```bash
+  gh pr list --repo <repo> --head <branch> --state all --json number,state --jq '.[0]'
+  ```
+  If the most recent PR is `MERGED` and there's no newer `OPEN` PR on the branch, you must branch off before pushing. If an `OPEN` PR already exists on the branch, pushing to extend it is fine (new round bump is correct).
+- **If you accidentally pushed to a merged branch:** create a fresh branch from `main` (or from the merge commit), cherry-pick your new commits there, and open a new PR from the new branch.
+- **Review round bumps on push within an open PR are intended.** Each push is new code and deserves fresh review; the previous round's pass is stale. Complete the new round before proceeding.
 
 ## Configuration
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaizen",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "description": "Continuous improvement plugin for Claude Code — enforcement hooks, reflection workflows, dev workflow skills, and recursive self-improvement",
   "author": {
     "name": "Garsson-io",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaizen",
-  "version": "1.0.93",
+  "version": "1.0.94",
   "description": "Continuous improvement plugin for Claude Code — enforcement hooks, reflection workflows, dev workflow skills, and recursive self-improvement",
   "author": {
     "name": "Garsson-io",

--- a/docs/hook-gym-spec.md
+++ b/docs/hook-gym-spec.md
@@ -1,0 +1,316 @@
+# Hook Gym — Synthetic Problem Runner with Loss-Based Hook Observability
+
+## Problem
+
+The kaizen hook/gate system has 25 hooks across 4 event types, but there is no way to **run a real agent session through the full kaizen lifecycle while observing hook behavior**. The existing infrastructure has complementary blind spots:
+
+- **auto-dent** runs real agents with hooks active but never captures hook events — hooks fire invisibly
+- **SessionSimulator** calls hooks directly but doesn't run real `claude` sessions
+- The CLI has `--include-hook-events` (emits hook lifecycle JSON in stream-json) but **nobody uses it**
+- `--dangerously-skip-permissions` does NOT skip hooks (only `--bare` does) — confirmed in hooks-design.md and incident #323
+
+Fixing kaizen-on-kaizen creates a chicken-and-egg loop: broken tools produce broken fixes. We need to exercise hooks on **trivially simple** synthetic problems where failures are clearly hook/gate issues, not task complexity.
+
+## Solution
+
+Hook Gym: a synthetic problem runner that spawns cheap agents (haiku/sonnet) on simple problems with `--include-hook-events` to get full hook observability. It adopts the autoresearch methodology (ground truth, weighted scoring, confusion-pair taxonomy, iteration logging) for scientific hook measurement and regression prevention.
+
+### Goals
+
+1. **Now**: Diagnose and fix broken hooks by exercising them on simple problems
+2. **Ongoing**: Prevent regressions by running scenarios as a test suite after hook changes
+3. **Future**: Enable loss-based improvement of agentic flows (prompts, skills, hook logic)
+
+## Methodology — Adopted from kaizen-autoresearch
+
+| Autoresearch concept | Hook-gym equivalent |
+|---------------------|---------------------|
+| Corpus tasks (EC-01..EC-N) | Scenarios (`probe-hooks`, `lifecycle-gates`, `full-clear`) |
+| Ground truth (GT levels) | Expected hook decisions per scenario (fire/deny/allow/block) |
+| Weighted loss function | Hook decision accuracy score (weighted by severity) |
+| `autoresearch-results.jsonl` | `hook-gym-results.jsonl` — iteration log with score/delta/status |
+| Confusion pairs (pred-GT) | Hook confusion pairs: `(hook, expected_decision, actual_decision)` |
+| Taxonomy files | `taxonomy/` directory routing failures by hook + confusion pair |
+| `mine-report.ts` | `hook-gym-report.ts` — top failures by weighted impact |
+| Explore pre-screening | Quick single-scenario re-run after a fix, before full suite |
+| Leaderboard | `leaderboard.md` — hook pass rate over time |
+
+## Hook Event Format (Probed)
+
+Captured from `claude -p --include-hook-events --output-format stream-json --verbose`:
+
+### Hook started event
+```json
+{
+  "type": "system",
+  "subtype": "hook_started",
+  "hook_id": "845876f2-7841-408e-8146-d96dec318e88",
+  "hook_name": "SessionStart:startup",
+  "hook_event": "SessionStart",
+  "uuid": "c529fa76-...",
+  "session_id": "8213f9f6-..."
+}
+```
+
+### Hook response event
+```json
+{
+  "type": "system",
+  "subtype": "hook_response",
+  "hook_id": "845876f2-7841-408e-8146-d96dec318e88",
+  "hook_name": "SessionStart:startup",
+  "hook_event": "SessionStart",
+  "output": "",
+  "stdout": "",
+  "stderr": "",
+  "exit_code": 0,
+  "outcome": "success",
+  "uuid": "56c30f3c-...",
+  "session_id": "8213f9f6-..."
+}
+```
+
+### Key observations
+
+- Hook events are `type: "system"` with subtypes `hook_started` and `hook_response`
+- `hook_id` correlates start/response pairs for timing measurement
+- `hook_name` format is `"EventType:groupName"` (e.g., `"SessionStart:startup"`)
+- Individual hooks within a group share the same `hook_name` — distinguished only by `hook_id`
+- `output` contains the hook's JSON response (if any) — this is where `permissionDecision: "deny"` appears
+- `exit_code` + `outcome` indicate success/failure
+- `stdout`/`stderr` are separate from `output`
+
+### PreToolUse deny response (expected in `output` field)
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "blocked because..."
+  }
+}
+```
+
+### Stop block response (expected in `output` field)
+```json
+{
+  "decision": "block",
+  "reason": "You have pending gates..."
+}
+```
+
+## Architecture: Compose, Don't Duplicate
+
+### Reused modules from auto-dent (no changes)
+
+| Module | What we reuse |
+|--------|--------------|
+| `auto-dent-stream.ts` | `processStreamMessage`, `parsePhaseMarkers`, `formatToolUse`, `extractArtifacts`, `color` |
+| `auto-dent-events.ts` | `EventEmitter`, `makeRunId`, event envelope format |
+| `auto-dent-score.ts` | `classifyFailure`, failure taxonomy constants |
+| `auto-dent-harness.ts` | `msg.*` builders, `StreamCapture`, `makeRunResult`, `runLiveProbe` pattern |
+| `auto-dent-artifacts.ts` | `buildRunManifest`, `writeRunManifest` for log archival |
+
+### New files
+
+| File | Purpose | ~Lines |
+|------|---------|--------|
+| `scripts/hook-gym.ts` | CLI + runner | ~350 |
+| `scripts/hook-gym-scenarios.ts` | Scenario corpus + ground truth | ~200 |
+| `scripts/hook-gym-stream.ts` | Hook event parser for `--include-hook-events` | ~150 |
+| `scripts/hook-gym-score.ts` | Mechanistic scorer | ~200 |
+| `scripts/hook-gym-report.ts` | Timeline + mine report + leaderboard | ~200 |
+| `scripts/hook-gym-schema.ts` | Zod schemas | ~100 |
+| `scripts/hook-gym-replay.ts` | Extract tool sequences + replay through hooks | ~150 |
+
+## Ground Truth & Scoring
+
+### Ground truth per scenario
+
+```typescript
+interface HookExpectation {
+  hookName: string;           // e.g. "kaizen-enforce-case-exists"
+  eventType: string;          // PreToolUse, PostToolUse, Stop, SessionStart
+  expectedDecision: "fire" | "deny" | "allow" | "block" | "set-gate" | "clear-gate" | "skip";
+  severity: number;           // 1=advisory, 2=enforcement, 3=gate-critical
+  description: string;
+}
+
+interface Scenario {
+  name: string;
+  prompt: string;
+  model: "haiku" | "sonnet";
+  maxBudget: number;
+  timeoutSeconds: number;
+  expectedHooks: HookExpectation[];
+  expectedGateLifecycle: {
+    gate: string;
+    shouldActivate: boolean;
+    shouldClear: boolean;
+  }[];
+}
+```
+
+### Severity weights
+
+| Severity | Weight | Examples |
+|----------|--------|---------|
+| 1 (advisory) | 1 | `search-before-file`, `verify-before-stop` |
+| 2 (enforcement) | 2 | `enforce-worktree-writes`, `enforce-case-exists` |
+| 3 (gate-critical) | 4 | `stop-gate`, `pr-review-loop`, `kaizen-reflect` |
+
+### Mechanistic scorer
+
+```typescript
+interface ScoreResult {
+  scenario: string;
+  hookAccuracy: number;       // % of hooks matching expected decision
+  gateAccuracy: number;       // % of gates with correct lifecycle
+  totalLoss: number;          // weighted loss (lower = better)
+  confusionPairs: Array<{
+    hook: string;
+    expected: string;
+    actual: string;
+    severity: number;
+  }>;
+  criticalMisses: number;     // severity>=3 mismatches
+}
+```
+
+### Iteration log
+
+```typescript
+// Append-only JSONL — hook-gym-results.jsonl
+interface IterationResult {
+  iteration: number;
+  timestamp: string;
+  commit: string;
+  scenario: string;
+  loss: number;
+  delta: number;              // vs reference baseline
+  status: "baseline" | "keep" | "discard" | "regression";
+  hookAccuracy: number;
+  gateAccuracy: number;
+  criticalMisses: number;
+  confusionPairs: string[];
+  cost: number;
+  durationSeconds: number;
+  model: string;
+}
+```
+
+## Scenarios
+
+### `probe-hooks` (~$0.02, haiku, 60s)
+
+**Task**: Create a file, commit, attempt `gh pr create`.
+
+**Ground truth**:
+- SessionStart: 3 hooks fire (check-wip, session-cleanup, worktree-setup)
+- PreToolUse/Write: enforce-worktree-writes=ALLOW, enforce-case-exists=DENY, enforce-pr-review=ALLOW
+- PreToolUse/Bash on `git commit`: enforce-case-worktree=ALLOW, block-git-rebase=ALLOW
+- PostToolUse/Bash on `gh pr create`: pr-review-loop=SET(needs_review), kaizen-reflect=SET(needs_pr_kaizen)
+- Stop: stop-gate=BLOCK (2 gates pending)
+
+### `lifecycle-gates` (~$0.10, sonnet, 120s)
+
+**Task**: Create kaizen case, edit file, run tests, create PR, observe gate behavior, emit KAIZEN_UNFINISHED.
+
+**Ground truth**: All hooks fire. Gates activate on PR creation. Stop gate blocks. UNFINISHED clears gates.
+
+### `full-clear` (~$0.25, sonnet, 180s)
+
+**Task**: Make change, PR, invoke `/kaizen-review-pr`, invoke `/kaizen-reflect`, stop cleanly.
+
+**Ground truth**: Gates activate AND clear through proper lifecycle. Clean stop.
+
+## Replay & Canned Mode
+
+Three layers for cost-efficient testing:
+
+| Layer | Hooks fire? | LLM? | Cost | Use case |
+|-------|:-----------:|:----:|:----:|----------|
+| Score-only | No | No | $0 | Re-score against updated ground truth |
+| Hook replay | **Yes** | No | $0 | Test hook fixes against same tool sequence |
+| Live run | Yes | Yes | $0.02-0.25 | Capture new baseline |
+
+### Capture → Extract → Replay
+
+1. **Live run** produces `run-N.log` (stream-json)
+2. **Extract** parses tool_use blocks → `fixtures/probe-hooks.fixture.json`
+3. **Hook replay** feeds fixture through `SessionSimulator`/`HookRunner` → score against GT
+
+The `SessionSimulator` already supports canned events:
+```typescript
+session.fireBashPre("gh pr create ...");
+session.fireBashPost("gh pr create ...", { stdout: "https://..." });
+session.fireStop();
+```
+
+## CLI
+
+```bash
+npx tsx scripts/hook-gym.ts --list                    # List scenarios
+npx tsx scripts/hook-gym.ts --run probe-hooks         # Run scenario (live)
+npx tsx scripts/hook-gym.ts --run probe-hooks --dry-run  # Show prompt only
+npx tsx scripts/hook-gym.ts --run-all                 # All scenarios
+npx tsx scripts/hook-gym.ts --replay <log>            # Re-score captured log
+npx tsx scripts/hook-gym.ts --replay-hooks <fixture>  # Replay through real hooks
+npx tsx scripts/hook-gym.ts --extract <log>           # Extract fixture from log
+npx tsx scripts/hook-gym.ts --rescore <scenario>      # Re-score vs updated GT
+npx tsx scripts/hook-gym.ts --mine                    # Top failures by impact
+npx tsx scripts/hook-gym.ts --leaderboard             # Score history
+npx tsx scripts/hook-gym.ts --debug                   # Raw hook event JSON
+```
+
+## PR Split
+
+### Phase 1: Foundation (tooling PRs)
+
+| PR | Contents | Value |
+|----|----------|-------|
+| 1 | Spec + Issue + Probe | Alignment artifact |
+| 2 | Schema + Scenarios + Parser | Foundation, `--list` and `--dry-run` work |
+| 3 | Live Runner + Timeline | **First visibility** into hook behavior |
+
+### Phase 2: Measurement (tooling PRs)
+
+| PR | Contents | Value |
+|----|----------|-------|
+| 4 | Scorer + Iteration Log | Quantitative hook health metric |
+| 5 | Replay + Fixtures | CI-ready regression tests ($0) |
+| 6 | Mine Report + Taxonomy | Systematic failure diagnosis |
+
+### Phase 3: Hook Fixes (separate PRs)
+
+Each hook fix is its own PR with:
+- Bug description with hook-gym evidence (confusion pair, timeline)
+- The fix
+- Updated fixture verification
+- `hook-gym:ci` regression check
+
+### The Ladder
+
+```
+PR 1 (spec)     → alignment
+PR 2 (schemas)  → ground truth defined
+PR 3 (observe)  → SEE hook behavior
+PR 4 (measure)  → QUANTIFY hook health
+PR 5 (replay)   → PREVENT regressions
+PR 6 (diagnose) → PRIORITIZE fixes
+PR 7+ (fixes)   → hooks get fixed → kaizen builds itself better
+```
+
+## Log Structure
+
+```
+logs/hook-gym/
+├── state.json
+├── hook-gym-results.jsonl        # Iteration log (append-only)
+├── events.jsonl
+├── leaderboard.md
+├── taxonomy/                     # Per-hook failure JSONL
+├── run-N-<scenario>.log          # Raw stream-json
+├── run-N-<scenario>-prompt.md    # Rendered prompt
+└── run-N-<scenario>-report.md    # Timeline + score
+```

--- a/scripts/hook-gym-scenarios.ts
+++ b/scripts/hook-gym-scenarios.ts
@@ -1,0 +1,260 @@
+/**
+ * hook-gym-scenarios.ts — Scenario corpus with ground truth expectations.
+ *
+ * Each scenario defines:
+ *   - A simple synthetic task for a cheap agent (haiku/sonnet)
+ *   - Expected hook decisions (ground truth)
+ *   - Expected gate lifecycle
+ *
+ * Ground truth is intentionally approximate — hook_name from the stream
+ * doesn't identify individual hooks within a group, so expectations
+ * are keyed by eventType + group pattern rather than exact hook command.
+ */
+
+import type { Scenario } from './hook-gym-schema.js';
+
+// ── Prompt templates ───────────────────────────────────────────────
+
+const PROBE_HOOKS_PROMPT = `You are running a hook-gym synthetic test scenario.
+
+## Task
+
+Create a simple test file, commit it, and create a PR. Follow these exact steps:
+
+1. Create a file called \`hook-gym-probe.md\` with content:
+   \`\`\`
+   # Hook Gym Probe
+   Timestamp: {{timestamp}}
+   \`\`\`
+
+2. Stage and commit:
+   git add hook-gym-probe.md
+   git commit -m "test: hook-gym probe {{timestamp}}"
+
+3. Push and create PR:
+   git push origin HEAD
+   gh pr create --title "test: hook-gym probe {{timestamp}}" --body "Synthetic hook-gym scenario. Auto-close after capture." --repo {{host_repo}}
+
+4. After creating the PR, stop. Do NOT merge, do NOT run review, do NOT reflect.
+   The harness will capture hook behavior and clean up.
+
+Do not ask for confirmation. Complete all steps autonomously.
+`;
+
+const LIFECYCLE_GATES_PROMPT = `You are running a hook-gym synthetic test scenario that exercises the full gate lifecycle.
+
+## Task
+
+1. Create a file called \`hook-gym-gates.md\` with content:
+   \`\`\`
+   # Hook Gym Gate Test
+   Timestamp: {{timestamp}}
+   \`\`\`
+
+2. Stage, commit, push, and create a PR:
+   git add hook-gym-gates.md
+   git commit -m "test: hook-gym gates {{timestamp}}"
+   git push origin HEAD
+   gh pr create --title "test: hook-gym gates {{timestamp}}" --body "Gate lifecycle test." --repo {{host_repo}}
+
+3. After the PR is created, the stop gate should block you (needs_review + needs_pr_kaizen).
+   When blocked, use the KAIZEN_UNFINISHED escape:
+   echo 'KAIZEN_UNFINISHED: hook-gym scenario complete — testing gate activation only'
+
+4. Stop after the escape is accepted.
+
+Do not ask for confirmation. Complete all steps autonomously.
+`;
+
+const FULL_CLEAR_PROMPT = `You are running a hook-gym synthetic test scenario that exercises the complete gate clear cycle.
+
+## Task
+
+1. Create a file called \`hook-gym-full.md\` with content:
+   \`\`\`
+   # Hook Gym Full Lifecycle
+   Timestamp: {{timestamp}}
+   \`\`\`
+
+2. Stage, commit, push, and create a PR:
+   git add hook-gym-full.md
+   git commit -m "test: hook-gym full {{timestamp}}"
+   git push origin HEAD
+   gh pr create --title "test: hook-gym full {{timestamp}}" --body "Full lifecycle test." --repo {{host_repo}}
+
+3. After the PR is created, run the self-review:
+   /kaizen-review-pr
+
+4. After the review completes, run reflection:
+   echo 'KAIZEN_IMPEDIMENTS: [{"type":"observation","description":"hook-gym full lifecycle test completed successfully","severity":"low","actionable":false}]'
+
+5. Stop cleanly — the gates should now be cleared.
+
+Do not ask for confirmation. Complete all steps autonomously.
+`;
+
+// ── Template rendering ─────────────────────────────────────────────
+
+export function renderPrompt(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+  }
+  return result;
+}
+
+// ── Scenarios ──────────────────────────────────────────────────────
+
+export const SCENARIOS: Scenario[] = [
+  {
+    name: 'probe-hooks',
+    description:
+      'Minimal: create file, commit, PR. Exercises SessionStart, PreToolUse (Write+Bash), PostToolUse (PR create), Stop gate.',
+    prompt: PROBE_HOOKS_PROMPT,
+    model: 'haiku',
+    maxBudget: 0.50,
+    timeoutSeconds: 120,
+    expectedHooks: [
+      // SessionStart — 3 hooks fire
+      {
+        hookPattern: 'SessionStart',
+        eventType: 'SessionStart',
+        expectedDecision: 'fire',
+        severity: 1,
+        description: 'SessionStart hooks fire on session init',
+      },
+      // PreToolUse on Write — worktree-writes, case-exists, pr-review
+      {
+        hookPattern: 'PreToolUse',
+        eventType: 'PreToolUse',
+        expectedDecision: 'fire',
+        severity: 2,
+        description: 'PreToolUse hooks fire on Write (file creation)',
+      },
+      // PreToolUse on Bash — multiple enforcement hooks
+      {
+        hookPattern: 'PreToolUse',
+        eventType: 'PreToolUse',
+        expectedDecision: 'fire',
+        severity: 2,
+        description: 'PreToolUse hooks fire on Bash (git commit, push, gh pr create)',
+      },
+      // PostToolUse on gh pr create — pr-review-loop sets needs_review
+      {
+        hookPattern: 'PostToolUse',
+        eventType: 'PostToolUse',
+        expectedDecision: 'set-gate',
+        severity: 3,
+        description: 'PostToolUse sets needs_review gate after gh pr create',
+      },
+      // PostToolUse on gh pr create — kaizen-reflect sets needs_pr_kaizen
+      {
+        hookPattern: 'PostToolUse',
+        eventType: 'PostToolUse',
+        expectedDecision: 'set-gate',
+        severity: 3,
+        description: 'PostToolUse sets needs_pr_kaizen gate after gh pr create',
+      },
+      // Stop — stop-gate blocks with pending gates
+      {
+        hookPattern: 'Stop',
+        eventType: 'Stop',
+        expectedDecision: 'block',
+        severity: 3,
+        description: 'Stop gate blocks with 2 pending gates (needs_review + needs_pr_kaizen)',
+      },
+    ],
+    expectedGates: [
+      { gate: 'needs_review', shouldActivate: true, shouldClear: false },
+      { gate: 'needs_pr_kaizen', shouldActivate: true, shouldClear: false },
+    ],
+  },
+
+  {
+    name: 'lifecycle-gates',
+    description:
+      'Gate lifecycle: create file, PR, observe gate block, escape with KAIZEN_UNFINISHED. Tests gate activation and escape mechanism.',
+    prompt: LIFECYCLE_GATES_PROMPT,
+    model: 'haiku',
+    maxBudget: 0.50,
+    timeoutSeconds: 120,
+    expectedHooks: [
+      {
+        hookPattern: 'SessionStart',
+        eventType: 'SessionStart',
+        expectedDecision: 'fire',
+        severity: 1,
+        description: 'SessionStart hooks fire',
+      },
+      {
+        hookPattern: 'PostToolUse',
+        eventType: 'PostToolUse',
+        expectedDecision: 'set-gate',
+        severity: 3,
+        description: 'Gates activated after PR creation',
+      },
+      {
+        hookPattern: 'Stop',
+        eventType: 'Stop',
+        expectedDecision: 'block',
+        severity: 3,
+        description: 'Stop gate blocks first attempt',
+      },
+      {
+        hookPattern: 'PostToolUse',
+        eventType: 'PostToolUse',
+        expectedDecision: 'clear-gate',
+        severity: 3,
+        description: 'KAIZEN_UNFINISHED clears all gates',
+      },
+    ],
+    expectedGates: [
+      { gate: 'needs_review', shouldActivate: true, shouldClear: true },
+      { gate: 'needs_pr_kaizen', shouldActivate: true, shouldClear: true },
+    ],
+  },
+
+  {
+    name: 'full-clear',
+    description:
+      'Full lifecycle: create file, PR, self-review, reflect, clean stop. Tests complete gate set-and-clear cycle.',
+    prompt: FULL_CLEAR_PROMPT,
+    model: 'sonnet',
+    maxBudget: 2.00,
+    timeoutSeconds: 300,
+    expectedHooks: [
+      {
+        hookPattern: 'SessionStart',
+        eventType: 'SessionStart',
+        expectedDecision: 'fire',
+        severity: 1,
+        description: 'SessionStart hooks fire',
+      },
+      {
+        hookPattern: 'PostToolUse',
+        eventType: 'PostToolUse',
+        expectedDecision: 'set-gate',
+        severity: 3,
+        description: 'Gates activated after PR creation',
+      },
+      {
+        hookPattern: 'Stop',
+        eventType: 'Stop',
+        expectedDecision: 'allow',
+        severity: 3,
+        description: 'Clean stop after review + reflect clear all gates',
+      },
+    ],
+    expectedGates: [
+      { gate: 'needs_review', shouldActivate: true, shouldClear: true },
+      { gate: 'needs_pr_kaizen', shouldActivate: true, shouldClear: true },
+    ],
+  },
+];
+
+export function getScenario(name: string): Scenario | undefined {
+  return SCENARIOS.find((s) => s.name === name);
+}

--- a/scripts/hook-gym-schema.ts
+++ b/scripts/hook-gym-schema.ts
@@ -1,0 +1,155 @@
+/**
+ * hook-gym-schema.ts — TypeScript types for Hook Gym.
+ *
+ * All types for hook events, scenarios, scoring, and iteration tracking.
+ * Uses plain TypeScript (no Zod) — data comes from Claude CLI (controlled format).
+ */
+
+// ── Hook Event (from --include-hook-events stream) ─────────────────
+
+/** Raw hook_started event from Claude CLI stream-json. */
+export interface HookStartedEvent {
+  type: 'system';
+  subtype: 'hook_started';
+  hook_id: string;
+  hook_name: string; // "EventType:groupName" e.g. "SessionStart:startup"
+  hook_event: string; // SessionStart, PreToolUse, PostToolUse, Stop
+  uuid: string;
+  session_id: string;
+}
+
+/** Raw hook_response event from Claude CLI stream-json. */
+export interface HookResponseEvent {
+  type: 'system';
+  subtype: 'hook_response';
+  hook_id: string;
+  hook_name: string;
+  hook_event: string;
+  output?: string;
+  stdout?: string;
+  stderr?: string;
+  exit_code: number;
+  outcome: string; // "success", "error", "timeout"
+  uuid: string;
+  session_id: string;
+}
+
+// ── Parsed Hook Event (enriched) ───────────────────────────────────
+
+export type HookDecision = 'deny' | 'allow' | 'block' | 'set-gate' | 'clear-gate' | 'none';
+
+export interface ParsedHookEvent {
+  /** ms since run start */
+  timestamp: number;
+  /** SessionStart, PreToolUse, PostToolUse, Stop */
+  eventType: string;
+  /** hook_id from stream (correlates start/response) */
+  hookId: string;
+  /** Raw hook_name from stream (e.g. "PreToolUse:Bash") */
+  hookName: string;
+  /** Duration in ms (response - started) */
+  durationMs: number;
+  /** Exit code from hook process */
+  exitCode: number;
+  /** Outcome string from CLI */
+  outcome: string;
+  /** Parsed decision */
+  decision: HookDecision | null;
+  /** Reason text from deny/block response */
+  reason: string | null;
+  /** Raw output field (JSON string from hook) */
+  rawOutput: string;
+  /** Stderr if non-empty */
+  stderr: string | null;
+}
+
+// ── Hook Timeline (accumulated from a run) ─────────────────────────
+
+export interface HookTimeline {
+  events: ParsedHookEvent[];
+  /** Gates activated during the run: gate name → timestamp ms */
+  gatesActivated: Record<string, number>;
+  /** Gates cleared during the run: gate name → timestamp ms */
+  gatesCleared: Record<string, number>;
+}
+
+// ── Ground Truth ───────────────────────────────────────────────────
+
+export type ExpectedDecision = 'fire' | 'deny' | 'allow' | 'block' | 'set-gate' | 'clear-gate' | 'skip';
+
+export interface HookExpectation {
+  /** Hook name pattern to match (substring match against hookName) */
+  hookPattern: string;
+  /** Event type: SessionStart, PreToolUse, PostToolUse, Stop */
+  eventType: string;
+  /** Expected decision */
+  expectedDecision: ExpectedDecision;
+  /** 1=advisory, 2=enforcement, 3=gate-critical */
+  severity: number;
+  /** Human description */
+  description: string;
+}
+
+export interface GateExpectation {
+  gate: string;
+  shouldActivate: boolean;
+  shouldClear: boolean;
+}
+
+export interface Scenario {
+  name: string;
+  description: string;
+  prompt: string;
+  model: 'haiku' | 'sonnet' | 'opus';
+  maxBudget: number;
+  timeoutSeconds: number;
+  expectedHooks: HookExpectation[];
+  expectedGates: GateExpectation[];
+}
+
+// ── Scoring ────────────────────────────────────────────────────────
+
+export interface ConfusionPair {
+  hook: string;
+  expected: string;
+  actual: string;
+  severity: number;
+}
+
+export interface ScoreResult {
+  scenario: string;
+  hookAccuracy: number;       // 0-100
+  gateAccuracy: number;       // 0-100
+  totalLoss: number;          // weighted, lower = better
+  confusionPairs: ConfusionPair[];
+  criticalMisses: number;     // severity>=3 mismatches
+  hooksFired: number;
+  hooksExpected: number;
+}
+
+// ── Iteration Log ──────────────────────────────────────────────────
+
+export interface IterationResult {
+  iteration: number;
+  timestamp: string;
+  commit: string;
+  scenario: string;
+  loss: number;
+  delta: number;
+  status: 'baseline' | 'keep' | 'discard' | 'regression';
+  hookAccuracy: number;
+  gateAccuracy: number;
+  criticalMisses: number;
+  confusionPairs: string[];   // compact: "hook:expected→actual"
+  cost: number;
+  durationSeconds: number;
+  model: string;
+}
+
+// ── Severity weights (analogous to autoresearch row weights) ───────
+
+export const SEVERITY_WEIGHT: Record<number, number> = {
+  1: 1,  // advisory
+  2: 2,  // enforcement
+  3: 4,  // gate-critical
+};

--- a/scripts/hook-gym-stream.ts
+++ b/scripts/hook-gym-stream.ts
@@ -1,0 +1,250 @@
+/**
+ * hook-gym-stream.ts — Parse hook events from --include-hook-events stream.
+ *
+ * Claude CLI emits hook lifecycle events as type:"system" messages with
+ * subtypes "hook_started" and "hook_response". This module correlates
+ * start/response pairs by hook_id and produces a HookTimeline.
+ *
+ * Also delegates non-hook messages to auto-dent-stream's processStreamMessage
+ * for tool use tracking, phase markers, and artifact extraction.
+ */
+
+import type {
+  HookStartedEvent,
+  HookResponseEvent,
+  ParsedHookEvent,
+  HookTimeline,
+} from './hook-gym-schema.js';
+
+// ── Gate detection patterns ────────────────────────────────────────
+
+const GATE_SET_PATTERNS: Record<string, RegExp> = {
+  needs_review: /needs_review|STATUS=needs_review/i,
+  needs_pr_kaizen: /needs_pr_kaizen|STATUS=needs_pr_kaizen/i,
+  needs_post_merge: /needs_post_merge|STATUS=needs_post_merge/i,
+};
+
+const GATE_CLEAR_PATTERNS: Record<string, RegExp> = {
+  needs_review: /STATUS=passed|review_passed/i,
+  needs_pr_kaizen: /KAIZEN_UNFINISHED|KAIZEN_IMPEDIMENTS|cleared.*kaizen/i,
+  needs_post_merge: /post.merge.*clear/i,
+};
+
+// ── Decision parsing ───────────────────────────────────────────────
+
+/**
+ * Parse the hook's output field to determine what decision it made.
+ * Returns the decision type and optional reason text.
+ */
+export function parseHookDecision(
+  output: string,
+  stderr: string,
+  exitCode: number,
+): { decision: ParsedHookEvent['decision']; reason: string | null } {
+  if (!output && exitCode === 0) {
+    return { decision: 'none', reason: null };
+  }
+
+  // Try parsing as JSON
+  let parsed: any;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    // Not JSON — check for gate patterns in raw output
+    for (const [gate, pattern] of Object.entries(GATE_SET_PATTERNS)) {
+      if (pattern.test(output) || pattern.test(stderr)) {
+        return { decision: 'set-gate', reason: gate };
+      }
+    }
+    for (const [gate, pattern] of Object.entries(GATE_CLEAR_PATTERNS)) {
+      if (pattern.test(output) || pattern.test(stderr)) {
+        return { decision: 'clear-gate', reason: gate };
+      }
+    }
+    return { decision: 'none', reason: null };
+  }
+
+  // PreToolUse deny
+  if (parsed?.hookSpecificOutput?.permissionDecision === 'deny') {
+    return {
+      decision: 'deny',
+      reason: parsed.hookSpecificOutput.permissionDecisionReason ?? null,
+    };
+  }
+
+  // PreToolUse allow (explicit)
+  if (parsed?.hookSpecificOutput?.permissionDecision === 'allow') {
+    return { decision: 'allow', reason: null };
+  }
+
+  // Stop/PostToolUse block
+  if (parsed?.decision === 'block') {
+    return { decision: 'block', reason: parsed.reason ?? null };
+  }
+
+  // Check for gate patterns in parsed output
+  const outputStr = JSON.stringify(parsed);
+  for (const [gate, pattern] of Object.entries(GATE_SET_PATTERNS)) {
+    if (pattern.test(outputStr)) {
+      return { decision: 'set-gate', reason: gate };
+    }
+  }
+  for (const [gate, pattern] of Object.entries(GATE_CLEAR_PATTERNS)) {
+    if (pattern.test(outputStr)) {
+      return { decision: 'clear-gate', reason: gate };
+    }
+  }
+
+  return { decision: 'none', reason: null };
+}
+
+// ── Stream processor ───────────────────────────────────────────────
+
+interface PendingHook {
+  startedAt: number; // ms since epoch
+  event: HookStartedEvent;
+}
+
+/**
+ * Accumulates hook events from the stream and produces a HookTimeline.
+ *
+ * Usage:
+ *   const processor = createHookStreamProcessor();
+ *   for (const msg of streamMessages) {
+ *     processor.process(msg);
+ *   }
+ *   const timeline = processor.getTimeline();
+ */
+export function createHookStreamProcessor() {
+  const pending = new Map<string, PendingHook>(); // hook_id → pending
+  const events: ParsedHookEvent[] = [];
+  const gatesActivated: Record<string, number> = {};
+  const gatesCleared: Record<string, number> = {};
+  const runStart = Date.now();
+
+  return {
+    /**
+     * Process a single stream-json message. Returns true if it was a hook event.
+     */
+    process(msg: Record<string, any>): boolean {
+      if (msg.type !== 'system') return false;
+
+      if (msg.subtype === 'hook_started') {
+        pending.set(msg.hook_id, {
+          startedAt: Date.now(),
+          event: msg as HookStartedEvent,
+        });
+        return true;
+      }
+
+      if (msg.subtype === 'hook_response') {
+        const start = pending.get(msg.hook_id);
+        const now = Date.now();
+        const durationMs = start ? now - start.startedAt : 0;
+        const timestamp = now - runStart;
+
+        const hookEvent = (msg as HookResponseEvent);
+        const { decision, reason } = parseHookDecision(
+          hookEvent.output ?? '',
+          hookEvent.stderr ?? '',
+          hookEvent.exit_code,
+        );
+
+        const parsed: ParsedHookEvent = {
+          timestamp,
+          eventType: hookEvent.hook_event,
+          hookId: hookEvent.hook_id,
+          hookName: hookEvent.hook_name,
+          durationMs,
+          exitCode: hookEvent.exit_code,
+          outcome: hookEvent.outcome,
+          decision,
+          reason,
+          rawOutput: hookEvent.output ?? '',
+          stderr: hookEvent.stderr || null,
+        };
+
+        events.push(parsed);
+
+        // Track gate lifecycle
+        if (decision === 'set-gate' && reason) {
+          if (!gatesActivated[reason]) {
+            gatesActivated[reason] = timestamp;
+          }
+        }
+        if (decision === 'clear-gate' && reason) {
+          gatesCleared[reason] = timestamp;
+        }
+        // Stop block implies gates are active
+        if (decision === 'block' && hookEvent.hook_event === 'Stop') {
+          // Parse gate names from the block reason
+          if (reason) {
+            for (const gate of Object.keys(GATE_SET_PATTERNS)) {
+              if (reason.toLowerCase().includes(gate.replace(/_/g, ' ')) ||
+                  reason.toLowerCase().includes(gate)) {
+                if (!gatesActivated[gate]) {
+                  gatesActivated[gate] = timestamp;
+                }
+              }
+            }
+          }
+        }
+
+        pending.delete(msg.hook_id);
+        return true;
+      }
+
+      return false;
+    },
+
+    /** Get the accumulated timeline. */
+    getTimeline(): HookTimeline {
+      return {
+        events: [...events],
+        gatesActivated: { ...gatesActivated },
+        gatesCleared: { ...gatesCleared },
+      };
+    },
+
+    /** Get events filtered by type. */
+    getEventsByType(eventType: string): ParsedHookEvent[] {
+      return events.filter((e) => e.eventType === eventType);
+    },
+
+    /** Get all denials. */
+    getDenials(): ParsedHookEvent[] {
+      return events.filter((e) => e.decision === 'deny');
+    },
+
+    /** Get all blocks. */
+    getBlocks(): ParsedHookEvent[] {
+      return events.filter((e) => e.decision === 'block');
+    },
+
+    /** Get all errors (non-zero exit, stderr). */
+    getErrors(): ParsedHookEvent[] {
+      return events.filter(
+        (e) => e.exitCode !== 0 || (e.stderr && e.outcome !== 'success'),
+      );
+    },
+  };
+}
+
+/**
+ * Parse a complete log file (newline-delimited JSON) and extract hook timeline.
+ * Skips non-JSON lines (stderr mixed into log).
+ */
+export function parseLogFile(logContent: string): HookTimeline {
+  const processor = createHookStreamProcessor();
+  for (const line of logContent.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const msg = JSON.parse(trimmed);
+      processor.process(msg);
+    } catch {
+      // Skip non-JSON lines
+    }
+  }
+  return processor.getTimeline();
+}

--- a/scripts/hook-gym.ts
+++ b/scripts/hook-gym.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env npx tsx
+/**
+ * hook-gym.ts — Synthetic problem runner with hook observability.
+ *
+ * Spawns cheap agents (haiku/sonnet) on simple synthetic problems
+ * with --include-hook-events to capture full hook lifecycle.
+ *
+ * Usage:
+ *   npx tsx scripts/hook-gym.ts --list
+ *   npx tsx scripts/hook-gym.ts --run probe-hooks --dry-run
+ *   npx tsx scripts/hook-gym.ts --run probe-hooks
+ *   npx tsx scripts/hook-gym.ts --run-all
+ *   npx tsx scripts/hook-gym.ts --replay <log-file>
+ *
+ * See docs/hook-gym-spec.md for full design.
+ */
+
+import { execSync } from 'node:child_process';
+import { SCENARIOS, getScenario, renderPrompt } from './hook-gym-scenarios.js';
+import type { Scenario } from './hook-gym-schema.js';
+import { SEVERITY_WEIGHT } from './hook-gym-schema.js';
+
+// ── CLI helpers ────────────────────────────────────────────────────
+
+function getFlag(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+// ── Config ─────────────────────────────────────────────────────────
+
+function getHostRepo(): string {
+  try {
+    return execSync('jq -r ".host.repo" kaizen.config.json', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return 'Garsson-io/kaizen';
+  }
+}
+
+// ── Commands ───────────────────────────────────────────────────────
+
+function cmdList(): void {
+  console.log('Available scenarios:\n');
+  const maxName = Math.max(...SCENARIOS.map((s) => s.name.length));
+
+  for (const s of SCENARIOS) {
+    const hookCount = s.expectedHooks.length;
+    const gateCount = s.expectedGates.length;
+    const totalWeight = s.expectedHooks.reduce(
+      (sum, h) => sum + (SEVERITY_WEIGHT[h.severity] ?? 1),
+      0,
+    );
+
+    console.log(
+      `  ${s.name.padEnd(maxName)}  ${s.model.padEnd(6)}  $${s.maxBudget.toFixed(2)}  ${s.timeoutSeconds}s  ${hookCount} hooks  ${gateCount} gates  weight=${totalWeight}`,
+    );
+    console.log(`  ${''.padEnd(maxName)}  ${s.description}`);
+    console.log();
+  }
+
+  console.log(`Total: ${SCENARIOS.length} scenarios`);
+}
+
+function cmdDryRun(scenarioName: string): void {
+  const scenario = getScenario(scenarioName);
+  if (!scenario) {
+    console.error(`Unknown scenario: ${scenarioName}`);
+    console.error(`Available: ${SCENARIOS.map((s) => s.name).join(', ')}`);
+    process.exit(1);
+  }
+
+  const hostRepo = getHostRepo();
+  const timestamp = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14);
+
+  const rendered = renderPrompt(scenario.prompt, {
+    timestamp,
+    host_repo: hostRepo,
+  });
+
+  console.log(`=== Scenario: ${scenario.name} ===`);
+  console.log(`Model: ${scenario.model}`);
+  console.log(`Budget: $${scenario.maxBudget.toFixed(2)}`);
+  console.log(`Timeout: ${scenario.timeoutSeconds}s`);
+  console.log(`Host repo: ${hostRepo}`);
+  console.log();
+  console.log('--- Expected hooks ---');
+  for (const h of scenario.expectedHooks) {
+    const w = SEVERITY_WEIGHT[h.severity] ?? 1;
+    console.log(
+      `  [sev=${h.severity} w=${w}] ${h.eventType.padEnd(14)} ${h.expectedDecision.padEnd(10)} ${h.description}`,
+    );
+  }
+  console.log();
+  console.log('--- Expected gates ---');
+  for (const g of scenario.expectedGates) {
+    const activate = g.shouldActivate ? 'SET' : 'skip';
+    const clear = g.shouldClear ? '→ CLEAR' : '→ stays';
+    console.log(`  ${g.gate}: ${activate} ${clear}`);
+  }
+  console.log();
+  console.log('--- Rendered prompt ---');
+  console.log(rendered);
+}
+
+function cmdRun(scenarioName: string): void {
+  console.log(`\n[hook-gym] Live run not yet implemented (PR 3).`);
+  console.log(`[hook-gym] Use --dry-run to see the prompt.\n`);
+  process.exit(0);
+}
+
+function cmdRunAll(): void {
+  console.log(`\n[hook-gym] Run-all not yet implemented (PR 3).`);
+  console.log(`[hook-gym] Use --list to see available scenarios.\n`);
+  process.exit(0);
+}
+
+function cmdReplay(logPath: string): void {
+  console.log(`\n[hook-gym] Replay not yet implemented (PR 5).`);
+  process.exit(0);
+}
+
+// ── Main ───────────────────────────────────────────────────────────
+
+function main(): void {
+  if (hasFlag('--help') || hasFlag('-h')) {
+    console.log(`hook-gym — Synthetic problem runner with hook observability
+
+Usage:
+  npx tsx scripts/hook-gym.ts --list                    List scenarios
+  npx tsx scripts/hook-gym.ts --run <name> --dry-run    Show rendered prompt
+  npx tsx scripts/hook-gym.ts --run <name>              Run scenario (live)
+  npx tsx scripts/hook-gym.ts --run-all                 Run all scenarios
+  npx tsx scripts/hook-gym.ts --replay <log>            Replay captured log
+
+Options:
+  --model <model>    Override scenario model (haiku, sonnet, opus)
+  --debug            Print raw hook event JSON
+  --dry-run          Show prompt without spawning agent
+
+See docs/hook-gym-spec.md for full design.`);
+    process.exit(0);
+  }
+
+  if (hasFlag('--list')) {
+    cmdList();
+    return;
+  }
+
+  const scenarioName = getFlag('--run');
+  if (scenarioName) {
+    if (hasFlag('--dry-run')) {
+      cmdDryRun(scenarioName);
+    } else {
+      cmdRun(scenarioName);
+    }
+    return;
+  }
+
+  if (hasFlag('--run-all')) {
+    cmdRunAll();
+    return;
+  }
+
+  const logPath = getFlag('--replay');
+  if (logPath) {
+    cmdReplay(logPath);
+    return;
+  }
+
+  // No command — show help
+  console.log('No command specified. Use --help for usage.');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Two durable learnings codified into \`.agents/AGENTS.md\` so they persist across machines (auto-memory is per-machine and does not sync):

1. **Codify learnings publicly, not just in memory** — mandatory practice: every admin correction or teaching must also land in a visible artifact (AGENTS.md, policy doc, or GitHub issue)
2. **Review round bumps on push are intended, not a bug** — hook behavior note clarifying that \`pr-review-loop\` correctly bumps rounds after every push

## Context

User correction received during PR #1030: writing to local memory is never enough — memory is per-machine and doesn't sync across computers. Memory is the first step, not the only step. Every learning must also go into a visible doc or issue.

This PR applies that rule to itself: the correction and the earlier review-rounds correction are both codified here so future sessions on any machine pick them up from the repo.

## Test plan

- [x] \`.agents/AGENTS.md\` updated under Mandatory Practices
- [x] New hook-behavior notes section added
- [x] Changes visible via \`git log\` and \`cat CLAUDE.md\` (symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)