### PR TITLE
fix(hooks): plan gate verifies issue matches the worktree, not just that a plan exists (Closes #1106)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -57,7 +57,7 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 | `src/cli-structured-data.ts` | CLI for structured data — the primary interface for skills |
 | `src/section-editor.ts` | Low-level: sections (## in bodies) + attachments (marker comments) — CRUD primitives |
 | `src/case-system.ts` | **Case FE** — single gateway for plan gate (I3, I8). Pluggable `CaseBackend`: `GitHubCaseBackend` today, Linear/custom tomorrow. Hooks and skills go through this, never call BE directly |
-| `src/hooks/enforce-plan-stored.ts` | PreToolUse hook enforcing I3/I8: Edit/Write/NotebookEdit require a stored plan on `git config kaizen.issue`; `gh pr create` adds a substance check |
+| `src/hooks/enforce-plan-stored.ts` | PreToolUse hook enforcing I3/I8: Edit/Write/NotebookEdit require a stored plan on `git config kaizen.issue`; `gh pr create` adds a substance check. Cross-checks the declared issue against the canonical case-branch token (`case/<date>-k<N>-*`) and fails closed on mismatch — a stale/inherited `kaizen.issue` can't sail through the plan gate for the wrong issue (#1106; the #943/#950 command-vs-outcome category). |
 | `src/hooks/pre-push.ts` | **Git pre-push hook** (epic #1059) — mechanistic L3 gate: agent-env gate + merged-branch block (I7) + needs_review gate creation. Replaces fragile Bash parsing path for push detection (#909, #1057). See `docs/git-hooks-design.md`. |
 | `src/hooks/prehook-no-verify.ts` | PreToolUse hook blocking `git push --no-verify` — prevents agents from bypassing the pre-push gate |
 | `src/setup-git-hooks.ts` | `/kaizen-setup install-git-hooks` implementation — detects host framework (pre-commit/husky/lefthook/raw/none) and injects kaizen's pre-push hook idempotently |

--- a/src/hooks/enforce-plan-stored.test.ts
+++ b/src/hooks/enforce-plan-stored.test.ts
@@ -10,6 +10,7 @@ import {
   checkPlanBeforePr,
   checkPlanBeforeEdit,
   extractIssueNumber,
+  extractCaseIssueFromBranch,
   isDocsOnly,
   isSourceFile,
   checkPlanSubstance,
@@ -81,6 +82,22 @@ describe('extractIssueNumber', () => {
   it('Closes #N', () => expect(extractIssueNumber('Closes #1055')).toBe('1055'));
   it('fixes #N', () => expect(extractIssueNumber('fixes #42')).toBe('42'));
   it('null when absent', () => expect(extractIssueNumber('no ref')).toBeNull());
+});
+
+describe('extractCaseIssueFromBranch', () => {
+  it('parses k<N> from a 6-digit-date case branch', () =>
+    expect(extractCaseIssueFromBranch('case/260626-k950-outcome-verification')).toBe('950'));
+  it('parses k<N> from a 10-digit-date case branch', () =>
+    expect(extractCaseIssueFromBranch('case/2606261001-k1102-hook-observability')).toBe('1102'));
+  it('parses k<N> when the slug is absent (trailing token)', () =>
+    expect(extractCaseIssueFromBranch('case/260626-k1106')).toBe('1106'));
+  it('returns null for main', () => expect(extractCaseIssueFromBranch('main')).toBeNull());
+  it('returns null for feature branches', () =>
+    expect(extractCaseIssueFromBranch('feature/k950-thing')).toBeNull());
+  it('returns null for harness worktree branches', () =>
+    expect(extractCaseIssueFromBranch('worktree-2606261134-38ae')).toBeNull());
+  it('returns null for a bare k<N> branch (not the canonical case shape)', () =>
+    expect(extractCaseIssueFromBranch('k40-something')).toBeNull());
 });
 
 
@@ -160,6 +177,48 @@ describe('checkPlanBeforeEdit', () => {
     const result = checkPlanBeforeEdit('src/thing.ts', makeDeps({ retrievePlan: () => null }));
     expect(result.reason).toContain('Wait for the skill to COMPLETE');
   });
+
+  // ── #1106: stale/inherited kaizen.issue cross-check ───────────────
+  describe('stale kaizen.issue (#1106)', () => {
+    it('BLOCKS when a case branch (k950) disagrees with declared issue (1108) — live repro', () => {
+      const result = checkPlanBeforeEdit('src/thing.ts', makeDeps({}, {
+        getCurrentBranch: () => 'case/260626-k950-outcome-verification',
+        getDeclaredIssue: () => '1108',
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.missing).toContain('issue-mismatch');
+      expect(result.reason).toContain('Stale kaizen.issue');
+      expect(result.reason).toContain('git config kaizen.issue 950');
+    });
+
+    it('ALLOWS when the case branch and declared issue agree', () => {
+      const result = checkPlanBeforeEdit('src/thing.ts', makeDeps({}, {
+        getCurrentBranch: () => 'case/260626-k950-outcome-verification',
+        getDeclaredIssue: () => '950',
+      }));
+      expect(result.allowed).toBe(true);
+    });
+
+    it('does NOT cross-check on a non-case branch even if names differ', () => {
+      // Declared 1108, branch is not the canonical case shape → no misfire,
+      // falls through to the normal plan gate (which has a plan → allowed).
+      const result = checkPlanBeforeEdit('src/thing.ts', makeDeps({}, {
+        getCurrentBranch: () => 'feature/k950-thing',
+        getDeclaredIssue: () => '1108',
+      }));
+      expect(result.allowed).toBe(true);
+    });
+
+    it('suggests the branch issue when none is declared on a case branch', () => {
+      const result = checkPlanBeforeEdit('src/thing.ts', makeDeps({}, {
+        getCurrentBranch: () => 'case/260626-k1106-plan-gate-issue-match',
+        getDeclaredIssue: () => null,
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.missing).toContain('issue-link');
+      expect(result.reason).toContain('git config kaizen.issue 1106');
+    });
+  });
 });
 
 // ── Gate 2: gh pr create ────────────────────────────────────────────
@@ -217,6 +276,19 @@ describe('checkPlanBeforePr', () => {
     );
     expect(result.allowed).toBe(false);
     expect(result.missing).toContain('substance');
+  });
+
+  it('#1106: BLOCKS when case branch (k950) disagrees with declared issue (1108)', () => {
+    const result = checkPlanBeforePr(
+      ghPrCreate('Closes #1108'),
+      makeDeps({}, {
+        getCurrentBranch: () => 'case/260626-k950-outcome-verification',
+        getDeclaredIssue: () => '1108',
+      }),
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain('issue-mismatch');
+    expect(result.reason).toContain('Stale kaizen.issue');
   });
 });
 

--- a/src/hooks/enforce-plan-stored.ts
+++ b/src/hooks/enforce-plan-stored.ts
@@ -86,11 +86,50 @@ export function extractIssueNumber(fullCommand: string): string | null {
   return match ? match[1] : null;
 }
 
-// NOTE: Branch-name parsing was intentionally removed.
-// The issue binding is EXPLICIT via `git config kaizen.issue <N>` (set by the
-// /kaizen-implement skill or the user). For PR creation, the canonical
-// `Closes #N` syntax in the PR body is the fallback. Parsing branch names
-// was fragile — every naming convention we didn't anticipate was a bypass.
+// NOTE: Branch-name parsing was intentionally removed as a *primary* issue
+// source. The issue binding is EXPLICIT via `git config kaizen.issue <N>` (set
+// by the /kaizen-implement skill or the user). For PR creation, the canonical
+// `Closes #N` syntax in the PR body is the fallback. Parsing arbitrary branch
+// names was fragile — every naming convention we didn't anticipate was a bypass.
+//
+// extractCaseIssueFromBranch below is the ONE exception, and it is NOT a primary
+// source — it is a *consistency cross-check*. It parses ONLY the canonical
+// case-branch shape that the case system itself produces, so a match is
+// trustworthy ground truth about which case this worktree is for. We use it to
+// catch a stale/inherited `kaizen.issue` that points at a different issue than
+// the worktree's branch (#1106) — the gate must verify "this work corresponds
+// to #N", not merely "a plan exists for #N" (the #943/#950 category error).
+
+/**
+ * Parse the issue number from a canonical case branch (`case/<date>-k<N>-<slug>`,
+ * e.g. `case/260626-k950-outcome-verification`). Returns null for ANY other
+ * branch shape (main, feature/*, worktree-*, bare k<N>-*), so it never misfires
+ * on names the case system did not create. This anchored, case-prefixed match is
+ * what makes the result safe to trust as a cross-check rather than a guess.
+ */
+export function extractCaseIssueFromBranch(branch: string): string | null {
+  const m = branch.match(/^case\/\d{6,}-k(\d+)(?:-|$)/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Build the BLOCKED result shown when the worktree's case branch says issue M
+ * but `git config kaizen.issue` says N (≠ M) — a stale/inherited config (#1106).
+ */
+function staleIssueResult(branchIssue: string, declaredIssue: string): PlanCheckResult {
+  return {
+    allowed: false,
+    missing: ['issue-mismatch'],
+    reason: `BLOCKED: Stale kaizen.issue — your worktree branch is for issue #${branchIssue}, but \`git config kaizen.issue\` says #${declaredIssue}.
+
+This config was almost certainly inherited from another run/worktree. The plan gate would otherwise verify a plan for the WRONG issue (#${declaredIssue}) while you edit code for #${branchIssue}.
+
+FIX IT NOW — point the config at this worktree's actual issue:
+  git config kaizen.issue ${branchIssue}
+
+Then retry. (If you really intend to work on #${declaredIssue}, you are on the wrong branch — switch to that issue's case worktree instead.)`,
+  };
+}
 
 // ── Source file detection ───────────────────────────────────────────
 //
@@ -166,23 +205,40 @@ export function checkPlanBeforeEdit(
 
   // Issue must be EXPLICITLY declared via `git config kaizen.issue <N>`.
   // This is the agent's binding contract: "I am working on #N".
-  // No branch-name parsing, no guessing.
   const issueNum = deps.getDeclaredIssue();
+
+  // Ground truth from the canonical case branch (if any). Used to (a) suggest
+  // the right issue when none is declared, and (b) catch a stale/inherited
+  // config that names a DIFFERENT issue than this worktree's branch (#1106).
+  const branchIssue = extractCaseIssueFromBranch(deps.getCurrentBranch());
+
   if (!issueNum) {
+    const declareHint = branchIssue
+      ? `This worktree's branch is for issue #${branchIssue}. Declare it:
+
+  git config kaizen.issue ${branchIssue}`
+      : `Every source-code edit must be tied to an issue. Declare it explicitly:
+
+  git config kaizen.issue <N>
+
+(where <N> is the issue number, e.g. 1055)`;
     return {
       allowed: false,
       missing: ['issue-link'],
       reason: `BLOCKED: You have not declared which issue you are working on.
 
-Every source-code edit must be tied to an issue. Declare it explicitly:
-
-  git config kaizen.issue <N>
-
-(where <N> is the issue number, e.g. 1055)
+${declareHint}
 
 Or use /kaizen-implement, which sets this for you.
 This hook enforces I8: implementation must be tied to a planned issue.`,
     };
+  }
+
+  // Cross-check: a canonical case branch is trustworthy ground truth. If it
+  // disagrees with the declared issue, the config is stale/inherited (#1106) —
+  // fail closed before the plan gate verifies a plan for the wrong issue.
+  if (branchIssue && branchIssue !== issueNum) {
+    return staleIssueResult(branchIssue, issueNum);
   }
 
   const repo = deps.detectRepo();
@@ -237,7 +293,7 @@ export function checkPlanBeforePr(
   if (isDocsOnly(changedFiles)) return { allowed: true };
 
   // Priority: declared issue > PR body "Closes #N" (canonical GitHub syntax).
-  // No branch-name parsing — too fragile.
+  // Arbitrary branch names are not a primary source — too fragile.
   const issueNum = deps.getDeclaredIssue() ?? extractIssueNumber(fullCommand);
   if (!issueNum) {
     return {
@@ -251,6 +307,14 @@ Declare the issue explicitly:
 Or include \`Closes #N\` in the PR body.
 This hook enforces I3 (stored test plan) and I8 (plan before implementation).`,
     };
+  }
+
+  // Cross-check the declared issue against the canonical case branch (#1106):
+  // a stale/inherited config that names a different issue than this worktree's
+  // branch would otherwise verify a plan for the wrong issue at PR time.
+  const branchIssue = extractCaseIssueFromBranch(deps.getCurrentBranch());
+  if (branchIssue && branchIssue !== issueNum) {
+    return staleIssueResult(branchIssue, issueNum);
   }
 
   // Use Case FE for existence check


### PR DESCRIPTION
## The problem

The `enforce-plan-stored` hook (I8) gates every source edit on
`checkPlanGate(git config kaizen.issue)`. It verifies that **a plan exists for
whatever issue the config names** — it never verifies that the config matches the
work *this worktree is actually for*.

So any run that inherits a stale `kaizen.issue` pointing at some issue that
happens to have a stored plan sails straight through the plan gate while editing
code for a completely different purpose.

## The discovery

This isn't hypothetical — it's live in the repo **right now**. The k950 worktree
(branch `case/260626-k950-outcome-verification`) reports:

```
$ git config kaizen.issue
1108        # ← an unrelated auto-dent batch issue, not k950
```

The gate would happily verify "#1108 has a plan" and let edits for #950 through.
This is the exact **command-vs-outcome category error** named by #943/#950, now
showing up at the plan-gate layer: the gate detects *"a plan exists for #N"*, not
*"this work corresponds to #N"*.

It surfaced while implementing #950 (PR #1105) and was filed as #1106.

## The solution

The canonical case-branch name (`case/<date>-k<N>-<slug>`) is reliable ground
truth — the case system creates it, and a stale inherited config can't forge it.
The fix cross-checks the declared `kaizen.issue` against the branch's `k<N>`
token and **fails closed on mismatch**, in both gates (Edit/Write and
`gh pr create`):

```
BLOCKED: Stale kaizen.issue — your worktree branch is for issue #950, but
`git config kaizen.issue` says #1108.
...
FIX IT NOW:  git config kaizen.issue 950
```

A missing declaration on a case branch now also suggests the exact issue number.

`extractCaseIssueFromBranch` parses **only** the anchored canonical shape, so it
returns null for `main`, `feature/*`, `worktree-*`, and bare `k<N>-*` branches.
It is a *consistency cross-check*, **not** a return to fragile
branch-name-as-primary-source parsing (which was deliberately removed earlier).
The declared `kaizen.issue` remains the binding contract; the branch token only
catches it lying.

## The evidence

- `extractCaseIssueFromBranch`: 7 unit tests (6/10-digit dates, slug-less,
  null on every non-canonical shape — no misfire).
- Edit gate: blocks the live k950/1108 repro; allows the matching case; ignores
  non-case branches; suggests the issue number when none is declared.
- PR gate: blocks on branch/declared mismatch.
- Full suite green: `enforce-plan-stored.test.ts` 43 passed, all hook tests
  751 passed, e2e 5 passed, `tsc --noEmit` clean, build clean.

## Impact

The plan gate now verifies **outcome** ("this work corresponds to #N"), not just
**command** ("a plan exists for #N"). Any future stale/inherited `kaizen.issue`
on a case branch is caught regardless of how it got stale — harness provisioning,
manual reuse, or a leftover worktree. One more harness↔hook choke point closed.

## Test plan

| # | Behavior | Level |
|---|----------|-------|
| 1 | `extractCaseIssueFromBranch` parses `k<N>` from canonical case branches (6–10 digit dates, slug-less) | Unit |
| 2 | `extractCaseIssueFromBranch` returns null for main/feature/worktree-*/bare-k (no misfire) | Unit |
| 3 | Edit on case-k950 branch + declared 1108 → BLOCKED with stale-config message (live repro) | Unit |
| 4 | Edit on case-k950 branch + declared 950 → allowed | Unit |
| 5 | Non-case branch with mismatched declared issue → cross-check does not fire | Unit |
| 6 | No declared issue + case branch → suggests exact `git config kaizen.issue <N>` | Unit |
| 7 | `gh pr create` cross-check blocks on branch/declared mismatch | Unit |

Closes #1106
Refs: #950, #943, #842

Run tag: sticky-lark/run-1
