### PR TITLE
feat: categorical fix for check-dirty-files cwd/stat drift (Closes #1073)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -64,6 +64,7 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 | `.githooks/pre-push` | Shell dispatcher — agent-env shortcut then `npx tsx src/hooks/pre-push.ts`; `core.hooksPath=.githooks` set by `prepare` script |
 | `docs/git-hooks-design.md` | Architecture + decision record for the pre-push git hook layer |
 | `src/plan-store.ts` | Plan-specific helpers (extractPlanText, re-exports from structured-data) |
+| `src/hooks/lib/git-state.ts` | **Shared primitive** for hooks that read git state — `resolveTargetWorktree`, `readDirtyFiles` (content-level verified), `formatDiagnostic`, `isBypassRequested`. Categorical fix for #1073 / #240; sibling-hook migration is gated by the CI invariant in `git-state-invariant.test.ts` (pending work tracked in #1074). See `docs/hooks-design.md` § State-reading discipline. |
 
 ## Skills
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaizen",
-  "version": "1.0.98",
+  "version": "1.0.99",
   "description": "Continuous improvement plugin for Claude Code — enforcement hooks, reflection workflows, dev workflow skills, and recursive self-improvement",
   "author": {
     "name": "Garsson-io",

--- a/.claude/hooks/tests/harness.py
+++ b/.claude/hooks/tests/harness.py
@@ -403,6 +403,12 @@ if echo "$@" | grep -q "rev-parse --git-dir"; then
   echo ".git"
   exit 0
 fi"""
+        # content_dirty: when status_output claims a file is modified, the
+        # new content-level check (`git diff --quiet HEAD -- <file>`) must
+        # agree (exit 1 = differs) or check-dirty-files will filter it out
+        # as stat-only drift. See docs/hooks-design.md § State-reading
+        # discipline, and the #1073 categorical fix.
+        content_dirty = "1" if status_output.strip() else "0"
         script = f"""#!/bin/bash
 if echo "$@" | grep -q "status --porcelain"; then
   printf '%s' '{status_output}'
@@ -411,6 +417,9 @@ fi
 if echo "$@" | grep -q "rev-parse --abbrev-ref"; then
   echo "{branch}"
   exit 0
+fi
+if echo "$@" | grep -q "diff --quiet HEAD"; then
+  exit {content_dirty}
 fi
 if echo "$@" | grep -q "diff --name-only"; then
   printf '%s' '{diff_output}'
@@ -422,6 +431,10 @@ if echo "$@" | grep -q "remote get-url"; then
 fi
 if echo "$@" | grep -q "rev-parse --git-common-dir"; then
   echo ".git"
+  exit 0
+fi
+if echo "$@" | grep -q "rev-parse --absolute-git-dir"; then
+  echo "$PWD/.git"
   exit 0
 fi{git_dir_handler}
 /usr/bin/git "$@" 2>/dev/null

--- a/.claude/hooks/tests/test-helpers.sh
+++ b/.claude/hooks/tests/test-helpers.sh
@@ -177,10 +177,22 @@ MOCK
 # Usage: setup_git_status_mock " M src/dirty.ts"
 setup_git_status_mock() {
   local status_output="$1"
+  # `diff --quiet HEAD --` must agree with status_output for the #1073
+  # categorical fix's content-level verification to deny. If status is
+  # non-empty we return exit 1 (content differs); if empty, exit 0.
+  local diff_exit="0"
+  [ -n "$(echo "$status_output" | tr -d '[:space:]')" ] && diff_exit="1"
   cat > "$MOCK_DIR/git" << MOCK
 #!/bin/bash
 if echo "\$@" | grep -q "status --porcelain"; then
   printf '%s' "$status_output"
+  exit 0
+fi
+if echo "\$@" | grep -q "diff --quiet HEAD"; then
+  exit $diff_exit
+fi
+if echo "\$@" | grep -q "rev-parse --absolute-git-dir"; then
+  echo "\$PWD/.git"
   exit 0
 fi
 /usr/bin/git "\$@"

--- a/.claude/hooks/tests/test-schema-validation.sh
+++ b/.claude/hooks/tests/test-schema-validation.sh
@@ -47,7 +47,9 @@ exit 0
 MOCK
 chmod +x "$MOCK_DIR/gh"
 
-# Mock git for deny tests to return main branch
+# Mock git for deny tests to return main branch. When status_output is
+# non-empty, `diff --quiet HEAD --` must also report dirt (exit 1) so the
+# content-level check in check-dirty-files (#1073 categorical fix) agrees.
 cat > "$MOCK_DIR/git" << 'MOCK'
 #!/bin/bash
 if echo "$@" | grep -q "status --porcelain"; then
@@ -56,6 +58,13 @@ if echo "$@" | grep -q "status --porcelain"; then
 fi
 if echo "$@" | grep -q "rev-parse --abbrev-ref"; then
   echo "main"
+  exit 0
+fi
+if echo "$@" | grep -q "diff --quiet HEAD"; then
+  exit 1
+fi
+if echo "$@" | grep -q "rev-parse --absolute-git-dir"; then
+  echo "$PWD/.git"
   exit 0
 fi
 if echo "$@" | grep -q "diff --name-only"; then

--- a/docs/hooks-design.md
+++ b/docs/hooks-design.md
@@ -261,6 +261,36 @@ The rule: **if a hook detects a state that needs fixing, fix it — don't just d
 
 **Also applies to lint rules:** Code quality checks (detecting anti-patterns in source files) belong in **ESLint / `npm run lint` / CI**, never in a PreToolUse(Bash) hook. A hook fires on every tool call; a lint rule fires only when source files change. Wrong tool for the job produces noise and latency without benefit.
 
+## State-reading discipline (#1073 / #240)
+
+Hooks that inspect git working-tree state MUST route through
+`src/hooks/lib/git-state.ts`. Historical false-positives (#232, #721, #871,
+#1073) share two root causes — cwd drift and stat-vs-content disagreement —
+both neutralised by the primitive:
+
+- **`resolveTargetWorktree(cmdLine, fallbackCwd)`** — extracts the directory
+  the *gated command* will run in from `git -C <path>`, `cd <path> && …`,
+  `(cd <path> …)`, and quoted variants. Falls back to the passed-in cwd.
+  Anchors every subsequent git call via `-C <target>`.
+- **`readDirtyFiles(targetDir)`** — runs `git status --porcelain` then
+  verifies each flagged tracked file with `git diff --quiet HEAD -- <file>`.
+  Files whose content matches HEAD are filtered out (content truth overrides
+  stat-only porcelain claims).
+- **`formatDiagnostic(ctx)`** — stable diagnostic block in every deny
+  message: `[cwd]`, `[target]`, `[target-source]`, `[git-dir]`,
+  `[porcelain]`, per-file `[diff-index]`. Failure modes are debuggable from
+  the transcript alone.
+- **`isBypassRequested(env)`** — documented escape hatch. Agents that
+  believe the hook is wrong set `KAIZEN_ALLOW_DIRTY_FILES=1`; the bypass
+  is logged to stderr and must be followed by a kaizen issue pasting the
+  diagnostic block.
+
+A CI invariant in `src/hooks/lib/git-state-invariant.test.ts` fails the
+build if a new hook file calls `execSync('git …')` without importing from
+`./lib/git-state.js`. Hooks whose migration is pending live in the
+`OPT_OUT` set in that test; removing an entry without migrating the hook
+re-introduces the anti-pattern and breaks CI.
+
 ## Lessons Learned
 
 | Incident | Lesson | Kaizen |
@@ -272,4 +302,5 @@ The rule: **if a hook detects a state that needs fixing, fix it — don't just d
 | Cross-worktree gate clearing failed | Active declarations need `_any_branch` lookup | #239 |
 | `npm build && echo KAIZEN_IMPEDIMENTS:` bypassed gate | Segment-split before matching | #172 |
 | Hook tests flaky due to real state files | Always override `STATE_DIR` in tests | #309 |
+| `.claude-plugin/plugin.json` phantom-staged, blocked PR create | Hooks must resolve the gated command's target worktree and verify porcelain with content-level diff (not stat) — see § State-reading discipline | #1073 |
 | scope-guard blocked ALL tools → 10-message deadlock | Auto-fix bad state; warn don't block; lint ≠ hook | #758 |

--- a/src/e2e/check-dirty-files-1073-differential.test.ts
+++ b/src/e2e/check-dirty-files-1073-differential.test.ts
@@ -1,0 +1,166 @@
+/**
+ * check-dirty-files-1073-differential.test.ts — differential proof for #1073.
+ *
+ * The existing host-plugin live fixture proves the NEW code path is correct.
+ * This test is stronger: it reproduces the EXACT field scenario the reporter
+ * hit and shows the SAME input produces two different answers under the two
+ * code paths preserved in `check-dirty-files.ts`:
+ *
+ *   • legacy `gitRunner` path (pre-#1073 behavior): DENY — the bug.
+ *   • new     `gitExec`    path (post-#1073 fix):    ALLOW — the fix.
+ *
+ * Both code paths are exercised by the same hook invocation, on the same
+ * live filesystem, with identical input. If either direction regresses this
+ * test fails.
+ *
+ * Field scenario reproduced from kaizen #1073:
+ *
+ *   - Agent's `process.cwd()` is some OTHER git repo (e.g. the main kaizen
+ *     checkout left with a staged `.claude-plugin/plugin.json` by
+ *     kaizen-bump-plugin-version).
+ *   - The agent runs `cd <host-repo> && gh pr create`.
+ *   - PreToolUse hooks fire BEFORE the shell `cd`, so `process.cwd()`
+ *     still points at the drifted repo.
+ *   - Pre-fix: hook runs `git status --porcelain` from the drifted cwd,
+ *     sees the unrelated staged change, denies — the exact "M
+ *     .claude-plugin/plugin.json" message the reporter pasted.
+ *   - Post-fix: hook parses `cd <host-repo>` out of the command, anchors
+ *     every git call via `git -C <host-repo>`, sees the host repo's
+ *     actually-clean state, allows.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { checkDirtyFiles } from '../hooks/check-dirty-files.js';
+import { createDefaultGitExec } from '../hooks/lib/git-state.js';
+
+describe('check-dirty-files #1073 — differential proof (legacy vs fixed)', () => {
+  let tmp: string;
+  let agentCwd: string;  // the drifted repo that supplies the phantom staged change
+  let hostRepo: string;  // the real target of `cd B && gh pr create` — clean
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'k1073-diff-'));
+    agentCwd = path.join(tmp, 'agent-cwd-repo');
+    hostRepo = path.join(tmp, 'host-project');
+
+    for (const r of [agentCwd, hostRepo]) {
+      fs.mkdirSync(r, { recursive: true });
+      execSync('git init -q -b main', { cwd: r });
+      execSync('git config user.email t@e', { cwd: r });
+      execSync('git config user.name t', { cwd: r });
+      fs.mkdirSync(path.join(r, '.claude-plugin'));
+      fs.writeFileSync(
+        path.join(r, '.claude-plugin/plugin.json'),
+        JSON.stringify({ name: path.basename(r), version: '0.1.0' }) + '\n',
+      );
+      fs.writeFileSync(path.join(r, 'README.md'), `# ${path.basename(r)}\n`);
+      execSync('git add -A && git commit -q -m init', { cwd: r });
+    }
+
+    // Drift ONLY in agentCwd — hostRepo stays clean. This is the #1073
+    // shape: two repos, staged change in the wrong one.
+    fs.writeFileSync(
+      path.join(agentCwd, '.claude-plugin/plugin.json'),
+      JSON.stringify({ name: 'agent-cwd-repo', version: '0.2.0' }) + '\n',
+    );
+    execSync('git add .claude-plugin/plugin.json', { cwd: agentCwd });
+
+    // Sanity: drift is where we put it and nowhere else.
+    expect(execSync('git status --porcelain', { cwd: agentCwd, encoding: 'utf-8' })).toBe(
+      'M  .claude-plugin/plugin.json\n',
+    );
+    expect(execSync('git status --porcelain', { cwd: hostRepo, encoding: 'utf-8' })).toBe('');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('legacy gitRunner path reproduces the #1073 false-positive deny', () => {
+    const command = `cd ${hostRepo} && gh pr create --title t`;
+
+    // Legacy runner: (args: string) => string. No argv isolation, no -C
+    // resolution, no content verification. cwd is fixed at `agentCwd`,
+    // mirroring what `process.cwd()` would have been in the field when the
+    // PreToolUse hook fired before the shell's `cd` ran.
+    const legacyRunner = (args: string): string => {
+      const parts = args.split(/\s+/).filter(Boolean);
+      const r = spawnSync('git', parts, { cwd: agentCwd, encoding: 'utf-8' });
+      return r.stdout ?? '';
+    };
+
+    const result = checkDirtyFiles(command, { gitRunner: legacyRunner });
+
+    expect(result.action).toBe('deny');
+    // Same exact message shape the #1073 reporter pasted.
+    expect(result.message).toContain('M  .claude-plugin/plugin.json');
+    expect(result.message).toContain('Staged but not committed');
+  });
+
+  it('fixed gitExec path allows the same input — #1073 resolved', () => {
+    const command = `cd ${hostRepo} && gh pr create --title t`;
+
+    // The fixed path: new runner (argv + exit codes) AND we pass `cwd:
+    // agentCwd` so the hook STARTS in the drifted repo. The fix must
+    // resolve the `cd <hostRepo>` target and anchor every git call via
+    // `-C <hostRepo>` — otherwise this would also deny.
+    const result = checkDirtyFiles(command, {
+      gitExec: createDefaultGitExec(),
+      cwd: agentCwd,
+    });
+
+    expect(result.action).toBe('allow');
+  });
+
+  it('fixed path still denies when the TARGET (not cwd) has real drift', () => {
+    // Flip the scenario: hostRepo dirty, agentCwd clean. The fix must
+    // still pick up the target's real drift, not be blind to it.
+    execSync('git reset --hard -q', { cwd: agentCwd });
+    fs.writeFileSync(
+      path.join(hostRepo, '.claude-plugin/plugin.json'),
+      JSON.stringify({ real: 'edit' }) + '\n',
+    );
+
+    const command = `cd ${hostRepo} && gh pr create --title t`;
+    const result = checkDirtyFiles(command, {
+      gitExec: createDefaultGitExec(),
+      cwd: agentCwd,
+    });
+
+    expect(result.action).toBe('deny');
+    expect(result.message).toContain('.claude-plugin/plugin.json');
+    expect(result.message).toContain('[target]');
+    expect(result.message).toContain(hostRepo);
+  });
+
+  it('fixed path diagnostic shows target=hostRepo, source=cd (proves resolution worked)', () => {
+    // Make hostRepo dirty so we get a deny message (which carries the
+    // diagnostic block). Purpose here is to assert the diagnostic
+    // *names* the resolved target, giving an operator a deterministic
+    // way to tell "the hook is looking at the right repo".
+    fs.writeFileSync(
+      path.join(hostRepo, '.claude-plugin/plugin.json'),
+      JSON.stringify({ real: 'edit' }) + '\n',
+    );
+
+    const result = checkDirtyFiles(`cd ${hostRepo} && gh pr create --title t`, {
+      gitExec: createDefaultGitExec(),
+      cwd: agentCwd,
+    });
+
+    expect(result.action).toBe('deny');
+    expect(result.message).toContain(`[target]          ${hostRepo}`);
+    expect(result.message).toContain('[target-source]   cd');
+    expect(result.message).toContain(`[cwd]             ${agentCwd}`);
+    // Proves the hook's per-file diff is reading hostRepo's state (the
+    // real dirty file there), not agentCwd's. Diagnostic labels like
+    // `[cwd]` naturally echo agentCwd; we assert on the content rows.
+    expect(result.message).toMatch(/\[git-dir\]\s+[^\n]*host-project/);
+    expect(result.message).not.toMatch(/agent-cwd-repo\/\.claude-plugin\/plugin\.json/);
+  });
+});

--- a/src/e2e/check-dirty-files-1073-differential.test.ts
+++ b/src/e2e/check-dirty-files-1073-differential.test.ts
@@ -163,4 +163,49 @@ describe('check-dirty-files #1073 — differential proof (legacy vs fixed)', () 
     expect(result.message).toMatch(/\[git-dir\]\s+[^\n]*host-project/);
     expect(result.message).not.toMatch(/agent-cwd-repo\/\.claude-plugin\/plugin\.json/);
   });
+
+  // #225 — `.worktree-lock.json` false positive. Plan Success Criterion 6
+  // enumerated #225 as a row the regression-guards table must cover. The
+  // prior fix (#144) added this file to `.gitignore`, so today it cannot
+  // show up in porcelain anyway — but an adjacent class of kaizen-specific
+  // state files in the worktree can: if any future state file slips the
+  // ignore list, the hook must not deny on it. This row exercises that
+  // class by creating an UNTRACKED kaizen state file in the target and
+  // asserting the hook allows (untracked files are not part of "uncommitted
+  // changes to tracked files" semantics for pr_create — by design).
+  it('#225: untracked kaizen state file in target does not cause deny', () => {
+    // Write an untracked .worktree-lock.json-shaped file in hostRepo.
+    fs.writeFileSync(
+      path.join(hostRepo, '.worktree-lock.json'),
+      JSON.stringify({ pid: 1234, holder: 'kaizen' }) + '\n',
+    );
+    // Sanity: porcelain sees it as untracked.
+    const porcelain = execSync('git status --porcelain', {
+      cwd: hostRepo,
+      encoding: 'utf-8',
+    });
+    expect(porcelain).toContain('?? .worktree-lock.json');
+
+    // The hook currently treats untracked as part of `report.total` when
+    // tracked files also differ — but in this scenario there are no
+    // tracked changes, only the untracked lock file. Assert that a lone
+    // untracked kaizen state file, on its own, is enough to deny (this
+    // documents the current semantics). The load-bearing part of the
+    // row is the *next* assertion: the deny message must NOT be about
+    // tracked-file drift — it must be reported as Untracked, so
+    // `.gitignore`-ing the file closes it cleanly (the #144 resolution
+    // of #225).
+    const result = checkDirtyFiles(`cd ${hostRepo} && gh pr create --title t`, {
+      gitExec: createDefaultGitExec(),
+      cwd: agentCwd,
+    });
+    expect(result.action).toBe('deny');
+    expect(result.message).toContain('Untracked');
+    expect(result.message).toContain('.worktree-lock.json');
+    // The hook must NOT claim this is staged or modified — that would
+    // be the #225 regression (stat-cache confusing untracked for
+    // tracked).
+    expect(result.message).not.toMatch(/Staged but not committed[\s\S]*worktree-lock/);
+    expect(result.message).not.toMatch(/Modified \(unstaged\)[\s\S]*worktree-lock/);
+  });
 });

--- a/src/e2e/check-dirty-files-1073-differential.test.ts
+++ b/src/e2e/check-dirty-files-1073-differential.test.ts
@@ -167,13 +167,13 @@ describe('check-dirty-files #1073 — differential proof (legacy vs fixed)', () 
   // #225 — `.worktree-lock.json` false positive. Plan Success Criterion 6
   // enumerated #225 as a row the regression-guards table must cover. The
   // prior fix (#144) added this file to `.gitignore`, so today it cannot
-  // show up in porcelain anyway — but an adjacent class of kaizen-specific
-  // state files in the worktree can: if any future state file slips the
-  // ignore list, the hook must not deny on it. This row exercises that
-  // class by creating an UNTRACKED kaizen state file in the target and
-  // asserting the hook allows (untracked files are not part of "uncommitted
-  // changes to tracked files" semantics for pr_create — by design).
-  it('#225: untracked kaizen state file in target does not cause deny', () => {
+  // show up in porcelain anyway. The regression class is not the deny
+  // itself (current semantics: a lone untracked file does deny — see
+  // inline comment below) but the *classification* the hook emits: a
+  // stat-cache bug that routed untracked entries into the Staged or
+  // Modified bucket was the #225 category. The assertions below lock
+  // that classification boundary in place.
+  it('#225: untracked kaizen state file classified as Untracked (not Staged/Modified)', () => {
     // Write an untracked .worktree-lock.json-shaped file in hostRepo.
     fs.writeFileSync(
       path.join(hostRepo, '.worktree-lock.json'),
@@ -186,15 +186,16 @@ describe('check-dirty-files #1073 — differential proof (legacy vs fixed)', () 
     });
     expect(porcelain).toContain('?? .worktree-lock.json');
 
-    // The hook currently treats untracked as part of `report.total` when
-    // tracked files also differ — but in this scenario there are no
-    // tracked changes, only the untracked lock file. Assert that a lone
-    // untracked kaizen state file, on its own, is enough to deny (this
-    // documents the current semantics). The load-bearing part of the
-    // row is the *next* assertion: the deny message must NOT be about
-    // tracked-file drift — it must be reported as Untracked, so
-    // `.gitignore`-ing the file closes it cleanly (the #144 resolution
-    // of #225).
+    // Current semantics: `verified.total` counts untracked entries, so
+    // a lone untracked file is enough to deny. That's the behaviour
+    // today — #144 closed the motivating #225 case by adding
+    // `.worktree-lock.json` to `.gitignore` so it never reaches
+    // porcelain. The load-bearing assertion for this regression guard
+    // is not the deny itself but the *classification* (the `not.toMatch`
+    // lines below): the category bug was stat-cache confusion routing
+    // untracked entries into the Staged/Modified buckets. If the hook
+    // ever regresses to misclassifying untracked as tracked drift,
+    // this row catches it.
     const result = checkDirtyFiles(`cd ${hostRepo} && gh pr create --title t`, {
       gitExec: createDefaultGitExec(),
       cwd: agentCwd,

--- a/src/e2e/check-dirty-files-host-plugin.test.ts
+++ b/src/e2e/check-dirty-files-host-plugin.test.ts
@@ -1,0 +1,174 @@
+/**
+ * check-dirty-files-host-plugin.test.ts — live fixture for #1073.
+ *
+ * Reproduces the exact scenario that blocked the langsmith-cli host repo:
+ * a project that ships its own `.claude-plugin/plugin.json`, with kaizen's
+ * check-dirty-files hook invoked from an UNRELATED cwd via a compound
+ * `cd <host-repo> && gh pr create …` payload.
+ *
+ * System-level: real tmp git repo, real subprocess invocation of the hook
+ * via tsx. The only way to prove the fix works against cwd-drift.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const KAIZEN_REPO_ROOT = path.resolve(__dirname, '../..');
+const HOOK_TS = path.join(KAIZEN_REPO_ROOT, 'src/hooks/check-dirty-files.ts');
+
+function findTsx(): string | null {
+  const local = path.join(KAIZEN_REPO_ROOT, 'node_modules/.bin/tsx');
+  if (fs.existsSync(local)) return local;
+  try {
+    const common = execSync('git rev-parse --git-common-dir', {
+      cwd: KAIZEN_REPO_ROOT,
+      encoding: 'utf-8',
+    }).trim();
+    const mainRoot = path.dirname(path.resolve(KAIZEN_REPO_ROOT, common));
+    const mainTsx = path.join(mainRoot, 'node_modules/.bin/tsx');
+    if (fs.existsSync(mainTsx)) return mainTsx;
+  } catch { /* ignore */ }
+  return null;
+}
+
+const TSX_BIN = findTsx();
+
+interface HookResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  parsed: unknown;
+}
+
+function runHook(command: string, cwd: string, extraEnv: Record<string, string> = {}): HookResult {
+  if (!TSX_BIN) throw new Error('tsx not found — cannot run live hook test');
+  const payload = JSON.stringify({
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command },
+  });
+  const r = spawnSync(TSX_BIN, [HOOK_TS], {
+    input: payload,
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...extraEnv },
+  });
+  let parsed: unknown = null;
+  if (r.stdout.trim()) {
+    try { parsed = JSON.parse(r.stdout); } catch { /* non-JSON stdout is fine */ }
+  }
+  return { exitCode: r.status ?? -1, stdout: r.stdout, stderr: r.stderr, parsed };
+}
+
+function isDeny(res: HookResult): boolean {
+  const p = res.parsed as { hookSpecificOutput?: { permissionDecision?: string } } | null;
+  return p?.hookSpecificOutput?.permissionDecision === 'deny';
+}
+
+describe('check-dirty-files live fixture — host repo with own .claude-plugin/plugin.json (#1073)', () => {
+  if (!TSX_BIN) {
+    it.skip('tsx not found — skipping live test', () => {});
+    return;
+  }
+
+  let tmpRoot: string;
+  let hostRepo: string;
+  let unrelatedCwd: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kaizen-1073-'));
+    hostRepo = path.join(tmpRoot, 'host-project');
+    unrelatedCwd = path.join(tmpRoot, 'elsewhere');
+    fs.mkdirSync(hostRepo, { recursive: true });
+    fs.mkdirSync(unrelatedCwd, { recursive: true });
+
+    // Init a non-kaizen git repo that happens to have its own plugin.json.
+    execSync('git init -q -b main', { cwd: hostRepo });
+    execSync('git config user.email "t@e"', { cwd: hostRepo });
+    execSync('git config user.name "t"', { cwd: hostRepo });
+
+    const pluginDir = path.join(hostRepo, '.claude-plugin');
+    fs.mkdirSync(pluginDir);
+    fs.writeFileSync(
+      path.join(pluginDir, 'plugin.json'),
+      JSON.stringify({ name: 'host-project', version: '0.1.0' }, null, 2) + '\n',
+    );
+    fs.writeFileSync(path.join(hostRepo, 'README.md'), '# host\n');
+    execSync('git add -A && git commit -q -m init', { cwd: hostRepo });
+
+    // `unrelatedCwd` is not even a git repo — it's some random dir the agent
+    // might be in when it runs `cd /host-project && gh pr create`.
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('allows gh pr create when cd into a clean host repo (the #1073 scenario)', () => {
+    // Sanity: host repo is genuinely clean.
+    const status = execSync('git status --porcelain', { cwd: hostRepo, encoding: 'utf-8' });
+    expect(status).toBe('');
+
+    const res = runHook(`cd ${hostRepo} && gh pr create --title t`, unrelatedCwd);
+
+    expect(isDeny(res)).toBe(false);
+    // Hook exited 0 with either empty stdout or a non-deny response.
+    expect(res.exitCode).toBe(0);
+  });
+
+  it('still denies when the host repo has a real uncommitted change', () => {
+    // Make a genuine content change.
+    fs.writeFileSync(
+      path.join(hostRepo, '.claude-plugin/plugin.json'),
+      JSON.stringify({ name: 'host-project', version: '0.2.0' }, null, 2) + '\n',
+    );
+
+    const res = runHook(`cd ${hostRepo} && gh pr create --title t`, unrelatedCwd);
+    expect(isDeny(res)).toBe(true);
+
+    // Diagnostic block must be visible.
+    const msg =
+      (res.parsed as { hookSpecificOutput?: { permissionDecisionReason?: string } } | null)
+        ?.hookSpecificOutput?.permissionDecisionReason ?? '';
+    expect(msg).toContain('[cwd]');
+    expect(msg).toContain('[target]');
+    expect(msg).toContain('[porcelain]');
+    expect(msg).toContain(unrelatedCwd); // cwd where hook actually ran
+    expect(msg).toContain(hostRepo); // resolved target
+  });
+
+  it('respects KAIZEN_ALLOW_DIRTY_FILES=1 escape hatch', () => {
+    fs.writeFileSync(
+      path.join(hostRepo, '.claude-plugin/plugin.json'),
+      JSON.stringify({ changed: true }) + '\n',
+    );
+
+    const res = runHook(
+      `cd ${hostRepo} && gh pr create --title t`,
+      unrelatedCwd,
+      { KAIZEN_ALLOW_DIRTY_FILES: '1' },
+    );
+    expect(isDeny(res)).toBe(false);
+    expect(res.stderr).toContain('BYPASS');
+  });
+
+  it('allows gh pr create when porcelain is stat-dirty but content matches HEAD (#871)', () => {
+    // Induce stat-dirty-but-content-clean: touch the file without changing
+    // content. On most filesystems this bumps mtime enough to make git's
+    // stat cache unhappy, though `git status --porcelain` alone may or may
+    // not flag it depending on the racy stat check. The content-level
+    // `git diff --quiet HEAD --` will always confirm identity.
+    const target = path.join(hostRepo, '.claude-plugin/plugin.json');
+    const contents = fs.readFileSync(target);
+    // Rewrite identical bytes a second later to perturb stat.
+    const future = new Date(Date.now() + 2000);
+    fs.writeFileSync(target, contents);
+    fs.utimesSync(target, future, future);
+
+    const res = runHook(`cd ${hostRepo} && gh pr create --title t`, unrelatedCwd);
+    expect(isDeny(res)).toBe(false);
+  });
+});

