### PR TITLE
feat(auto-dent): make hook rejections observable to the harness (Closes #1102)

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -2928,3 +2928,23 @@ describe('extractPlanText — plan section regex extraction (kaizen #901)', () =
     expect(result).toContain('Lowercase header');
   });
 });
+
+describe('classifyFailure live wiring (#1102 regression guard)', () => {
+  // The log-based heuristic branch (hook_rejection, infrastructure, timeout...)
+  // is dead code unless the live call site passes the run log. This test pins
+  // that the production call in auto-dent-run.ts passes a log argument, so the
+  // branch can never be silently re-orphaned.
+  const source = readFileSync(join(__dirname, 'auto-dent-run.ts'), 'utf8');
+
+  it('reads the run log before classifying', () => {
+    expect(source).toMatch(/readFileSync\(logFile, 'utf8'\)/);
+  });
+
+  it('passes a non-empty second argument to classifyFailure', () => {
+    // Match the production call (not a bare metrics-only call). The second arg
+    // must be the run log variable.
+    const call = source.match(/classifyFailure\(runMetrics,\s*([A-Za-z0-9_]+)\)/);
+    expect(call).not.toBeNull();
+    expect(call![1]).not.toBe('');
+  });
+});

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -26,6 +26,7 @@ import { readFileSync, writeFileSync, appendFileSync, existsSync, renameSync, co
 import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
+import { firstHookReason } from './hook-signals.js';
 import { claimNextItem, markItem, resetAssignedItems } from './auto-dent-plan.js';
 import { writeAttachment, addSection } from '../src/section-editor.js';
 import {
@@ -178,6 +179,8 @@ export interface RunMetrics {
   prompt_hash?: string;
   /** Structured failure classification (populated post-run) */
   failure_class?: string;
+  /** Reason a hook blocked this run, when failure_class is hook_rejection (#1102) */
+  hook_rejection_reason?: string;
   /** Number of lifecycle ordering violations detected post-run */
   lifecycle_violations?: number;
   /** Review battery verdict for PRs created in this run */
@@ -1953,8 +1956,14 @@ async function main(): Promise<void> {
     review_verdict: reviewVerdict,
     review_cost_usd: reviewCostUsd,
   };
-  // Classify failure: wall-clock timeout is authoritative (#686), then heuristics
-  runMetrics.failure_class = result.timedOut ? 'timeout' : classifyFailure(runMetrics);
+  // Classify failure: wall-clock timeout is authoritative (#686), then heuristics.
+  // Feed the run log so the log-based branch (hook_rejection, infrastructure,
+  // etc.) actually runs — without this argument it was dead code (#1102).
+  const runLog = existsSync(logFile) ? readFileSync(logFile, 'utf8') : undefined;
+  runMetrics.failure_class = result.timedOut ? 'timeout' : classifyFailure(runMetrics, runLog);
+  if (runMetrics.failure_class === 'hook_rejection' && runLog) {
+    runMetrics.hook_rejection_reason = firstHookReason(runLog);
+  }
   if (!freshState.run_history) freshState.run_history = [];
   freshState.run_history.push(runMetrics);
 

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -1221,11 +1221,30 @@ describe('classifyFailure', () => {
     expect(classifyFailure(makeRunMetrics({ exit_code: 1, prs: [] }))).toBe('crash');
   });
 
-  it('classifies hook rejection from log', () => {
+  it('classifies hook rejection from log (legacy English-prose fallback)', () => {
     expect(classifyFailure(
       makeRunMetrics({ exit_code: 1, prs: [] }),
       'Error: hook rejected the commit',
     )).toBe('hook_rejection');
+  });
+
+  it('classifies hook rejection from a structured deny envelope without any prose (#1102)', () => {
+    // No English "hook rejected/blocked/failed" string anywhere — detection must
+    // come from the structured contract, not prose.
+    const log = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'BLOCKED: No plan stored for issue #5.',
+      },
+    });
+    expect(log.toLowerCase()).not.toContain('hook rejected');
+    expect(classifyFailure(makeRunMetrics({ exit_code: 1, prs: [] }), log)).toBe('hook_rejection');
+  });
+
+  it('classifies hook rejection from a stop-gate block envelope (#1102)', () => {
+    const log = JSON.stringify({ decision: 'block', reason: 'PR REVIEW required' });
+    expect(classifyFailure(makeRunMetrics({ exit_code: 1, prs: [] }), log)).toBe('hook_rejection');
   });
 
   it('classifies infrastructure failure from log', () => {

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -8,6 +8,7 @@
  */
 
 import type { RunMetrics, RunResult, MergeStatus } from './auto-dent-run.js';
+import { hasHookRejection } from './hook-signals.js';
 
 /**
  * Structured failure taxonomy for auto-dent runs.
@@ -45,7 +46,15 @@ export function classifyFailure(
   if (metrics.exit_code === 0 && !hasArtifacts) return 'empty_success';
 
   if (logOutput) {
+    // Structured detection first: consume the canonical hook contract
+    // (permissionDecision:"deny", decision:"block", gate-signal YAML) instead
+    // of guessing from English prose. See scripts/hook-signals.ts (#1102).
+    if (hasHookRejection(logOutput)) {
+      return 'hook_rejection';
+    }
     const log = logOutput.toLowerCase();
+    // Legacy fallback: pre-commit / framework hooks that don't speak the kaizen
+    // structured contract still surface as English prose. Kept as a safety net.
     if (log.includes('hook rejected') || log.includes('hook blocked') || log.includes('pre-commit hook') || log.includes('hook failed')) {
       return 'hook_rejection';
     }

--- a/scripts/hook-signals.test.ts
+++ b/scripts/hook-signals.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { detectHookSignals, hasHookRejection, firstHookReason } from './hook-signals.js';
+import { formatHookOutput } from '../src/hooks/lib/gate-signal.js';
+
+/**
+ * These tests pin the harness↔hook boundary contract: anything a kaizen hook
+ * emits as a structured deny/block must be detectable by the harness, without
+ * relying on English prose. See issue #1102.
+ */
+describe('detectHookSignals', () => {
+  it('detects a PreToolUse permissionDecision:"deny" envelope', () => {
+    // Exact shape emitted by enforce-plan-stored.ts (stdout JSON).
+    const log = [
+      'some prior tool output',
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'BLOCKED: No plan stored for issue #5.',
+        },
+      }),
+      'trailing output',
+    ].join('\n');
+
+    const signals = detectHookSignals(log);
+    expect(signals.length).toBe(1);
+    expect(signals[0].kind).toBe('deny');
+    expect(signals[0].source).toBe('permission-decision');
+    expect(signals[0].reason).toContain('No plan stored');
+  });
+
+  it('detects a stop-gate decision:"block" envelope', () => {
+    // Exact shape emitted by stop-gate.ts.
+    const log = JSON.stringify({
+      decision: 'block',
+      reason: 'PR REVIEW required — run /kaizen-review-pr',
+    });
+
+    const signals = detectHookSignals(log);
+    expect(signals.length).toBe(1);
+    expect(signals[0].kind).toBe('block');
+    expect(signals[0].source).toBe('stop-decision');
+    expect(signals[0].reason).toContain('PR REVIEW');
+  });
+
+  it('BOUNDARY CONTRACT: output of formatHookOutput({type:"deny"}) is detected', () => {
+    // This is the compound-interest test: any hook that emits via the canonical
+    // gate-signal schema is automatically observable to the harness. If the
+    // schema drifts from what the harness parses, this fails.
+    const yaml = formatHookOutput({
+      hook: 'check-dirty-files',
+      type: 'deny',
+      reason: 'Dirty files present at gh pr create.',
+    });
+    const log = `==> hook output\n${yaml}\n==> next`;
+
+    const signals = detectHookSignals(log);
+    expect(signals.some((s) => s.kind === 'deny')).toBe(true);
+    const sig = signals.find((s) => s.kind === 'deny')!;
+    expect(sig.source).toBe('canonical-yaml');
+    expect(sig.hook).toBe('check-dirty-files');
+    expect(sig.reason).toContain('Dirty files');
+  });
+
+  it('BOUNDARY CONTRACT: canonical block signal is detected', () => {
+    const yaml = formatHookOutput({
+      hook: 'stop-gate',
+      type: 'block',
+      reason: 'Pending review gate.',
+    });
+    const signals = detectHookSignals(`prefix\n${yaml}`);
+    expect(signals.some((s) => s.kind === 'block' && s.source === 'canonical-yaml')).toBe(true);
+  });
+
+  it('does not flag a clean log (no false positives)', () => {
+    const log = [
+      'AUTO_DENT_PHASE: PICK | issue=#5',
+      'Running tests... 12 passed',
+      'gate-set needs_review (this is fine, not a deny/block)',
+      JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } }),
+    ].join('\n');
+    expect(detectHookSignals(log)).toEqual([]);
+    expect(hasHookRejection(log)).toBe(false);
+  });
+
+  it('hasHookRejection is true when any deny/block is present', () => {
+    const log = JSON.stringify({ decision: 'block', reason: 'gate' });
+    expect(hasHookRejection(log)).toBe(true);
+  });
+
+  it('firstHookReason surfaces the first rejection reason for observability', () => {
+    const log = [
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'first reason',
+        },
+      }),
+      JSON.stringify({ decision: 'block', reason: 'second reason' }),
+    ].join('\n');
+    expect(firstHookReason(log)).toContain('first reason');
+  });
+
+  it('ignores malformed JSON lines without throwing', () => {
+    const log = '{not valid json\n{"decision":"block","reason":"ok"}\nhalf {';
+    const signals = detectHookSignals(log);
+    expect(signals.length).toBe(1);
+    expect(signals[0].kind).toBe('block');
+  });
+});

