### PR TITLE
feat(auto-dent): verify lifecycle phase claims + steer on critical (Closes #1103)

### DIFF
--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -61,6 +61,10 @@ export interface RunCompleteEvent extends BaseEvent {
   stop_requested: boolean;
   failure_class?: string;
   lifecycle_violations: number;
+  /** Lifecycle health: clean | degraded (ordering) | critical (gaps/phantoms) (#1103) */
+  lifecycle_health?: 'clean' | 'degraded' | 'critical';
+  /** Count of critical lifecycle findings (gaps + phantom phases) (#1103) */
+  lifecycle_critical?: number;
   outcome: 'success' | 'empty_success' | 'failure' | 'stop';
   /** Cognitive mode used, for context in analysis */
   mode?: string;

--- a/scripts/auto-dent-lifecycle.test.ts
+++ b/scripts/auto-dent-lifecycle.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  validateRunLifecycle,
+  summarizeLifecycle,
+  LIFECYCLE_ORDER,
+  REQUIRED_PREDECESSORS,
+} from './auto-dent-lifecycle.js';
+
+/**
+ * The lifecycle validator turns the agent's AUTO_DENT_PHASE claims into a
+ * verified, classified signal. These tests are the category-prevention battery
+ * for issue #1103: ordering (back-compat), critical gaps, phantom-test claims,
+ * health classification, and the one-line summary.
+ */
+describe('validateRunLifecycle — back-compat (ordering + presence)', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'lifecycle-bc-'));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function logWith(lines: string[]): string {
+    const f = join(tmpDir, `${Math.abs(lines.join().length)}.log`);
+    writeFileSync(f, lines.join('\n'));
+    return f;
+  }
+
+  it('returns valid + clean for a correct full lifecycle', () => {
+    const f = logWith([
+      'AUTO_DENT_PHASE: PICK | issue=#1 | title=test',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed | reason=ok',
+      'AUTO_DENT_PHASE: IMPLEMENT | case=test-case',
+      'AUTO_DENT_PHASE: TEST | result=pass | count=5',
+      'AUTO_DENT_PHASE: PR | url=https://example.com/pr/1',
+      'AUTO_DENT_PHASE: MERGE | url=https://example.com/pr/1 | status=queued',
+      'AUTO_DENT_PHASE: REFLECT | issues_filed=0',
+    ]);
+    const r = validateRunLifecycle(f);
+    expect(r.valid).toBe(true);
+    expect(r.violations).toEqual([]);
+    expect(r.phasesMissing).toEqual([]);
+    expect(r.criticalGaps).toEqual([]);
+    expect(r.phantomPhases).toEqual([]);
+    expect(r.health).toBe('clean');
+    expect(r.phasesPresent).toEqual(LIFECYCLE_ORDER);
+  });
+
+  it('detects ordering violations (valid=false) and classifies degraded', () => {
+    const f = logWith([
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: IMPLEMENT | case=c',
+      'AUTO_DENT_PHASE: TEST | result=pass | count=3',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed',
+      'AUTO_DENT_PHASE: PR | url=u',
+    ]);
+    const r = validateRunLifecycle(f);
+    expect(r.valid).toBe(false);
+    expect(r.violations).toContainEqual({ phase: 'EVALUATE', after: 'TEST' });
+    // ordering-only problem (no gaps/phantoms) => degraded, not critical
+    expect(r.criticalGaps).toEqual([]);
+    expect(r.phantomPhases).toEqual([]);
+    expect(r.health).toBe('degraded');
+  });
+
+  it('ignores floating phases (DECOMPOSE, STOP)', () => {
+    const f = logWith([
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed',
+      'AUTO_DENT_PHASE: DECOMPOSE | epic=#100',
+      'AUTO_DENT_PHASE: STOP | reason=done',
+    ]);
+    const r = validateRunLifecycle(f);
+    expect(r.valid).toBe(true);
+    expect(r.phasesPresent).toContain('DECOMPOSE');
+    expect(r.phasesPresent).toContain('STOP');
+  });
+
+  it('handles a log with no phases (all missing, but clean)', () => {
+    const f = logWith(['just some log output', 'no phases here']);
+    const r = validateRunLifecycle(f);
+    expect(r.valid).toBe(true);
+    expect(r.phasesPresent).toEqual([]);
+    expect(r.phasesMissing).toEqual(LIFECYCLE_ORDER);
+    expect(r.health).toBe('clean');
+  });
+});
+
+describe('validateRunLifecycle — critical gaps (claim to ship without building)', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'lifecycle-gap-'));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+  const write = (lines: string[]) => {
+    const f = join(tmpDir, 'g.log');
+    writeFileSync(f, lines.join('\n'));
+    return f;
+  };
+
+  it('flags PR without IMPLEMENT as a critical gap', () => {
+    const f = write([
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed',
+      'AUTO_DENT_PHASE: PR | url=u',
+    ]);
+    const r = validateRunLifecycle(f);
+    expect(r.criticalGaps).toContainEqual({ phase: 'PR', requires: 'IMPLEMENT' });
+    expect(r.health).toBe('critical');
+  });
+
+  it('flags MERGE without PR as a critical gap', () => {
+    const f = write([
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: IMPLEMENT | case=c',
+      'AUTO_DENT_PHASE: MERGE | url=u | status=queued',
+    ]);
+    const r = validateRunLifecycle(f);
+    expect(r.criticalGaps).toContainEqual({ phase: 'MERGE', requires: 'PR' });
+    expect(r.health).toBe('critical');
+  });
+
+  it('does NOT flag a gap when the required predecessor is present', () => {
+    const f = write([
+      'AUTO_DENT_PHASE: IMPLEMENT | case=c',
+      'AUTO_DENT_PHASE: TEST | result=pass | count=2',
+      'AUTO_DENT_PHASE: PR | url=u',
+      'AUTO_DENT_PHASE: MERGE | url=u | status=queued',
+    ]);
+    const r = validateRunLifecycle(f);
+    expect(r.criticalGaps).toEqual([]);
+  });
+
+  it('REQUIRED_PREDECESSORS encodes PR<=IMPLEMENT and MERGE<=PR', () => {
+    expect(REQUIRED_PREDECESSORS.PR).toBe('IMPLEMENT');
+    expect(REQUIRED_PREDECESSORS.MERGE).toBe('PR');
+  });
+});
+
+describe('validateRunLifecycle — phantom test claims (verify outcomes not claims)', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'lifecycle-phantom-'));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+  const write = (lines: string[]) => {
+    const f = join(tmpDir, 'p.log');
+    writeFileSync(f, lines.join('\n'));
+    return f;
+  };
+  const fullExcept = (testLine: string) => [
+    'AUTO_DENT_PHASE: PICK | issue=#1',
+    'AUTO_DENT_PHASE: EVALUATE | verdict=proceed',
+    'AUTO_DENT_PHASE: IMPLEMENT | case=c',
+    testLine,
+    'AUTO_DENT_PHASE: PR | url=u',
+  ];
+
+  it('flags TEST result=pass count=0 as phantom', () => {
+    const r = validateRunLifecycle(write(fullExcept('AUTO_DENT_PHASE: TEST | result=pass | count=0')));
+    expect(r.phantomPhases).toHaveLength(1);
+    expect(r.phantomPhases[0].phase).toBe('TEST');
+    expect(r.health).toBe('critical');
+  });
+
+  it('flags TEST result=pass with missing count as phantom', () => {
+    const r = validateRunLifecycle(write(fullExcept('AUTO_DENT_PHASE: TEST | result=pass')));
+    expect(r.phantomPhases).toHaveLength(1);
+    expect(r.health).toBe('critical');
+  });
+
+  it('does NOT flag TEST result=pass with positive count', () => {
+    const r = validateRunLifecycle(write(fullExcept('AUTO_DENT_PHASE: TEST | result=pass | count=7')));
+    expect(r.phantomPhases).toEqual([]);
+    expect(r.health).toBe('clean');
+  });
+
+  it('does NOT flag an honest TEST result=fail (failing is not phantom)', () => {
+    const r = validateRunLifecycle(write(fullExcept('AUTO_DENT_PHASE: TEST | result=fail | count=0')));
+    expect(r.phantomPhases).toEqual([]);
+  });
+});
+
+describe('summarizeLifecycle', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'lifecycle-sum-'));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+  const write = (lines: string[]) => {
+    const f = join(tmpDir, 's.log');
+    writeFileSync(f, lines.join('\n'));
+    return f;
+  };
+
+  it('summarizes a clean run with the phase chain', () => {
+    const r = validateRunLifecycle(write([
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=proceed',
+      'AUTO_DENT_PHASE: IMPLEMENT | case=c',
+    ]));
+    const s = summarizeLifecycle(r);
+    expect(s.toLowerCase()).toContain('clean');
+  });
+
+  it('names the critical findings in the summary', () => {
+    const r = validateRunLifecycle(write([
+      'AUTO_DENT_PHASE: PICK | issue=#1',
+      'AUTO_DENT_PHASE: TEST | result=pass | count=0',
+      'AUTO_DENT_PHASE: PR | url=u',
+    ]));
+    const s = summarizeLifecycle(r);
+    expect(s.toUpperCase()).toContain('CRITICAL');
+    // mentions both the phantom test and the PR-without-IMPLEMENT gap
+    expect(s).toMatch(/phantom|TEST/i);
+    expect(s).toMatch(/IMPLEMENT/);
+  });
+});

