### PR TITLE
feat(hooks): outcome-verification contract + reflection-gate ref check (Closes #950)

### DIFF
--- a/docs/hooks-design.md
+++ b/docs/hooks-design.md
@@ -40,6 +40,45 @@ Gates are the primary control flow mechanism:
 
 This creates a "you must do X before you can do Y" enforcement.
 
+### Outcome Verification Contract (kaizen #950, #943)
+
+**A gate clears on a verified outcome, not on a command-shaped declaration.**
+
+The category error (#943): every gate originally fired on command *invocation*. A review
+gate cleared when it saw `gh pr create` in a tool call — not when a PR was actually created
+and reviewed. An agent could satisfy a gate by issuing the gated command in a context where
+it fails silently, or by emitting a declaration whose claimed effect never happened. This is
+how #843 shipped 25 PRs with zero review: the gate detected the command, not the outcome.
+
+**The contract:** every clearing path declares the *outcome predicate* it verifies, and
+checks it before clearing. Verification has three results, and the fail direction matters:
+
+| Result | Meaning | Gate behavior |
+|--------|---------|---------------|
+| `exists` / verified | the claimed effect is real | **clear** |
+| `missing` / refuted | tool resolved cleanly, effect absent | **fail closed** — keep the gate |
+| `unverifiable` | parse failure, no target, network/auth error | **fail open** — clear, but log |
+
+Fail-open on `unverifiable` is deliberate: a flaky network must never deadlock an autonomous
+run. Fail-closed on a *definitive* refutation is the whole point — a fabricated outcome
+cannot clear the gate. Make the predicate injectable so tests exercise all three results
+without a live network (see `pr-kaizen-clear.ts`'s `verifyRef` option and
+`src/hooks/lib/issue-ref-verifier.ts`).
+
+#### Gate audit — outcome verification status
+
+| Gate (file) | Trigger | Outcome predicate | Status |
+|-------------|---------|-------------------|:------:|
+| `pr-review-loop.ts` | `gh pr diff` for a round | review **sentinel** written by `store-review-summary` (findings stored) — `gh pr diff` alone does not clear (#920) | ✅ verifies outcome |
+| `bump-plugin-version.ts` | `gh pr create` | manifest version is incremented vs `main` (auto-bumps + pushes if not — guarantees the effect) | ✅ ensures outcome |
+| `pr-kaizen-clear.ts` | `KAIZEN_IMPEDIMENTS` | JSON validates **and** every `filed`/`incident` `ref` resolves to a real issue/PR (#950) | ✅ verifies outcome |
+| `enforce-plan-stored.ts` | Edit/Write/`gh pr create` | a plan attachment exists on `git config kaizen.issue` (checked via the Case FE, not command text) | ✅ verifies outcome |
+| `pre-push.ts` | `git push` | reads real git state (merged-branch / remote ref); content-level, not command-string | ✅ verifies outcome |
+| `check-dirty-files.ts` | `gh pr create` | per-file `git diff --quiet HEAD` content check (#1073), not stat | ✅ verifies outcome |
+
+When adding a gate, fill in its row. A gate that only matches a command string and has no
+outcome predicate is the #943 anti-pattern — name the effect it should verify and check it.
+
 ### Kaizen Reflection Flow (kaizen #794)
 
 The reflection gate uses the gate pattern with a subagent for automated issue filing:

--- a/src/hooks/lib/issue-ref-verifier.test.ts
+++ b/src/hooks/lib/issue-ref-verifier.test.ts
@@ -1,0 +1,121 @@
+/**
+ * issue-ref-verifier.test.ts — unit tests for the outcome-verification predicate
+ * that backs the reflection gate (kaizen #950 / #943).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseIssueRef,
+  verifyIssueRef,
+  type GhRunner,
+} from './issue-ref-verifier.js';
+
+describe('parseIssueRef', () => {
+  it('parses bare #N', () => {
+    expect(parseIssueRef('#123')).toEqual({ number: 123 });
+  });
+  it('parses bare N', () => {
+    expect(parseIssueRef('456')).toEqual({ number: 456 });
+  });
+  it('parses owner/repo#N', () => {
+    expect(parseIssueRef('Garsson-io/kaizen#789')).toEqual({
+      repo: 'Garsson-io/kaizen',
+      number: 789,
+    });
+  });
+  it('parses a full issues URL', () => {
+    expect(
+      parseIssueRef('https://github.com/Garsson-io/kaizen/issues/950'),
+    ).toEqual({ repo: 'Garsson-io/kaizen', number: 950 });
+  });
+  it('parses a full pull URL', () => {
+    expect(
+      parseIssueRef('https://github.com/owner/repo/pull/42'),
+    ).toEqual({ repo: 'owner/repo', number: 42 });
+  });
+  it('tolerates trailing text after #N', () => {
+    expect(parseIssueRef('#321 (filed)')).toEqual({ number: 321 });
+  });
+  it('returns null when there is no number', () => {
+    expect(parseIssueRef('not a ref')).toBeNull();
+    expect(parseIssueRef('')).toBeNull();
+  });
+});
+
+// A runner factory: maps "repo#number" lookups to a canned result.
+function runnerFor(
+  existing: Set<string>,
+  opts: { infraError?: boolean } = {},
+): GhRunner {
+  return (args: string[]) => {
+    if (opts.infraError) {
+      return { status: 1, stdout: '', stderr: 'error connecting to api.github.com' };
+    }
+    // args: ['issue'|'pr', 'view', '<n>', '--repo', '<repo>', '--json', ...]
+    const sub = args[0];
+    const num = args[2];
+    const repoIdx = args.indexOf('--repo');
+    const repo = repoIdx >= 0 ? args[repoIdx + 1] : '';
+    const key = `${sub}:${repo}#${num}`;
+    if (existing.has(key)) return { status: 0, stdout: '{"number":' + num + '}', stderr: '' };
+    return {
+      status: 1,
+      stdout: '',
+      stderr: `GraphQL: Could not resolve to an Issue with the number of ${num}. (repository.issue)`,
+    };
+  };
+}
+
+describe('verifyIssueRef', () => {
+  it('returns "exists" when the issue exists in a candidate repo', () => {
+    const runner = runnerFor(new Set(['issue:Garsson-io/kaizen#123']));
+    expect(verifyIssueRef('#123', ['Garsson-io/kaizen'], runner)).toBe('exists');
+  });
+
+  it('returns "exists" when the ref is a PR (not an issue) in the repo', () => {
+    const runner = runnerFor(new Set(['pr:Garsson-io/kaizen#42']));
+    expect(verifyIssueRef('#42', ['Garsson-io/kaizen'], runner)).toBe('exists');
+  });
+
+  it('returns "missing" when the number resolves to nothing in any candidate repo', () => {
+    const runner = runnerFor(new Set()); // nothing exists
+    expect(verifyIssueRef('#9999', ['Garsson-io/kaizen'], runner)).toBe('missing');
+  });
+
+  it('finds the issue in a secondary candidate repo (host mode)', () => {
+    const runner = runnerFor(new Set(['issue:host/app#5']));
+    expect(
+      verifyIssueRef('#5', ['Garsson-io/kaizen', 'host/app'], runner),
+    ).toBe('exists');
+  });
+
+  it('prefers the repo embedded in a full URL over candidates', () => {
+    const runner = runnerFor(new Set(['issue:explicit/repo#7']));
+    expect(
+      verifyIssueRef(
+        'https://github.com/explicit/repo/issues/7',
+        ['Garsson-io/kaizen'],
+        runner,
+      ),
+    ).toBe('exists');
+  });
+
+  it('returns "unverifiable" on infra/network error (fail-open)', () => {
+    const runner = runnerFor(new Set(), { infraError: true });
+    expect(verifyIssueRef('#123', ['Garsson-io/kaizen'], runner)).toBe(
+      'unverifiable',
+    );
+  });
+
+  it('returns "unverifiable" when the ref cannot be parsed', () => {
+    const runner = runnerFor(new Set());
+    expect(verifyIssueRef('garbage', ['Garsson-io/kaizen'], runner)).toBe(
+      'unverifiable',
+    );
+  });
+
+  it('returns "unverifiable" when there are no candidate repos and no URL', () => {
+    const runner = runnerFor(new Set());
+    expect(verifyIssueRef('#123', [], runner)).toBe('unverifiable');
+  });
+});

--- a/src/hooks/lib/issue-ref-verifier.ts
+++ b/src/hooks/lib/issue-ref-verifier.ts
@@ -1,0 +1,126 @@
+/**
+ * issue-ref-verifier.ts — Outcome-verification predicate for issue/PR references.
+ *
+ * Part of the Outcome Verification Contract (docs/hooks-design.md): a clearing
+ * gate must verify the *outcome* a declaration claims, not merely that the
+ * declaration was made. The reflection gate (pr-kaizen-clear.ts) accepts
+ * `{"disposition":"filed","ref":"#N"}` to clear — this module checks that `#N`
+ * actually exists, so a fabricated ref cannot clear the gate (kaizen #950, #943).
+ *
+ * Design (meet reality):
+ *   - exists       → the referenced issue/PR resolves in a candidate repo.
+ *   - missing      → gh resolved cleanly but the number does not exist anywhere
+ *                    we looked. The gate fails CLOSED on this.
+ *   - unverifiable → we could not get a definitive answer (parse failure, no
+ *                    candidate repo, network/auth error). The gate fails OPEN —
+ *                    a flaky network must never deadlock a run.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+export type RefStatus = 'exists' | 'missing' | 'unverifiable';
+
+export interface ParsedRef {
+  /** owner/repo if the ref carried one (URL or owner/repo#N form). */
+  repo?: string;
+  number: number;
+}
+
+export type GhRunner = (args: string[]) => {
+  status: number;
+  stdout: string;
+  stderr: string;
+};
+
+const defaultRunner: GhRunner = (args) => {
+  const r = spawnSync('gh', args, {
+    encoding: 'utf8',
+    timeout: 15_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    status: r.status ?? 1,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  };
+};
+
+/**
+ * Parse an issue/PR reference. Accepts: a full github URL, `owner/repo#N`,
+ * `#N`, or a bare number (optionally followed by other text). Returns null
+ * when no issue number can be found.
+ */
+export function parseIssueRef(ref: string): ParsedRef | null {
+  const trimmed = (ref ?? '').trim();
+  if (!trimmed) return null;
+
+  const urlMatch = trimmed.match(
+    /github\.com\/([^/\s]+\/[^/\s]+)\/(?:issues|pull)\/(\d+)/,
+  );
+  if (urlMatch) {
+    return { repo: urlMatch[1], number: parseInt(urlMatch[2], 10) };
+  }
+
+  const ownerRepoHash = trimmed.match(/^([^/\s]+\/[^/\s#]+)#(\d+)\b/);
+  if (ownerRepoHash) {
+    return { repo: ownerRepoHash[1], number: parseInt(ownerRepoHash[2], 10) };
+  }
+
+  const numMatch = trimmed.match(/^#?(\d+)\b/);
+  if (numMatch) {
+    return { number: parseInt(numMatch[1], 10) };
+  }
+
+  return null;
+}
+
+/** True when stderr indicates gh resolved cleanly but found no such issue/PR. */
+function isDefinitiveNotFound(stderr: string): boolean {
+  const s = stderr.toLowerCase();
+  return (
+    s.includes('could not resolve to') ||
+    s.includes('no issue found') ||
+    s.includes('no pull request found') ||
+    s.includes('not found')
+  );
+}
+
+/**
+ * Verify that `ref` points to an issue or PR that exists.
+ *
+ * If the ref embeds a repo (URL / owner-repo form) that repo is authoritative;
+ * otherwise every repo in `candidateRepos` is tried (covers self-dogfood where
+ * issues.repo == host repo, and host mode where meta-kaizen issues live in the
+ * kaizen repo). A number that is a PR rather than an issue still counts as
+ * `exists` — refs legitimately point at PRs.
+ */
+export function verifyIssueRef(
+  ref: string,
+  candidateRepos: string[],
+  runner: GhRunner = defaultRunner,
+): RefStatus {
+  const parsed = parseIssueRef(ref);
+  if (!parsed) return 'unverifiable';
+
+  const repos = parsed.repo
+    ? [parsed.repo]
+    : candidateRepos.filter((r) => !!r);
+  if (repos.length === 0) return 'unverifiable';
+
+  const num = String(parsed.number);
+  let sawDefinitiveMissing = false;
+
+  for (const repo of repos) {
+    for (const kind of ['issue', 'pr'] as const) {
+      const r = runner([kind, 'view', num, '--repo', repo, '--json', 'number']);
+      if (r.status === 0) return 'exists';
+      if (!isDefinitiveNotFound(r.stderr)) {
+        // Network / auth / unexpected error — cannot conclude. Fail open.
+        return 'unverifiable';
+      }
+      sawDefinitiveMissing = true;
+    }
+  }
+
+  return sawDefinitiveMissing ? 'missing' : 'unverifiable';
+}

--- a/src/hooks/pr-kaizen-clear-outcome.test.ts
+++ b/src/hooks/pr-kaizen-clear-outcome.test.ts
@@ -1,0 +1,135 @@
+/**
+ * pr-kaizen-clear-outcome.test.ts — Categorical prevention test for the
+ * Outcome Verification Contract (kaizen #950, #943, #921's 3-case spec).
+ *
+ * The reflection gate must clear on a *verified outcome*, not on a
+ * command-shaped declaration. A "filed"/"incident" disposition whose ref does
+ * not resolve to a real issue/PR must NOT clear the gate.
+ *
+ *   1. trigger + real outcome (ref exists)        → gate clears
+ *   2. trigger + fabricated outcome (ref missing) → gate stays, clear message
+ *   3. trigger + infra error (unverifiable)       → fail open, gate clears
+ *   4. no trigger                                 → state unchanged
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { processHookInput } from './pr-kaizen-clear.js';
+import type { RefStatus } from './lib/issue-ref-verifier.js';
+
+function stateExists(stateDir: string): boolean {
+  return fs
+    .readdirSync(stateDir)
+    .some((f) =>
+      fs
+        .readFileSync(path.join(stateDir, f), 'utf-8')
+        .includes('STATUS=needs_pr_kaizen'),
+    );
+}
+
+describe('processHookInput: outcome verification (kaizen #950)', () => {
+  let stateDir: string;
+  let auditDir: string;
+
+  const filed = (ref: string) =>
+    `KAIZEN_IMPEDIMENTS: [{"impediment":"real bug","disposition":"filed","ref":"${ref}"}]`;
+
+  const inputFor = (ref: string) => ({
+    tool_name: 'Bash',
+    tool_input: { command: `echo '${filed(ref)}'` },
+    tool_response: { stdout: filed(ref), exit_code: 0 },
+  });
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kz-outcome-'));
+    auditDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kz-outcome-audit-'));
+    process.env.AUDIT_DIR = auditDir;
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf-8',
+    }).trim();
+    fs.writeFileSync(
+      path.join(stateDir, 'pr-kaizen-Garsson-io_kaizen_42'),
+      `PR_URL=https://github.com/Garsson-io/kaizen/pull/42\nSTATUS=needs_pr_kaizen\nBRANCH=${branch}\n`,
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    fs.rmSync(auditDir, { recursive: true, force: true });
+    delete process.env.AUDIT_DIR;
+  });
+
+  it('CASE 1: ref that exists → gate clears', () => {
+    const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'exists');
+    const result = processHookInput(inputFor('#950'), {
+      stateDir,
+      verifyRef,
+      postComment: () => {},
+    });
+    expect(verifyRef).toHaveBeenCalledWith('#950');
+    expect(result).toContain('PR kaizen gate cleared');
+    expect(stateExists(stateDir)).toBe(false);
+  });
+
+  it('CASE 2: fabricated ref (missing) → gate stays, explains why', () => {
+    const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'missing');
+    const result = processHookInput(inputFor('#99999'), {
+      stateDir,
+      verifyRef,
+      postComment: () => {},
+    });
+    expect(result).toContain('Outcome verification failed');
+    expect(result).toContain('#99999');
+    // Gate must NOT have cleared.
+    expect(stateExists(stateDir)).toBe(true);
+    // And the rejection is audited.
+    const log = fs.readFileSync(path.join(auditDir, 'no-action.log'), 'utf-8');
+    expect(log).toContain('unverified-ref');
+  });
+
+  it('CASE 3: unverifiable (infra/network) → fail open, gate clears', () => {
+    const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'unverifiable');
+    const result = processHookInput(inputFor('#950'), {
+      stateDir,
+      verifyRef,
+      postComment: () => {},
+    });
+    expect(result).toContain('PR kaizen gate cleared');
+    expect(stateExists(stateDir)).toBe(false);
+  });
+
+  it('CASE 4: no impediment trigger → state unchanged', () => {
+    const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'missing');
+    const result = processHookInput(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: `echo "hello world"` },
+        tool_response: { stdout: 'hello world', exit_code: 0 },
+      },
+      { stateDir, verifyRef, postComment: () => {} },
+    );
+    expect(result).toBeNull();
+    expect(verifyRef).not.toHaveBeenCalled();
+    expect(stateExists(stateDir)).toBe(true);
+  });
+
+  it('does not block when the failed-to-resolve item is no-action (no ref to verify)', () => {
+    const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'missing');
+    const cmd =
+      'KAIZEN_IMPEDIMENTS: [{"type":"positive","impediment":"smooth run","disposition":"no-action","reason":"genuinely frictionless, well-scoped 30-line change"}]';
+    const result = processHookInput(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: `echo '${cmd}'` },
+        tool_response: { stdout: cmd, exit_code: 0 },
+      },
+      { stateDir, verifyRef, postComment: () => {} },
+    );
+    expect(verifyRef).not.toHaveBeenCalled();
+    expect(result).toContain('PR kaizen gate cleared');
+    expect(stateExists(stateDir)).toBe(false);
+  });
+});

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -16,10 +16,12 @@
  */
 
 import { execSync } from 'node:child_process';
-import { appendFileSync, mkdirSync } from 'node:fs';
+import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
+import { verifyIssueRef, type RefStatus } from './lib/issue-ref-verifier.js';
+import { resolveProjectRoot } from '../lib/resolve-project-root.js';
 import { stripHeredocBody } from './parse-command.js';
 import {
   buildReflectionRecord,
@@ -101,6 +103,29 @@ const POSITIVE_DISPOSITIONS = new Set([
   'no-action',
 ]);
 const STANDARD_DISPOSITIONS = new Set(['filed', 'incident', 'fixed-in-pr']);
+
+// ── Outcome verification (kaizen #950, #943) ─────────────────────────
+// A "filed"/"incident" disposition is only honored if its ref points to a
+// real issue/PR. Candidate repos: the PR's own repo plus whatever the host
+// config declares (self-dogfood → one repo; host mode → host + kaizen repo).
+
+function getCandidateRepos(gatePrUrl: string): string[] {
+  const repos: string[] = [];
+  const prRepo = gatePrUrl?.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
+  if (prRepo) repos.push(prRepo);
+  try {
+    const root = resolveProjectRoot(process.cwd());
+    const cfg = JSON.parse(
+      readFileSync(join(root, 'kaizen.config.json'), 'utf-8'),
+    );
+    for (const r of [cfg?.issues?.repo, cfg?.host?.repo, cfg?.kaizen?.repo]) {
+      if (typeof r === 'string' && r) repos.push(r);
+    }
+  } catch {
+    // No config / unreadable → fall back to whatever the PR URL gave us.
+  }
+  return [...new Set(repos)];
+}
 
 function validateImpediments(items: Impediment[]): string[] {
   const errors: string[] = [];
@@ -454,6 +479,8 @@ export function processHookInput(
     stateDir?: string;
     postComment?: (prUrl: string, comment: string) => void;
     getPrFiles?: (prUrl: string) => string[];
+    /** Outcome predicate for filed/incident refs (injected in tests). */
+    verifyRef?: (ref: string) => RefStatus;
   } = {},
 ): string | null {
   if (input.tool_name !== 'Bash') return null;
@@ -601,6 +628,39 @@ export function processHookInput(
     shouldClear = true;
     isNoAction = true;
     clearReason = `no action needed [${noAction.category}]: ${noAction.reason}`;
+  }
+
+  // ── Outcome verification (kaizen #950, #943) ──────────────────
+  // Before clearing, confirm every "filed"/"incident" ref points to a real
+  // issue/PR. A fabricated ref (e.g. {"disposition":"filed","ref":"#9999"})
+  // declares an outcome that never happened — the gate must NOT clear on it.
+  // Network/parse failures return 'unverifiable' → fail open (never deadlock
+  // a run on a flaky network).
+  if (shouldClear && validatedItems.length > 0) {
+    const verifyRef =
+      options.verifyRef ??
+      ((ref: string) => verifyIssueRef(ref, getCandidateRepos(gatePrUrl)));
+    const missingRefs: string[] = [];
+    for (const item of validatedItems) {
+      if (
+        (item.disposition === 'filed' || item.disposition === 'incident') &&
+        item.ref &&
+        verifyRef(item.ref) === 'missing'
+      ) {
+        const desc = item.impediment || item.finding || 'impediment';
+        missingRefs.push(`${item.ref} (${desc})`);
+      }
+    }
+    if (missingRefs.length > 0) {
+      logNoAction('unverified-ref', missingRefs.join('; '), gatePrUrl);
+      return (
+        '\nKAIZEN_IMPEDIMENTS: Outcome verification failed.\n' +
+        'These "filed"/"incident" refs do not resolve to a real issue or PR:\n' +
+        missingRefs.map((m) => `  - ${m}`).join('\n') +
+        '\n\nFile the issue for real (or correct the ref), then resubmit.\n' +
+        '(A gate clears on the verified outcome, not the declaration — kaizen #950.)\n'
+      );
+    }
   }
 
   // ── Clear gate ─────────────────────────────────────────────────


### PR DESCRIPTION
## The Problem

Kaizen's enforcement gates were built to fire on **command invocation, not verified outcome** (#943). The reflection gate (`pr-kaizen-clear`) is a textbook case: it accepts a structured impediment declaration like

```json
[{"impediment":"flaky test","disposition":"filed","ref":"#9999"}]
```

and clears. It validated the JSON shape and required a `ref` string — but **never checked that `#9999` actually exists**. An agent (or a confused autonomous run) could fabricate a ref and satisfy the gate without ever filing anything. This is the same failure class that let #843 ship 25 PRs with *zero* review: the gate saw the command, not the effect.

## The Discovery

A deep-dive across the auto-dent ↔ hooks cluster (#950, #943, #843, #954) found the category was only **half-closed**. Outcome verification had been applied surgically to the review gate (#920 sentinel) and the version-bump gate, but:

1. **No gate audit existed** — nothing classified which gates verify outcomes vs. just detect commands (#950 DoD #1, unbuilt).
2. **No documented contract** for the pattern in `docs/hooks-design.md` (DoD #3, unbuilt).
3. **One category-(b) gate remained**: the reflection gate's `filed`/`incident` ref was presence-checked but never existence-checked.

(Orthogonal to PR #1104 / #1103, which verifies *harness-layer phase claims* — this PR is the *hook-layer* gate predicate.)

## The Solution

**A reusable outcome predicate + the missing contract.**

- **`src/hooks/lib/issue-ref-verifier.ts`** — `parseIssueRef` (`#N` / `N` / `owner/repo#N` / full URL) and `verifyIssueRef` returning `exists | missing | unverifiable` via an **injectable** gh runner.
- **`pr-kaizen-clear`** now verifies every `filed`/`incident` ref before clearing, on both the `KAIZEN_IMPEDIMENTS` and `KAIZEN_BG_RESULTS` paths. Wired through a new `verifyRef` option (same injection seam as `postComment`/`getPrFiles`).
- The fail direction is deliberate — **meet reality**:
  - `missing` (gh resolved cleanly, issue absent everywhere) → **fail closed**, gate stays.
  - `unverifiable` (parse failure / no candidate repo / network/auth error) → **fail open**, gate clears + audit log. A flaky network must never deadlock an autonomous run.
- **`docs/hooks-design.md`** gains the **Outcome Verification Contract** section + a **gate audit table** classifying every gate's outcome predicate. New gates fill in their row; a gate with no predicate is the named anti-pattern.

## The Evidence

```
src/hooks/lib/issue-ref-verifier.test.ts ... 15 passed
src/hooks/pr-kaizen-clear-outcome.test.ts ... 5 passed   (#921's 3-case spec)
src/hooks/pr-kaizen-clear{,.seams,.fallback}.test.ts ... 110 passed (regression)
npm run build (tsc) ... clean
```

Categorical prevention test (#921 spec): real ref → clears · fabricated ref → stays blocked with a clear message · infra error → fails open · no trigger → unchanged · no-action item (no ref) → not verified.

## Impact

The reflection gate now clears on a **verified outcome**, not a command-shaped claim — closing the last command-only predicate in the reflection path and turning #950's audit + contract from unbuilt deliverables into living documentation the next gate author must extend.

## Test plan (behaviors × levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| parseIssueRef (#N/N/url/garbage) | ✅ | | | | |
| verifyIssueRef exists/missing/unverifiable | ✅ | | | | |
| filed ref exists → clears | | ✅ | | | |
| fabricated ref → stays + message | | ✅ | | | |
| infra error → fail-open | | ✅ | | | |
| no trigger / no-action → unchanged | | ✅ | | | |
| existing gate behavior (regression) | ✅ | ✅ | | | |

Live network is not exercised in CI — the runner is injected; fail-open keeps existing un-injected tests green regardless of gh auth state.

Run-tag: sticky-lark/run-1

Closes #950
Refs #943, #843, #954