--- a/scripts/hook-signals.test.ts
+++ b/scripts/hook-signals.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 import { detectHookSignals, hasHookRejection, firstHookReason } from './hook-signals.js';
 import { formatHookOutput } from '../src/hooks/lib/gate-signal.js';
 
@@ -107,5 +109,63 @@ describe('detectHookSignals', () => {
     const signals = detectHookSignals(log);
     expect(signals.length).toBe(1);
     expect(signals[0].kind).toBe('block');
+  });
+});
+
+/**
+ * REAL HARNESS SHAPE — the harness captures `claude --output-format stream-json`,
+ * where the hook payload is nested as an escaped JSON string inside a
+ * `hook_response` envelope's `output`/`stdout`, NOT as a bare top-level line.
+ * These tests pin detection against that actual shape so the detector can never
+ * again parse a format the harness doesn't produce (the #1102 fix's own bug).
+ */
+describe('detectHookSignals — real stream-json envelope nesting', () => {
+  it('detects a deny nested-and-escaped inside a hook_response envelope', () => {
+    const innerPayload = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'BLOCKED: Bash is not allowed during PR review.',
+      },
+    });
+    // The harness writes one stream-json envelope per line; the payload appears
+    // in BOTH output and stdout — detection must de-dupe to a single signal.
+    const envelope = JSON.stringify({
+      type: 'system',
+      subtype: 'hook_response',
+      hook_event: 'PreToolUse',
+      output: innerPayload,
+      stdout: innerPayload,
+      exit_code: 2,
+    });
+    const log = `{"type":"system","subtype":"init"}\n${envelope}\n{"type":"result"}`;
+
+    const signals = detectHookSignals(log);
+    expect(signals.length).toBe(1);
+    expect(signals[0].kind).toBe('deny');
+    expect(signals[0].source).toBe('permission-decision');
+    expect(signals[0].reason).toContain('not allowed during PR review');
+    expect(hasHookRejection(log)).toBe(true);
+  });
+
+  it('detects a stop-gate block nested inside a stream-json envelope', () => {
+    const inner = JSON.stringify({ decision: 'block', reason: 'PR REVIEW required' });
+    const envelope = JSON.stringify({ type: 'system', subtype: 'hook_response', stdout: inner });
+    const signals = detectHookSignals(envelope);
+    expect(signals.some((s) => s.kind === 'block' && s.reason?.includes('PR REVIEW'))).toBe(true);
+  });
+
+  it('REGRESSION (#1102): real captured probe-hooks.jsonl yields ≥1 hook rejection', () => {
+    // This fixture is a genuine `--output-format stream-json` capture committed
+    // in #1049. The original #1102 fix returned ZERO signals against it because
+    // it assumed bare top-level payloads. This test is the one that catches it.
+    const fixture = fileURLToPath(new URL('../fixtures/live/probe-hooks.jsonl', import.meta.url));
+    const log = readFileSync(fixture, 'utf8');
+    const signals = detectHookSignals(log);
+    expect(signals.length).toBeGreaterThan(0);
+    expect(hasHookRejection(log)).toBe(true);
+    expect(firstHookReason(log)).toBeTruthy();
+    // Every detected signal must be a genuine rejection, never an allow.
+    expect(signals.every((s) => s.kind === 'deny' || s.kind === 'block')).toBe(true);
   });
 });