--- a/scripts/auto-dent-lifecycle.ts
+++ b/scripts/auto-dent-lifecycle.ts
@@ -1,0 +1,138 @@
+// Auto-dent run lifecycle validation.
+//
+// The agent emits AUTO_DENT_PHASE markers as it moves through the pipeline
+// (PICK -> EVALUATE -> IMPLEMENT -> TEST -> PR -> MERGE -> REFLECT). Those
+// markers are *claims*. This module turns the claims into a verified, classified
+// signal so the harness can see — and steer on — when a run's narrative doesn't
+// hold together:
+//
+//   - ordering violations  : a phase appeared earlier than a prior phase (degraded)
+//   - critical gaps         : a phase that implies prior work is present without it,
+//                             e.g. PR without IMPLEMENT or MERGE without PR (critical)
+//   - phantom phases        : a claimed-green outcome that ran nothing,
+//                             e.g. TEST result=pass with count=0 (critical) — the
+//                             "verify outcomes, not commands" failure (#943, #950)
+//
+// Validation is observability + steering, never a hard block (#1103): a heuristic
+// false-positive must not halt an unattended batch.
+
+import { readFileSync } from 'fs';
+import { parsePhaseMarkers } from './auto-dent-stream.js';
+
+/** Canonical phase order. Phases not in this list (floating) are ignored for ordering. */
+export const LIFECYCLE_ORDER = ['PICK', 'EVALUATE', 'IMPLEMENT', 'TEST', 'PR', 'MERGE', 'REFLECT'];
+
+/** Phases that can appear anywhere without breaking ordering. */
+export const FLOATING_PHASES = new Set(['DECOMPOSE', 'STOP']);
+
+/**
+ * Phases that, when present, require an earlier phase to also be present.
+ * A present phase whose required predecessor is absent is a *critical gap* —
+ * the run claims to have shipped without doing the prerequisite work.
+ */
+export const REQUIRED_PREDECESSORS: Record<string, string> = {
+  PR: 'IMPLEMENT',
+  MERGE: 'PR',
+};
+
+export type LifecycleHealth = 'clean' | 'degraded' | 'critical';
+
+export interface LifecycleValidation {
+  /** Back-compat: true when there are no *ordering* violations. */
+  valid: boolean;
+  phasesPresent: string[];
+  phasesMissing: string[];
+  /** Ordering violations: `phase` appeared after `after` (out of canonical order). */
+  violations: Array<{ phase: string; after: string }>;
+  /** Critical gaps: `phase` is present but its required `requires` predecessor is absent. */
+  criticalGaps: Array<{ phase: string; requires: string }>;
+  /** Phantom phases: a claimed-green outcome that ran nothing. */
+  phantomPhases: Array<{ phase: string; reason: string }>;
+  /** Overall health: critical (gaps/phantoms) > degraded (ordering) > clean. */
+  health: LifecycleHealth;
+}
+
+/**
+ * Validate lifecycle phase ordering and integrity from a run log file.
+ * Reads the log, extracts AUTO_DENT_PHASE markers, and classifies the run.
+ */
+export function validateRunLifecycle(logFile: string): LifecycleValidation {
+  const logContent = readFileSync(logFile, 'utf8');
+  const markers = parsePhaseMarkers(logContent);
+  const phasesPresent = markers.map((m) => m.phase);
+  const orderedPhases = phasesPresent.filter((p) => !FLOATING_PHASES.has(p));
+  const presentSet = new Set(phasesPresent);
+
+  // Ordering violations (back-compat).
+  const violations: Array<{ phase: string; after: string }> = [];
+  for (let i = 1; i < orderedPhases.length; i++) {
+    const prevIdx = LIFECYCLE_ORDER.indexOf(orderedPhases[i - 1]);
+    const currIdx = LIFECYCLE_ORDER.indexOf(orderedPhases[i]);
+    if (prevIdx === -1 || currIdx === -1) continue;
+    if (currIdx < prevIdx) {
+      violations.push({ phase: orderedPhases[i], after: orderedPhases[i - 1] });
+    }
+  }
+
+  // Critical gaps: a present phase whose required predecessor never appeared.
+  const criticalGaps: Array<{ phase: string; requires: string }> = [];
+  for (const [phase, requires] of Object.entries(REQUIRED_PREDECESSORS)) {
+    if (presentSet.has(phase) && !presentSet.has(requires)) {
+      criticalGaps.push({ phase, requires });
+    }
+  }
+
+  // Phantom phases: a claimed-green outcome that ran nothing.
+  // Today: TEST result=pass with a count that is missing or zero.
+  const phantomPhases: Array<{ phase: string; reason: string }> = [];
+  for (const marker of markers) {
+    if (marker.phase !== 'TEST') continue;
+    if (marker.fields.result !== 'pass') continue;
+    const rawCount = marker.fields.count;
+    const count = rawCount === undefined ? NaN : Number.parseInt(rawCount, 10);
+    if (rawCount === undefined || !Number.isFinite(count) || count <= 0) {
+      phantomPhases.push({
+        phase: 'TEST',
+        reason: `result=pass but count=${rawCount ?? 'missing'} (claimed green, ran nothing)`,
+      });
+    }
+  }
+
+  const phasesMissing = LIFECYCLE_ORDER.filter((p) => !presentSet.has(p));
+
+  const health: LifecycleHealth =
+    criticalGaps.length > 0 || phantomPhases.length > 0
+      ? 'critical'
+      : violations.length > 0
+        ? 'degraded'
+        : 'clean';
+
+  return {
+    valid: violations.length === 0,
+    phasesPresent,
+    phasesMissing,
+    violations,
+    criticalGaps,
+    phantomPhases,
+    health,
+  };
+}
+
+/**
+ * Render a one-line human summary of a lifecycle validation result, suitable for
+ * console logs, run logs, and steering insights. Critical findings are named.
+ */
+export function summarizeLifecycle(v: LifecycleValidation): string {
+  if (v.health === 'clean') {
+    const chain = v.phasesPresent.length > 0 ? v.phasesPresent.join(' -> ') : 'no phases';
+    return `lifecycle clean (${chain})`;
+  }
+
+  const parts: string[] = [];
+  for (const g of v.criticalGaps) parts.push(`${g.phase} without ${g.requires}`);
+  for (const p of v.phantomPhases) parts.push(`phantom ${p.phase} (${p.reason})`);
+  for (const o of v.violations) parts.push(`${o.phase} after ${o.after}`);
+
+  const label = v.health === 'critical' ? 'CRITICAL' : 'degraded';
+  return `lifecycle ${label}: ${parts.join('; ')}`;
+}

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -93,6 +93,17 @@ export {
   type StreamContext,
 } from './auto-dent-stream.js';
 
