### PR TITLE
feat(auto-dent): durable machine-readable batch-outcome attachment (Closes #1108, #940 Phase 1)

### DIFF
--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -38,6 +38,7 @@ import {
 import { EventEmitter, makeRunId, type AutoDentEvent } from './auto-dent-events.js';
 import { runFixLoop, type CliArgs as ReviewFixArgs } from './review-fix.js';
 import { buildRunManifest, writeRunManifest, bundleArtifacts, formatManifestSummary } from './auto-dent-artifacts.js';
+import { buildBatchOutcome, writeBatchOutcomeAttachment } from './batch-outcome.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -1100,6 +1101,19 @@ export function closeBatchProgressIssue(
   ghExec(
     `gh issue comment ${m[1]} --repo ${kaizenRepo} --body ${JSON.stringify(summary)}`,
   );
+
+  // Durable cross-batch learning (#1108, #940 Phase 1): write a machine-readable
+  // batch-outcome attachment BEFORE closing, so future batches can read back what
+  // this batch measured instead of starting blind. Best-effort — a failed write
+  // must never block batch close (this runs on abnormal exits too).
+  try {
+    const outcome = buildBatchOutcome(state, batchScore, Math.floor(Date.now() / 1000));
+    writeBatchOutcomeAttachment(m[1], kaizenRepo, outcome);
+    console.log(`  [intelligence] stored batch-outcome attachment on #${m[1]}`);
+  } catch (err) {
+    console.log(`  [intelligence] batch-outcome write skipped: ${(err as Error).message}`);
+  }
+
   ghExec(`gh issue close ${m[1]} --repo ${kaizenRepo} --reason completed`);
   console.log(`  [hygiene] closed batch progress issue`);
 }

--- a/scripts/batch-outcome.test.ts
+++ b/scripts/batch-outcome.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  buildBatchOutcome,
+  writeBatchOutcomeAttachment,
+  readBatchOutcome,
+  BatchOutcomeSchema,
+  BATCH_OUTCOME_ATTACHMENT,
+  BATCH_OUTCOME_SCHEMA_VERSION,
+} from './batch-outcome.js';
+import { clearCommentCache } from '../src/section-editor.js';
+import type { BatchState } from './auto-dent-run.js';
+import type { BatchScore } from './auto-dent-score.js';
+
+vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }));
+const mockGh = vi.mocked(spawnSync);
+function ghReturns(stdout: string) {
+  mockGh.mockReturnValueOnce({ status: 0, stdout, stderr: '', signal: null, pid: 0, output: [null, stdout, ''] } as any);
+}
+
+// Minimal but realistic fixtures ------------------------------------------------
+
+function makeState(overrides: Partial<BatchState> = {}): BatchState {
+  return {
+    batch_id: 'sticky-lark',
+    batch_start: 1_000,
+    guidance: 'bring half-written features to a good place',
+    max_runs: 0,
+    cooldown: 30,
+    budget: '',
+    max_failures: 3,
+    kaizen_repo: 'Garsson-io/kaizen',
+    host_repo: 'Garsson-io/kaizen',
+    run: 3,
+    prs: ['https://github.com/Garsson-io/kaizen/pull/1108'],
+    issues_filed: ['#1108'],
+    issues_closed: ['#940'],
+    cases: [],
+    consecutive_failures: 0,
+    current_cooldown: 30,
+    stop_reason: '',
+    last_issue: '',
+    last_pr: '',
+    last_case: '',
+    last_branch: '',
+    last_worktree: '',
+    ...overrides,
+  };
+}
+
+function makeScore(overrides: Partial<BatchScore> = {}): BatchScore {
+  return {
+    total_runs: 3,
+    successful_runs: 2,
+    success_rate: 2 / 3,
+    total_cost_usd: 4.5,
+    total_prs: 1,
+    total_issues_closed: 1,
+    total_duration_seconds: 600,
+    total_lines_deleted: 10,
+    total_issues_pruned: 0,
+    avg_cost_per_success: 2.25,
+    avg_duration_seconds: 200,
+    overall_efficiency: 1 / 4.5,
+    runs: [],
+    mode_breakdown: [
+      { mode: 'exploit', runs: 2, successes: 2, success_rate: 1, cost_usd: 3, prs: 1, avg_cost: 1.5, efficiency: 0.33, lines_deleted: 10, issues_pruned: 0 },
+    ],
+    cost_anomaly_count: 0,
+    mode_diversity: 0,
+    trend: null,
+    review_fail_count: 0,
+    review_fail_rate: 0,
+    review_total_cost_usd: 0,
+    ...overrides,
+  };
+}
+
+describe('buildBatchOutcome — pure derivation', () => {
+  it('maps state + score into a schema-valid outcome', () => {
+    const outcome = buildBatchOutcome(makeState(), makeScore(), 1_600);
+    // Must parse against the schema readers use.
+    expect(() => BatchOutcomeSchema.parse(outcome)).not.toThrow();
+    expect(outcome.schema_version).toBe(BATCH_OUTCOME_SCHEMA_VERSION);
+    expect(outcome.batch_id).toBe('sticky-lark');
+    expect(outcome.wall_seconds).toBe(600); // 1600 - 1000
+    expect(outcome.totals.prs).toBe(1);
+    expect(outcome.totals.issues_filed).toBe(1);
+    expect(outcome.totals.cost_usd).toBeCloseTo(4.5);
+    expect(outcome.mode_breakdown[0].mode).toBe('exploit');
+    expect(outcome.prs).toEqual(['https://github.com/Garsson-io/kaizen/pull/1108']);
+  });
+
+  it('defaults stop_reason to "completed" when blank', () => {
+    expect(buildBatchOutcome(makeState({ stop_reason: '' }), makeScore(), 1_600).stop_reason).toBe('completed');
+  });
+
+  it('preserves an abnormal stop_reason (budget exhausted)', () => {
+    const outcome = buildBatchOutcome(makeState({ stop_reason: 'budget_exhausted' }), makeScore(), 1_600);
+    expect(outcome.stop_reason).toBe('budget_exhausted');
+  });
+
+  it('normalizes non-finite derived numbers so the result is schema-valid and JSON-clean', () => {
+    // No successes: avg_cost_per_success = NaN, overall_efficiency = Infinity upstream.
+    const score = makeScore({ successful_runs: 0, avg_cost_per_success: NaN, overall_efficiency: Infinity, total_cost_usd: NaN });
+    const outcome = buildBatchOutcome(makeState({ stop_reason: 'failed' }), score, 1_600);
+    expect(() => BatchOutcomeSchema.parse(outcome)).not.toThrow();
+    expect(outcome.avg_cost_per_success).toBeNull();
+    expect(outcome.overall_efficiency).toBe(0);
+    expect(outcome.totals.cost_usd).toBe(0);
+    // And it survives a JSON roundtrip (no NaN/Infinity tokens).
+    expect(JSON.parse(JSON.stringify(outcome))).toEqual(outcome);
+  });
+
+  it('handles an empty batch (no runs, no PRs)', () => {
+    const outcome = buildBatchOutcome(
+      makeState({ prs: [], issues_filed: [], issues_closed: [], stop_reason: 'no_work' }),
+      makeScore({ total_runs: 0, successful_runs: 0, total_prs: 0, mode_breakdown: [], success_rate: 0 }),
+      1_001,
+    );
+    expect(() => BatchOutcomeSchema.parse(outcome)).not.toThrow();
+    expect(outcome.totals.runs).toBe(0);
+    expect(outcome.wall_seconds).toBe(1);
+  });
+});
+
+describe('BatchOutcomeSchema — drift guard', () => {
+  it('rejects a malformed payload (wrong schema_version)', () => {
+    const good = buildBatchOutcome(makeState(), makeScore(), 1_600);
+    expect(() => BatchOutcomeSchema.parse({ ...good, schema_version: 99 })).toThrow();
+  });
+
+  it('rejects a payload missing required totals', () => {
+    const good: any = buildBatchOutcome(makeState(), makeScore(), 1_600);
+    delete good.totals;
+    expect(() => BatchOutcomeSchema.parse(good)).toThrow();
+  });
+});
+
+describe('write/read attachment wrappers — gh-backed', () => {
+  beforeEach(() => { vi.clearAllMocks(); clearCommentCache(); });
+
+  it('writes the outcome as the batch-outcome named attachment', () => {
+    ghReturns(''); // fetchComments: empty
+    ghReturns('https://github.com/Garsson-io/kaizen/issues/1099#issuecomment-789'); // createComment
+    const outcome = buildBatchOutcome(makeState(), makeScore(), 1_600);
+    const url = writeBatchOutcomeAttachment('1099', 'Garsson-io/kaizen', outcome);
+    expect(url).toContain('issuecomment');
+    // The created comment body carries the kaizen marker + serialized JSON.
+    const createArgs = (mockGh.mock.calls[1][1] as string[]).join(' ');
+    expect(createArgs).toContain(`<!-- kaizen:${BATCH_OUTCOME_ATTACHMENT} -->`);
+    expect(createArgs).toContain('"batch_id"');
+  });
+
+  it('reads a written outcome back and validates it (roundtrip)', () => {
+    const outcome = buildBatchOutcome(makeState(), makeScore(), 1_600);
+    const body = `<!-- kaizen:${BATCH_OUTCOME_ATTACHMENT} -->\n${JSON.stringify(outcome, null, 2)}`;
+    ghReturns(JSON.stringify({ url: 'https://...#issuecomment-456', body }));
+    const read = readBatchOutcome('1099', 'Garsson-io/kaizen');
+    expect(read).toEqual(outcome);
+  });
+
+  it('returns null when no batch-outcome attachment exists', () => {
+    ghReturns(JSON.stringify({ url: 'https://...#issuecomment-1', body: 'Just the markdown table' }));
+    expect(readBatchOutcome('1099', 'Garsson-io/kaizen')).toBeNull();
+  });
+
+  it('throws on a malformed stored attachment (drift is a bug, not a silent miss)', () => {
+    const body = `<!-- kaizen:${BATCH_OUTCOME_ATTACHMENT} -->\n{"schema_version": 99}`;
+    ghReturns(JSON.stringify({ url: 'https://...#issuecomment-456', body }));
+    expect(() => readBatchOutcome('1099', 'Garsson-io/kaizen')).toThrow();
+  });
+});