--- a/scripts/hook-signals.ts
+++ b/scripts/hook-signals.ts
@@ -1,0 +1,142 @@
+/**
+ * hook-signals.ts — Structured detection of kaizen hook rejections in a run log.
+ *
+ * The auto-dent harness and the kaizen hooks share a structured contract for
+ * "this tool/stop/push was blocked". This module lets the harness consume that
+ * contract instead of guessing from English prose (issue #1102).
+ *
+ * Three structured shapes a kaizen hook can emit into a run log:
+ *
+ *   1. PreToolUse deny (JSON, e.g. enforce-plan-stored, check-dirty-files):
+ *        {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+ *          "permissionDecision":"deny","permissionDecisionReason":"..."}}
+ *
+ *   2. Stop / decision block (JSON, e.g. stop-gate):
+ *        {"decision":"block","reason":"..."}
+ *
+ *   3. Canonical hook output (YAML, gate-signal.ts via formatHookOutput):
+ *        ---
+ *        hook: check-dirty-files
+ *        type: deny|block
+ *        reason: ...
+ *        ---
+ *
+ * All three are deterministic. We never match English substrings here — that
+ * stays in classifyFailure() only as a documented legacy fallback.
+ */
+
+import { z } from 'zod';
+import { parseHookOutput } from '../src/hooks/lib/gate-signal.js';
+
+export type HookSignalSource = 'permission-decision' | 'stop-decision' | 'canonical-yaml';
+
+export interface HookSignal {
+  /** 'deny' = PreToolUse blocked; 'block' = Stop/session blocked. */
+  kind: 'deny' | 'block';
+  /** Which structured shape it was parsed from. */
+  source: HookSignalSource;
+  /** Hook name, when the shape carries one (canonical YAML). */
+  hook?: string;
+  /** Human-readable rejection reason, for observability. */
+  reason?: string;
+}
+
+// Zod schemas for the two JSON envelopes — no hand-rolled parsing (invariant I29).
+const PermissionDecisionSchema = z.object({
+  hookSpecificOutput: z.object({
+    permissionDecision: z.string(),
+    permissionDecisionReason: z.string().optional(),
+  }),
+});
+
+const StopDecisionSchema = z.object({
+  decision: z.string(),
+  reason: z.string().optional(),
+});
+
+/**
+ * Try to parse a single line as one of the JSON deny/block envelopes.
+ * Returns a signal only for genuine rejections (deny / block).
+ */
+function jsonSignalFromLine(line: string): HookSignal | null {
+  const trimmed = line.trim();
+  // Cheap pre-filter: only attempt JSON.parse on lines that look like an object.
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  const perm = PermissionDecisionSchema.safeParse(parsed);
+  if (perm.success && perm.data.hookSpecificOutput.permissionDecision === 'deny') {
+    return {
+      kind: 'deny',
+      source: 'permission-decision',
+      reason: perm.data.hookSpecificOutput.permissionDecisionReason,
+    };
+  }
+
+  const stop = StopDecisionSchema.safeParse(parsed);
+  if (stop.success && stop.data.decision === 'block') {
+    return { kind: 'block', source: 'stop-decision', reason: stop.data.reason };
+  }
+
+  return null;
+}
+
+/**
+ * Extract canonical-YAML hook outputs (gate-signal.ts) of type deny/block.
+ * The YAML blocks are delimited by `---` fences and may appear anywhere in the
+ * log, so we scan each fenced block independently.
+ */
+function yamlSignals(log: string): HookSignal[] {
+  const signals: HookSignal[] = [];
+  // Match each `---\n...\n---` fenced block; parseHookOutput validates content.
+  const fenceRe = /^---\n[\s\S]*?\n---/gm;
+  const blocks = log.match(fenceRe);
+  if (!blocks) return signals;
+  for (const block of blocks) {
+    const output = parseHookOutput(block);
+    if (output && (output.type === 'deny' || output.type === 'block')) {
+      signals.push({
+        kind: output.type,
+        source: 'canonical-yaml',
+        hook: output.hook,
+        reason: output.reason,
+      });
+    }
+  }
+  return signals;
+}
+
+/**
+ * Detect all structured hook rejections (deny/block) in a run log.
+ */
+export function detectHookSignals(log: string): HookSignal[] {
+  if (!log) return [];
+  const signals: HookSignal[] = [];
+
+  for (const line of log.split('\n')) {
+    const sig = jsonSignalFromLine(line);
+    if (sig) signals.push(sig);
+  }
+  signals.push(...yamlSignals(log));
+
+  return signals;
+}
+
+/** True if the run log contains any structured hook deny/block. */
+export function hasHookRejection(log: string): boolean {
+  return detectHookSignals(log).length > 0;
+}
+
+/** First rejection reason in the log, for compact observability display. */
+export function firstHookReason(log: string): string | undefined {
+  for (const sig of detectHookSignals(log)) {
+    if (sig.reason) return sig.reason;
+  }
+  return undefined;
+}

