### PR TITLE
feat(hooks): migrate bump-plugin-version + hook-io onto git-state.ts (#1074)

### DIFF
--- a/src/hooks/bump-plugin-version.test.ts
+++ b/src/hooks/bump-plugin-version.test.ts
@@ -2,30 +2,42 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { bumpPluginVersion } from './bump-plugin-version.js';
+import type { GitExec } from './lib/git-state.js';
 
 const TEST_DIR = '/tmp/.test-bump-plugin';
 const PLUGIN_DIR = join(TEST_DIR, '.claude-plugin');
 const PLUGIN_JSON = join(PLUGIN_DIR, 'plugin.json');
 
+function writePluginAt(root: string, version: string) {
+  const dir = join(root, '.claude-plugin');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify({ name: 'test', version }, null, 2));
+}
+
 function writePlugin(version: string) {
-  mkdirSync(PLUGIN_DIR, { recursive: true });
-  writeFileSync(PLUGIN_JSON, JSON.stringify({ name: 'test', version }, null, 2));
+  writePluginAt(TEST_DIR, version);
 }
 
+// argv-safe GitExec seam (git-state.ts contract). Records each git argv so
+// tests can assert command ordering AND -C worktree anchoring (#1073/#240).
 function trackingGit(mainVersion: string) {
-  const calls: string[] = [];
-  const runner = (args: string) => {
-    calls.push(args);
-    if (args.includes('rev-parse --show-toplevel')) return TEST_DIR;
-    if (args.includes('show origin/main:.claude-plugin/plugin.json')) {
-      return JSON.stringify({ version: mainVersion });
+  const calls: string[][] = [];
+  const exec: GitExec = (args) => {
+    const argv = [...args];
+    calls.push(argv);
+    const joined = argv.join(' ');
+    if (joined.includes('show origin/main:.claude-plugin/plugin.json')) {
+      return { stdout: JSON.stringify({ version: mainVersion }), stderr: '', exitCode: 0 };
     }
-    return '';
+    if (joined.includes('rev-parse --show-toplevel')) {
+      return { stdout: TEST_DIR, stderr: '', exitCode: 0 };
+    }
+    return { stdout: '', stderr: '', exitCode: 0 };
   };
-  return { runner, calls };
+  return { exec, calls };
 }
 
-const mockGit = (mainVersion: string) => trackingGit(mainVersion).runner;
+const mockGit = (mainVersion: string) => trackingGit(mainVersion).exec;
 
 beforeEach(() => {
   if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
@@ -46,7 +58,7 @@ describe('bumpPluginVersion', () => {
   it('bumps patch version when main and current match', () => {
     writePlugin('1.0.5');
     const result = bumpPluginVersion('gh pr create --title "test"', {
-      gitRunner: mockGit('1.0.5'),
+      exec: mockGit('1.0.5'),
       projectRoot: TEST_DIR,
     });
     expect(result).toContain('1.0.5 -> 1.0.6');
@@ -57,7 +69,7 @@ describe('bumpPluginVersion', () => {
   it('skips when already bumped (different from main)', () => {
     writePlugin('1.1.0');
     const result = bumpPluginVersion('gh pr create --title "test"', {
-      gitRunner: mockGit('1.0.5'),
+      exec: mockGit('1.0.5'),
       projectRoot: TEST_DIR,
     });
     expect(result).toBeNull();
@@ -73,7 +85,7 @@ describe('bumpPluginVersion', () => {
   it('does not create temp files', () => {
     writePlugin('1.0.0');
     bumpPluginVersion('gh pr create --title "test"', {
-      gitRunner: mockGit('1.0.0'),
+      exec: mockGit('1.0.0'),
       projectRoot: TEST_DIR,
     });
     expect(existsSync(join(PLUGIN_DIR, 'plugin.json.tmp'))).toBe(false);
@@ -84,15 +96,15 @@ describe('bumpPluginVersion', () => {
 describe('INVARIANT: bump hook pushes after committing (#919)', () => {
   it('calls git push after git add + git commit', () => {
     writePlugin('1.0.5');
-    const { runner, calls } = trackingGit('1.0.5');
+    const { exec, calls } = trackingGit('1.0.5');
     bumpPluginVersion('gh pr create --title "test"', {
-      gitRunner: runner,
+      exec,
       projectRoot: TEST_DIR,
     });
     // Must have add → commit → push in order
     const addIdx = calls.findIndex(c => c.includes('add'));
     const commitIdx = calls.findIndex(c => c.includes('commit'));
-    const pushIdx = calls.findIndex(c => c === 'push');
+    const pushIdx = calls.findIndex(c => c.includes('push'));
     expect(addIdx).toBeGreaterThanOrEqual(0);
     expect(commitIdx).toBeGreaterThan(addIdx);
     expect(pushIdx).toBeGreaterThan(commitIdx);
@@ -100,18 +112,66 @@ describe('INVARIANT: bump hook pushes after committing (#919)', () => {
 
   it('returns success even if push fails (fail-open)', () => {
     writePlugin('1.0.5');
-    const { runner } = trackingGit('1.0.5');
+    const { exec } = trackingGit('1.0.5');
     // Override to throw on push
-    const failOnPush = (args: string) => {
-      if (args.includes('push')) throw new Error('push failed');
-      return runner(args);
+    const failOnPush: GitExec = (args) => {
+      if ([...args].includes('push')) throw new Error('push failed');
+      return exec(args);
     };
     const result = bumpPluginVersion('gh pr create --title "test"', {
-      gitRunner: failOnPush,
+      exec: failOnPush,
       projectRoot: TEST_DIR,
     });
     // Should still succeed — push failure is non-blocking
     expect(result).toContain('1.0.5 -> 1.0.6');
+  });
+});
+
+// #1073/#240: REGRESSION — bump must anchor git reads to the gated command's
+// worktree, never the agent's process.cwd(). Without -C anchoring, an agent
+// running `cd <worktree> && gh pr create` from a cwd in the MAIN checkout
+// would bump the MAIN repo's plugin.json (the phantom-plugin.json family).
+describe('REGRESSION: bump resolves the gated command worktree, not cwd (#1073)', () => {
+  const MAIN_DIR = join(TEST_DIR, 'main');
+  const WORKTREE_DIR = join(TEST_DIR, 'wt');
+
+  it('bumps the worktree plugin.json named in `cd <wt> && gh pr create`', () => {
+    writePluginAt(MAIN_DIR, '1.0.5');
+    writePluginAt(WORKTREE_DIR, '1.0.5');
+
+    const calls: string[][] = [];
+    // Resolve --show-toplevel per -C anchor so projectRoot follows the target.
+    const exec: GitExec = (args) => {
+      const argv = [...args];
+      calls.push(argv);
+      const joined = argv.join(' ');
+      // argv[0..1] is `-C <target>` for every anchored read.
+      const target = argv[0] === '-C' ? argv[1] : '';
+      if (joined.includes('rev-parse --show-toplevel')) {
+        return { stdout: target, stderr: '', exitCode: 0 };
+      }
+      if (joined.includes('show origin/main:.claude-plugin/plugin.json')) {
+        return { stdout: JSON.stringify({ version: '1.0.5' }), stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    };
+
+    const result = bumpPluginVersion(`cd ${WORKTREE_DIR} && gh pr create --title x`, {
+      exec,
+      cwd: MAIN_DIR, // agent process.cwd() is the MAIN checkout — the trap
+    });
+
+    // The worktree's plugin.json is bumped...
+    expect(result).toContain('1.0.5 -> 1.0.6');
+    expect(JSON.parse(readFileSync(join(WORKTREE_DIR, '.claude-plugin/plugin.json'), 'utf-8')).version)
+      .toBe('1.0.6');
+    // ...and the MAIN checkout's plugin.json is left untouched.
+    expect(JSON.parse(readFileSync(join(MAIN_DIR, '.claude-plugin/plugin.json'), 'utf-8')).version)
+      .toBe('1.0.5');
+    // Every git read was anchored to the worktree, never the main cwd.
+    const anchors = calls.filter(c => c[0] === '-C').map(c => c[1]);
+    expect(anchors.every(a => a === WORKTREE_DIR)).toBe(true);
+    expect(anchors).not.toContain(MAIN_DIR);
   });
 });
 

--- a/src/hooks/bump-plugin-version.ts
+++ b/src/hooks/bump-plugin-version.ts
@@ -12,38 +12,56 @@
  * Part of kAIzen Agent Control Flow — kaizen #775
  */
 
-import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { readHookInput, traceNullInput } from './hook-io.js';
 import { isGhPrCommand, stripHeredocBody } from './parse-command.js';
+import { createDefaultGitExec, resolveTargetWorktree, type GitExec } from './lib/git-state.js';
 
 export function bumpPluginVersion(
   command: string,
   options: {
-    gitRunner?: (args: string) => string;
+    /**
+     * argv-safe git runner (git-state.ts contract). The default routes
+     * through `spawnSync('git', argv)` — no shell string interpolation.
+     */
+    exec?: GitExec;
     projectRoot?: string;
+    /** Agent process cwd; used as the fallback target worktree (#1073/#240). */
+    cwd?: string;
   } = {},
 ): string | null {
   const cmdLine = stripHeredocBody(command);
   if (!isGhPrCommand(cmdLine, 'create')) return null;
 
-  const git = options.gitRunner ?? ((args: string) => {
+  const exec = options.exec ?? createDefaultGitExec();
+  const fallbackCwd = options.cwd ?? process.cwd();
+
+  // #1073/#240: anchor every git read to the *gated command's* worktree, not
+  // the agent's inherited process.cwd(). When the agent runs
+  // `cd <worktree> && gh pr create` while its cwd is the main checkout, an
+  // un-anchored `rev-parse --show-toplevel` resolves the MAIN repo and bumps
+  // the wrong .claude-plugin/plugin.json — the exact #1073 phantom-plugin.json
+  // failure mode.
+  const target = resolveTargetWorktree(command, fallbackCwd).dir;
+  const anchor: readonly string[] = target ? ['-C', target] : [];
+  const git = (args: readonly string[]): string => {
     try {
-      return execSync(`git ${args}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      const r = exec([...anchor, ...args]);
+      return r.exitCode === 0 ? r.stdout.trim() : '';
     } catch {
       return '';
     }
-  });
+  };
 
-  const projectRoot = options.projectRoot ?? (git('rev-parse --show-toplevel') || process.cwd());
+  const projectRoot = options.projectRoot ?? (git(['rev-parse', '--show-toplevel']) || fallbackCwd);
   const pluginJson = join(projectRoot, '.claude-plugin', 'plugin.json');
   if (!existsSync(pluginJson)) return null;
 
   // Compare version on current branch vs main
   const mainVersion = (() => {
     try {
-      const raw = git('show origin/main:.claude-plugin/plugin.json');
+      const raw = git(['show', 'origin/main:.claude-plugin/plugin.json']);
       return raw ? JSON.parse(raw).version || '0.0.0' : '0.0.0';
     } catch {
       return '0.0.0';
@@ -64,15 +82,21 @@ export function bumpPluginVersion(
   content.version = newVersion;
   writeFileSync(pluginJson, JSON.stringify(content, null, 2) + '\n');
 
-  // Stage, commit, and push (#919: push so gh pr create doesn't fail)
+  // Stage, commit, and push (#919: push so gh pr create doesn't fail).
+  // argv form — the filename is a discrete array element, never interpolated
+  // into a shell string (#1073 review: kill the shell-injection surface).
   try {
-    git(`add "${pluginJson}"`);
-    git(`commit -m "chore: bump plugin version to ${newVersion}" -m "Auto-bumped by kaizen-bump-plugin-version hook."`);
+    git(['add', pluginJson]);
+    git([
+      'commit',
+      '-m', `chore: bump plugin version to ${newVersion}`,
+      '-m', 'Auto-bumped by kaizen-bump-plugin-version hook.',
+    ]);
   } catch {
     // If commit fails (nothing to commit, etc.), ignore
   }
   try {
-    git('push');
+    git(['push']);
   } catch {
     // Push failure is non-blocking — agent can retry (#919: fail-open)
   }

--- a/src/hooks/hook-io.test.ts
+++ b/src/hooks/hook-io.test.ts
@@ -1,17 +1,10 @@
-import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import { Readable } from 'node:stream';
 import { readFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { writeHookOutput, getCurrentBranch, readHookInput, traceNullInput } from './hook-io.js';
-
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
-}));
-
-// Access the mocked execSync
-import { execSync } from 'node:child_process';
-const mockedExecSync = vi.mocked(execSync);
+import type { GitExec } from './lib/git-state.js';
 
 describe('hook-io', () => {
   afterEach(() => {
@@ -171,16 +164,44 @@ describe('hook-io', () => {
   });
 
   describe('getCurrentBranch', () => {
+    const okBranch = (name: string): GitExec => () => ({ stdout: name + '\n', stderr: '', exitCode: 0 });
+
     it('returns trimmed branch name on success', () => {
-      mockedExecSync.mockReturnValue('feat-branch\n');
-      expect(getCurrentBranch()).toBe('feat-branch');
+      expect(getCurrentBranch('', { exec: okBranch('feat-branch'), cwd: '/repo' })).toBe('feat-branch');
     });
 
-    it('returns empty string on git failure', () => {
-      mockedExecSync.mockImplementation(() => {
-        throw new Error('not a git repo');
-      });
-      expect(getCurrentBranch()).toBe('');
+    it('returns empty string on git failure (nonzero exit)', () => {
+      const fail: GitExec = () => ({ stdout: '', stderr: 'fatal: not a git repo', exitCode: 128 });
+      expect(getCurrentBranch('', { exec: fail, cwd: '/repo' })).toBe('');
+    });
+
+    it('returns empty string when the runner throws', () => {
+      const thrower: GitExec = () => { throw new Error('boom'); };
+      expect(getCurrentBranch('', { exec: thrower, cwd: '/repo' })).toBe('');
+    });
+
+    // #1073/#240 REGRESSION: read the branch from the gated command's target
+    // worktree (`cd <wt> && ...`), not the agent's inherited process.cwd().
+    it('anchors rev-parse to the cd-target worktree, not cwd', () => {
+      const calls: string[][] = [];
+      const exec: GitExec = (args) => {
+        calls.push([...args]);
+        return { stdout: 'wt-branch\n', stderr: '', exitCode: 0 };
+      };
+      const branch = getCurrentBranch('cd /work/wt && git status', { exec, cwd: '/main/checkout' });
+      expect(branch).toBe('wt-branch');
+      expect(calls[0].slice(0, 2)).toEqual(['-C', '/work/wt']);
+      expect(calls[0]).not.toContain('/main/checkout');
+    });
+
+    it('falls back to the cwd anchor when the command names no target', () => {
+      const calls: string[][] = [];
+      const exec: GitExec = (args) => {
+        calls.push([...args]);
+        return { stdout: 'main\n', stderr: '', exitCode: 0 };
+      };
+      getCurrentBranch('', { exec, cwd: '/repo' });
+      expect(calls[0].slice(0, 2)).toEqual(['-C', '/repo']);
     });
   });
 

--- a/src/hooks/hook-io.ts
+++ b/src/hooks/hook-io.ts
@@ -6,7 +6,7 @@
  */
 
 import { appendFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { createDefaultGitExec, resolveTargetWorktree, type GitExec } from './lib/git-state.js';
 
 const getTraceFile = (): string => process.env.KAIZEN_HOOK_TRACE ?? '/tmp/.kaizen-hook-trace.jsonl';
 const isTraceEnabled = (): boolean => process.env.KAIZEN_HOOK_TRACE !== '0';
@@ -75,13 +75,25 @@ export function writeHookOutput(text: string): void {
   process.stdout.write(text);
 }
 
-/** Get the current git branch name. Returns empty string on failure. */
-export function getCurrentBranch(): string {
+/**
+ * Get the current git branch name. Returns empty string on failure.
+ *
+ * cmdLine-aware (#1073/#240): when the gated command is available, the branch
+ * is read from that command's *target worktree* (`git -C <target> rev-parse
+ * --abbrev-ref HEAD`) instead of the agent's inherited `process.cwd()`. With
+ * no cmdLine the target falls back to cwd — behaviorally identical to the
+ * legacy un-anchored call, but routed through the argv-safe git-state runner.
+ */
+export function getCurrentBranch(
+  cmdLine = '',
+  options: { cwd?: string; exec?: GitExec } = {},
+): string {
   try {
-    return execSync('git rev-parse --abbrev-ref HEAD', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    const exec = options.exec ?? createDefaultGitExec();
+    const target = resolveTargetWorktree(cmdLine, options.cwd ?? process.cwd()).dir;
+    const anchor: readonly string[] = target ? ['-C', target] : [];
+    const r = exec([...anchor, 'rev-parse', '--abbrev-ref', 'HEAD']);
+    return r.exitCode === 0 ? r.stdout.trim() : '';
   } catch {
     return '';
   }

--- a/src/hooks/lib/git-state-invariant.test.ts
+++ b/src/hooks/lib/git-state-invariant.test.ts
@@ -21,9 +21,9 @@ const HOOKS_DIR = join(__dirname, '..');
 // Hooks whose migration to git-state.ts is pending. Removing an entry here
 // without migrating the hook will re-introduce the cwd-drift anti-pattern.
 const OPT_OUT = new Set<string>([
-  'bump-plugin-version.ts',
+  // bump-plugin-version.ts — migrated to git-state.ts (#1074)
+  // hook-io.ts — migrated to git-state.ts (#1074)
   'kaizen-reflect.ts',
-  'hook-io.ts',
   'pr-kaizen-clear.ts',
   'pr-kaizen-clear-fallback.ts',
   'pr-review-loop.ts',


### PR DESCRIPTION
## Problem

The categorical fix for the cwd/stat false-positive family (#1073, epic #240)
shipped the shared `src/hooks/lib/git-state.ts` primitive and migrated
`check-dirty-files.ts` onto it — but stopped there. Nine sibling hooks were
left carrying the exact anti-pattern the primitive exists to kill: they read
git state via `execSync('git …')` from the agent's inherited `process.cwd()`
rather than the *gated command's* target worktree. That ledger of pending work
lives in the `OPT_OUT` set of `git-state-invariant.test.ts`, and #1074 tracks
draining it.

Two of those entries are the same shape as #1073 itself.

## Discovery

`bump-plugin-version.ts` is the hook at the literal center of the #1073
incident — it's the thing that rewrites `.claude-plugin/plugin.json`. It
resolved its project root with an un-anchored `git rev-parse --show-toplevel`
run from `process.cwd()`. When an agent runs `cd <worktree> && gh pr create`
while its cwd is still the **main** checkout (the normal multi-worktree
workflow), that call resolves the *main* repo and bumps the *wrong*
`plugin.json` — the phantom-plugin.json failure mode by another door. It also
built git commands by interpolating filenames into a shell string
(`execSync(\`git \${args}\`)`), the very shell-injection surface the #1073
review flagged.

`hook-io.ts`'s shared `getCurrentBranch()` had the same un-anchored read,
inherited by every hook that asks "what branch am I on?".

## Solution

Migrate both onto `git-state.ts`, the batch the issue green-lights ("small
batches when the calls are trivial and the semantic is identical"):

- **`bump-plugin-version.ts`** — `resolveTargetWorktree(command, cwd)` anchors
  every git invocation with `-C <target>`, so the worktree's `plugin.json` is
  bumped, never the main checkout's. The string `gitRunner` seam becomes the
  argv-safe `GitExec` (filenames are discrete array elements, no shell), while
  the #919 push-after-commit ordering and fail-open-on-push-failure invariants
  are preserved.
- **`hook-io.ts` `getCurrentBranch()`** — now `cmdLine`-aware: with a command
  it reads the branch from that command's target worktree; with none it falls
  back to cwd, keeping all existing callers behaviorally identical but routed
  through the safe argv runner.
- Both removed from `OPT_OUT`; the `git-state-invariant` CI test now passes
  with two fewer opt-outs — the ledger advances mechanically, not on trust.

## Evidence

- New cwd-drift regression in `bump-plugin-version.test.ts`: agent cwd =
  main checkout, command = `cd <wt> && gh pr create` → asserts the **worktree's**
  plugin.json is bumped, the main one is untouched, and every git read was
  anchored to the worktree.
- New `getCurrentBranch` regression: `cd /work/wt && …` with cwd `/main/checkout`
  → asserts the rev-parse is anchored `-C /work/wt`, never the cwd.
- `git-state-invariant.test.ts` (the mechanistic ledger) passes with both
  files removed from `OPT_OUT`.
- Full suite: **2640 passed / 10 skipped**; `tsc` build clean.

## Impact

Two more choke-point hooks can no longer misfire across worktrees — directly
relevant to unattended auto-dent batches, where a phantom-plugin.json block or
a wrong-branch read silently derails a run. The OPT_OUT ledger drops from 11 to
9; remaining siblings (`kaizen-reflect`, `pr-review-loop`, `pr-kaizen-clear*`,
`post-merge-clear`, `pre-push`, `prehook-no-verify`, `enforce-plan-stored`,
`pr-quality-checks`) are tracked follow-ups under #1074.

## Behaviors × Levels

| Behavior | Unit | Integration |
|----------|:----:|:-----------:|
| bump resolves worktree from `cd wt && gh pr create`, bumps wt's plugin.json | ✅ | |
| bump preserves #919 push-after-commit ordering on argv seam | ✅ | |
| bump fail-open when push errors | ✅ | |
| getCurrentBranch anchors `-C <target>` when given a cmdLine | ✅ | |
| getCurrentBranch cwd-fallback unchanged for no-arg callers | ✅ | |
| git-state-invariant passes with bump + hook-io off OPT_OUT | | ✅ |

Closes #1074
Parent: #240
Refs: #1073

Run tag: sticky-lark/run-1