--- a/scripts/batch-outcome.test.ts
+++ b/scripts/batch-outcome.test.ts
@@ -88,6 +88,12 @@ describe('buildBatchOutcome — pure derivation', () => {
     expect(outcome.totals.issues_filed).toBe(1);
     expect(outcome.totals.cost_usd).toBeCloseTo(4.5);
     expect(outcome.mode_breakdown[0].mode).toBe('exploit');
+    expect(outcome.mode_breakdown[0].efficiency).toBeCloseTo(0.33);
+    // Durable record carries measurements Phase 2 trend analysis needs.
+    expect(outcome.totals.duration_seconds).toBe(600);
+    expect(outcome.totals.lines_deleted).toBe(10);
+    expect(outcome.cost_anomaly_count).toBe(0);
+    expect(outcome.trend).toBeNull();
     expect(outcome.prs).toEqual(['https://github.com/Garsson-io/kaizen/pull/1108']);
   });
 
@@ -102,7 +108,7 @@ describe('buildBatchOutcome — pure derivation', () => {
 
   it('normalizes non-finite derived numbers so the result is schema-valid and JSON-clean', () => {
     // No successes: avg_cost_per_success = NaN, overall_efficiency = Infinity upstream.
-    const score = makeScore({ successful_runs: 0, avg_cost_per_success: NaN, overall_efficiency: Infinity, total_cost_usd: NaN });
+    const score = makeScore({ successful_runs: 0, success_rate: 0, avg_cost_per_success: NaN, overall_efficiency: Infinity, total_cost_usd: NaN });
     const outcome = buildBatchOutcome(makeState({ stop_reason: 'failed' }), score, 1_600);
     expect(() => BatchOutcomeSchema.parse(outcome)).not.toThrow();
     expect(outcome.avg_cost_per_success).toBeNull();

--- a/scripts/batch-outcome.ts
+++ b/scripts/batch-outcome.ts
@@ -28,7 +28,7 @@ export const BATCH_OUTCOME_ATTACHMENT = 'batch-outcome';
  */
 export const BATCH_OUTCOME_SCHEMA_VERSION = 1;
 
-/** Per-mode effectiveness rollup carried in the outcome (subset of ModeStats). */
+/** Per-mode effectiveness rollup carried in the outcome (mirrors ModeStats). */
 const ModeBreakdownSchema = z.object({
   mode: z.string(),
   runs: z.number(),
@@ -36,7 +36,23 @@ const ModeBreakdownSchema = z.object({
   success_rate: z.number(),
   cost_usd: z.number(),
   prs: z.number(),
+  avg_cost: z.number(),
+  efficiency: z.number(),
+  lines_deleted: z.number(),
+  issues_pruned: z.number(),
 });
+
+/** Batch trend analysis (mirrors BatchTrend); null when fewer than 4 runs. */
+const BatchTrendSchema = z
+  .object({
+    cost_slope: z.number(),
+    first_half_success_rate: z.number(),
+    second_half_success_rate: z.number(),
+    efficiency_slope: z.number(),
+    duration_slope: z.number(),
+    summary: z.string(),
+  })
+  .nullable();
 
 /**
  * The structured batch outcome. Derived purely from `BatchState` + `BatchScore`.
@@ -57,11 +73,17 @@ export const BatchOutcomeSchema = z.object({
     issues_closed: z.number(),
     issues_filed: z.number(),
     cost_usd: z.number(),
+    duration_seconds: z.number(),
+    lines_deleted: z.number(),
+    issues_pruned: z.number(),
   }),
   success_rate: z.number(),
   avg_cost_per_success: z.number().nullable(),
   overall_efficiency: z.number(),
   review_fail_rate: z.number(),
+  cost_anomaly_count: z.number(),
+  mode_diversity: z.number(),
+  trend: BatchTrendSchema,
   mode_breakdown: z.array(ModeBreakdownSchema),
   prs: z.array(z.string()),
   issues_closed: z.array(z.string()),
@@ -101,11 +123,17 @@ export function buildBatchOutcome(
       issues_closed: score.total_issues_closed,
       issues_filed: state.issues_filed.length,
       cost_usd: finite(score.total_cost_usd),
+      duration_seconds: finite(score.total_duration_seconds),
+      lines_deleted: finite(score.total_lines_deleted),
+      issues_pruned: finite(score.total_issues_pruned),
     },
     success_rate: finite(score.success_rate),
     avg_cost_per_success: finiteOrNull(score.avg_cost_per_success),
     overall_efficiency: finite(score.overall_efficiency),
     review_fail_rate: finite(score.review_fail_rate),
+    cost_anomaly_count: score.cost_anomaly_count,
+    mode_diversity: finite(score.mode_diversity),
+    trend: score.trend,
     mode_breakdown: score.mode_breakdown.map((m) => ({
       mode: m.mode,
       runs: m.runs,
@@ -113,6 +141,10 @@ export function buildBatchOutcome(
       success_rate: finite(m.success_rate),
       cost_usd: finite(m.cost_usd),
       prs: m.prs,
+      avg_cost: finite(m.avg_cost),
+      efficiency: finite(m.efficiency),
+      lines_deleted: finite(m.lines_deleted),
+      issues_pruned: finite(m.issues_pruned),
     })),
     prs: state.prs,
     issues_closed: state.issues_closed,

--- a/scripts/batch-outcome.ts
+++ b/scripts/batch-outcome.ts
@@ -1,0 +1,155 @@
+/**
+ * batch-outcome.ts — durable, machine-readable batch outcome attachment (#1108, #940 Phase 1).
+ *
+ * At batch close, auto-dent posts a human markdown table to the progress issue
+ * (see `closeBatchProgressIssue`). That table is unreadable by the cross-batch
+ * analysis tools — every new batch starts blind. This module derives a
+ * structured, schema-validated `batch-outcome` object from the batch state and
+ * writes it as a named attachment (`<!-- kaizen:batch-outcome -->`) on the
+ * progress issue, so any machine can resolve the batch's outcome with zero
+ * parsing — using the same named-attachment primitive every other kaizen skill
+ * uses.
+ *
+ * Phase 2 (#940) wires `batch-trends.ts` / `auto-dent-ctl.ts history` to read
+ * these attachments back via `readBatchOutcome` (`--from-github`).
+ */
+
+import { z } from 'zod';
+import { writeAttachment, readAttachment } from '../src/section-editor.js';
+import type { BatchState } from './auto-dent-run.js';
+import type { BatchScore } from './auto-dent-score.js';
+
+/** Named-attachment key on the progress issue. Stable contract with Phase 2 readers. */
+export const BATCH_OUTCOME_ATTACHMENT = 'batch-outcome';
+
+/**
+ * Schema version for the attachment payload. Bump when the shape changes
+ * incompatibly so readers can branch. Phase 2 readers assert on this.
+ */
+export const BATCH_OUTCOME_SCHEMA_VERSION = 1;
+
+/** Per-mode effectiveness rollup carried in the outcome (subset of ModeStats). */
+const ModeBreakdownSchema = z.object({
+  mode: z.string(),
+  runs: z.number(),
+  successes: z.number(),
+  success_rate: z.number(),
+  cost_usd: z.number(),
+  prs: z.number(),
+});
+
+/**
+ * The structured batch outcome. Derived purely from `BatchState` + `BatchScore`.
+ * This is the cross-batch learning record — keep it machine-resolvable, not prose.
+ */
+export const BatchOutcomeSchema = z.object({
+  schema_version: z.literal(BATCH_OUTCOME_SCHEMA_VERSION),
+  batch_id: z.string(),
+  guidance: z.string(),
+  batch_start: z.number(),
+  batch_end: z.number(),
+  wall_seconds: z.number(),
+  stop_reason: z.string(),
+  totals: z.object({
+    runs: z.number(),
+    successful_runs: z.number(),
+    prs: z.number(),
+    issues_closed: z.number(),
+    issues_filed: z.number(),
+    cost_usd: z.number(),
+  }),
+  success_rate: z.number(),
+  avg_cost_per_success: z.number().nullable(),
+  overall_efficiency: z.number(),
+  review_fail_rate: z.number(),
+  mode_breakdown: z.array(ModeBreakdownSchema),
+  prs: z.array(z.string()),
+  issues_closed: z.array(z.string()),
+  issues_filed: z.array(z.string()),
+});
+
+export type BatchOutcome = z.infer<typeof BatchOutcomeSchema>;
+
+/**
+ * Build the structured outcome from batch state + score. Pure: `nowEpoch` is
+ * injected (seconds since epoch) so the builder is deterministic and testable.
+ * Non-finite derived numbers (e.g. efficiency / avg-per-success with no
+ * successes) are normalized so the result always passes `BatchOutcomeSchema`
+ * and JSON-serializes cleanly (JSON.stringify turns NaN/Infinity into null).
+ */
+export function buildBatchOutcome(
+  state: BatchState,
+  score: BatchScore,
+  nowEpoch: number,
+): BatchOutcome {
+  const finite = (n: number): number => (Number.isFinite(n) ? n : 0);
+  const finiteOrNull = (n: number): number | null =>
+    Number.isFinite(n) ? n : null;
+
+  return {
+    schema_version: BATCH_OUTCOME_SCHEMA_VERSION,
+    batch_id: state.batch_id,
+    guidance: state.guidance ?? '',
+    batch_start: state.batch_start,
+    batch_end: nowEpoch,
+    wall_seconds: Math.max(0, nowEpoch - state.batch_start),
+    stop_reason: state.stop_reason || 'completed',
+    totals: {
+      runs: score.total_runs,
+      successful_runs: score.successful_runs,
+      prs: score.total_prs,
+      issues_closed: score.total_issues_closed,
+      issues_filed: state.issues_filed.length,
+      cost_usd: finite(score.total_cost_usd),
+    },
+    success_rate: finite(score.success_rate),
+    avg_cost_per_success: finiteOrNull(score.avg_cost_per_success),
+    overall_efficiency: finite(score.overall_efficiency),
+    review_fail_rate: finite(score.review_fail_rate),
+    mode_breakdown: score.mode_breakdown.map((m) => ({
+      mode: m.mode,
+      runs: m.runs,
+      successes: m.successes,
+      success_rate: finite(m.success_rate),
+      cost_usd: finite(m.cost_usd),
+      prs: m.prs,
+    })),
+    prs: state.prs,
+    issues_closed: state.issues_closed,
+    issues_filed: state.issues_filed,
+  };
+}
+
+/**
+ * Write the outcome as a named attachment on the progress issue. Idempotent:
+ * `writeAttachment` updates the existing marker comment if present. Returns the
+ * comment URL.
+ */
+export function writeBatchOutcomeAttachment(
+  issueNumber: string,
+  repo: string,
+  outcome: BatchOutcome,
+): string {
+  return writeAttachment(
+    { kind: 'issue', number: issueNumber, repo },
+    BATCH_OUTCOME_ATTACHMENT,
+    JSON.stringify(outcome, null, 2),
+  );
+}
+
+/**
+ * Read the outcome back from a progress issue. Returns null if no attachment is
+ * present. Throws (via Zod) if the attachment exists but is malformed — drift
+ * is a bug, not a silent miss.
+ */
+export function readBatchOutcome(
+  issueNumber: string,
+  repo: string,
+): BatchOutcome | null {
+  const attachment = readAttachment(
+    { kind: 'issue', number: issueNumber, repo },
+    BATCH_OUTCOME_ATTACHMENT,
+  );
+  if (!attachment) return null;
+  return BatchOutcomeSchema.parse(JSON.parse(attachment.content));
+}


### PR DESCRIPTION
## The Problem

Auto-dent runs are a learning machine — except the learning never compounds. Every batch produces a rich `BatchScore` (success rate, per-mode effectiveness, failure classes, cost), but at batch close `closeBatchProgressIssue()` rendered all of it into a **human markdown table** and closed the issue. The cross-batch analysis tools (`batch-trends.ts`, `auto-dent-ctl history`) are local-disk only and can't read a markdown table. So **every new batch starts blind** — its guidance is written from what a human remembers, not from what the system measured. This is the core of epic #940's "intelligence debt."

## The Discovery

The fix isn't a new data pipeline — the schema and the analysis tools already exist. The only missing link was a **machine-readable write path to GitHub**. Kaizen already has the right primitive for exactly this: named attachments (`<!-- kaizen:<name> -->` marker comments) via `writeAttachment`/`readAttachment`, the same mechanism plans, test plans, and review findings already use. The progress issue already carries the `auto-dent` label, so a Phase 2 reader can find these with one `gh issue list`.

## The Solution

`scripts/batch-outcome.ts` (new):
- **`BatchOutcomeSchema`** — a Zod schema (per **I29**: no hand-rolled parsing) describing the structured outcome: totals, success rate, per-mode breakdown, stop reason, PRs, issues. Carries a `schema_version` so Phase 2 readers can branch on drift.
- **`buildBatchOutcome(state, score, nowEpoch)`** — pure, deterministic (time injected), fully unit-testable. Normalizes non-finite derived numbers (a batch with zero successes yields `NaN`/`Infinity` upstream) so the result is always schema-valid and JSON-clean.
- **`writeBatchOutcomeAttachment` / `readBatchOutcome`** — thin wrappers over the existing attachment primitive (`batch-outcome` name). The reader validates with the same schema the writer used.

`closeBatchProgressIssue()` gains **one guarded call** — built to keep the collision surface in this shared file minimal (k1102/k1103 are active there). The write runs *before* the close and on **abnormal exits too** (budget exhausted, stop signal); a failed write is best-effort and never blocks batch close.

## The Evidence

- 11 new tests: pure mapping, `stop_reason` defaulting, abnormal-exit/empty-batch paths, non-finite normalization + JSON roundtrip, schema drift guard, and gh-mocked **write → read roundtrip** proving fields survive serialization and re-validation.
- Full suite: **2673 passed, 10 skipped, 0 failed**. `tsc --noEmit` clean.

## The Impact

This is Phase 1 of #940 — the persistence layer that makes cross-batch learning durable and cloud-accessible. Once batch outcomes are machine-resolvable on GitHub, Phase 2 wires `--from-github` onto `batch-trends.ts` / `auto-dent-ctl history` so the *next* batch can steer from what *past* batches measured. It's the substrate for "becoming better at becoming better."

## Test Plan

Behaviors × levels and deferral rationale stored as the `testplan` attachment on #1108.

Closes #1108
Parent: #940
Refs: #691, #842, #688

Run tag: sticky-lark/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