--- a/scripts/hook-signals.ts
+++ b/scripts/hook-signals.ts
@@ -21,8 +21,19 @@
  *        reason: ...
  *        ---
  *
- * All three are deterministic. We never match English substrings here — that
- * stays in classifyFailure() only as a documented legacy fallback.
+ * CRITICAL — the harness captures `claude --output-format stream-json`, so in a
+ * real run log the hook payload is NOT a bare top-level line. It is *nested as
+ * an escaped JSON string* inside a `hook_response` envelope, e.g.
+ *
+ *   {"type":"system","subtype":"hook_response","hook_event":"PreToolUse",
+ *     "output":"{\"hookSpecificOutput\":{...\"permissionDecision\":\"deny\"...}}",
+ *     "stdout":"{\"hookSpecificOutput\":...}", ...}
+ *
+ * So detection must (a) match a bare payload line (legacy / direct-hook output),
+ * AND (b) parse each stream-json envelope and re-scan its de-escaped string
+ * leaves (output/stdout/...) for the same three shapes. Both paths are
+ * deterministic and contract-coupled. We never match English substrings here —
+ * that stays in classifyFailure() only as a documented legacy fallback.
  */
 
 import { z } from 'zod';
@@ -55,12 +66,13 @@ const StopDecisionSchema = z.object({
 });
 
 /**
- * Try to parse a single line as one of the JSON deny/block envelopes.
- * Returns a signal only for genuine rejections (deny / block).
+ * Try to interpret a chunk of text as one of the JSON deny/block envelopes.
+ * Works on a bare log line OR a de-escaped string leaf pulled out of a
+ * stream-json envelope. Returns a signal only for genuine rejections.
  */