+// Lifecycle validation — re-exported for back-compat (#1103).
+export {
+  validateRunLifecycle,
+  summarizeLifecycle,
+  LIFECYCLE_ORDER,
+  FLOATING_PHASES,
+  REQUIRED_PREDECESSORS,
+  type LifecycleValidation,
+  type LifecycleHealth,
+} from './auto-dent-lifecycle.js';
+
 // Import for internal use
 import {
   ghExec,
@@ -113,6 +124,11 @@ import {
   IN_FLIGHT_UPDATE_INTERVAL_MS,
   type StreamContext,
 } from './auto-dent-stream.js';
+import {
+  validateRunLifecycle,
+  summarizeLifecycle,
+  type LifecycleHealth,
+} from './auto-dent-lifecycle.js';
 
 // Types
 
@@ -179,6 +195,8 @@ export interface RunMetrics {
   failure_class?: string;
   /** Number of lifecycle ordering violations detected post-run */
   lifecycle_violations?: number;
+  /** Lifecycle health: clean (ok) | degraded (ordering) | critical (gaps/phantoms) (#1103) */
+  lifecycle_health?: LifecycleHealth;
   /** Review battery verdict for PRs created in this run */
   review_verdict?: 'pass' | 'fail' | 'skipped';
   /** Review battery cost (USD) */
@@ -1380,44 +1398,10 @@ function printRunSummary(
   console.log('');
 }
 
-// Lifecycle validation
-
-const LIFECYCLE_ORDER = ['PICK', 'EVALUATE', 'IMPLEMENT', 'TEST', 'PR', 'MERGE', 'REFLECT'];
-const FLOATING_PHASES = new Set(['DECOMPOSE', 'STOP']);
-
-export interface LifecycleValidation {
-  valid: boolean;
-  phasesPresent: string[];
-  phasesMissing: string[];
-  violations: Array<{ phase: string; after: string }>;
-}
-
-/**
- * Validate lifecycle phase ordering from a run log file.
- * Reads the log, extracts AUTO_DENT_PHASE markers, and checks ordering.
- * Advisory only — violations are logged but don't block the batch.
- */
-export function validateRunLifecycle(logFile: string): LifecycleValidation {
-  const logContent = readFileSync(logFile, 'utf8');
-  const markers = parsePhaseMarkers(logContent);
-  const phasesPresent = markers.map(m => m.phase);
-  const orderedPhases = phasesPresent.filter(p => !FLOATING_PHASES.has(p));
-  const violations: Array<{ phase: string; after: string }> = [];
-
-  for (let i = 1; i < orderedPhases.length; i++) {
-    const prevIdx = LIFECYCLE_ORDER.indexOf(orderedPhases[i - 1]);
-    const currIdx = LIFECYCLE_ORDER.indexOf(orderedPhases[i]);
-    if (prevIdx === -1 || currIdx === -1) continue;
-    if (currIdx < prevIdx) {
-      violations.push({ phase: orderedPhases[i], after: orderedPhases[i - 1] });
-    }
-  }
-
-  const presentSet = new Set(phasesPresent);
-  const phasesMissing = LIFECYCLE_ORDER.filter(p => !presentSet.has(p));
-
-  return { valid: violations.length === 0, phasesPresent, phasesMissing, violations };
-}
+// Lifecycle validation — implementation lives in ./auto-dent-lifecycle.ts.
+// Re-exported here for back-compat (existing importers and tests reference it
+// from './auto-dent-run'). See that module for the enriched gap/phantom/health
+// detection (#1103).
 
 // Review wiring — extracted for testability (#896, #914)
 
@@ -1723,23 +1707,33 @@ async function main(): Promise<void> {
   result.reviewVerdict = reviewVerdict;
   result.reviewCostUsd = reviewCostUsd;
 
-  // Lifecycle validation (#639) — advisory, not blocking
+  // Lifecycle validation (#639, #1103) — observability + steering, never a hard
+  // block. Beyond ordering, this detects critical gaps (PR without IMPLEMENT,
+  // MERGE without PR) and phantom claims (TEST result=pass with count=0) — the
+  // "verify outcomes, not commands" category (#943, #950).
   let lifecycleViolationCount = 0;
+  let lifecycleHealth: LifecycleHealth = 'clean';
+  let lifecycleCriticalCount = 0;
+  let lifecycleSteeringNote: string | null = null;
   try {
     const lifecycle = validateRunLifecycle(logFile);
     lifecycleViolationCount = lifecycle.violations.length;
-    if (!lifecycle.valid) {
-      const details = lifecycle.violations
-        .map(v => `${v.phase} appeared after ${v.after}`)
-        .join(', ');
-      console.log(
-        `  ${color.yellow('[lifecycle]')} ${lifecycle.violations.length} violation(s): ${details}`,
-      );
-      appendFileSync(logFile, `\nlifecycle_violations=${lifecycle.violations.length}: ${details}\n`);
+    lifecycleHealth = lifecycle.health;
+    lifecycleCriticalCount = lifecycle.criticalGaps.length + lifecycle.phantomPhases.length;
+    const summary = summarizeLifecycle(lifecycle);
+    if (lifecycle.health === 'critical') {
+      // Claimed-to-ship-without-building, or claimed-green-but-ran-nothing.
+      console.log(`  ${color.red('[lifecycle]')} ${summary}`);
+      appendFileSync(logFile, `\nlifecycle_health=critical: ${summary}\n`);
+      // Steer the next run: warn the agent that this run's narrative didn't hold.
+      lifecycleSteeringNote =
+        `Prior run had a CRITICAL lifecycle problem (${summary}). ` +
+        `Do not emit PR/MERGE without a real IMPLEMENT, and never emit TEST result=pass with count=0 — run the tests.`;
+    } else if (lifecycle.health === 'degraded') {
+      console.log(`  ${color.yellow('[lifecycle]')} ${summary}`);
+      appendFileSync(logFile, `\nlifecycle_violations=${lifecycle.violations.length}: ${summary}\n`);
     } else {
-      console.log(
-        `  ${color.dim('[lifecycle]')} valid (${lifecycle.phasesPresent.join(' -> ')})`,
-      );
+      console.log(`  ${color.dim('[lifecycle]')} ${summary}`);
     }
     if (lifecycle.phasesMissing.length > 0) {
       console.log(
@@ -1801,6 +1795,8 @@ async function main(): Promise<void> {
       stop_requested: result.stopRequested,
       failure_class: result.failureClass,
       lifecycle_violations: lifecycleViolationCount,
+      lifecycle_health: lifecycleHealth,
+      lifecycle_critical: lifecycleCriticalCount,
       review_verdict: reviewVerdict,
       review_cost_usd: reviewCostUsd,
       outcome,
@@ -1936,6 +1932,7 @@ async function main(): Promise<void> {
     prompt_template: promptMeta.template,
     prompt_hash: promptMeta.hash,
     lifecycle_violations: lifecycleViolationCount,
+    lifecycle_health: lifecycleHealth,
     review_verdict: reviewVerdict,
     review_cost_usd: reviewCostUsd,
   };
@@ -1982,6 +1979,17 @@ async function main(): Promise<void> {
     const newInsights = result.reflectionInsights.filter(r => !existing.has(r));
     freshState.reflection_insights.push(...newInsights);
     console.log(`  [reflect] ${newInsights.length} new insight(s) stored (${result.reflectionInsights.length - newInsights.length} duplicates skipped)`);
+  }
+
+  // Steer the next run on a CRITICAL lifecycle problem (#1103). Observable data
+  // must steer future runs (#940) — feed the warning into the next prompt via
+  // the same reflection-insight channel, deduped.
+  if (lifecycleSteeringNote) {
+    if (!freshState.reflection_insights) freshState.reflection_insights = [];
+    if (!freshState.reflection_insights.includes(lifecycleSteeringNote)) {
+      freshState.reflection_insights.push(lifecycleSteeringNote);
+      console.log(`  ${color.red('[lifecycle]')} steering insight added for next run`);
+    }
   }
 
   if (result.prs.length > 0) {


### PR DESCRIPTION
## Once upon a time…

Auto-dent agents narrate their work with `AUTO_DENT_PHASE:` markers — PICK, EVALUATE, IMPLEMENT, TEST, PR, MERGE, REFLECT. The harness parsed them in `validateRunLifecycle()` and proudly reported a green "lifecycle valid" line. It looked like enforcement.

## Every day…

It wasn't. The check did exactly one thing — flag phases that appeared *out of order* — and trusted everything else the agent claimed. A run could emit `PR` and `MERGE` without ever emitting `IMPLEMENT` and still be "valid." A run could emit `TEST | result=pass | count=0` — claiming a green test pass while running **zero tests** — and the harness nodded along. Even the one signal it did compute (`lifecycle_violations`) terminated in a metric **nothing read**. The data was observable but steered nothing.

This is the category named by #943 and #950: *enforcement verifies command detection, not outcomes.* And it's the #940 failure mode: *observable data doesn't steer future batches.* The lifecycle layer was both.

## One day…

#1103 made it concrete: turn the lifecycle claims into a **verified, classified, steering** signal — without ever hard-blocking the unattended loop (a heuristic false-positive must not halt a batch).

## Because of that…

**Extracted** the lifecycle logic into a focused, pure module — `scripts/auto-dent-lifecycle.ts` — and taught it to sanity-check the claims against each other:

- **Critical gaps** — a required-predecessor map (`PR ⇐ IMPLEMENT`, `MERGE ⇐ PR`). A phase present without its prerequisite means the run claimed to ship without building.
- **Phantom phases** — `TEST | result=pass` with `count` missing or `0`: claimed-green-but-ran-nothing. An honest `result=fail` is *not* phantom.
- **Health classification** — `clean` → `degraded` (ordering only) → `critical` (gaps/phantoms).

**Made it steer** instead of dead-end:
- Critical findings are surfaced in **red** in the run console + log.
- `lifecycle_health` + `lifecycle_critical` now ride the `run.complete` telemetry event and `RunMetrics` — the cloud/scoring layer finally sees it.
- On `critical` health, a one-line warning is fed into the **next run's prompt** via the existing reflection-insight channel — closing the observe→steer loop (#940) for this dimension.

## Until finally…

The lifecycle signal verifies outcomes, not just order, and it changes what the next run sees. The choke point is **visibility and steering**, deliberately *not* a gate — meeting reality.

## Evidence

- New module: `scripts/auto-dent-lifecycle.ts` (pure, no I/O beyond reading the log).
- `scripts/auto-dent-lifecycle.test.ts` — 14 tests: ordering back-compat, both critical gaps, phantom across `count=0`/missing/`result=fail`, health table, one-line summary.
- Back-compat: existing `validateRunLifecycle` tests in `auto-dent-run.test.ts` pass unchanged via re-export.
- Full suite: **2654 passed, 10 skipped, 0 failures**. `npm run build` clean.

## Behaviors × Levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Ordering violation detected (back-compat) | ✅ | — | — | — | — |
| Critical gap: PR w/o IMPLEMENT, MERGE w/o PR | ✅ | — | — | — | — |
| Phantom test: pass+count0 / missing count | ✅ | — | — | — | — |
| Honest fail not flagged phantom | ✅ | — | — | — | — |
| Health classification clean/degraded/critical | ✅ | — | — | — | — |
| `lifecycle_health` on event + RunMetrics | — | ✅ build+populate | — | — | — |
| Steering note feeds next run's prompt | — | ✅ state wiring | — | — | — |
| No harness regression | — | — | ✅ full suite | — | — |

## Scope

- **In:** extraction, gap + phantom detection, health, loud surfacing, telemetry fields, steering insight, prevention tests.
- **Deferred:** hard-gating runs on lifecycle health; cross-run lifecycle-health trend analysis (belongs to #940's knowledge-layer work).

Closes #1103
Parent: #940
Refs: #943, #950, #732
