### PR TITLE
docs: codify codify-learnings rule + branch hygiene in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -107,9 +107,11 @@ Store plans immediately after creating them. Review findings are stored per-roun
 - **Workflow changes** → update the relevant SKILL.md
 Memory-only retention means the next session on a different machine repeats the same mistake.
 
-### Hook behavior notes
+### Branch & PR hygiene
 
-- **Review round bumps on push are intended, not a bug.** `pr-review-loop` sets `needs_review` for a new round after every `git push` — including pushes to branches whose prior PR was merged. Rationale: new code deserves a fresh review; the previous round's pass is stale. Do not file this as a hook bug.
+- **Never push new commits to a branch whose PR has already been merged.** Commits pushed to a merged branch get orphaned or confuse the review loop. Always create a new branch (via `EnterWorktree` or `git checkout -b`) for follow-up work.
+- **If you accidentally pushed to a merged branch, detect and recover.** Check `gh pr list --head <branch>` and `gh pr view <last-pr> --json state`. If the last PR on the branch is `MERGED`, create a fresh branch from `main` (or from the merge commit), cherry-pick or re-apply your new commits there, and open a new PR from the new branch.
+- **Review round bumps on push are intended.** Within a single open PR, `pr-review-loop` correctly sets `needs_review` for a new round after every `git push`. Each push is new code and deserves fresh review; the previous round's pass is stale. This is not a bug — complete the new review round before proceeding.
 
 ## Configuration
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -101,6 +101,16 @@ Store plans immediately after creating them. Review findings are stored per-roun
 
 **PR review dimensions**: When running `/kaizen-review-pr`, bundle dimensions by shared data needs (use the briefing from `npx tsx src/cli-dimensions.ts briefing --lines N`). Don't spawn one agent per dimension — batch dims with identical `needs` into single agents.
 
+**Codify learnings publicly, not just in memory**: Local auto-memory (`~/.claude/projects/.../memory/`) is per-machine and does NOT sync across devices. When an admin corrects you or teaches a rule, memory is the FIRST step, never the only step. You MUST also codify the learning in at least one visible artifact:
+- **Durable rules** → add to this file (`.agents/AGENTS.md`) or a dedicated policy doc under `.agents/kaizen/`
+- **Actionable bugs / follow-ups** → file a GitHub issue
+- **Workflow changes** → update the relevant SKILL.md
+Memory-only retention means the next session on a different machine repeats the same mistake.
+
+### Hook behavior notes
+
+- **Review round bumps on push are intended, not a bug.** `pr-review-loop` sets `needs_review` for a new round after every `git push` — including pushes to branches whose prior PR was merged. Rationale: new code deserves a fresh review; the previous round's pass is stale. Do not file this as a hook bug.
+
 ## Configuration
 
 All skills and hooks read `kaizen.config.json` from the host project root:

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -109,9 +109,14 @@ Memory-only retention means the next session on a different machine repeats the 
 
 ### Branch & PR hygiene
 
-- **Never push new commits to a branch whose PR has already been merged.** Commits pushed to a merged branch get orphaned or confuse the review loop. Always create a new branch (via `EnterWorktree` or `git checkout -b`) for follow-up work.
-- **If you accidentally pushed to a merged branch, detect and recover.** Check `gh pr list --head <branch>` and `gh pr view <last-pr> --json state`. If the last PR on the branch is `MERGED`, create a fresh branch from `main` (or from the merge commit), cherry-pick or re-apply your new commits there, and open a new PR from the new branch.
-- **Review round bumps on push are intended.** Within a single open PR, `pr-review-loop` correctly sets `needs_review` for a new round after every `git push`. Each push is new code and deserves fresh review; the previous round's pass is stale. This is not a bug — complete the new review round before proceeding.
+- **Never push new commits to a branch whose most recent PR was already merged with no subsequent open PR.** Commits pushed to such a branch can get orphaned and the review-loop state file points at the merged PR, not the new work. Always create a new branch (via `EnterWorktree` or `git checkout -b`) for follow-up work.
+- **Detect merged-branch state before pushing.** Run:
+  ```bash
+  gh pr list --repo <repo> --head <branch> --state all --json number,state --jq '.[0]'
+  ```
+  If the most recent PR is `MERGED` and there's no newer `OPEN` PR on the branch, you must branch off before pushing. If an `OPEN` PR already exists on the branch, pushing to extend it is fine (new round bump is correct).
+- **If you accidentally pushed to a merged branch:** create a fresh branch from `main` (or from the merge commit), cherry-pick your new commits there, and open a new PR from the new branch.
+- **Review round bumps on push within an open PR are intended.** Each push is new code and deserves fresh review; the previous round's pass is stale. Complete the new round before proceeding.
 
 ## Configuration
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaizen",
-  "version": "1.0.93",
+  "version": "1.0.94",
   "description": "Continuous improvement plugin for Claude Code — enforcement hooks, reflection workflows, dev workflow skills, and recursive self-improvement",
   "author": {
     "name": "Garsson-io",


### PR DESCRIPTION
## Summary

Two durable policy learnings codified into `.agents/AGENTS.md` so they persist across machines (auto-memory is per-machine and does not sync).

## Related issues

- **Closes #1031** (superseded — duplicated diff, redone on clean branch)
- **Partial address of #1032** — codifies the branch-hygiene rule at L1 (policy); full L2 enforcement tracked in #1032

## Content

1. **Codify-learnings rule** (Mandatory Practices): every admin correction must land in a visible artifact, not just local memory
2. **Branch & PR hygiene** (new section): never push to a branch whose most recent PR is merged with no newer open PR; exact detection command; recovery steps
3. Clarification: review-round bumps on push within an open PR are intended behavior

## Test Plan (Behaviors × Levels)

| # | Behavior | Level | Coverage |
|---|----------|-------|----------|
| D1 | `.agents/AGENTS.md` contains the codify-learnings rule with three artifact targets (AGENTS.md, policy doc, issue) | **Unit** | ✅ `grep -q 'Codify learnings publicly'` passes |
| D2 | `.agents/AGENTS.md` contains the branch-hygiene rule with the `gh pr list --head` detection command | **Unit** | ✅ `grep -q 'gh pr list --repo.*--head.*--state all'` passes |
| D3 | `CLAUDE.md` symlink reflects the updated AGENTS.md | **Integration** | ✅ symlink verified with `readlink CLAUDE.md && cat CLAUDE.md \| grep 'branch whose most recent PR'` |

### Why these levels
- **D1, D2 = Unit**: text assertion on a single file — no I/O, no composition, no LLM
- **D3 = Integration**: verifies the symlink relationship (two file paths composed via filesystem)

### Not in scope
- L2 hook enforcement of the branch-hygiene rule — tracked in #1032 (requires new PreToolUse hook on `git push`)

## Verification

```bash
grep -c "Codify learnings publicly" .agents/AGENTS.md  # → 1
grep -c "gh pr list --repo" .agents/AGENTS.md          # → 1
readlink CLAUDE.md                                     # → .agents/AGENTS.md
```

## Diff

17 lines added to `.agents/AGENTS.md` — one file, zero code risk.

Closes #1031
Refs #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)