### PR TITLE
feat(auto-dent): cross-batch outcomes steer the next batch (Closes #1116, #940 Phase 2)

### DIFF
--- a/prompts/deep-dive-default.md
+++ b/prompts/deep-dive-default.md
@@ -27,6 +27,17 @@ Prior mid-batch reflection produced these insights. Use them to guide your work:
 Factor these insights into your issue selection and approach.
 {{/reflection_insights}}
 
+{{#cross_batch_steering}}
+## Cross-Batch Steering (from prior batches)
+
+Earlier auto-dent batches recorded structured outcomes on GitHub. Analyzing them
+surfaced these steering signals — weigh them when choosing what to work on and how:
+
+{{cross_batch_steering}}
+
+These reflect what worked and what didn't across batches, not just this one.
+{{/cross_batch_steering}}
+
 {{#contemplation_recommendations}}
 ## Strategic Recommendations (from contemplation)
 

--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -20,6 +20,7 @@ import {
   readAggregate,
   computeAggregateStats,
   formatAggregateStats,
+  buildSteerOutput,
   DEFAULT_WATCHDOG_THRESHOLD_SEC,
   type BatchInfo,
   type WatchdogResult,
@@ -1091,5 +1092,33 @@ describe('formatAggregateStats', () => {
     expect(output).toContain('60%');
     expect(output).toContain('Recent batches');
     expect(output).toContain('b1');
+  });
+});
+
+describe('buildSteerOutput — cloud-backed steer command (#940 Phase 2)', () => {
+  function outcome(over: Record<string, unknown> = {}): any {
+    return {
+      schema_version: 1, batch_id: 'b', guidance: 'g', batch_start: 1, batch_end: 2,
+      wall_seconds: 1, stop_reason: 'completed',
+      totals: { runs: 4, successful_runs: 3, prs: 3, issues_closed: 3, issues_filed: 0, cost_usd: 10, duration_seconds: 100, lines_deleted: 0, issues_pruned: 0 },
+      success_rate: 0.75, avg_cost_per_success: 3, overall_efficiency: 0.3, review_fail_rate: 0,
+      cost_anomaly_count: 0, mode_diversity: 1, trend: null, mode_breakdown: [], prs: [], issues_closed: [], issues_filed: [],
+      ...over,
+    };
+  }
+
+  it('wires read → analyze → format end to end with injected deps', () => {
+    const out = buildSteerOutput('Garsson-io/kaizen', {}, {
+      listIssues: () => [101, 102],
+      readOutcome: (n) =>
+        outcome({ batch_id: `b${n}`, batch_start: Number(n), review_fail_rate: 0.5 }),
+    });
+    expect(out).toContain('Cross-Batch Steering');
+    expect(out).toContain('Review fail rate');
+  });
+
+  it('renders the cold-start report when no outcomes are found', () => {
+    const out = buildSteerOutput('Garsson-io/kaizen', {}, { listIssues: () => [] });
+    expect(out).toMatch(/without cross-batch steering/i);
   });
 });

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -34,6 +34,12 @@ import {
   failureClassLabel,
   formatFailureDistribution,
 } from './auto-dent-score.js';
+import {
+  readBatchOutcomesFromGithub,
+  computeSteeringRecommendations,
+  formatSteeringReport,
+  type ReadOutcomesDeps,
+} from './batch-outcome.js';
 
 function getRepoRoot(): string {
   try {
@@ -49,6 +55,40 @@ function getRepoRoot(): string {
 
 function getLogsDir(): string {
   return join(getRepoRoot(), 'logs', 'auto-dent');
+}
+
+/**
+ * Resolve the kaizen repo for cloud reads. Priority: explicit `--repo`, then the
+ * newest discovered batch's `kaizen_repo`, then `kaizen.config.json`. Returns ''
+ * if none can be found.
+ */
+function resolveKaizenRepo(explicit: string | undefined, logsDir: string): string {
+  if (explicit) return explicit;
+  const batches = discoverBatches(logsDir);
+  for (const b of batches) {
+    const r = b.state.kaizen_repo || b.state.host_repo;
+    if (r && r !== 'unknown') return r;
+  }
+  try {
+    const cfg = JSON.parse(readFileSync(join(getRepoRoot(), 'kaizen.config.json'), 'utf8'));
+    return cfg?.kaizen?.repo || cfg?.host?.repo || '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Read cross-batch outcomes from GitHub, analyze them, and render the steering
+ * report (#940 Phase 2). Exported so the read→analyze→format wiring is testable
+ * with injected deps (no network).
+ */
+export function buildSteerOutput(
+  repo: string,
+  opts: { limit?: number } = {},
+  deps: ReadOutcomesDeps = {},
+): string {
+  const outcomes = readBatchOutcomesFromGithub(repo, { limit: opts.limit }, deps);
+  return formatSteeringReport(computeSteeringRecommendations(outcomes));
 }
 
 export interface BatchInfo {
@@ -974,6 +1014,7 @@ Usage:
   auto-dent-ctl.ts reflect --post [batch-id]  Post reflection summary to progress issue (#571)
   auto-dent-ctl.ts reflect --prompt [batch-id]  Output rendered prompt for Claude reflection
   auto-dent-ctl.ts history             Cross-batch aggregate stats (#586)
+  auto-dent-ctl.ts steer [--repo R] [--limit N]  Cross-batch steering read from GitHub outcomes (#940 Phase 2)
   auto-dent-ctl.ts aggregate [batch-id]  Append batch(es) to aggregate.jsonl (called at batch end)
   auto-dent-ctl.ts watchdog [--threshold N]  Check heartbeats, halt stale batches (default: 600s)
 
@@ -1223,6 +1264,25 @@ Cross-batch learning (#586):
       }
       const stats = computeAggregateStats(records);
       console.log(formatAggregateStats(stats));
+      break;
+    }
+
+    case 'steer': {
+      // Cloud-backed cross-batch steering (#940 Phase 2): read batch-outcome
+      // attachments from GitHub progress issues and print the recommendations the
+      // next batch would receive in its prompt.
+      let repoArg: string | undefined;
+      let limit: number | undefined;
+      for (let i = 1; i < args.length; i++) {
+        if (args[i] === '--repo' && args[i + 1]) repoArg = args[++i];
+        else if (args[i] === '--limit' && args[i + 1]) limit = parseInt(args[++i], 10);
+      }
+      const repo = resolveKaizenRepo(repoArg, logsDir);
+      if (!repo) {
+        console.error('Could not resolve kaizen repo. Pass --repo <owner/name>.');
+        process.exit(1);
+      }
+      console.log(buildSteerOutput(repo, { limit }));
       break;
     }
 

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -47,6 +47,7 @@ import {
   findExistingProgressIssue,
   ensureBatchProgressIssue,
   extractPlanText,
+  populateCrossBatchSteering,
 } from './auto-dent-run.js';
 import * as github from './auto-dent-github.js';
 
@@ -320,6 +321,78 @@ describe('buildTemplateVars with reflection insights', () => {
     const state = makeBatchState();
     const vars = buildTemplateVars(state, 3, tmpDir);
     expect(vars.reflection_insights).toBe('');
+  });
+
+  it('surfaces cross_batch_steering as a numbered list when state has it', () => {
+    const state = makeBatchState({ cross_batch_steering: ['Prefer exploit mode', 'Tighten test plans'] });
+    const vars = buildTemplateVars(state, 1);
+    expect(vars.cross_batch_steering).toContain('1. Prefer exploit mode');
+    expect(vars.cross_batch_steering).toContain('2. Tighten test plans');
+  });
+
+  it('renders the cross-batch steering block in the prompt only when non-empty', () => {
+    const withSteering = buildPrompt(makeBatchState({ cross_batch_steering: ['Reduce scope per run'] }), 1);
+    expect(withSteering).toContain('Cross-Batch Steering');
+    expect(withSteering).toContain('Reduce scope per run');
+
+    const without = buildPrompt(makeBatchState({ cross_batch_steering: [] }), 1);
+    expect(without).not.toContain('Cross-Batch Steering');
+  });
+});
+
+describe('populateCrossBatchSteering — close the loop (#940 Phase 2)', () => {
+  function tmpState(state: BatchState): string {
+    const dir = mkdtempSync(join(tmpdir(), 'cbs-'));
+    const f = join(dir, 'state.json');
+    writeState(f, state);
+    return f;
+  }
+
+  it('stores steering derived from prior outcomes and persists it', () => {
+    const state = makeBatchState({ batch_id: 'self' });
+    const f = tmpState(state);
+    const result = populateCrossBatchSteering(state, f, {
+      read: () => [
+        // Two batches, both stopped "backlog exhausted" → recurring stop-reason signal.
+        {
+          schema_version: 1, batch_id: 'p1', guidance: 'g', batch_start: 1, batch_end: 2,
+          wall_seconds: 1, stop_reason: 'backlog exhausted — no more open issues',
+          totals: { runs: 2, successful_runs: 2, prs: 2, issues_closed: 2, issues_filed: 0, cost_usd: 4, duration_seconds: 100, lines_deleted: 0, issues_pruned: 0 },
+          success_rate: 1, avg_cost_per_success: 2, overall_efficiency: 0.5, review_fail_rate: 0,
+          cost_anomaly_count: 0, mode_diversity: 1, trend: null, mode_breakdown: [], prs: [], issues_closed: [], issues_filed: [],
+        },
+        {
+          schema_version: 1, batch_id: 'p2', guidance: 'g', batch_start: 3, batch_end: 4,
+          wall_seconds: 1, stop_reason: 'backlog exhausted matching guidance',
+          totals: { runs: 2, successful_runs: 2, prs: 2, issues_closed: 2, issues_filed: 0, cost_usd: 4, duration_seconds: 100, lines_deleted: 0, issues_pruned: 0 },
+          success_rate: 1, avg_cost_per_success: 2, overall_efficiency: 0.5, review_fail_rate: 0,
+          cost_anomaly_count: 0, mode_diversity: 1, trend: null, mode_breakdown: [], prs: [], issues_closed: [], issues_filed: [],
+        },
+      ],
+    });
+    expect(result.some((s) => /backlog exhausted/i.test(s))).toBe(true);
+    // Persisted to state and onto disk.
+    expect(state.cross_batch_steering).toEqual(result);
+    expect(readState(f).cross_batch_steering).toEqual(result);
+  });
+
+  it('is idempotent — does not refetch when already populated', () => {
+    const state = makeBatchState({ cross_batch_steering: ['already here'] });
+    const f = tmpState(state);
+    let called = false;
+    const result = populateCrossBatchSteering(state, f, { read: () => { called = true; return []; } });
+    expect(called).toBe(false);
+    expect(result).toEqual(['already here']);
+  });
+
+  it('fails open — a GitHub error yields empty steering, never a throw', () => {
+    const state = makeBatchState({ batch_id: 'self' });
+    const f = tmpState(state);
+    const result = populateCrossBatchSteering(state, f, {
+      read: () => { throw new Error('gh issue list failed: network'); },
+    });
+    expect(result).toEqual([]);
+    expect(state.cross_batch_steering).toEqual([]);
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -39,7 +39,12 @@ import {
 import { EventEmitter, makeRunId, type AutoDentEvent } from './auto-dent-events.js';
 import { runFixLoop, type CliArgs as ReviewFixArgs } from './review-fix.js';
 import { buildRunManifest, writeRunManifest, bundleArtifacts, formatManifestSummary } from './auto-dent-artifacts.js';
-import { buildBatchOutcome, writeBatchOutcomeAttachment } from './batch-outcome.js';
+import {
+  buildBatchOutcome,
+  writeBatchOutcomeAttachment,
+  readBatchOutcomesFromGithub,
+  computeSteeringRecommendations,
+} from './batch-outcome.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -153,6 +158,12 @@ export interface BatchState {
   contemplation_recommendations?: string[];
   /** Insights from reflect-mode runs that feed back into subsequent runs (#699) */
   reflection_insights?: string[];
+  /**
+   * Cross-batch steering derived from PRIOR batches' GitHub outcomes (#940 Phase 2).
+   * Populated once per batch (fail-open) and surfaced as {{cross_batch_steering}}
+   * so observable cloud data biases this batch's choices.
+   */
+  cross_batch_steering?: string[];
 }
 
 export interface RunMetrics {
@@ -424,6 +435,12 @@ export function buildTemplateVars(
     ? contemplationRecs.map((r, i) => `${i + 1}. ${r}`).join('\n')
     : '';
 
+  // Cross-batch steering from prior batches' GitHub outcomes (#940 Phase 2).
+  const crossBatchSteering = [...new Set(state.cross_batch_steering || [])];
+  const crossBatchSteeringText = crossBatchSteering.length > 0
+    ? crossBatchSteering.map((r, i) => `${i + 1}. ${r}`).join('\n')
+    : '';
+
   return {
     guidance: state.guidance,
     run_tag: runTag,
@@ -440,6 +457,7 @@ export function buildTemplateVars(
     plan_assignment: planAssignment,
     claimed_plan_issue: claimedPlanIssue,
     reflection_insights: reflectionInsights,
+    cross_batch_steering: crossBatchSteeringText,
     run_history_table: runHistoryTable,
     total_cost: totalCost,
     pr_count: prCount,
@@ -755,6 +773,61 @@ export interface PromptMetadata {
 
 export function buildPrompt(state: BatchState, runNum: number, logDir?: string): string {
   return buildPromptWithMetadata(state, runNum, logDir).prompt;
+}
+
+/**
+ * Populate `state.cross_batch_steering` from PRIOR batches' GitHub outcomes,
+ * once per batch (#940 Phase 2). This is what closes the cross-batch learning
+ * loop: Phase 1 wrote durable `batch-outcome` records to GitHub; here a later
+ * batch reads them, derives steering recommendations, and persists them so every
+ * run in this batch sees them via {{cross_batch_steering}}.
+ *
+ * Fail-open and idempotent: runs only when the field is unset, and any GitHub /
+ * parse error degrades to an empty array (no steering) rather than breaking the
+ * run. The result is persisted so it is computed at most once per batch. `deps`
+ * is injectable for tests. Returns the steering strings that were stored.
+ */
+export function populateCrossBatchSteering(
+  state: BatchState,
+  stateFile: string,
+  deps: { read?: typeof readBatchOutcomesFromGithub } = {},
+): string[] {
+  // Already attempted this batch (possibly resumed) — don't refetch.
+  if (state.cross_batch_steering !== undefined) return state.cross_batch_steering;
+
+  const repo = state.kaizen_repo;
+  let steering: string[] = [];
+  if (repo && repo !== 'unknown') {
+    try {
+      const read = deps.read ?? readBatchOutcomesFromGithub;
+      const outcomes = read(repo, { excludeBatchId: state.batch_id });
+      const report = computeSteeringRecommendations(outcomes);
+      steering = report.recommendations.map((r) => r.text);
+      if (steering.length > 0) {
+        console.log(
+          `  [intelligence] cross-batch steering: ${steering.length} signal(s) from ${report.batches_analyzed} prior batch(es)`,
+        );
+      } else {
+        console.log(
+          `  [intelligence] cross-batch steering: no strong signal from ${report.batches_analyzed} prior batch(es)`,
+        );
+      }
+    } catch (err) {
+      // Fail-open: prior-batch intelligence is a nicety, never a blocker.
+      console.log(
+        `  [intelligence] cross-batch steering skipped: ${(err as Error).message?.split('\n')[0]}`,
+      );
+      steering = [];
+    }
+  }
+
+  state.cross_batch_steering = steering;
+  try {
+    writeState(stateFile, state);
+  } catch {
+    /* best-effort persistence; in-memory value still steers this run */
+  }
+  return steering;
 }
 
 export function buildPromptWithMetadata(state: BatchState, runNum: number, logDir?: string): PromptMetadata {
@@ -1620,6 +1693,10 @@ async function main(): Promise<void> {
   if (resetCount > 0) {
     console.log(`  [plan] reset ${resetCount} interrupted item(s) from 'assigned' to 'pending'`);
   }
+
+  // Close the cross-batch learning loop (#940 Phase 2): read prior batches'
+  // GitHub outcomes once per batch and surface steering via the prompt. Fail-open.
+  populateCrossBatchSteering(state, stateFile);
 
   const timestamp = new Date().toISOString().replace(/[-:T]/g, '').slice(2, 14);
   const logFile = `${logDir}/run-${runNum}-${timestamp}.log`;

--- a/scripts/batch-outcome.test.ts
+++ b/scripts/batch-outcome.test.ts
@@ -4,10 +4,15 @@ import {
   buildBatchOutcome,
   writeBatchOutcomeAttachment,
   readBatchOutcome,
+  readBatchOutcomesFromGithub,
+  computeSteeringRecommendations,
+  formatSteeringReport,
+  steeringPromptText,
   BatchOutcomeSchema,
   BATCH_OUTCOME_ATTACHMENT,
   BATCH_OUTCOME_SCHEMA_VERSION,
 } from './batch-outcome.js';
+import type { BatchOutcome } from './batch-outcome.js';
 import { clearCommentCache } from '../src/section-editor.js';
 import type { BatchState } from './auto-dent-run.js';
 import type { BatchScore } from './auto-dent-score.js';
@@ -175,5 +180,197 @@ describe('write/read attachment wrappers — gh-backed', () => {
     const body = `<!-- kaizen:${BATCH_OUTCOME_ATTACHMENT} -->\n{"schema_version": 99}`;
     ghReturns(JSON.stringify({ url: 'https://...#issuecomment-456', body }));
     expect(() => readBatchOutcome('1099', 'Garsson-io/kaizen')).toThrow();
+  });
+});
+
+// --- Phase 2 (#940): read-back + steering analysis --------------------------
+
+/** Build a steering-relevant outcome fixture. Only fields the analysis reads matter. */
+function makeOutcome(overrides: Partial<BatchOutcome> = {}): BatchOutcome {
+  const base: BatchOutcome = {
+    schema_version: BATCH_OUTCOME_SCHEMA_VERSION,
+    batch_id: 'batch-a',
+    guidance: 'g',
+    batch_start: 1_000,
+    batch_end: 2_000,
+    wall_seconds: 1_000,
+    stop_reason: 'completed',
+    totals: {
+      runs: 4, successful_runs: 3, prs: 3, issues_closed: 3, issues_filed: 0,
+      cost_usd: 10, duration_seconds: 1000, lines_deleted: 0, issues_pruned: 0,
+    },
+    success_rate: 0.75,
+    avg_cost_per_success: 3.3,
+    overall_efficiency: 0.3,
+    review_fail_rate: 0,
+    cost_anomaly_count: 0,
+    mode_diversity: 1,
+    trend: null,
+    mode_breakdown: [],
+    prs: [],
+    issues_closed: [],
+    issues_filed: [],
+  };
+  return { ...base, ...overrides };
+}
+
+const mode = (mode: string, runs: number, successes: number, prs: number, cost: number) => ({
+  mode, runs, successes, success_rate: runs ? successes / runs : 0,
+  cost_usd: cost, prs, avg_cost: runs ? cost / runs : 0,
+  efficiency: cost ? prs / cost : 0, lines_deleted: 0, issues_pruned: 0,
+});
+
+describe('computeSteeringRecommendations — pure analysis', () => {
+  it('returns a cold-start report for no outcomes', () => {
+    const r = computeSteeringRecommendations([]);
+    expect(r.batches_analyzed).toBe(0);
+    expect(r.span).toBeNull();
+    expect(r.recommendations).toEqual([]);
+    expect(r.summary).toMatch(/without cross-batch steering/i);
+  });
+
+  it('ranks modes and recommends the more productive one when the gap is meaningful', () => {
+    // exploit: 100% success across batches; explore: 0%.
+    const a = makeOutcome({ batch_id: 'a', batch_start: 1, mode_breakdown: [mode('exploit', 3, 3, 3, 9)] });
+    const b = makeOutcome({ batch_id: 'b', batch_start: 2, mode_breakdown: [mode('explore', 3, 0, 0, 9)] });
+    const r = computeSteeringRecommendations([a, b]);
+    expect(r.best_mode).toBe('exploit');
+    expect(r.worst_mode).toBe('explore');
+    const modeRec = r.recommendations.find((x) => x.kind === 'mode');
+    expect(modeRec?.text).toMatch(/Prefer "exploit"/);
+  });
+
+  it('does not rank modes with too little evidence (<3 runs)', () => {
+    const a = makeOutcome({ batch_start: 1, mode_breakdown: [mode('exploit', 2, 2, 2, 4), mode('explore', 1, 0, 0, 2)] });
+    const r = computeSteeringRecommendations([a]);
+    expect(r.recommendations.find((x) => x.kind === 'mode')).toBeUndefined();
+  });
+
+  it('flags a declining success-rate trajectory', () => {
+    const good = makeOutcome({ batch_id: 'g1', batch_start: 1, success_rate: 0.9 });
+    const good2 = makeOutcome({ batch_id: 'g2', batch_start: 2, success_rate: 0.9 });
+    const bad = makeOutcome({ batch_id: 'b1', batch_start: 3, success_rate: 0.4 });
+    const bad2 = makeOutcome({ batch_id: 'b2', batch_start: 4, success_rate: 0.3 });
+    const r = computeSteeringRecommendations([bad2, good, bad, good2]); // unsorted on purpose
+    const traj = r.recommendations.find((x) => x.kind === 'trajectory');
+    expect(traj?.text).toMatch(/declining/i);
+    // Declining trajectory is the highest-priority signal → sorts first.
+    expect(r.recommendations[0].kind).toBe('trajectory');
+  });
+
+  it('notes an improving trajectory', () => {
+    const r = computeSteeringRecommendations([
+      makeOutcome({ batch_start: 1, success_rate: 0.3 }),
+      makeOutcome({ batch_start: 2, success_rate: 0.4 }),
+      makeOutcome({ batch_start: 3, success_rate: 0.9 }),
+      makeOutcome({ batch_start: 4, success_rate: 0.9 }),
+    ]);
+    expect(r.recommendations.find((x) => x.kind === 'trajectory')?.text).toMatch(/improving/i);
+  });
+
+  it('flags high review fail rate', () => {
+    const r = computeSteeringRecommendations([makeOutcome({ review_fail_rate: 0.5 })]);
+    expect(r.recommendations.find((x) => x.kind === 'review')?.text).toMatch(/Review fail rate/);
+  });
+
+  it('surfaces a recurring stop reason when it dominates', () => {
+    const r = computeSteeringRecommendations([
+      makeOutcome({ batch_id: '1', batch_start: 1, stop_reason: 'backlog exhausted — no more open issues' }),
+      makeOutcome({ batch_id: '2', batch_start: 2, stop_reason: 'backlog exhausted matching guidance' }),
+    ]);
+    const stop = r.recommendations.find((x) => x.kind === 'stop_reason');
+    expect(stop?.text).toMatch(/backlog exhausted/i);
+    expect(stop?.text).toMatch(/decompose an epic/i);
+  });
+
+  it('does not surface a stop reason that appears only once', () => {
+    const r = computeSteeringRecommendations([
+      makeOutcome({ batch_id: '1', batch_start: 1, stop_reason: 'backlog exhausted' }),
+      makeOutcome({ batch_id: '2', batch_start: 2, stop_reason: 'completed' }),
+    ]);
+    expect(r.recommendations.find((x) => x.kind === 'stop_reason')).toBeUndefined();
+  });
+
+  it('flags recurring cost anomalies', () => {
+    const r = computeSteeringRecommendations([
+      makeOutcome({ batch_id: '1', batch_start: 1, cost_anomaly_count: 2 }),
+      makeOutcome({ batch_id: '2', batch_start: 2, cost_anomaly_count: 1 }),
+    ]);
+    expect(r.recommendations.find((x) => x.kind === 'cost')?.text).toMatch(/Cost anomalies recur/);
+  });
+
+  it('gives no strong signal for a single healthy batch', () => {
+    const r = computeSteeringRecommendations([makeOutcome()]);
+    expect(r.batches_analyzed).toBe(1);
+    expect(r.recommendations).toEqual([]);
+    expect(r.summary).toMatch(/no strong steering signal/i);
+  });
+
+  it('is deterministic — same input, same report', () => {
+    const outcomes = [
+      makeOutcome({ batch_start: 1, success_rate: 0.9 }),
+      makeOutcome({ batch_start: 2, success_rate: 0.4 }),
+    ];
+    expect(computeSteeringRecommendations(outcomes)).toEqual(computeSteeringRecommendations(outcomes));
+  });
+});
+
+describe('formatSteeringReport / steeringPromptText', () => {
+  it('renders a cold-start report compactly', () => {
+    const text = formatSteeringReport(computeSteeringRecommendations([]));
+    expect(text).toMatch(/Cross-Batch Steering/);
+    expect(text).not.toMatch(/Recommendations:/);
+  });
+
+  it('lists recommendations and best/worst mode', () => {
+    const a = makeOutcome({ batch_id: 'a', batch_start: 1, mode_breakdown: [mode('exploit', 3, 3, 3, 9)] });
+    const b = makeOutcome({ batch_id: 'b', batch_start: 2, mode_breakdown: [mode('explore', 3, 0, 0, 9)] });
+    const text = formatSteeringReport(computeSteeringRecommendations([a, b]));
+    expect(text).toMatch(/Best mode: exploit/);
+    expect(text).toMatch(/Recommendations:/);
+  });
+
+  it('steeringPromptText is empty when no recommendations, numbered otherwise', () => {
+    expect(steeringPromptText(computeSteeringRecommendations([]))).toBe('');
+    const r = computeSteeringRecommendations([makeOutcome({ review_fail_rate: 0.6 })]);
+    expect(steeringPromptText(r)).toMatch(/^1\. /);
+  });
+});
+
+describe('readBatchOutcomesFromGithub — discovery (injected deps)', () => {
+  it('reads outcomes for each discovered issue, skipping ones without an attachment', () => {
+    const out = readBatchOutcomesFromGithub('Garsson-io/kaizen', {}, {
+      listIssues: () => [10, 11, 12],
+      readOutcome: (n) =>
+        n === '11' ? null : makeOutcome({ batch_id: `b${n}` }),
+    });
+    expect(out.map((o) => o.batch_id)).toEqual(['b10', 'b12']);
+  });
+
+  it('excludes the current batch via excludeBatchId', () => {
+    const out = readBatchOutcomesFromGithub('Garsson-io/kaizen', { excludeBatchId: 'self' }, {
+      listIssues: () => [1, 2],
+      readOutcome: (n) => makeOutcome({ batch_id: n === '1' ? 'self' : 'other' }),
+    });
+    expect(out.map((o) => o.batch_id)).toEqual(['other']);
+  });
+
+  it('passes the limit through to the lister', () => {
+    let seenLimit = -1;
+    readBatchOutcomesFromGithub('Garsson-io/kaizen', { limit: 5 }, {
+      listIssues: (_repo, limit) => { seenLimit = limit; return []; },
+    });
+    expect(seenLimit).toBe(5);
+  });
+
+  it('skips a malformed attachment instead of aborting the whole sweep', () => {
+    const out = readBatchOutcomesFromGithub('Garsson-io/kaizen', {}, {
+      listIssues: () => [1, 2, 3],
+      readOutcome: (n) => {
+        if (n === '2') throw new Error('schema drift');
+        return makeOutcome({ batch_id: `b${n}` });
+      },
+    });
+    expect(out.map((o) => o.batch_id)).toEqual(['b1', 'b3']);
   });
 });

--- a/scripts/batch-outcome.ts
+++ b/scripts/batch-outcome.ts
@@ -16,6 +16,7 @@
 
 import { z } from 'zod';
 import { writeAttachment, readAttachment } from '../src/section-editor.js';
+import { gh } from '../src/lib/gh-exec.js';
 import type { BatchState } from './auto-dent-run.js';
 import type { BatchScore } from './auto-dent-score.js';
 
@@ -184,4 +185,332 @@ export function readBatchOutcome(
   );
   if (!attachment) return null;
   return BatchOutcomeSchema.parse(JSON.parse(attachment.content));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 (#940) — read prior batch outcomes back from GitHub and turn them
+// into steering recommendations that bias the next batch's prompt.
+//
+// Phase 1 made the outcome durable and cloud-accessible. The loop only closes
+// when a *later* batch reads those outcomes and changes what it does. This is
+// the read + analyze side: discovery (`readBatchOutcomesFromGithub`), analysis
+// (`computeSteeringRecommendations`), and display (`formatSteeringReport`).
+// ---------------------------------------------------------------------------
+
+/** Options for {@link readBatchOutcomesFromGithub}. */
+export interface ReadOutcomesOpts {
+  /** Max progress issues to scan, newest-first. Default 20. */
+  limit?: number;
+  /** Skip the outcome whose `batch_id` matches (exclude the current batch's own record). */
+  excludeBatchId?: string;
+}
+
+/**
+ * Injectable I/O for {@link readBatchOutcomesFromGithub}, so the discovery
+ * logic is unit-testable without touching the network. Defaults shell out to
+ * `gh` and reuse {@link readBatchOutcome}.
+ */
+export interface ReadOutcomesDeps {
+  /** Return auto-dent progress-issue numbers, newest-first, bounded by `limit`. */
+  listIssues?: (repo: string, limit: number) => number[];
+  /** Resolve one issue's batch-outcome attachment (null if absent). */
+  readOutcome?: (issueNumber: string, repo: string) => BatchOutcome | null;
+}
+
+/** Default lister: every batch progress issue carries the `auto-dent` label (see auto-dent-run.ts). */
+function defaultListIssues(repo: string, limit: number): number[] {
+  const out = gh([
+    'issue', 'list', '--repo', repo,
+    '--label', 'auto-dent', '--state', 'all',
+    '--json', 'number', '--jq', '.[].number',
+    '--limit', String(limit),
+  ]);
+  return out
+    .split('\n')
+    .map((l) => parseInt(l.trim(), 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+
+/**
+ * Discover prior batches' outcomes from GitHub. Enumerates `auto-dent`-labeled
+ * progress issues (newest-first), reads each one's `batch-outcome` attachment,
+ * and returns the validated outcomes.
+ *
+ * Fail-soft per issue: a missing attachment is skipped, and a malformed one is
+ * skipped (not thrown) so a single drifted batch can't blind the next — this is
+ * read-side steering, where fail-open beats fail-closed. The current batch's own
+ * record is excluded via `excludeBatchId`.
+ */
+export function readBatchOutcomesFromGithub(
+  repo: string,
+  opts: ReadOutcomesOpts = {},
+  deps: ReadOutcomesDeps = {},
+): BatchOutcome[] {
+  const limit = opts.limit ?? 20;
+  const listIssues = deps.listIssues ?? defaultListIssues;
+  const readOutcome = deps.readOutcome ?? readBatchOutcome;
+
+  const numbers = listIssues(repo, limit);
+  const outcomes: BatchOutcome[] = [];
+  for (const n of numbers) {
+    let outcome: BatchOutcome | null = null;
+    try {
+      outcome = readOutcome(String(n), repo);
+    } catch {
+      // Malformed attachment on one issue — skip, don't abort the sweep.
+      continue;
+    }
+    if (!outcome) continue;
+    if (opts.excludeBatchId && outcome.batch_id === opts.excludeBatchId) continue;
+    outcomes.push(outcome);
+  }
+  return outcomes;
+}
+
+/** One steering recommendation with a priority for stable ordering. */
+export interface SteeringRecommendation {
+  /** Lower sorts first. */
+  priority: number;
+  /** Category, for grouping/telemetry. */
+  kind: 'trajectory' | 'mode' | 'review' | 'stop_reason' | 'cost';
+  /** Concrete, actionable guidance the next batch should weigh. */
+  text: string;
+}
+
+/** Result of {@link computeSteeringRecommendations}. */
+export interface SteeringReport {
+  batches_analyzed: number;
+  /** Oldest/newest `batch_start` seen, or null when empty. */
+  span: { from: number; to: number } | null;
+  best_mode: string | null;
+  worst_mode: string | null;
+  recommendations: SteeringRecommendation[];
+  /** One-line headline. */
+  summary: string;
+}
+
+/** Per-mode rollup across all analyzed batches. */
+interface ModeRollup {
+  mode: string;
+  runs: number;
+  successes: number;
+  prs: number;
+  cost_usd: number;
+  success_rate: number;
+  efficiency: number; // PRs per $ — higher is better
+}
+
+function rollupModes(outcomes: BatchOutcome[]): ModeRollup[] {
+  const acc = new Map<string, { runs: number; successes: number; prs: number; cost: number }>();
+  for (const o of outcomes) {
+    for (const m of o.mode_breakdown) {
+      const cur = acc.get(m.mode) ?? { runs: 0, successes: 0, prs: 0, cost: 0 };
+      cur.runs += m.runs;
+      cur.successes += m.successes;
+      cur.prs += m.prs;
+      cur.cost += m.cost_usd;
+      acc.set(m.mode, cur);
+    }
+  }
+  return [...acc.entries()].map(([mode, v]) => ({
+    mode,
+    runs: v.runs,
+    successes: v.successes,
+    prs: v.prs,
+    cost_usd: v.cost,
+    success_rate: v.runs > 0 ? v.successes / v.runs : 0,
+    efficiency: v.cost > 0 ? v.prs / v.cost : 0,
+  }));
+}
+
+const pct = (x: number): string => `${Math.round(x * 100)}%`;
+
+/**
+ * Turn a set of batch outcomes into prioritized, concrete steering
+ * recommendations. PURE and deterministic: no clock, no I/O. Trajectory is
+ * computed from the outcomes' own `batch_start` timestamps, so the same input
+ * always yields the same report. Degrades gracefully on empty / single-batch
+ * input (no false signals from one data point).
+ */
+export function computeSteeringRecommendations(
+  outcomes: BatchOutcome[],
+): SteeringReport {
+  if (outcomes.length === 0) {
+    return {
+      batches_analyzed: 0,
+      span: null,
+      best_mode: null,
+      worst_mode: null,
+      recommendations: [],
+      summary: 'No prior batch outcomes on GitHub — this batch starts without cross-batch steering.',
+    };
+  }
+
+  // Chronological order for trajectory comparisons.
+  const sorted = [...outcomes].sort((a, b) => a.batch_start - b.batch_start);
+  const span = { from: sorted[0].batch_start, to: sorted[sorted.length - 1].batch_start };
+  const recs: SteeringRecommendation[] = [];
+
+  // --- Mode effectiveness: prefer the mode that actually ships work ----------
+  // Only rank modes with enough evidence (>=3 runs) to avoid noise.
+  const modes = rollupModes(sorted).filter((m) => m.runs >= 3);
+  let bestMode: string | null = null;
+  let worstMode: string | null = null;
+  if (modes.length >= 2) {
+    const ranked = [...modes].sort(
+      (a, b) => b.success_rate - a.success_rate || b.efficiency - a.efficiency,
+    );
+    const best = ranked[0];
+    const worst = ranked[ranked.length - 1];
+    bestMode = best.mode;
+    worstMode = worst.mode;
+    // Only recommend if there's a meaningful gap.
+    if (best.success_rate - worst.success_rate >= 0.2) {
+      recs.push({
+        priority: 20,
+        kind: 'mode',
+        text: `Mode "${best.mode}" has been more productive than "${worst.mode}" across recent batches (${pct(best.success_rate)} vs ${pct(worst.success_rate)} success). Prefer "${best.mode}" unless guidance dictates otherwise.`,
+      });
+    }
+  }
+
+  // --- Success-rate trajectory ----------------------------------------------
+  if (sorted.length >= 2) {
+    const mid = Math.floor(sorted.length / 2);
+    const firstHalf = sorted.slice(0, mid);
+    const secondHalf = sorted.slice(mid);
+    const avg = (arr: BatchOutcome[]) =>
+      arr.reduce((s, o) => s + o.success_rate, 0) / arr.length;
+    const before = avg(firstHalf);
+    const after = avg(secondHalf);
+    if (after - before <= -0.15) {
+      recs.push({
+        priority: 10,
+        kind: 'trajectory',
+        text: `Batch success rate is declining (${pct(before)} → ${pct(after)} across recent batches). Reduce scope per run, prefer well-specified leaf issues, and verify before stopping.`,
+      });
+    } else if (after - before >= 0.15) {
+      recs.push({
+        priority: 90,
+        kind: 'trajectory',
+        text: `Batch success rate is improving (${pct(before)} → ${pct(after)}). Current approach is working — keep the same scope discipline.`,
+      });
+    }
+  }
+
+  // --- Review fail rate ------------------------------------------------------
+  const avgReviewFail =
+    sorted.reduce((s, o) => s + o.review_fail_rate, 0) / sorted.length;
+  if (avgReviewFail >= 0.3) {
+    recs.push({
+      priority: 30,
+      kind: 'review',
+      text: `Review fail rate has averaged ${pct(avgReviewFail)} — strengthen the test plan and self-review before opening PRs so review rounds pass first time.`,
+    });
+  }
+
+  // --- Recurring stop reasons ------------------------------------------------
+  // Group free-text stop reasons by a coarse category; if one category recurs in
+  // at least half the batches, surface tailored guidance.
+  const stopCounts = new Map<string, number>();
+  for (const o of sorted) {
+    const cat = classifyStopReason(o.stop_reason);
+    if (cat) stopCounts.set(cat, (stopCounts.get(cat) ?? 0) + 1);
+  }
+  const threshold = Math.ceil(sorted.length / 2);
+  for (const [cat, count] of stopCounts) {
+    if (count < threshold || count < 2) continue;
+    recs.push({
+      priority: 40,
+      kind: 'stop_reason',
+      text: stopReasonGuidance(cat, count, sorted.length),
+    });
+  }
+
+  // --- Recurring cost anomalies ---------------------------------------------
+  const batchesWithAnomalies = sorted.filter((o) => o.cost_anomaly_count > 0).length;
+  if (batchesWithAnomalies >= 2 && batchesWithAnomalies >= threshold) {
+    const total = sorted.reduce((s, o) => s + o.cost_anomaly_count, 0);
+    recs.push({
+      priority: 50,
+      kind: 'cost',
+      text: `Cost anomalies recur (${total} flagged across ${batchesWithAnomalies} batches). Watch for runaway runs — split large issues and stop early when work is exhausted.`,
+    });
+  }
+
+  recs.sort((a, b) => a.priority - b.priority);
+
+  const summary =
+    recs.length > 0
+      ? `${recs.length} cross-batch steering signal(s) from ${sorted.length} prior batch(es).`
+      : `${sorted.length} prior batch(es) analyzed — no strong steering signal; proceed on guidance.`;
+
+  return {
+    batches_analyzed: sorted.length,
+    span,
+    best_mode: bestMode,
+    worst_mode: worstMode,
+    recommendations: recs,
+    summary,
+  };
+}
+
+/** Coarse category for a free-text stop reason, or null if uninformative. */
+function classifyStopReason(reason: string): string | null {
+  const r = reason.toLowerCase();
+  if (!r || r === 'completed') return null;
+  if (r.includes('backlog') || r.includes('exhaust') || r.includes('no more') || r.includes('no open'))
+    return 'backlog_exhausted';
+  if (r.includes('budget') || r.includes('cost') || r.includes('cap'))
+    return 'budget_cap';
+  if (r.includes('fail')) return 'failures';
+  if (r.includes('halt')) return 'halted';
+  return null;
+}
+
+function stopReasonGuidance(cat: string, count: number, total: number): string {
+  const prefix = `${count}/${total} recent batches stopped for the same reason`;
+  switch (cat) {
+    case 'backlog_exhausted':
+      return `${prefix}: backlog exhausted. The leaf-issue supply is thin — decompose an epic/PRD into concrete issues before stopping, or broaden the guidance.`;
+    case 'budget_cap':
+      return `${prefix}: budget cap. Scope each run smaller so it completes before the cap, or raise the budget deliberately.`;
+    case 'failures':
+      return `${prefix}: consecutive failures. Investigate the failure class (hooks vs. agent logic) before picking similar work.`;
+    case 'halted':
+      return `${prefix}: halted. Check for a stuck choke point (gate, lock, or watchdog) that keeps tripping.`;
+    default:
+      return `${prefix}.`;
+  }
+}
+
+/** Render a steering report as human-readable text (CLI / progress-issue display). */
+export function formatSteeringReport(report: SteeringReport): string {
+  const lines: string[] = [];
+  lines.push('=== Cross-Batch Steering ===');
+  lines.push('');
+  lines.push(report.summary);
+  if (report.batches_analyzed === 0) return lines.join('\n');
+  if (report.best_mode && report.worst_mode) {
+    lines.push('');
+    lines.push(`Best mode: ${report.best_mode}   Worst mode: ${report.worst_mode}`);
+  }
+  if (report.recommendations.length > 0) {
+    lines.push('');
+    lines.push('Recommendations:');
+    report.recommendations.forEach((r, i) => {
+      lines.push(`  ${i + 1}. [${r.kind}] ${r.text}`);
+    });
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format steering recommendations as a numbered list for prompt injection
+ * (mirrors how reflection insights are rendered). Returns '' when there is
+ * nothing to steer on, so the prompt's conditional block stays collapsed.
+ */
+export function steeringPromptText(report: SteeringReport): string {
+  if (report.recommendations.length === 0) return '';
+  return report.recommendations.map((r, i) => `${i + 1}. ${r.text}`).join('\n');
 }


### PR DESCRIPTION
## The problem

Auto-dent learns within a batch but forgets between batches. Mid-batch, reflection insights and contemplation recommendations feed back into the next run. But **every batch starts blind** — the cross-batch loop was built as local-disk tooling (`aggregate.jsonl`, `batch-trends.ts`) that dies with the machine, and the cloud only ever saw a human markdown table.

Phase 1 (#1108) fixed the **write** side: at batch close, a schema-validated `batch-outcome` JSON is now a durable named attachment on each GitHub progress issue. But `readBatchOutcome()` was wired into nothing. The data was in the cloud, machine-readable, and **completely unread**. That's the exact half-finished pattern this run was asked to close.

## The discovery

Closing the loop needs three things, and only the third actually changes behavior:
1. **Discovery** — enumerate prior batches and pull their outcomes from GitHub.
2. **Analysis** — turn a set of outcomes into concrete, prioritized steering.
3. **Injection** — feed that steering into the next batch's prompt, the way `{{reflection_insights}}` already feeds the within-batch loop.

Without injection, observable cloud data is just a dashboard nobody reads.

## The solution

**Read-back** (`scripts/batch-outcome.ts`):
- `readBatchOutcomesFromGithub(repo, opts, deps)` — discovers `auto-dent`-labeled progress issues (newest-first, bounded), reads each `batch-outcome` attachment via the existing `readBatchOutcome`. Fail-soft per issue: a missing or malformed attachment is skipped, never aborting the sweep. GitHub I/O is injected, so the logic is unit-testable with no network.

**Analysis** (pure, deterministic — no clock, no I/O):
- `computeSteeringRecommendations(outcomes)` ranks modes by success × efficiency, detects success-rate trajectory (improving/declining), surfaces recurring `stop_reason` categories, rising review-fail rate, and recurring cost anomalies — each as a prioritized `SteeringRecommendation`. Degrades cleanly on empty/single-batch input so one data point never fabricates a signal.
- `formatSteeringReport` / `steeringPromptText` render for humans and prompts.

**Injection — the loop closes** (`scripts/auto-dent-run.ts`, `prompts/deep-dive-default.md`):
- `BatchState.cross_batch_steering` + a `{{cross_batch_steering}}` prompt block (collapsed when empty).
- `populateCrossBatchSteering()` runs **once per batch**, **fail-open**, before the run builds its prompt. A GitHub outage degrades to "no steering," never a broken run.

**Observability** (`scripts/auto-dent-ctl.ts`):
- `auto-dent-ctl.ts steer [--repo R] [--limit N]` prints exactly the steering the next batch would receive — cloud-backed, no local state required.

## Evidence

- **+33 tests**, all green; full suite **2739 passed / 10 skipped**; `tsc --noEmit` clean.
  - Pure analysis: mode ranking, trajectory both directions, recurring stop reason (and the single-occurrence non-signal), review-fail, cost anomalies, empty/single-batch, determinism.
  - Discovery with injected deps: skips attachment-less issues, honors `excludeBatchId`/`limit`, survives a malformed attachment mid-sweep.
  - Wiring: `buildTemplateVars` surfaces the var; prompt block renders only when non-empty; `populateCrossBatchSteering` persists, is idempotent on resume, and fails open on a GitHub error.
  - CLI: `buildSteerOutput` wires read → analyze → format end to end.
- **Live smoke test:** `auto-dent-ctl.ts steer --repo Garsson-io/kaizen` enumerates real issues and renders the cold-start report (no batch has closed with a Phase-1 attachment yet — the path is exercised, the data will arrive as batches close).

## Impact

The cross-batch learning loop is closed. As batches close and accumulate `batch-outcome` records, each new batch reads what prior batches learned — which modes ship work, whether the backlog is thinning, where reviews keep failing — and weighs it before choosing what to do. Auto-dent gets better at getting better.

## Test plan (behaviors × levels)

| Behavior | Unit | Integration | System |
|---|:-:|:-:|:-:|
| Steering analysis: mode ranking, trajectory, stop reasons, review/cost, edge cases, determinism | ✅ | | |
| `readBatchOutcomesFromGithub`: discovery, skip-empty, exclude/limit, malformed-skip | ✅ | | |
| `buildTemplateVars` + prompt block conditional rendering | ✅ | | |
| `populateCrossBatchSteering`: persist, idempotent, fail-open | ✅ | | |
| `steer` CLI read→analyze→format | | ✅ | |
| Live `steer` against the real repo | | | ✅ |

Closes #1116
Parent: #940
Refs: #1108, #691
