### PR TITLE
test(ci): wire orphaned auto-dent shell tests into CI + orphan guard (Closes #806)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       - run: npm run build
       - name: Run shell hook tests
         run: bash .claude/hooks/tests/run-all-tests.sh
+      - name: Run script-level shell tests (auto-dent batch-state logic, #806)
+        run: npm run test:shell
       - name: Verify no test side-effects on repo files
         run: |
           DIRTY=$(git status --porcelain)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:e2e:live": "KAIZEN_LIVE_TEST=1 timeout --kill-after=10 120 vitest run src/e2e/",
     "test:e2e:skills": "KAIZEN_SKILL_TEST=1 timeout --kill-after=10 180 vitest run src/e2e/skill-change.test.ts",
     "test:hooks": "bash .claude/hooks/tests/run-all-tests.sh",
+    "test:shell": "bash scripts/auto-dent.test.sh",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/scripts/shell-tests-wired.test.ts
+++ b/scripts/shell-tests-wired.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, basename } from 'node:path';
+
+/**
+ * Category-prevention test for #806.
+ *
+ * A shell test file (`*.test.sh`) that lives in the repo but is wired into no
+ * runner silently rots: it passes locally, never runs in CI, and the code it
+ * guards drifts unprotected. `scripts/auto-dent.test.sh` (66 tests over the
+ * batch-state logic in `auto-dent-lib.sh`) was exactly this — added in
+ * 14887d7 for #595/#748, referenced nowhere.
+ *
+ * This test fails if ANY tracked `*.test.sh` is not reachable from a CI
+ * runner surface, so the next orphaned shell test is caught the moment it
+ * lands rather than years later.
+ */
+
+const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  encoding: 'utf8',
+}).trim();
+
+/** All tracked `*.test.sh` files, repo-relative. */
+function trackedShellTests(): string[] {
+  const out = execFileSync('git', ['ls-files', '*.test.sh'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return out.split('\n').filter((l) => l.trim().length > 0);
+}
+
+/** Concatenated text of every CI workflow yml + package.json. */
+function runnerSurfaceText(): string {
+  const parts: string[] = [];
+  const pkg = join(repoRoot, 'package.json');
+  if (existsSync(pkg)) parts.push(readFileSync(pkg, 'utf8'));
+  const wfDir = join(repoRoot, '.github', 'workflows');
+  if (existsSync(wfDir)) {
+    for (const f of readdirSync(wfDir)) {
+      if (f.endsWith('.yml') || f.endsWith('.yaml')) {
+        parts.push(readFileSync(join(wfDir, f), 'utf8'));
+      }
+    }
+  }
+  return parts.join('\n');
+}
+
+/**
+ * A shell test is "wired" when a CI runner can reach it. Either:
+ *  (a) it is auto-discovered by `run-all-tests.sh` — it lives in
+ *      `.claude/hooks/tests/` and matches the `test-*.sh` glob — and that
+ *      runner is itself invoked by ci.yml; or
+ *  (b) its basename is referenced by name on a runner surface (package.json
+ *      script or a workflow yml), i.e. it is explicitly plumbed in.
+ */
+function isWired(relPath: string, surface: string): boolean {
+  const base = basename(relPath);
+  const autoDiscovered =
+    relPath.startsWith('.claude/hooks/tests/') && base.startsWith('test-');
+  return autoDiscovered || surface.includes(base);
+}
+
+describe('shell tests are wired into CI (#806)', () => {
+  it('every tracked *.test.sh is reachable from a CI runner', () => {
+    const surface = runnerSurfaceText();
+    const orphans = trackedShellTests().filter((p) => !isWired(p, surface));
+    expect(
+      orphans,
+      `Orphaned shell test(s) — written but wired into no CI runner, so they ` +
+        `silently rot (#806). Add them to package.json scripts or a CI ` +
+        `workflow, or place them under .claude/hooks/tests/ as test-*.sh:\n  ` +
+        orphans.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('finds shell tests to check (guards against a vacuous pass)', () => {
+    // If git ls-files ever returns nothing, the orphan check above is
+    // trivially satisfied and proves nothing. Pin a non-empty expectation.
+    expect(trackedShellTests().length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## The Problem

Kaizen's mandate is to make auto-dent *stronger* — yet the 66 tests that guard auto-dent's own batch-state logic had quietly stopped mattering. `scripts/auto-dent.test.sh` exercises every function in `auto-dent-lib.sh` (`ad_read_state`, `ad_update_state`, `ad_init_state`, `ad_check_max_runs`, `ad_check_consecutive_failures`, `ad_check_budget`, `ad_check_halt_file`, `ad_parse_args`) — the 235 lines that decide when a batch halts, how many runs it gets, and how budget is enforced.

It passed locally. It ran in CI **never**.

## The Discovery

Issue #806 framed it as "extracted for testability but never tested." Digging in, the test file *does* exist and *does* pass — so what's wrong? The wiring:

- `package.json` `test` runs `vitest run` — ignores `.test.sh`.
- `npm run test:hooks` → `run-all-tests.sh` — auto-discovers only `.claude/hooks/tests/test-*.sh`.
- No CI workflow references it.
- `grep -rl auto-dent.test.sh` → the file references only itself.

It was added in `14887d7` (#595/#748) and orphaned on arrival. A test that runs nowhere can't fail, so the batch-state logic it covers has been drifting unprotected ever since — the exact "half-finished feature" pattern this run was sent to close.

## The Fix

Two moves — the concrete one, and the compound one.

**Concrete (closes #806):**
- `package.json`: `"test:shell": "bash scripts/auto-dent.test.sh"`
- `ci.yml`: a `npm run test:shell` step in the existing `shell-tests` job — so the 66 tests now gate every push, ahead of the `#448` side-effect guard.

**Compound (prevents the category):**
- `scripts/shell-tests-wired.test.ts` — a vitest guard that enumerates every tracked `*.test.sh` and fails if any is unreachable from a CI runner surface (auto-discovered as `.claude/hooks/tests/test-*.sh`, or named in `package.json` / a workflow yml). The next orphaned shell test is caught at land time instead of years later. A second assertion pins the enumeration non-empty so the guard can never pass vacuously.

## The Evidence

- TDD: the guard **failed first**, naming `scripts/auto-dent.test.sh` as the sole orphan; **passes after** the wiring.
- `npm run test:shell` → **66 passed, 0 failed**.
- `npm test` → **2662 passed, 10 skipped** (new guard included).
- `npm run typecheck` clean; `ci.yml` validates as YAML; `test:shell` leaves zero repo side-effects (verified against the `#448` guard that runs immediately after it).

## Impact

auto-dent's batch-state logic is now CI-protected, and the orphaned-test category is closed mechanically (L2): you cannot land a `*.test.sh` that runs nowhere without the suite going red. One stale test wired in; the next ten can't go stale silently.

Closes #806
Refs #937 (already resolved — assertions migrated to `AUTO_DENT_PHASE: STOP`; closing as backlog hygiene)

Run tag: sticky-lark/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