-function jsonSignalFromLine(line: string): HookSignal | null {
-  const trimmed = line.trim();
-  // Cheap pre-filter: only attempt JSON.parse on lines that look like an object.
+function jsonSignalFromText(text: string): HookSignal | null {
+  const trimmed = text.trim();
+  // Cheap pre-filter: only attempt JSON.parse on text that looks like an object.
   if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
 
   let parsed: unknown;
@@ -113,19 +125,80 @@ function yamlSignals(log: string): HookSignal[] {
 }
 
 /**
+ * Recursively collect the de-escaped string leaves of a parsed JSON value.
+ * The real harness shape nests the hook payload as an escaped JSON string in a
+ * `hook_response` envelope's `output`/`stdout` fields, so we must re-scan those
+ * de-escaped strings. Depth-bounded to stay O(envelope size) on large lines.
+ */
+function collectStringLeaves(value: unknown, acc: string[], depth = 0): void {
+  if (depth > 6) return;
+  if (typeof value === 'string') {
+    acc.push(value);
+  } else if (Array.isArray(value)) {
+    for (const v of value) collectStringLeaves(v, acc, depth + 1);
+  } else if (value && typeof value === 'object') {
+    for (const v of Object.values(value)) collectStringLeaves(v, acc, depth + 1);
+  }
+}
+
+/** Stable identity for de-duplicating signals (output and stdout often dupe). */
+function signalKey(s: HookSignal): string {
+  return `${s.kind}|${s.source}|${s.hook ?? ''}|${s.reason ?? ''}`;
+}
+
+/**
  * Detect all structured hook rejections (deny/block) in a run log.
+ *
+ * Two coupled paths, both contract-based:
+ *   - Bare payload lines (direct hook output / legacy): match the line itself.
+ *   - stream-json envelopes (real harness, `--output-format stream-json`):
+ *     parse the envelope and re-scan its de-escaped string leaves, because the
+ *     payload lives nested-and-escaped inside `output`/`stdout` (issue #1102).
  */
 export function detectHookSignals(log: string): HookSignal[] {
   if (!log) return [];
   const signals: HookSignal[] = [];
 
   for (const line of log.split('\n')) {
-    const sig = jsonSignalFromLine(line);
-    if (sig) signals.push(sig);
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // (a) bare payload line — the whole line IS the hook JSON.
+    const bare = jsonSignalFromText(trimmed);
+    if (bare) signals.push(bare);
+
+    // (b) stream-json envelope — re-scan de-escaped string leaves for the same
+    //     JSON and canonical-YAML shapes nested inside output/stdout/etc.
+    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      let env: unknown;
+      try {
+        env = JSON.parse(trimmed);
+      } catch {
+        env = null;
+      }
+      if (env && typeof env === 'object') {
+        const leaves: string[] = [];
+        collectStringLeaves(env, leaves);
+        for (const leaf of leaves) {
+          const inner = jsonSignalFromText(leaf);
+          if (inner) signals.push(inner);
+          signals.push(...yamlSignals(leaf));
+        }
+      }
+    }
   }
+
+  // Canonical YAML emitted as bare `---` fences directly in the log.
   signals.push(...yamlSignals(log));
 
-  return signals;
+  // De-duplicate: the same rejection surfaces in both `output` and `stdout`.
+  const seen = new Set<string>();
+  return signals.filter((s) => {
+    const key = signalKey(s);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 /** True if the run log contains any structured hook deny/block. */


### PR DESCRIPTION
## The Problem

The auto-dent harness runs unattended batches of kaizen work, then scores each
run to steer the next one. But it was **blind to its own hook interactions**.

`classifyFailure()` in `scripts/auto-dent-score.ts` has a rich log-based
heuristic branch — `hook_rejection`, `timeout`, `infrastructure`,
`scope_overflow`, `issue_blocked`. The catch: **every live caller invoked it
without the `logOutput` argument**. So the entire branch was dead code in
production, exercised only by unit tests. Non-crash failures fell through to
`crash`/`unknown`, and hook rejections — the precise choke-point signal the
harness needs to learn from — were invisible.

## The Discovery

Even the heuristic itself was **prose-coupled**: it matched English substrings
(`log.includes('hook rejected')`). Yet the harness and the hooks already share a
*structured contract* — `src/hooks/lib/gate-signal.ts` canonical YAML plus the
`permissionDecision:"deny"` / `decision:"block"` JSON envelopes hooks actually
emit. The harness ignored it and guessed from prose, so any reword silently
broke detection.

The boundary was prose-coupled, not contract-coupled, and the classifier was
built to read logs but never wired to receive them.

## The Solution

1. **New `scripts/hook-signals.ts`** consumes the canonical hook contract
   directly — Zod-validated `permissionDecision:"deny"` and `decision:"block"`
   JSON envelopes, plus canonical `gate-signal.ts` YAML blocks via the shared
   `parseHookOutput`. No English-substring matching here; that stays only as a
   documented legacy fallback in `classifyFailure` for non-kaizen framework
   hooks (e.g. raw pre-commit).
2. **Wire the run log into the classifier** at the live call site in
   `auto-dent-run.ts`: read `logFile` and pass it, so the heuristic branch
   finally receives input.
3. **Surface observability** — store `hook_rejection_reason` on `RunMetrics` so
   batch reporting can say *which* hook blocked and *why*.

## The Evidence

| Behavior | Level |
|----------|-------|
| Detect `permissionDecision:"deny"` envelope | Unit |
| Detect stop-gate `decision:"block"` envelope | Unit |
| BOUNDARY CONTRACT: `formatHookOutput({type:'deny'})` output is detected by `detectHookSignals` | Integration (contract) |
| BOUNDARY CONTRACT: canonical block signal is detected | Integration (contract) |
| No false positives on a clean log | Unit |
| `firstHookReason` surfaces the reason for observability | Unit |
| Malformed JSON lines ignored without throwing | Unit |
| LIVE-WIRING REGRESSION: `auto-dent-run.ts` reads `logFile` and passes it to `classifyFailure` | Integration (source-pin) |

Full suite: 2711 passed, 10 skipped.

## The Impact

The compound interest: **any hook that speaks the canonical `gate-signal.ts`
schema is now automatically observable to the harness** — no per-hook wiring.
The boundary-contract test fails if the schema ever drifts from what the harness
parses, and the live-wiring regression test pins the call site so the heuristic
branch can never be silently re-orphaned. This is the first concrete step of the
auto-dent intelligence/observability debt (#940, #842): the harness can finally
see the hooks as a structured choke-point signal, not English prose.

This PR finishes work that was implemented but never opened as a PR — bringing a
half-written improvement to a good place.

Closes #1102
Refs: #843, #940, #842

Run tag: sticky-lark/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review correction (round 1)

Adversarial review caught a critical defect in the first cut: `detectHookSignals` assumed a **bare top-level** hook payload, but the harness captures `claude --output-format stream-json`, where the deny/block is **nested as an escaped JSON string** inside a `hook_response` envelope's `output`/`stdout`. Proven against the real committed capture `fixtures/live/probe-hooks.jsonl`: 0 signals detected, `classifyFailure` returned `crash`.

Fixed (commit 32fb499): the detector now parses each stream-json envelope and re-scans its de-escaped string leaves for the same three structured shapes, de-duping the output/stdout duplicate. End-to-end on the real capture: **3 signals detected, `classifyFailure` → `hook_rejection`**. Added a fixture-backed regression test that feeds the genuine capture — the test that would have caught the original bug. The irony: the fix had the same boundary blind-spot #1102 set out to cure, one layer down. Now closed.