--- a/src/e2e/check-dirty-files-host-plugin.test.ts
+++ b/src/e2e/check-dirty-files-host-plugin.test.ts
@@ -155,6 +155,45 @@ describe('check-dirty-files live fixture — host repo with own .claude-plugin/p
     expect(res.stderr).toContain('BYPASS');
   });
 
+  it('allows when agent cwd is a DIFFERENT git repo with staged drift (#1073 field scenario)', () => {
+    // Strongest end-to-end proof. The field bug: the agent process's cwd
+    // was a git repo (e.g. the main kaizen checkout) with a phantom
+    // `M  .claude-plugin/plugin.json` entry left by kaizen-bump-plugin-
+    // version. When `cd <host-repo> && gh pr create` ran, PreToolUse
+    // fired before the shell cd, so `git status --porcelain` inherited
+    // the drifted cwd and denied. We reproduce that exact topology here:
+    // `driftedCwd` is a real git repo with a real staged change, the
+    // target `hostRepo` is clean, and the hook must allow.
+    const driftedCwd = path.join(tmpRoot, 'drifted-agent-repo');
+    fs.mkdirSync(driftedCwd, { recursive: true });
+    execSync('git init -q -b main', { cwd: driftedCwd });
+    execSync('git config user.email t@e', { cwd: driftedCwd });
+    execSync('git config user.name t', { cwd: driftedCwd });
+    fs.mkdirSync(path.join(driftedCwd, '.claude-plugin'));
+    fs.writeFileSync(
+      path.join(driftedCwd, '.claude-plugin/plugin.json'),
+      JSON.stringify({ name: 'drifted', version: '0.1.0' }) + '\n',
+    );
+    execSync('git add -A && git commit -q -m init', { cwd: driftedCwd });
+    // Stage a change without committing — the exact shape of the #1073
+    // phantom.
+    fs.writeFileSync(
+      path.join(driftedCwd, '.claude-plugin/plugin.json'),
+      JSON.stringify({ name: 'drifted', version: '0.2.0' }) + '\n',
+    );
+    execSync('git add .claude-plugin/plugin.json', { cwd: driftedCwd });
+    // Sanity: drift is real in driftedCwd, hostRepo stays clean.
+    expect(execSync('git status --porcelain', { cwd: driftedCwd, encoding: 'utf-8' })).toContain(
+      '.claude-plugin/plugin.json',
+    );
+    expect(execSync('git status --porcelain', { cwd: hostRepo, encoding: 'utf-8' })).toBe('');
+
+    const res = runHook(`cd ${hostRepo} && gh pr create --title t`, driftedCwd);
+
+    expect(isDeny(res)).toBe(false);
+    expect(res.exitCode).toBe(0);
+  });
+
   it('allows gh pr create when porcelain is stat-dirty but content matches HEAD (#871)', () => {
     // Induce stat-dirty-but-content-clean: touch the file without changing
     // content. On most filesystems this bumps mtime enough to make git's

--- a/src/hooks/bash-ts-parity.test.ts
+++ b/src/hooks/bash-ts-parity.test.ts
@@ -29,6 +29,12 @@ const EXCLUSIONS: Record<string, string> = {
   // TS splits extractPrUrl from reconstructPrUrl; bash inlines the grep
   extractPrUrl:
     'ts-only: extracted helper, bash inlines grep in reconstruct_pr_url',
+
+  // Added in the #1073 categorical fix. The sibling .claude/hooks/*.sh layer
+  // is being phased out (#762) — all new hook logic is TS-only, and the
+  // check-dirty-files bash wrapper just dispatches to the TS hook.
+  extractCdTarget:
+    'ts-only: cwd-drift fix landed in TS hook (#1073); bash wrapper only dispatches',
 };
 
 /** Extract function names from a bash script (matches `function_name() {`). */

--- a/src/hooks/check-dirty-files.test.ts
+++ b/src/hooks/check-dirty-files.test.ts
@@ -230,15 +230,18 @@ describe('checkDirtyFiles', () => {
  * that verifies porcelain claims with `git diff --quiet HEAD -- <file>`.
  */
 describe('checkDirtyFiles — categorical (#1073)', () => {
-  type ExecResult = { stdout: string; exitCode: number };
-  type ExecRunner = (args: string) => ExecResult;
+  type ExecResult = { stdout: string; stderr: string; exitCode: number };
+  type ExecRunner = (args: readonly string[]) => ExecResult;
 
-  function makeExec(handlers: Array<[string, ExecResult]>): ExecRunner {
-    return (args: string) => {
+  function makeExec(handlers: Array<[string, Partial<ExecResult>]>): ExecRunner {
+    return (args) => {
+      const joined = args.join(' ');
       for (const [pattern, out] of handlers) {
-        if (args.includes(pattern)) return out;
+        if (joined.includes(pattern)) {
+          return { stdout: out.stdout ?? '', stderr: out.stderr ?? '', exitCode: out.exitCode ?? 0 };
+        }
       }
-      return { stdout: '', exitCode: 0 };
+      return { stdout: '', stderr: '', exitCode: 0 };
     };
   }
 
@@ -252,14 +255,15 @@ describe('checkDirtyFiles — categorical (#1073)', () => {
 
       const calls: string[] = [];
       const exec: ExecRunner = (args) => {
-        calls.push(args);
-        if (args.includes('rev-parse --absolute-git-dir')) {
-          return { stdout: '/clean-wt/.git', exitCode: 0 };
+        const joined = args.join(' ');
+        calls.push(joined);
+        if (joined.includes('rev-parse --absolute-git-dir')) {
+          return { stdout: '/clean-wt/.git', stderr: '', exitCode: 0 };
         }
-        if (args.includes('status --porcelain')) {
-          return { stdout: '', exitCode: 0 };
+        if (joined.includes('status --porcelain')) {
+          return { stdout: '', stderr: '', exitCode: 0 };
         }
-        return { stdout: '', exitCode: 0 };
+        return { stdout: '', stderr: '', exitCode: 0 };
       };
 
       const result = checkDirtyFiles('cd /clean-wt && gh pr create --title t', {
@@ -270,6 +274,8 @@ describe('checkDirtyFiles — categorical (#1073)', () => {
       const anchored = calls.filter((c) => c.includes('status --porcelain'));
       expect(anchored.length).toBeGreaterThan(0);
       for (const c of anchored) {
+        // Argv form joined: "-C /clean-wt status --porcelain" — target appears as
+        // a separate argv element, never concatenated into a shell string.
         expect(c).toContain('-C /clean-wt');
       }
     });
@@ -374,12 +380,13 @@ describe('checkDirtyFiles — categorical (#1073)', () => {
       vi.mocked(existsSync).mockImplementation(() => false);
       const calls: string[] = [];
       const exec: ExecRunner = (args) => {
-        calls.push(args);
-        if (args.includes('rev-parse --absolute-git-dir')) {
-          return { stdout: '/other-wt/.git', exitCode: 0 };
+        const joined = args.join(' ');
+        calls.push(joined);
+        if (joined.includes('rev-parse --absolute-git-dir')) {
+          return { stdout: '/other-wt/.git', stderr: '', exitCode: 0 };
         }
-        if (args.includes('status --porcelain')) return { stdout: '', exitCode: 0 };
-        return { stdout: '', exitCode: 0 };
+        if (joined.includes('status --porcelain')) return { stdout: '', stderr: '', exitCode: 0 };
+        return { stdout: '', stderr: '', exitCode: 0 };
       };
       checkDirtyFiles('git -C /other-wt push origin feat', { gitExec: exec });
       const anchored = calls.filter((c) => c.includes('status --porcelain'));

--- a/src/hooks/check-dirty-files.test.ts
+++ b/src/hooks/check-dirty-files.test.ts
@@ -220,3 +220,171 @@ describe('checkDirtyFiles', () => {
     mockedExistsSync.mockRestore();
   });
 });
+
+/**
+ * Categorical fix — #1073 and the cwd/stat-drift family.
+ *
+ * Closes #1073 (plugin.json phantom staged). Regression-guards #871 (MM
+ * false-positive), #232 (cross-worktree cwd drift). Uses the gitExec
+ * option (new-style runner with exit codes) to exercise the code path
+ * that verifies porcelain claims with `git diff --quiet HEAD -- <file>`.
+ */
+describe('checkDirtyFiles — categorical (#1073)', () => {
+  type ExecResult = { stdout: string; exitCode: number };
+  type ExecRunner = (args: string) => ExecResult;
+
+  function makeExec(handlers: Array<[string, ExecResult]>): ExecRunner {
+    return (args: string) => {
+      for (const [pattern, out] of handlers) {
+        if (args.includes(pattern)) return out;
+      }
+      return { stdout: '', exitCode: 0 };
+    };
+  }
+
+  afterEach(() => {
+    vi.mocked(existsSync).mockRestore();
+  });
+
+  describe('cwd-drift: cd X && gh pr create (#1073, #232)', () => {
+    it('resolves to cd target and anchors every git call via -C <target>', () => {
+      vi.mocked(existsSync).mockImplementation(() => false);
+
+      const calls: string[] = [];
+      const exec: ExecRunner = (args) => {
+        calls.push(args);
+        if (args.includes('rev-parse --absolute-git-dir')) {
+          return { stdout: '/clean-wt/.git', exitCode: 0 };
+        }
+        if (args.includes('status --porcelain')) {
+          return { stdout: '', exitCode: 0 };
+        }
+        return { stdout: '', exitCode: 0 };
+      };
+
+      const result = checkDirtyFiles('cd /clean-wt && gh pr create --title t', {
+        gitExec: exec,
+      });
+
+      expect(result.action).toBe('allow');
+      const anchored = calls.filter((c) => c.includes('status --porcelain'));
+      expect(anchored.length).toBeGreaterThan(0);
+      for (const c of anchored) {
+        expect(c).toContain('-C /clean-wt');
+      }
+    });
+  });
+
+  describe('stat-vs-content: content-clean files are filtered (#871)', () => {
+    it('allows pr create when porcelain reports MM but diff HEAD says clean', () => {
+      vi.mocked(existsSync).mockImplementation(() => false);
+
+      const exec = makeExec([
+        ['rev-parse --absolute-git-dir', { stdout: '/r/.git', exitCode: 0 }],
+        ['status --porcelain', { stdout: 'MM .claude-plugin/plugin.json\n', exitCode: 0 }],
+        ['diff --quiet HEAD --', { stdout: '', exitCode: 0 }],
+      ]);
+
+      const result = checkDirtyFiles('gh pr create --title t', { gitExec: exec });
+      expect(result.action).toBe('allow');
+    });
+
+    it('still denies when a tracked file actually differs from HEAD', () => {
+      vi.mocked(existsSync).mockImplementation(() => false);
+
+      const exec = makeExec([
+        ['rev-parse --absolute-git-dir', { stdout: '/r/.git', exitCode: 0 }],
+        ['status --porcelain', { stdout: ' M src/real.ts\n', exitCode: 0 }],
+        ['diff --quiet HEAD --', { stdout: '', exitCode: 1 }],
+      ]);
+
+      const result = checkDirtyFiles('gh pr create --title t', { gitExec: exec });
+      expect(result.action).toBe('deny');
+    });
+  });
+
+  describe('observability: deny message diagnostic block (#1073 comment:2)', () => {
+    it('includes [cwd], [target], [target-source], [git-dir], [porcelain] markers', () => {
+      vi.mocked(existsSync).mockImplementation(() => false);
+
+      const exec = makeExec([
+        ['rev-parse --absolute-git-dir', { stdout: '/r/.git', exitCode: 0 }],
+        ['status --porcelain', { stdout: ' M real.ts\n', exitCode: 0 }],
+        ['diff --quiet HEAD --', { stdout: '', exitCode: 1 }],
+      ]);
+
+      const result = checkDirtyFiles('gh pr create --title t', { gitExec: exec });
+      expect(result.action).toBe('deny');
+      expect(result.message).toContain('[cwd]');
+      expect(result.message).toContain('[target]');
+      expect(result.message).toContain('[target-source]');
+      expect(result.message).toContain('[git-dir]');
+      expect(result.message).toContain('[porcelain]');
+    });
+  });
+
+  describe('escape hatch: KAIZEN_ALLOW_DIRTY_FILES', () => {
+    it('bypasses hook when env var is "1"', () => {
+      vi.mocked(existsSync).mockImplementation(() => false);
+
+      const exec = makeExec([
+        ['rev-parse --absolute-git-dir', { stdout: '/r/.git', exitCode: 0 }],
+        ['status --porcelain', { stdout: ' M real.ts\n', exitCode: 0 }],
+        ['diff --quiet HEAD --', { stdout: '', exitCode: 1 }],
+      ]);
+
+      const result = checkDirtyFiles('gh pr create --title t', {
+        gitExec: exec,
+        env: { KAIZEN_ALLOW_DIRTY_FILES: '1' },
+      });
+      expect(result.action).toBe('allow');
+      expect(result.bypassed).toBe(true);
+    });
+
+    it('does not bypass when env var is "0"', () => {
+      vi.mocked(existsSync).mockImplementation(() => false);
+
+      const exec = makeExec([
+        ['rev-parse --absolute-git-dir', { stdout: '/r/.git', exitCode: 0 }],
+        ['status --porcelain', { stdout: ' M real.ts\n', exitCode: 0 }],
+        ['diff --quiet HEAD --', { stdout: '', exitCode: 1 }],
+      ]);
+
+      const result = checkDirtyFiles('gh pr create --title t', {
+        gitExec: exec,
+        env: { KAIZEN_ALLOW_DIRTY_FILES: '0' },
+      });
+      expect(result.action).toBe('deny');
+    });
+  });
+
+  describe('regression guards (labeled param rows)', () => {
+    it('#721: compound commit+push stays allowed even when dirty', () => {
+      vi.mocked(existsSync).mockImplementation(() => false);
+      const exec = makeExec([
+        ['status --porcelain', { stdout: ' M anything.ts\n', exitCode: 0 }],
+      ]);
+      const result = checkDirtyFiles('git add -A && git commit -m fix && git push', {
+        gitExec: exec,
+      });
+      expect(result.action).toBe('allow');
+    });
+
+    it('#232: git -C <other-wt> push anchors every git call to that worktree', () => {
+      vi.mocked(existsSync).mockImplementation(() => false);
+      const calls: string[] = [];
+      const exec: ExecRunner = (args) => {
+        calls.push(args);
+        if (args.includes('rev-parse --absolute-git-dir')) {
+          return { stdout: '/other-wt/.git', exitCode: 0 };
+        }
+        if (args.includes('status --porcelain')) return { stdout: '', exitCode: 0 };
+        return { stdout: '', exitCode: 0 };
+      };
+      checkDirtyFiles('git -C /other-wt push origin feat', { gitExec: exec });
+      const anchored = calls.filter((c) => c.includes('status --porcelain'));
+      expect(anchored.length).toBeGreaterThan(0);
+      for (const c of anchored) expect(c).toContain('-C /other-wt');
+    });
+  });
+});

--- a/src/hooks/check-dirty-files.ts
+++ b/src/hooks/check-dirty-files.ts
@@ -37,6 +37,7 @@ import {
   createDefaultGitExec,
   formatDiagnostic,
   isBypassRequested,
+  parsePorcelain,
   readDirtyFiles,
   resolveTargetWorktree,
   type DirtyFileReport,
@@ -66,21 +67,12 @@ export function detectTrigger(cmdLine: string): TriggerType {
   return 'none';
 }
 
-export function parseDirtyFiles(porcelainOutput: string): DirtyFileReport {
-  const lines = porcelainOutput.split('\n').filter(Boolean);
-  const staged: string[] = [];
-  const modified: string[] = [];
-  const untracked: string[] = [];
-
-  for (const line of lines) {
-    if (/^\?\?/.test(line)) untracked.push(line);
-    else if (/^[MARCD][MARCD]/.test(line)) staged.push(line);
-    else if (/^[MARCD] /.test(line)) staged.push(line);
-    else if (/^ [M]/.test(line)) modified.push(line);
-  }
-
-  return { staged, modified, untracked, total: lines.length };
-}
+/**
+ * Re-export of the shared parser. Kept as `parseDirtyFiles` for backward
+ * compatibility with existing test imports; the canonical implementation
+ * lives in `lib/git-state.ts` (DRY — single source of porcelain parsing).
+ */
+export const parseDirtyFiles = parsePorcelain;
 
 export function formatFileList(report: DirtyFileReport): string {
   const parts: string[] = [];

--- a/src/hooks/check-dirty-files.ts
+++ b/src/hooks/check-dirty-files.ts
@@ -5,8 +5,6 @@
  * @enforces I25 — No dirty files between ops (currently advisory on push/merge; escalation tracked in #1037).
  *                 Canonical: docs/kaizen-invariants.md.
  *
- * TypeScript port of .claude/hooks/kaizen-check-dirty-files.sh (kaizen #775).
- *
  * Triggers:
  *   gh pr create — BLOCK (agent is declaring "work is done")
  *   git push     — WARN  (push is intermediate, PR create is the gate — kaizen #775)
@@ -14,10 +12,16 @@
  *
  * Skips entirely when MERGE_HEAD exists (merge resolution in progress — kaizen #775).
  *
- * Part of kAIzen Agent Control Flow — kaizen #775
+ * Part of kAIzen Agent Control Flow — kaizen #775.
+ *
+ * Categorical fix (#1073) — every git invocation is anchored to the
+ * resolved target worktree (see lib/git-state.ts), every porcelain entry
+ * is verified at content-level, every deny includes a diagnostic block,
+ * and KAIZEN_ALLOW_DIRTY_FILES=1 is a documented escape. The shared
+ * primitive closes the category for this hook and stages the same
+ * discipline for sibling hooks via the git-state invariant test.
  */
 
-import { execSync, type ExecSyncOptions } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { readHookInput, traceNullInput } from './hook-io.js';
@@ -28,17 +32,20 @@ import {
   splitCommandSegments,
   stripHeredocBody,
 } from './parse-command.js';
-
-const EXEC_OPTS: ExecSyncOptions = { encoding: 'utf-8' as const, stdio: ['pipe', 'pipe', 'pipe'] };
+import {
+  BYPASS_ENV,
+  createDefaultGitExec,
+  formatDiagnostic,
+  isBypassRequested,
+  readDirtyFiles,
+  resolveTargetWorktree,
+  type DirtyFileReport,
+  type DirtyState,
+  type GitExec,
+} from './lib/git-state.js';
 
 type TriggerType = 'pr_create' | 'git_push' | 'pr_merge' | 'none';
 
-/**
- * Check if a compound command has `git commit` before `git push`.
- * When the user runs `git add -A && git commit -m '...' && git push`,
- * dirty files will be committed before push runs — so the dirty-files
- * check would be a false positive (kaizen #721).
- */
 export function hasCommitBeforePush(cmdLine: string): boolean {
   const segments = splitCommandSegments(cmdLine);
   let foundCommit = false;
@@ -52,19 +59,11 @@ export function hasCommitBeforePush(cmdLine: string): boolean {
 export function detectTrigger(cmdLine: string): TriggerType {
   if (isGhPrCommand(cmdLine, 'create')) return 'pr_create';
   if (isGitCommand(cmdLine, 'push')) {
-    // Skip false positive when commit precedes push in compound command (kaizen #721)
     if (hasCommitBeforePush(cmdLine)) return 'none';
     return 'git_push';
   }
   if (isGhPrCommand(cmdLine, 'merge')) return 'pr_merge';
   return 'none';
-}
-
-interface DirtyFileReport {
-  staged: string[];
-  modified: string[];
-  untracked: string[];
-  total: number;
 }
 
 export function parseDirtyFiles(porcelainOutput: string): DirtyFileReport {
@@ -74,16 +73,10 @@ export function parseDirtyFiles(porcelainOutput: string): DirtyFileReport {
   const untracked: string[] = [];
 
   for (const line of lines) {
-    if (/^\?\?/.test(line)) {
-      untracked.push(line);
-    } else if (/^[MARCD][MARCD]/.test(line)) {
-      // Both staged and modified (e.g. MM) — count as staged (the primary state)
-      staged.push(line);
-    } else if (/^[MARCD] /.test(line)) {
-      staged.push(line);
-    } else if (/^ [M]/.test(line)) {
-      modified.push(line);
-    }
+    if (/^\?\?/.test(line)) untracked.push(line);
+    else if (/^[MARCD][MARCD]/.test(line)) staged.push(line);
+    else if (/^[MARCD] /.test(line)) staged.push(line);
+    else if (/^ [M]/.test(line)) modified.push(line);
   }
 
   return { staged, modified, untracked, total: lines.length };
@@ -103,40 +96,128 @@ export function formatFileList(report: DirtyFileReport): string {
   return parts.join('\n');
 }
 
+export interface CheckDirtyFilesOptions {
+  /**
+   * Legacy runner: string → string. When provided (and `gitExec` is not),
+   * the hook uses the pre-#1073 code path that trusts porcelain directly —
+   * this preserves the semantics of every historical unit test. New tests
+   * should use `gitExec` to exercise the content-level verification path.
+   */
+  gitRunner?: (args: string) => string;
+  /**
+   * Post-#1073 runner: string → { stdout, exitCode }. Enables
+   * content-level verification via `git diff --quiet HEAD -- <file>` and
+   * the full diagnostic block.
+   */
+  gitExec?: GitExec;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  stderr?: { write: (s: string) => void };
+}
+
+export interface CheckDirtyFilesResult {
+  action: 'allow' | 'warn' | 'deny';
+  message?: string;
+  bypassed?: boolean;
+}
+
 export function checkDirtyFiles(
   command: string,
-  options: { gitRunner?: (args: string) => string } = {},
-): { action: 'allow' | 'warn' | 'deny'; message?: string } {
+  options: CheckDirtyFilesOptions = {},
+): CheckDirtyFilesResult {
   const cmdLine = stripHeredocBody(command);
   const trigger = detectTrigger(cmdLine);
 
   if (trigger === 'none') return { action: 'allow' };
 
-  const git = options.gitRunner ?? ((args: string) => {
-    try {
-      return execSync(`git ${args}`, EXEC_OPTS as { encoding: 'utf-8' }).trim();
-    } catch {
-      return '';
-    }
-  });
+  if (options.gitRunner && !options.gitExec) {
+    return legacyCheckDirtyFiles(cmdLine, trigger, options.gitRunner);
+  }
 
-  // Skip during merge resolution (kaizen #773, #775)
-  // Use --git-dir instead of .git/MERGE_HEAD — in worktrees, .git is a file,
-  // not a directory, so the naive path doesn't work.
-  const gitDir = git('rev-parse --git-dir');
-  if (gitDir && existsSync(join(gitDir, 'MERGE_HEAD'))) {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+
+  if (isBypassRequested(env)) {
+    options.stderr?.write(
+      `[check-dirty-files] BYPASS: ${BYPASS_ENV} is set — skipping dirty check\n`,
+    );
+    return { action: 'allow', bypassed: true };
+  }
+
+  const exec: GitExec = options.gitExec ?? createDefaultGitExec();
+  const target = resolveTargetWorktree(cmdLine, cwd);
+  const state: DirtyState = readDirtyFiles(target.dir, { runner: exec });
+
+  if (state.gitDir && existsSync(join(state.gitDir, 'MERGE_HEAD'))) {
     return { action: 'allow' };
   }
 
-  // Handle git -C <path> push (cross-worktree — kaizen #232)
+  if (state.verified.total === 0) return { action: 'allow' };
+
+  const fileList = formatFileList(state.verified);
+  const diagnostic = formatDiagnostic({
+    cwd,
+    target: target.dir,
+    targetSource: target.source,
+    gitDir: state.gitDir,
+    rawPorcelain: state.raw,
+    perFileDiff: state.perFileDiff,
+  });
+
+  if (trigger === 'pr_merge' || trigger === 'git_push') {
+    const actionLabel = trigger === 'pr_merge' ? 'merging a PR' : 'pushing code';
+    return {
+      action: 'warn',
+      message: `DIRTY FILES DETECTED — ${state.verified.total} file(s) with uncommitted changes:
+
+${fileList}You're ${actionLabel}, so this is advisory only.
+But dirty files suggest unfinished or forgotten work.
+Consider committing or discarding before proceeding.
+
+${diagnostic}`,
+    };
+  }
+
+  return {
+    action: 'deny',
+    message: `DIRTY FILES — ${state.verified.total} file(s) with uncommitted changes while creating a PR.
+
+${fileList}You MUST handle each file before proceeding:
+
+FOR USEFUL FILES (part of this work):
+  git add <file> && git commit -m 'meaningful message about what and why'
+
+FOR ARTIFACTS/DEBUG/LEFTOVER FILES (not part of this work):
+  git checkout -- <file>    (for modified tracked files)
+  rm <file>                 (for untracked files)
+
+If you believe the hook is wrong (content-clean file flagged as dirty, or
+stale stat), set ${BYPASS_ENV}=1 to bypass — please include the diagnostic
+block below in the follow-up kaizen issue.
+
+${diagnostic}`,
+  };
+}
+
+/**
+ * Legacy code path preserving pre-#1073 behavior for tests that pass
+ * `gitRunner: (args: string) => string`. No content-level verification
+ * (legacy runner can't signal exit code), no diagnostic block.
+ */
+function legacyCheckDirtyFiles(
+  cmdLine: string,
+  trigger: Exclude<TriggerType, 'none'>,
+  gitRunner: (args: string) => string,
+): CheckDirtyFilesResult {
+  const git = gitRunner;
+
+  const gitDir = git('rev-parse --git-dir');
+  if (gitDir && existsSync(join(gitDir, 'MERGE_HEAD'))) return { action: 'allow' };
+
   const targetDir = extractGitCPath(cmdLine);
   const gitPrefix = targetDir ? `-C ${targetDir}` : '';
 
-  // Refresh the index to clear stale stat info — prevents false positives
-  // when a file was modified and restored (content matches HEAD but stat differs).
-  // Observed: MM status for .claude-plugin/plugin.json with no actual changes (kaizen #871).
   git(`${gitPrefix} update-index -q --refresh`);
-
   const porcelain = git(`${gitPrefix} status --porcelain`);
   if (!porcelain) return { action: 'allow' };
 
@@ -146,7 +227,6 @@ export function checkDirtyFiles(
   const fileList = formatFileList(report);
 
   if (trigger === 'pr_merge' || trigger === 'git_push') {
-    // Advisory for merge and push (kaizen #775: push downgraded to warn)
     const actionLabel = trigger === 'pr_merge' ? 'merging a PR' : 'pushing code';
     return {
       action: 'warn',
@@ -158,7 +238,6 @@ Consider committing or discarding before proceeding.`,
     };
   }
 
-  // For pr create — BLOCK
   return {
     action: 'deny',
     message: `DIRTY FILES — ${report.total} file(s) with uncommitted changes while creating a PR.
@@ -179,7 +258,7 @@ async function main(): Promise<void> {
   if (!input) { traceNullInput("check-dirty-files"); process.exit(0); }
 
   const command = input.tool_input?.command ?? '';
-  const result = checkDirtyFiles(command);
+  const result = checkDirtyFiles(command, { stderr: process.stderr });
 
   if (result.action === 'deny') {
     const output = JSON.stringify({

--- a/src/hooks/lib/git-state-invariant.test.ts
+++ b/src/hooks/lib/git-state-invariant.test.ts
@@ -1,0 +1,80 @@
+/**
+ * git-state-invariant.test.ts — category-prevention lint for #240.
+ *
+ * Fails loudly if any hook in src/hooks/*.ts reads git state via a raw
+ * execSync('git ...') call WITHOUT going through the git-state.ts primitive.
+ * This is the mechanistic trigger for the sibling-hook migration tracked in
+ * the follow-up sub-issue.
+ *
+ * The OPT_OUT list below names hooks whose migration is pending. Adding a
+ * new hook that reads git state without routing through the lib will fail
+ * this test; the remediation is either (a) migrate to git-state.ts or
+ * (b) add to OPT_OUT with a linked follow-up issue.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HOOKS_DIR = join(__dirname, '..');
+
+// Hooks whose migration to git-state.ts is pending. Removing an entry here
+// without migrating the hook will re-introduce the cwd-drift anti-pattern.
+const OPT_OUT = new Set<string>([
+  'bump-plugin-version.ts',
+  'kaizen-reflect.ts',
+  'hook-io.ts',
+  'pr-kaizen-clear.ts',
+  'pr-kaizen-clear-fallback.ts',
+  'pr-review-loop.ts',
+  'pre-push.ts',
+  'prehook-no-verify.ts',
+  'post-merge-clear.ts',
+]);
+
+function isHookSource(name: string): boolean {
+  if (!name.endsWith('.ts')) return false;
+  if (name.endsWith('.test.ts')) return false;
+  return true;
+}
+
+function readsGitState(content: string): boolean {
+  // Naive but sufficient: any execSync call whose args start with `git `
+  // (with template literal or string literal). Excludes comments.
+  const withoutComments = content
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  return /execSync\(\s*[`'"][^`'"]*git\s/.test(withoutComments);
+}
+
+function importsGitState(content: string): boolean {
+  return /from\s+['"]\.\/lib\/git-state\.js['"]/.test(content);
+}
+
+describe('git-state invariant (#240 category prevention)', () => {
+  const files = readdirSync(HOOKS_DIR)
+    .filter(isHookSource);
+
+  it('finds hook source files', () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  for (const f of files) {
+    if (OPT_OUT.has(f)) continue;
+    it(`${f} routes git-state reads through lib/git-state.ts (or does not read state)`, () => {
+      const content = readFileSync(join(HOOKS_DIR, f), 'utf-8');
+      if (!readsGitState(content)) return; // no violation possible
+      expect(
+        importsGitState(content),
+        `${f} calls execSync('git ...') but does not import from ./lib/git-state.js. ` +
+          `Route through the shared primitive or add to OPT_OUT with a tracked follow-up.`,
+      ).toBe(true);
+    });
+  }
+
+  it('OPT_OUT entries correspond to real files (no stale opt-outs)', () => {
+    for (const f of OPT_OUT) {
+      expect(files, `${f} in OPT_OUT is missing from src/hooks/`).toContain(f);
+    }
+  });
+});

--- a/src/hooks/lib/git-state-invariant.test.ts
+++ b/src/hooks/lib/git-state-invariant.test.ts
@@ -30,6 +30,8 @@ const OPT_OUT = new Set<string>([
   'pre-push.ts',
   'prehook-no-verify.ts',
   'post-merge-clear.ts',
+  'enforce-plan-stored.ts',
+  'pr-quality-checks.ts',
 ]);
 
 function isHookSource(name: string): boolean {
@@ -39,12 +41,26 @@ function isHookSource(name: string): boolean {
 }
 
 function readsGitState(content: string): boolean {
-  // Naive but sufficient: any execSync call whose args start with `git `
-  // (with template literal or string literal). Excludes comments.
+  // Widened from the initial `execSync('git ...')` pattern to catch the
+  // full family of subprocess-invoking APIs flagged in the #1073 review:
+  // execSync, execFileSync, exec, spawnSync, spawn — with git as the
+  // binary or first argument. We strip comments first so commented-out
+  // examples don't trip the lint.
   const withoutComments = content
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/\/\/.*$/gm, '');
-  return /execSync\(\s*[`'"][^`'"]*git\s/.test(withoutComments);
+
+  // Case 1: `execSync(\`git ...\`)` or `execSync('git ...')` — binary name
+  // embedded in a shell-interpreted string. This IS the shell-injection
+  // anti-pattern the primitive exists to eliminate.
+  if (/exec(File)?(Sync)?\s*\(\s*[`'"][^`'"]*\bgit\b/.test(withoutComments)) return true;
+
+  // Case 2: `spawnSync('git', argv)` / `execFileSync('git', argv)` —
+  // argv-safe but still cwd-drift-prone unless the argv is built by
+  // git-state.ts (which pins `-C <resolved-target>` as the first args).
+  if (/(?:spawn|execFile)(?:Sync)?\s*\(\s*[`'"]git[`'"]/.test(withoutComments)) return true;
+
+  return false;
 }
 
 function importsGitState(content: string): boolean {

--- a/src/hooks/lib/git-state.test.ts
+++ b/src/hooks/lib/git-state.test.ts
@@ -1,0 +1,210 @@
+/**
+ * git-state.test.ts — unit tests for the hook state-reading primitive.
+ *
+ * Closes #1073 (plugin.json false positive) by establishing a categorical
+ * fix for the family of false-positives produced by reading git state from
+ * process.cwd() and by trusting stat-based porcelain output. See
+ * docs/hooks-design.md § "State-reading discipline".
+ *
+ * Related closed regressions this module guards against:
+ *   #232 — cwd drift cross-worktree
+ *   #721 — compound commit+push timing
+ *   #871 — MM status on content-identical file ("update-index --refresh"
+ *          workaround; demonstrably insufficient — #1073 regressed)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  formatDiagnostic,
+  isBypassRequested,
+  readDirtyFiles,
+  resolveTargetWorktree,
+} from './git-state.js';
+
+describe('resolveTargetWorktree', () => {
+  const CWD = '/agent/cwd';
+
+  it('returns fallbackCwd when command has neither -C nor cd', () => {
+    const r = resolveTargetWorktree('gh pr create --title t', CWD);
+    expect(r).toEqual({ dir: CWD, source: 'cwd' });
+  });
+
+  it('extracts git -C <path>', () => {
+    const r = resolveTargetWorktree('git -C /work/repo push', CWD);
+    expect(r).toEqual({ dir: '/work/repo', source: 'git-C' });
+  });
+
+  it('extracts cd X && <cmd>', () => {
+    const r = resolveTargetWorktree('cd /wt && gh pr create', CWD);
+    expect(r).toEqual({ dir: '/wt', source: 'cd' });
+  });
+
+  it('extracts cd X ; <cmd>', () => {
+    const r = resolveTargetWorktree('cd /a ; gh pr create', CWD);
+    expect(r).toEqual({ dir: '/a', source: 'cd' });
+  });
+
+  it('extracts (cd X && <cmd>) subshell form', () => {
+    const r = resolveTargetWorktree('(cd /b && gh pr create)', CWD);
+    expect(r).toEqual({ dir: '/b', source: 'cd' });
+  });
+
+  it('extracts cd "quoted path"', () => {
+    const r = resolveTargetWorktree('cd "/q path" && gh pr create', CWD);
+    expect(r).toEqual({ dir: '/q path', source: 'cd' });
+  });
+
+  it("extracts cd 'quoted path'", () => {
+    const r = resolveTargetWorktree("cd '/sq' && gh pr create", CWD);
+    expect(r).toEqual({ dir: '/sq', source: 'cd' });
+  });
+
+  it('prefers explicit git -C over preceding cd', () => {
+    const r = resolveTargetWorktree('cd /a && git -C /b push', CWD);
+    expect(r).toEqual({ dir: '/b', source: 'git-C' });
+  });
+
+  it('does not match cdlock or other prefixes (word boundary)', () => {
+    const r = resolveTargetWorktree('cdlock /x && gh pr create', CWD);
+    expect(r.source).toBe('cwd');
+    expect(r.dir).toBe(CWD);
+  });
+
+  it('does not treat bare `cd -` as a target', () => {
+    const r = resolveTargetWorktree('cd - && gh pr create', CWD);
+    expect(r.source).toBe('cwd');
+  });
+
+  it('handles cd with no argument (bare cd = HOME) by falling back to cwd', () => {
+    const r = resolveTargetWorktree('cd && gh pr create', CWD);
+    expect(r.source).toBe('cwd');
+  });
+});
+
+describe('readDirtyFiles', () => {
+  type Runner = (args: string) => { stdout: string; exitCode: number };
+
+  function makeRunner(handlers: Record<string, { stdout?: string; exitCode?: number }>): Runner {
+    return (args: string) => {
+      for (const [pattern, out] of Object.entries(handlers)) {
+        if (args.includes(pattern)) {
+          return { stdout: out.stdout ?? '', exitCode: out.exitCode ?? 0 };
+        }
+      }
+      return { stdout: '', exitCode: 0 };
+    };
+  }
+
+  it('returns empty report when porcelain is empty', () => {
+    const runner = makeRunner({
+      'rev-parse --absolute-git-dir': { stdout: '/fake/.git' },
+      'status --porcelain': { stdout: '' },
+    });
+    const r = readDirtyFiles('/fake', { runner });
+    expect(r.verified.total).toBe(0);
+    expect(r.raw).toBe('');
+  });
+
+  it('filters out files where content matches HEAD (kaizen #871)', () => {
+    // porcelain claims MM .claude-plugin/plugin.json, but git diff HEAD says clean
+    const runner = makeRunner({
+      'rev-parse --absolute-git-dir': { stdout: '/fake/.git' },
+      'status --porcelain': { stdout: 'MM .claude-plugin/plugin.json\n' },
+      // `git diff --quiet HEAD -- <file>` returns 0 when file matches HEAD
+      'diff --quiet HEAD -- ': { exitCode: 0 },
+    });
+    const r = readDirtyFiles('/fake', { runner });
+    expect(r.verified.total).toBe(0);
+    expect(r.raw).toContain('.claude-plugin/plugin.json');
+  });
+
+  it('keeps files whose content differs from HEAD', () => {
+    const runner = makeRunner({
+      'rev-parse --absolute-git-dir': { stdout: '/fake/.git' },
+      'status --porcelain': { stdout: ' M src/real.ts\n' },
+      'diff --quiet HEAD -- ': { exitCode: 1 }, // real diff
+    });
+    const r = readDirtyFiles('/fake', { runner });
+    expect(r.verified.total).toBe(1);
+    expect(r.verified.modified).toHaveLength(1);
+  });
+
+  it('keeps untracked files (no HEAD to compare against)', () => {
+    const runner = makeRunner({
+      'rev-parse --absolute-git-dir': { stdout: '/fake/.git' },
+      'status --porcelain': { stdout: '?? data/ipc/pending.json\n' },
+    });
+    const r = readDirtyFiles('/fake', { runner });
+    expect(r.verified.total).toBe(1);
+    expect(r.verified.untracked).toHaveLength(1);
+  });
+
+  it('returns gitDir for MERGE_HEAD skip decision', () => {
+    const runner = makeRunner({
+      'rev-parse --absolute-git-dir': { stdout: '/fake/.git/worktrees/wt' },
+      'status --porcelain': { stdout: '' },
+    });
+    const r = readDirtyFiles('/fake', { runner });
+    expect(r.gitDir).toBe('/fake/.git/worktrees/wt');
+  });
+});
+
+describe('formatDiagnostic', () => {
+  it('includes all required markers', () => {
+    const out = formatDiagnostic({
+      cwd: '/a',
+      target: '/b',
+      targetSource: 'cd',
+      gitDir: '/b/.git',
+      rawPorcelain: ' M foo\n',
+      perFileDiff: [{ file: 'foo', diffIndexExitCode: 1, blobMatch: false }],
+    });
+    expect(out).toContain('[cwd]');
+    expect(out).toContain('/a');
+    expect(out).toContain('[target]');
+    expect(out).toContain('/b');
+    expect(out).toContain('[target-source]');
+    expect(out).toContain('cd');
+    expect(out).toContain('[git-dir]');
+    expect(out).toContain('[porcelain]');
+    expect(out).toContain('[diff-index]');
+    expect(out).toContain('foo');
+  });
+
+  it('truncates long porcelain output to 20 lines', () => {
+    const many = Array.from({ length: 50 }, (_, i) => ` M file${i}.ts`).join('\n');
+    const out = formatDiagnostic({
+      cwd: '/a',
+      target: '/a',
+      targetSource: 'cwd',
+      gitDir: '/a/.git',
+      rawPorcelain: many,
+      perFileDiff: [],
+    });
+    expect(out).toContain('file0.ts');
+    expect(out).toContain('truncated');
+    expect(out).not.toContain('file49.ts');
+  });
+});
+
+describe('isBypassRequested', () => {
+  it('returns false when env var is unset', () => {
+    expect(isBypassRequested({})).toBe(false);
+  });
+
+  it('returns true for "1"', () => {
+    expect(isBypassRequested({ KAIZEN_ALLOW_DIRTY_FILES: '1' })).toBe(true);
+  });
+
+  it('returns true for "true"', () => {
+    expect(isBypassRequested({ KAIZEN_ALLOW_DIRTY_FILES: 'true' })).toBe(true);
+  });
+
+  it('returns false for "0"', () => {
+    expect(isBypassRequested({ KAIZEN_ALLOW_DIRTY_FILES: '0' })).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isBypassRequested({ KAIZEN_ALLOW_DIRTY_FILES: '' })).toBe(false);
+  });
+});

--- a/src/hooks/lib/git-state.test.ts
+++ b/src/hooks/lib/git-state.test.ts
@@ -81,6 +81,27 @@ describe('resolveTargetWorktree', () => {
   });
 });
 
+describe('readDirtyFiles — porcelain whitespace invariant (live-fixture regression)', () => {
+  // Porcelain v1 distinguishes ` M file` (unstaged-modified) from `M  file`
+  // (staged-modified) by the leading space. Dropping that whitespace caused
+  // the hook to misbucket unstaged files as staged and to corrupt the file
+  // path via slice(3). Regression guard for the first iteration of #1073.
+  it('preserves leading whitespace when classifying unstaged-modified entries', () => {
+    const runner = (args: string) => {
+      if (args.includes('rev-parse --absolute-git-dir')) return { stdout: '/r/.git', exitCode: 0 };
+      if (args.includes('status --porcelain')) {
+        return { stdout: ' M .claude-plugin/plugin.json\n', exitCode: 0 };
+      }
+      if (args.includes('diff --quiet HEAD -- ')) return { stdout: '', exitCode: 1 };
+      return { stdout: '', exitCode: 0 };
+    };
+    const r = readDirtyFiles('/r', { runner });
+    expect(r.verified.modified).toHaveLength(1);
+    expect(r.verified.staged).toHaveLength(0);
+    expect(r.perFileDiff[0]?.file).toBe('.claude-plugin/plugin.json');
+  });
+});
+
 describe('readDirtyFiles', () => {
   type Runner = (args: string) => { stdout: string; exitCode: number };
 

--- a/src/hooks/lib/git-state.test.ts
+++ b/src/hooks/lib/git-state.test.ts
@@ -87,13 +87,14 @@ describe('readDirtyFiles — porcelain whitespace invariant (live-fixture regres
   // the hook to misbucket unstaged files as staged and to corrupt the file
   // path via slice(3). Regression guard for the first iteration of #1073.
   it('preserves leading whitespace when classifying unstaged-modified entries', () => {
-    const runner = (args: string) => {
-      if (args.includes('rev-parse --absolute-git-dir')) return { stdout: '/r/.git', exitCode: 0 };
-      if (args.includes('status --porcelain')) {
-        return { stdout: ' M .claude-plugin/plugin.json\n', exitCode: 0 };
-      }
-      if (args.includes('diff --quiet HEAD -- ')) return { stdout: '', exitCode: 1 };
-      return { stdout: '', exitCode: 0 };
+    const runner = (args: readonly string[]) => {
+      const joined = args.join(' ');
+      if (joined.includes('rev-parse --absolute-git-dir'))
+        return { stdout: '/r/.git', stderr: '', exitCode: 0 };
+      if (joined.includes('status --porcelain'))
+        return { stdout: ' M .claude-plugin/plugin.json\n', stderr: '', exitCode: 0 };
+      if (joined.includes('diff --quiet HEAD')) return { stdout: '', stderr: '', exitCode: 1 };
+      return { stdout: '', stderr: '', exitCode: 0 };
     };
     const r = readDirtyFiles('/r', { runner });
     expect(r.verified.modified).toHaveLength(1);
@@ -103,16 +104,19 @@ describe('readDirtyFiles — porcelain whitespace invariant (live-fixture regres
 });
 
 describe('readDirtyFiles', () => {
-  type Runner = (args: string) => { stdout: string; exitCode: number };
+  // Tests exercise the argv-based runner contract. Helper joins argv with
+  // a space so existing pattern-based specs stay readable.
+  type Runner = (args: readonly string[]) => { stdout: string; stderr: string; exitCode: number };
 
   function makeRunner(handlers: Record<string, { stdout?: string; exitCode?: number }>): Runner {
-    return (args: string) => {
+    return (args) => {
+      const joined = args.join(' ');
       for (const [pattern, out] of Object.entries(handlers)) {
-        if (args.includes(pattern)) {
-          return { stdout: out.stdout ?? '', exitCode: out.exitCode ?? 0 };
+        if (joined.includes(pattern)) {
+          return { stdout: out.stdout ?? '', stderr: '', exitCode: out.exitCode ?? 0 };
         }
       }
-      return { stdout: '', exitCode: 0 };
+      return { stdout: '', stderr: '', exitCode: 0 };
     };
   }
 

--- a/src/hooks/lib/git-state.ts
+++ b/src/hooks/lib/git-state.ts
@@ -79,13 +79,19 @@ export function createDefaultGitExec(): GitExec {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       });
-      return { stdout: stdout.trim(), exitCode: 0 };
+      // IMPORTANT: do NOT .trim() — porcelain output has significant leading
+      // whitespace (` M file` vs `M  file` distinguishes unstaged-modified
+      // from staged-modified). Trimming corrupted the parse for unstaged
+      // files; caught by the live fixture test for #1073. Callers that
+      // want single-line trimmed output (e.g., rev-parse) should trim
+      // themselves.
+      return { stdout, exitCode: 0 };
     } catch (e) {
       const err = e as { status?: number; stdout?: string | Buffer };
       const out = typeof err.stdout === 'string'
         ? err.stdout
         : err.stdout?.toString('utf-8') ?? '';
-      return { stdout: out.trim(), exitCode: err.status ?? 1 };
+      return { stdout: out, exitCode: err.status ?? 1 };
     }
   };
 }
@@ -122,12 +128,13 @@ export function readDirtyFiles(
   const runner = options.runner ?? createDefaultGitExec();
   const prefix = targetDir ? `-C ${targetDir} ` : '';
 
-  const gitDir = runner(`${prefix}rev-parse --absolute-git-dir`).stdout;
+  const gitDir = runner(`${prefix}rev-parse --absolute-git-dir`).stdout.trim();
 
   // Refresh the index to clear stat-only drift (retained as belt-and-suspenders
   // alongside the content-level check below; observed as the #871 partial fix).
   runner(`${prefix}update-index -q --refresh`);
 
+  // Do NOT trim: porcelain's leading whitespace is significant.
   const porcelain = runner(`${prefix}status --porcelain`).stdout;
   const rawReport = parsePorcelain(porcelain);
 

--- a/src/hooks/lib/git-state.ts
+++ b/src/hooks/lib/git-state.ts
@@ -1,0 +1,211 @@
+/**
+ * git-state.ts — shared primitive for hooks that gate on git working-tree state.
+ *
+ * Established as the single source of state-reading discipline in response to
+ * the recurring cwd/stat false-positive family: #232, #721, #871, #1073
+ * (category umbrella: #240). See docs/hooks-design.md § "State-reading
+ * discipline" for the rationale and the CI invariant that keeps new hooks
+ * routed through this module.
+ *
+ * Four responsibilities:
+ *   1. resolveTargetWorktree — anchor git reads to the *gated command's*
+ *      worktree, not process.cwd().
+ *   2. readDirtyFiles — verify every porcelain entry with a content-level
+ *      `git diff --quiet HEAD -- <file>` call, neutralising the stat-vs-
+ *      content-clean false-positive family (#871 regression class).
+ *   3. formatDiagnostic — stable deny-time diagnostic block so the next
+ *      false-positive is debuggable from the failure transcript alone
+ *      (#1073 comment:2 explicit request).
+ *   4. isBypassRequested — read the documented escape-hatch env var.
+ */
+
+import { execSync } from 'node:child_process';
+
+import { extractCdTarget, extractGitCPath, stripHeredocBody } from '../parse-command.js';
+
+export type TargetSource = 'git-C' | 'cd' | 'cwd';
+
+export interface ResolvedTarget {
+  dir: string;
+  source: TargetSource;
+}
+
+/**
+ * Resolve the directory the *gated* command will execute against. Explicit
+ * `git -C <path>` wins over `cd <path> && …`; both win over the fallback cwd.
+ */
+export function resolveTargetWorktree(
+  cmdLine: string,
+  fallbackCwd: string,
+): ResolvedTarget {
+  const stripped = stripHeredocBody(cmdLine);
+  const gitC = extractGitCPath(stripped);
+  if (gitC) return { dir: gitC, source: 'git-C' };
+  const cd = extractCdTarget(stripped);
+  if (cd) return { dir: cd, source: 'cd' };
+  return { dir: fallbackCwd, source: 'cwd' };
+}
+
+export interface DirtyFileReport {
+  staged: string[];
+  modified: string[];
+  untracked: string[];
+  total: number;
+}
+
+export interface PerFileDiff {
+  file: string;
+  diffIndexExitCode: number;
+  blobMatch: boolean;
+}
+
+export interface DirtyState {
+  verified: DirtyFileReport;
+  raw: string;
+  gitDir: string;
+  perFileDiff: PerFileDiff[];
+}
+
+export interface GitExecResult {
+  stdout: string;
+  exitCode: number;
+}
+export type GitExec = (args: string) => GitExecResult;
+
+export function createDefaultGitExec(): GitExec {
+  return (args) => {
+    try {
+      const stdout = execSync(`git ${args}`, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      return { stdout: stdout.trim(), exitCode: 0 };
+    } catch (e) {
+      const err = e as { status?: number; stdout?: string | Buffer };
+      const out = typeof err.stdout === 'string'
+        ? err.stdout
+        : err.stdout?.toString('utf-8') ?? '';
+      return { stdout: out.trim(), exitCode: err.status ?? 1 };
+    }
+  };
+}
+
+function extractFilePath(porcelainLine: string): string {
+  // porcelain v1 format: XY <path>  (XY = 2 status chars, then space)
+  return porcelainLine.slice(3).trim();
+}
+
+function parsePorcelain(output: string): DirtyFileReport {
+  const lines = output.split('\n').filter(Boolean);
+  const staged: string[] = [];
+  const modified: string[] = [];
+  const untracked: string[] = [];
+  for (const line of lines) {
+    if (/^\?\?/.test(line)) untracked.push(line);
+    else if (/^[MARCD][MARCD]/.test(line)) staged.push(line);
+    else if (/^[MARCD] /.test(line)) staged.push(line);
+    else if (/^ [M]/.test(line)) modified.push(line);
+  }
+  return { staged, modified, untracked, total: lines.length };
+}
+
+/**
+ * Read the git state of `targetDir` and verify every tracked-file claim
+ * with `git diff --quiet HEAD -- <file>`. Files where porcelain says
+ * "modified" but diff says "content matches HEAD" are filtered out —
+ * this is the direct regression guard for #871.
+ */
+export function readDirtyFiles(
+  targetDir: string,
+  options: { runner?: GitExec } = {},
+): DirtyState {
+  const runner = options.runner ?? createDefaultGitExec();
+  const prefix = targetDir ? `-C ${targetDir} ` : '';
+
+  const gitDir = runner(`${prefix}rev-parse --absolute-git-dir`).stdout;
+
+  // Refresh the index to clear stat-only drift (retained as belt-and-suspenders
+  // alongside the content-level check below; observed as the #871 partial fix).
+  runner(`${prefix}update-index -q --refresh`);
+
+  const porcelain = runner(`${prefix}status --porcelain`).stdout;
+  const rawReport = parsePorcelain(porcelain);
+
+  const verifiedStaged: string[] = [];
+  const verifiedModified: string[] = [];
+  const perFileDiff: PerFileDiff[] = [];
+
+  const checkFile = (line: string, bucket: string[]): void => {
+    const file = extractFilePath(line);
+    if (!file) return;
+    const r = runner(`${prefix}diff --quiet HEAD -- ${file}`);
+    const blobMatch = r.exitCode === 0;
+    perFileDiff.push({ file, diffIndexExitCode: r.exitCode, blobMatch });
+    if (!blobMatch) bucket.push(line);
+  };
+
+  for (const line of rawReport.staged) checkFile(line, verifiedStaged);
+  for (const line of rawReport.modified) checkFile(line, verifiedModified);
+
+  const verified: DirtyFileReport = {
+    staged: verifiedStaged,
+    modified: verifiedModified,
+    untracked: rawReport.untracked, // untracked is unambiguous — no HEAD to diff
+    total: verifiedStaged.length + verifiedModified.length + rawReport.untracked.length,
+  };
+
+  return { verified, raw: porcelain, gitDir, perFileDiff };
+}
+
+export interface DiagnosticContext {
+  cwd: string;
+  target: string;
+  targetSource: TargetSource;
+  gitDir: string;
+  rawPorcelain: string;
+  perFileDiff: PerFileDiff[];
+}
+
+const PORCELAIN_MAX_LINES = 20;
+
+export function formatDiagnostic(ctx: DiagnosticContext): string {
+  const rawLines = ctx.rawPorcelain.split('\n').filter(Boolean);
+  const shown = rawLines.slice(0, PORCELAIN_MAX_LINES).join('\n');
+  const truncatedNote =
+    rawLines.length > PORCELAIN_MAX_LINES
+      ? `\n... (${rawLines.length - PORCELAIN_MAX_LINES} lines truncated)`
+      : '';
+
+  const perFile = ctx.perFileDiff.length
+    ? ctx.perFileDiff
+        .map(
+          (f) =>
+            `  ${f.file}: diff-index exit=${f.diffIndexExitCode} content-match=${f.blobMatch}`,
+        )
+        .join('\n')
+    : '  (no per-file diff evidence)';
+
+  return [
+    '--- diagnostic ---',
+    `[cwd]             ${ctx.cwd}`,
+    `[target]          ${ctx.target}`,
+    `[target-source]   ${ctx.targetSource}`,
+    `[git-dir]         ${ctx.gitDir}`,
+    `[porcelain]       (${rawLines.length} line(s))`,
+    shown + truncatedNote,
+    `[diff-index]`,
+    perFile,
+    '--- end diagnostic ---',
+  ].join('\n');
+}
+
+const BYPASS_ENV = 'KAIZEN_ALLOW_DIRTY_FILES';
+
+export function isBypassRequested(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env[BYPASS_ENV];
+  if (!v) return false;
+  const norm = v.trim().toLowerCase();
+  return norm === '1' || norm === 'true' || norm === 'yes';
+}
+
+export { BYPASS_ENV };

--- a/src/hooks/lib/git-state.ts
+++ b/src/hooks/lib/git-state.ts
@@ -17,9 +17,17 @@
  *      false-positive is debuggable from the failure transcript alone
  *      (#1073 comment:2 explicit request).
  *   4. isBypassRequested — read the documented escape-hatch env var.
+ *
+ * Security posture: every git invocation goes through `spawnSync('git',
+ * argv)` — a fixed binary with an explicit argv array. No shell, no
+ * interpolation. Nothing in the resolved target path, porcelain filename,
+ * or any other user-influenced value reaches a shell interpreter. The
+ * original `execSync(\`git ${args}\`)` form was flagged in the #1073
+ * review as the very shell-injection anti-pattern the PR claims to
+ * neutralise; fixing it is part of the categorical fix.
  */
 
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 
 import { extractCdTarget, extractGitCPath, stripHeredocBody } from '../parse-command.js';
 
@@ -68,40 +76,37 @@ export interface DirtyState {
 
 export interface GitExecResult {
   stdout: string;
+  stderr: string;
   exitCode: number;
 }
-export type GitExec = (args: string) => GitExecResult;
+
+/**
+ * Runner contract: takes an argv array (no shell), returns stdout + stderr
+ * + exitCode. All internal uses build the argv programmatically — user
+ * input (paths, porcelain-reported filenames) is always a dedicated array
+ * element and never concatenated into a shell-interpreted string.
+ */
+export type GitExec = (args: readonly string[]) => GitExecResult;
 
 export function createDefaultGitExec(): GitExec {
   return (args) => {
-    try {
-      const stdout = execSync(`git ${args}`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      // IMPORTANT: do NOT .trim() — porcelain output has significant leading
-      // whitespace (` M file` vs `M  file` distinguishes unstaged-modified
-      // from staged-modified). Trimming corrupted the parse for unstaged
-      // files; caught by the live fixture test for #1073. Callers that
-      // want single-line trimmed output (e.g., rev-parse) should trim
-      // themselves.
-      return { stdout, exitCode: 0 };
-    } catch (e) {
-      const err = e as { status?: number; stdout?: string | Buffer };
-      const out = typeof err.stdout === 'string'
-        ? err.stdout
-        : err.stdout?.toString('utf-8') ?? '';
-      return { stdout: out, exitCode: err.status ?? 1 };
-    }
+    const r = spawnSync('git', [...args], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return {
+      stdout: r.stdout ?? '',
+      stderr: r.stderr ?? '',
+      exitCode: r.status ?? 1,
+    };
   };
 }
 
-function extractFilePath(porcelainLine: string): string {
-  // porcelain v1 format: XY <path>  (XY = 2 status chars, then space)
-  return porcelainLine.slice(3).trim();
-}
-
-function parsePorcelain(output: string): DirtyFileReport {
+/**
+ * Parse porcelain v1 output into staged/modified/untracked buckets.
+ * Exported so check-dirty-files.ts can reuse the single parser.
+ */
+export function parsePorcelain(output: string): DirtyFileReport {
   const lines = output.split('\n').filter(Boolean);
   const staged: string[] = [];
   const modified: string[] = [];
@@ -116,6 +121,21 @@ function parsePorcelain(output: string): DirtyFileReport {
 }
 
 /**
+ * Extract the destination file path from a porcelain v1 line.
+ *
+ * Porcelain format: `XY path` where X/Y are status chars. Rename/copy
+ * entries take the form `R  orig -> new` (or `C  orig -> new`); we want
+ * the destination, because that's the file whose working-tree content
+ * we content-verify. Dropping the ` -> ` arrow into the git argv would
+ * cause git to treat `->` as an operand — caught by the #1073 review.
+ */
+export function extractFilePath(porcelainLine: string): string {
+  const tail = porcelainLine.slice(3);
+  const arrow = tail.indexOf(' -> ');
+  return (arrow >= 0 ? tail.slice(arrow + 4) : tail).trim();
+}
+
+/**
  * Read the git state of `targetDir` and verify every tracked-file claim
  * with `git diff --quiet HEAD -- <file>`. Files where porcelain says
  * "modified" but diff says "content matches HEAD" are filtered out —
@@ -126,16 +146,16 @@ export function readDirtyFiles(
   options: { runner?: GitExec } = {},
 ): DirtyState {
   const runner = options.runner ?? createDefaultGitExec();
-  const prefix = targetDir ? `-C ${targetDir} ` : '';
+  const anchor: readonly string[] = targetDir ? ['-C', targetDir] : [];
 
-  const gitDir = runner(`${prefix}rev-parse --absolute-git-dir`).stdout.trim();
+  const gitDir = runner([...anchor, 'rev-parse', '--absolute-git-dir']).stdout.trim();
 
-  // Refresh the index to clear stat-only drift (retained as belt-and-suspenders
-  // alongside the content-level check below; observed as the #871 partial fix).
-  runner(`${prefix}update-index -q --refresh`);
+  // Refresh the index to clear stat-only drift (belt-and-suspenders alongside
+  // the content-level check below; observed as the #871 partial fix).
+  runner([...anchor, 'update-index', '-q', '--refresh']);
 
   // Do NOT trim: porcelain's leading whitespace is significant.
-  const porcelain = runner(`${prefix}status --porcelain`).stdout;
+  const porcelain = runner([...anchor, 'status', '--porcelain']).stdout;
   const rawReport = parsePorcelain(porcelain);
 
   const verifiedStaged: string[] = [];
@@ -145,7 +165,7 @@ export function readDirtyFiles(
   const checkFile = (line: string, bucket: string[]): void => {
     const file = extractFilePath(line);
     if (!file) return;
-    const r = runner(`${prefix}diff --quiet HEAD -- ${file}`);
+    const r = runner([...anchor, 'diff', '--quiet', 'HEAD', '--', file]);
     const blobMatch = r.exitCode === 0;
     perFileDiff.push({ file, diffIndexExitCode: r.exitCode, blobMatch });
     if (!blobMatch) bucket.push(line);
@@ -157,7 +177,7 @@ export function readDirtyFiles(
   const verified: DirtyFileReport = {
     staged: verifiedStaged,
     modified: verifiedModified,
-    untracked: rawReport.untracked, // untracked is unambiguous — no HEAD to diff
+    untracked: rawReport.untracked, // untracked has no HEAD to diff against
     total: verifiedStaged.length + verifiedModified.length + rawReport.untracked.length,
   };
 

--- a/src/hooks/parse-command.test.ts
+++ b/src/hooks/parse-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   detectGhRepo,
+  extractCdTarget,
   extractGitCPath,
   extractPrNumber,
   extractPrUrl,
@@ -161,6 +162,48 @@ describe('extractGitCPath', () => {
 
   it('handles piped commands', () => {
     expect(extractGitCPath('echo test | git -C /foo status')).toBe('/foo');
+  });
+});
+
+describe('extractCdTarget', () => {
+  it('extracts target from cd X && <cmd>', () => {
+    expect(extractCdTarget('cd /wt && gh pr create')).toBe('/wt');
+  });
+
+  it('extracts target from cd X ; <cmd>', () => {
+    expect(extractCdTarget('cd /a ; gh pr create')).toBe('/a');
+  });
+
+  it('extracts target from (cd X && <cmd>) subshell', () => {
+    expect(extractCdTarget('(cd /b && gh pr create)')).toBe('/b');
+  });
+
+  it('extracts target from double-quoted path', () => {
+    expect(extractCdTarget('cd "/q path" && gh pr create')).toBe('/q path');
+  });
+
+  it('extracts target from single-quoted path', () => {
+    expect(extractCdTarget("cd '/sq path' && gh pr create")).toBe('/sq path');
+  });
+
+  it('returns undefined for commands with no cd prefix', () => {
+    expect(extractCdTarget('gh pr create')).toBeUndefined();
+  });
+
+  it('does not match cdlock or other word prefixes', () => {
+    expect(extractCdTarget('cdlock /x && gh pr create')).toBeUndefined();
+  });
+
+  it('ignores cd - (previous dir, not a path target)', () => {
+    expect(extractCdTarget('cd - && gh pr create')).toBeUndefined();
+  });
+
+  it('ignores bare cd (HOME, not explicit)', () => {
+    expect(extractCdTarget('cd && gh pr create')).toBeUndefined();
+  });
+
+  it('returns first cd target when multiple present', () => {
+    expect(extractCdTarget('cd /a && cd /b && gh pr create')).toBe('/a');
   });
 });
 

--- a/src/hooks/parse-command.ts
+++ b/src/hooks/parse-command.ts
@@ -94,6 +94,31 @@ export function extractGitCPath(cmdLine: string): string | undefined {
 }
 
 /**
+ * Extract the target of a leading `cd <dir>` in a compound command.
+ * Returns the directory a following command will execute in, or undefined
+ * when the command has no `cd`, uses `cd -` / bare `cd`, or the path is
+ * unrecognised.
+ *
+ * Category prevention for #1073 / #240: hooks resolve the *gated command's*
+ * target worktree before running git queries, instead of inheriting the
+ * agent's `process.cwd()`.
+ */
+export function extractCdTarget(cmdLine: string): string | undefined {
+  const stripped = cmdLine.trim().replace(/^\(\s*/, '');
+  const segments = splitCommandSegments(stripped);
+  for (const seg of segments) {
+    // `cd <arg>` with word boundary (so `cdlock` is ignored).
+    // Arg is one of: "quoted", 'quoted', or a bare \S+.
+    const m = seg.match(/^cd\s+(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/);
+    if (!m) continue;
+    const target = m[1] ?? m[2] ?? m[3];
+    if (!target || target === '-') return undefined;
+    return target;
+  }
+  return undefined;
+}
+
+/**
  * Extract --repo flag value from a command line.
  */
 export function extractRepoFlag(cmdLine: string): string | undefined {


### PR DESCRIPTION
## The Problem — a 10-bug pattern finally named

**The setup.** An agent working in `gigaverse-app/langsmith-cli` — a host repo that ships its own `.claude-plugin/plugin.json` — ran `gh pr create`. The kaizen `check-dirty-files` hook denied with `M .claude-plugin/plugin.json — Staged but not committed`. Every direct measurement the reporter took said the index was clean: `git status --porcelain` empty in both main checkout and worktree, `git diff-index --cached HEAD` empty, `git ls-files --stage` matched the HEAD blob SHA. The hook still denied. Admin told the agent to stop trying to work around it and file the bug — **#1073**.

**The context.** This is the 10th+ incident in the same category. The recurring pattern:

| # | Issue | Symptom | Prior fix |
|---|---|---|---|
| #232 | closed | cwd drift cross-worktree | handled `git -C` case only |
| #225 | closed | `.worktree-lock.json` false positive | gitignore (#144) |
| #721 | closed | compound `commit && push` fires early | `hasCommitBeforePush` |
| #871 | closed | phantom MM on `plugin.json` | `update-index --refresh` |
| **#1073** | **open** | **same file, same hook, regressed** | **—** |

Plus open sibling cases (#412, #972) and the category umbrella itself (**#240** hook worktree isolation, #445 execution-context checklist, #163 hook interaction matrix, #943 command-detection-vs-outcome).

## The Discovery — three root causes, not one

Grounding the plan against `src/hooks/check-dirty-files.ts` and a 7-hook grep across `src/hooks/`:

1. **CWD drift.** `execSync('git …')` inherits `process.cwd()`. `extractGitCPath` only handles the `git -C <dir>` shape — not `cd <dir> && gh pr create`, the compound form agents actually run. The PreToolUse hook fires **before** the shell `cd`, so git queries the wrong worktree.
2. **Stat-vs-content mismatch.** `git status --porcelain` reads a stat cache that can lie. `update-index --refresh` (the #871 workaround) narrows the window but doesn't close it. The only authoritative read is content-level: `git diff --quiet HEAD -- <file>`.
3. **Shell injection** (found during review). The original `execSync(\`git ${args}\`)` form was itself the anti-pattern it claimed to neutralize — a crafted `cd /tmp$(id)` or a porcelain filename with shell metachars would execute via the shell interpreter.

And `execSync(...).trim()` — added to normalise single-line output — corrupted porcelain parsing for unstaged-modified entries. Leading space is significant in porcelain v1. This regression was caught **only** by the live fixture test; all four of my unit tests with mocked runners passed against broken code. That discovery earned its own unit regression test.

## The Solution — one primitive, one discipline, one invariant

```
src/hooks/lib/git-state.ts            ← the primitive (5 public surfaces)
  resolveTargetWorktree(cmd, cwd)     →  anchors git to the gated command's target
  readDirtyFiles(dir)                 →  porcelain + content-level verification
  formatDiagnostic(ctx)               →  mandatory deny-time diagnostic block
  isBypassRequested(env)              →  KAIZEN_ALLOW_DIRTY_FILES escape hatch
  parsePorcelain / extractFilePath    →  shared parsers (handle rename "R orig -> new")

src/hooks/check-dirty-files.ts        ← routes through the primitive
src/hooks/parse-command.ts            ← new extractCdTarget helper
src/hooks/lib/git-state-invariant.ts  ← CI lint: no hook may bypass the primitive
```

Every git invocation goes through `spawnSync('git', argv)` — explicit argv array, no shell interpretation. Nothing derived from a resolved path or porcelain filename ever reaches an interpreter.

**Scope decision — what this PR credibly closes vs defers.** Nine sibling hooks share the anti-pattern (`pr-review-loop.ts`, `kaizen-reflect.ts`, `pr-kaizen-clear.ts`, `bump-plugin-version.ts`, `hook-io.ts`, `pr-kaizen-clear-fallback.ts`, `post-merge-clear.ts`, `enforce-plan-stored.ts`, `pr-quality-checks.ts`). Migrating all of them in one PR would balloon the diff; each encodes different semantics ("current branch" vs "target branch" vs state-file keying). Instead: **ship the primitive, migrate the presenting bug, let the CI invariant force the sibling migration conversation at the right moment.** Follow-up sub-issue: **#1074**.

Separately surfaced during review: the `.claude/hooks/tests/` wrapper test suite is still Python (bash-mock-as-f-string) while the rest of the repo is TypeScript. Follow-up: **#1076**.

**Scope Reduction Discipline mechanism**: the invariant test (`git-state-invariant.test.ts`) fails the moment any new hook adds an `execSync('git …')` / `spawnSync('git', argv)` call without going through the primitive. Non-LLM mechanistic signal — the exact discipline required by the plan gate.

## Evidence

**All TS tests green** (102 files, 2627+ passed; kaizen-reflect race in parallel mode is pre-existing and passes in isolation). **Shell hook suite green** (394/394) after updating the Python/bash mock to answer the content-level `diff --quiet HEAD --` query introduced by the fix. **Round-3 tests green** — 5 differential cases + 5 host-plugin cases (10/10).

### Behaviours × Levels (I4)

| Behaviour | Unit | Integration | System | File |
|---|:-:|:-:|:-:|---|
| `extractCdTarget` parses every command shape | ✅ | | | `parse-command.test.ts` |
| `resolveTargetWorktree` prefers `-C` over `cd` over cwd | ✅ | | | `lib/git-state.test.ts` |
| `readDirtyFiles` filters content-clean files (#871) | ✅ | | | `lib/git-state.test.ts` |
| Porcelain-whitespace invariant (caught by live fixture) | ✅ | | | `lib/git-state.test.ts` |
| `formatDiagnostic` emits every required marker | ✅ | | | `lib/git-state.test.ts` |
| Porcelain rename `R  orig -> new` → destination only | ✅ | | | `lib/git-state.test.ts` |
| Deny message contains diagnostic block (#1073 comment:2) | ✅ | | | `check-dirty-files.test.ts` |
| `KAIZEN_ALLOW_DIRTY_FILES=1` bypasses + logs | ✅ | | | `check-dirty-files.test.ts` |
| CI invariant: new hooks must use primitive | ✅ | | | `lib/git-state-invariant.test.ts` |
| Host repo with own `.claude-plugin/plugin.json` does not false-deny | | | ✅ | `e2e/check-dirty-files-host-plugin.test.ts` |
| Real dirty file denies with diagnostic | | | ✅ | same |
| Stat-dirty/content-clean allows (#871 live) | | | ✅ | same |
| Escape hatch works end-to-end | | | ✅ | same |
| **Round 3** — Agent cwd is a DIFFERENT git repo with real staged drift (#1073 field topology) | | | ✅ | same (new) |
| **Round 3** — Legacy `gitRunner` path DENIES with exact `M  .claude-plugin/plugin.json` message (reproduces bug) | | ✅ | | `e2e/check-dirty-files-1073-differential.test.ts` (new) |
| **Round 3** — Fixed `gitExec` path ALLOWS same input (proves fix is load-bearing) | | ✅ | | same |
| **Round 3** — Fixed path still denies when TARGET has real drift (not blind) | | ✅ | | same |
| **Round 3** — Diagnostic names resolved target, not drifted cwd | | ✅ | | same |
| **Round 3** — #225 untracked kaizen-state file reports as Untracked, not Staged/Modified | | ✅ | | same |

Agentic / Workflow: N/A — no LLM decision in this work.

### Round 3 — differential proof

The round-3 commit adds **proof that the fix is load-bearing**. Prior rounds shipped passing unit tests with mocked runners and a live fixture from a non-git cwd — none of which reproduced the #1073 bug under the PRE-fix code path. The differential test runs both code paths on identical input on a real filesystem:

```
[PRE-FIX legacy path] action = deny    "M  .claude-plugin/plugin.json — Staged but not committed"
[POST-FIX new path]   action = allow
```

Same two git repos, same compound command, same cwd. Only the hook's internal code path changes. The legacy path reproduces the exact message the #1073 reporter pasted; the fixed path allows. This is the strongest possible behavioral-delta evidence for a bug fix.

## Review round 1 — findings addressed

- **[security]** `execSync(shell-string)` → `spawnSync('git', argv)`. All call sites converted.
- **[correctness]** Rename porcelain `R  orig -> new` → destination-only parse.
- **[correctness]** `createDefaultGitExec` captures stderr alongside stdout/exitCode.
- **[dry]** `parsePorcelain` / `extractFilePath` single-sourced in `lib/git-state.ts`; `check-dirty-files.ts` re-exports `parseDirtyFiles` for back-compat.
- **[tooling-fitness]** Invariant regex widened from `execSync('git ...')` only to the full `exec*`/`spawn*` family + argv-form `spawnSync('git', argv)`. `enforce-plan-stored.ts` and `pr-quality-checks.ts` joined OPT_OUT (#1074).
- **[ci]** Python test harness + shell helpers teach the mock git about `diff --quiet HEAD --` exit codes (content-level verification contract).

## Impact — what "finally" means here

- **#1073** (primary): closed. Live fixture reproduces and asserts the fix.
- **#871** (closed, regressed, now guarded): content-level verification supersedes `update-index --refresh`.
- **#232, #721** (closed): regression-guarded via explicit parameterized rows.
- **#240** (epic): partial progress. The primitive exists; the invariant forces the rest of the migration.
- **#1074** (new): ledger of pending sibling-hook migrations.
- **#1076** (new): follow-up for porting the wrapper test harness from Python to TypeScript.

## Non-goals (deferred with mechanism)

- Migrating 9 sibling hooks onto the primitive → **#1074**. Mechanistic trigger: CI invariant fails on any new violation.
- Python→TS port of `.claude/hooks/tests/` harness → **#1076**.
- **#412** squash-merge-safety false positive — different hook, different data model.
- **#972** ExitWorktree discard warning — worktree lib, not dirty-files hook.
- **#445** execution context checklist — this PR contributes the primitive + invariant as one concrete enforcement point the checklist can cite.
- **Plan Task 6 — hook-gym #1073 scenario → superseded**. The round-3 live-fixture differential test (`src/e2e/check-dirty-files-1073-differential.test.ts`) is a stronger form of what a hook-gym scenario would have proved: it runs the real hook function on a real filesystem through BOTH the legacy and fixed code paths on identical input and asserts opposite outcomes. Hook-gym's value is dispatcher-level observability, which does not add signal beyond the differential test for this bug.
- **Sunset of the legacy `gitRunner` code path** → **#1077**. The legacy path exists today because the differential test depends on both paths coexisting. A sunset decision (delete / permanent back-compat / archive post-proof) is deferred to the follow-up.
- **Edge-case coverage breadth** (shell metachars, unicode, renames, submodules, nested worktrees) → **#1078**. Category breadth, not a known bug — extends coverage to adjacent shapes once the primary #1073 categorical fix is in production.
- **Bypass-rate observability for `KAIZEN_ALLOW_DIRTY_FILES`** → **#1079**. The env var is stderr-logged today; persisting a counter or case-attachment so `/kaizen-reflect` can surface bypass patterns is the next step.

## Dual failure mode check

- **If this rule is absent**: the category keeps regressing. 10+ incidents in 18 months is the evidence.
- **If this rule is present**: sibling hooks legitimately needing `process.cwd()` (e.g., kaizen-reflect) must either be on the OPT_OUT list or be migrated. The escape hatch (`KAIZEN_ALLOW_DIRTY_FILES`) prevents the hook from becoming a dead-end when an agent hits a bug not anticipated.

Fixes #1073
Refs #240, #445, #163, #943, #950, #871, #232, #721, #225, #412, #972, #1074, #1076, #1077, #1078, #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)



