### PR TITLE
feat(hooks): mechanically auto-bind kaizen.issue per-worktree at provisioning (Closes #1113)

### DIFF
--- a/.claude/hooks/kaizen-worktree-setup.sh
+++ b/.claude/hooks/kaizen-worktree-setup.sh
@@ -42,20 +42,41 @@ for artifact in node_modules dist; do
   fi
 done
 
-# Provisioning guard for a leaked kaizen.issue (#1111, harness-side half of #1106).
+# Per-worktree kaizen.issue provisioning (#1111 advisory → #1113 mechanism).
 # `kaizen.issue` is per-worktree state, but raw `git config kaizen.issue <N>` writes
-# to the SHARED .git/config, so a fresh worktree inherits the previous run's value.
-# Detect that leak at the provisioning choke point and steer to the per-worktree fix.
-# Advisory only (SessionStart never blocks); the #1106 edit-time hook fail-closes.
-# Canonical logic + tests live in src/issue-binding.ts — this is a fast bash mirror.
-MERGED_ISSUE=$(git config --get kaizen.issue 2>/dev/null || true)
+# to the SHARED .git/config, so a fresh worktree starts with no binding of its own
+# and inherits the previous run's value. This is the provisioning choke point.
+#
+# On a canonical case branch (`case/<date>-k<N>-*`) the branch token IS the
+# authoritative issue, so we self-heal: bind it mechanically — no manual step,
+# before the first edit. Writing --worktree scope only is concurrency-safe (it
+# cannot clobber a sibling). On a tokenless branch (e.g. a `worktree-*` run
+# worktree) there is nothing authoritative to derive from, so we fall back to the
+# advisory warning when a leaked shared value would be inherited.
+# Canonical logic + tests live in src/issue-binding.ts (selfHealBinding) — this is
+# a fast bash mirror that avoids a node startup on every SessionStart.
 WT_ISSUE=$(git config --worktree --get kaizen.issue 2>/dev/null || true)
-if [ -n "$MERGED_ISSUE" ] && [ -z "$WT_ISSUE" ]; then
+if [ -z "$WT_ISSUE" ]; then
   CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
   BRANCH_TOKEN=$(printf '%s' "$CUR_BRANCH" | sed -n 's#^case/[0-9]\{6,\}-k\([0-9]\+\).*#\1#p')
-  if [ -z "$BRANCH_TOKEN" ] || [ "$BRANCH_TOKEN" != "$MERGED_ISSUE" ]; then
-    echo "kaizen-worktree-setup: ⚠️  Leaked kaizen.issue — this worktree inherits #$MERGED_ISSUE from shared config with no binding of its own." >&2
-    echo "kaizen-worktree-setup:    Bind this worktree to its real issue: npx tsx src/cli-issue-binding.ts bind --issue <N>" >&2
+  if [ -n "$BRANCH_TOKEN" ]; then
+    # Authoritative source present — bind mechanically (L3 self-heal). The
+    # worktree-scoped value wins the merged read, so this also overrides any
+    # inherited (leaked) shared value.
+    git config extensions.worktreeConfig true 2>/dev/null
+    if git config --worktree kaizen.issue "$BRANCH_TOKEN" 2>/dev/null; then
+      echo "kaizen-worktree-setup: 🔗 Auto-bound this worktree to #$BRANCH_TOKEN from its case branch (no manual step needed)." >&2
+    else
+      echo "kaizen-worktree-setup: ⚠️  Could not auto-bind kaizen.issue to #$BRANCH_TOKEN — bind manually: npx tsx src/cli-issue-binding.ts bind --issue $BRANCH_TOKEN" >&2
+    fi
+  else
+    # Tokenless branch — nothing authoritative to bind to. Warn if a shared value
+    # would leak in.
+    MERGED_ISSUE=$(git config --get kaizen.issue 2>/dev/null || true)
+    if [ -n "$MERGED_ISSUE" ]; then
+      echo "kaizen-worktree-setup: ⚠️  Leaked kaizen.issue — this worktree inherits #$MERGED_ISSUE from shared config with no binding of its own." >&2
+      echo "kaizen-worktree-setup:    Bind this worktree to its real issue: npx tsx src/cli-issue-binding.ts bind --issue <N>" >&2
+    fi
   fi
 fi
 

--- a/.claude/hooks/tests/test-worktree-setup-leak.sh
+++ b/.claude/hooks/tests/test-worktree-setup-leak.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-# Tests for kaizen-worktree-setup.sh leaked-kaizen.issue provisioning guard (#1111).
-# A fresh worktree that inherits a shared kaizen.issue (the leak) must be warned
-# at SessionStart; a worktree with its own per-worktree binding must NOT be.
+# Tests for kaizen-worktree-setup.sh per-worktree kaizen.issue provisioning
+# (#1111 advisory → #1113 mechanism).
+#
+# On a canonical case branch the hook now SELF-HEALS: it binds the worktree to
+# its branch token mechanically (no manual step), overriding any inherited leak.
+# On a tokenless branch (run worktree) it cannot derive an issue, so it falls
+# back to the advisory warning when a shared value would leak in. A worktree
+# that already owns a binding is left untouched.
 source "$(dirname "$0")/test-helpers.sh"
 
 HOOK="$REPO_ROOT/.claude/hooks/kaizen-worktree-setup.sh"
@@ -24,26 +29,44 @@ git -C "$MAIN" config kaizen.issue 1106
 WT="$ROOT/wt"
 git -C "$MAIN" worktree add -q -b case/260626-k1111-b "$WT"
 
-echo "=== Leak present: fresh worktree inherits shared kaizen.issue ==="
+echo "=== Case branch + leaked shared value: auto-bind to branch token, override the leak ==="
 OUT=$(cd "$WT" && bash "$HOOK" 2>&1 >/dev/null)
-assert_contains "warns about leaked kaizen.issue" "Leaked kaizen.issue" "$OUT"
-assert_contains "names the inherited issue" "#1106" "$OUT"
-assert_contains "points to the bind CLI" "cli-issue-binding.ts bind" "$OUT"
+assert_contains "announces the auto-bind" "Auto-bound this worktree to #1111" "$OUT"
+assert_not_contains "does not merely warn about a leak" "Leaked kaizen.issue" "$OUT"
+# The binding is now worktree-scoped to the branch token, beating the shared 1106.
+WT_BOUND=$(cd "$WT" && git config --worktree --get kaizen.issue 2>/dev/null)
+assert_eq "worktree-scoped binding set to branch token" "1111" "$WT_BOUND"
+MERGED=$(cd "$WT" && git config --get kaizen.issue 2>/dev/null)
+assert_eq "merged read now wins for the worktree, not the leak" "1111" "$MERGED"
 
 echo ""
-echo "=== Bound per-worktree: no leak warning ==="
-git -C "$WT" config extensions.worktreeConfig true
+echo "=== Already bound per-worktree: untouched, no auto-bind, no warning ==="
 git -C "$WT" config --worktree kaizen.issue 1111
 OUT2=$(cd "$WT" && bash "$HOOK" 2>&1 >/dev/null)
+assert_not_contains "no auto-bind announcement when already bound" "Auto-bound" "$OUT2"
 assert_not_contains "no leak warning once worktree owns its binding" "Leaked kaizen.issue" "$OUT2"
 
 echo ""
-echo "=== Inherited value matches branch token: not flagged ==="
-# New worktree whose case token equals the shared value — harmless to read.
+echo "=== Fresh case worktree (no shared leak): still auto-binds before first edit ==="
 WT2="$ROOT/wt2"
+git -C "$MAIN" config --unset kaizen.issue  # no shared leak this time
 git -C "$MAIN" worktree add -q -b case/260626-k1106-c "$WT2"
 OUT3=$(cd "$WT2" && bash "$HOOK" 2>&1 >/dev/null)
-assert_not_contains "no warning when inherited value matches branch token" "Leaked kaizen.issue" "$OUT3"
+assert_contains "auto-binds a fresh case worktree to its token" "Auto-bound this worktree to #1106" "$OUT3"
+WT2_BOUND=$(cd "$WT2" && git config --worktree --get kaizen.issue 2>/dev/null)
+assert_eq "fresh case worktree bound to its token" "1106" "$WT2_BOUND"
+
+echo ""
+echo "=== Tokenless run worktree inheriting a shared leak: advisory warning, no auto-bind ==="
+git -C "$MAIN" config kaizen.issue 1106  # restore a shared leak
+WT3="$ROOT/wt3"
+git -C "$MAIN" worktree add -q -b worktree-2606261501-3542 "$WT3"
+OUT4=$(cd "$WT3" && bash "$HOOK" 2>&1 >/dev/null)
+assert_contains "warns about the leak on a tokenless branch" "Leaked kaizen.issue" "$OUT4"
+assert_contains "names the inherited issue" "#1106" "$OUT4"
+assert_not_contains "does not auto-bind a tokenless worktree" "Auto-bound" "$OUT4"
+WT3_BOUND=$(cd "$WT3" && git config --worktree --get kaizen.issue 2>/dev/null || true)
+assert_eq "tokenless worktree gets no worktree-scoped binding" "" "$WT3_BOUND"
 
 echo ""
 print_results

--- a/src/cli-issue-binding.ts
+++ b/src/cli-issue-binding.ts
@@ -7,6 +7,7 @@
  *
  * Commands:
  *   bind --issue <N>          Bind this worktree to issue N (worktree-scoped).
+ *   auto-bind                 Self-heal: bind from the canonical case-branch token (#1113).
  *   read                      Print the merged binding the hooks would see.
  *   check-leak                Detect an inherited (leaked) binding; exit 1 if leaked.
  *   ensure-worktree-config    Enable extensions.worktreeConfig (idempotent).
@@ -23,6 +24,7 @@ import {
   ensureWorktreeConfig,
   unsetSharedIssue,
   currentBranch,
+  selfHealBinding,
 } from './issue-binding.js';
 
 export function parseArgs(argv: string[]): void {
@@ -45,6 +47,24 @@ export function parseArgs(argv: string[]): void {
         `Bound this worktree to #${r.issue} (worktree-scoped).` +
           (r.enabledWorktreeConfig ? ' Enabled extensions.worktreeConfig.' : ''),
       );
+      break;
+    }
+    case 'auto-bind': {
+      const branch = currentBranch(run);
+      const r = selfHealBinding(branch, run);
+      if (r.healed) {
+        console.log(
+          `Auto-bound this worktree to #${r.issue} from its case branch (${branch}).` +
+            (r.enabledWorktreeConfig ? ' Enabled extensions.worktreeConfig.' : ''),
+        );
+      } else if (r.reason === 'already-bound') {
+        console.log(`Already bound to #${r.issue} (worktree-scoped) — nothing to do.`);
+      } else {
+        console.log(
+          `No case-branch token on '${branch || '(detached)'}' — cannot auto-derive an issue. ` +
+            `Bind explicitly: bind --issue <N>.`,
+        );
+      }
       break;
     }
     case 'read': {
@@ -82,7 +102,9 @@ export function parseArgs(argv: string[]): void {
     }
     default: {
       console.error(`Unknown command: ${command ?? '(none)'}`);
-      console.error('Commands: bind --issue <N> | read | check-leak | ensure-worktree-config | unset-shared');
+      console.error(
+        'Commands: bind --issue <N> | auto-bind | read | check-leak | ensure-worktree-config | unset-shared',
+      );
       process.exit(1);
     }
   }

--- a/src/issue-binding.test.ts
+++ b/src/issue-binding.test.ts
@@ -22,6 +22,7 @@ import {
   ensureWorktreeConfig,
   makeGitRun,
   readBoundIssue,
+  selfHealBinding,
   sharedIssue,
   unsetSharedIssue,
   worktreeScopedIssue,
@@ -170,6 +171,42 @@ describe('detectLeak', () => {
   });
 });
 
+describe('selfHealBinding (#1113 L3 mechanism)', () => {
+  it('binds from the case-branch token when the worktree is unbound', () => {
+    const { run, state } = makeStub({ branch: 'case/260626-k1113-x', worktree: null });
+    const r = selfHealBinding('case/260626-k1113-x', run);
+    expect(r).toMatchObject({ healed: true, issue: 1113 });
+    expect(state.worktree).toBe(1113);
+    expect(state.worktreeConfig).toBe(true); // enabled as part of the heal
+  });
+
+  it('overrides a leaked inherited value by binding the branch token', () => {
+    // Shared config leaks #1106; the worktree is on a k1113 branch with no binding.
+    const { run, state } = makeStub({ branch: 'case/260626-k1113-x', shared: 1106, worktree: null });
+    expect(detectLeak('case/260626-k1113-x', run).leaked).toBe(true);
+    const r = selfHealBinding('case/260626-k1113-x', run);
+    expect(r.healed).toBe(true);
+    expect(r.issue).toBe(1113);
+    // Worktree value now wins the merged read — the leak is healed, not just warned.
+    expect(readBoundIssue(run)).toBe(1113);
+    expect(state.shared).toBe(1106); // shared untouched — concurrency-safe
+  });
+
+  it('is a no-op when the worktree already owns a binding (never overrides)', () => {
+    const { run, state } = makeStub({ branch: 'case/260626-k1113-x', worktree: 999 });
+    const r = selfHealBinding('case/260626-k1113-x', run);
+    expect(r).toMatchObject({ healed: false, issue: 999, reason: 'already-bound' });
+    expect(state.worktree).toBe(999); // unchanged — #1106's domain, not provisioning's
+  });
+
+  it('is a no-op on a tokenless branch (run worktree)', () => {
+    const { run, state } = makeStub({ branch: 'worktree-2606261501-3542', shared: 1106, worktree: null });
+    const r = selfHealBinding('worktree-2606261501-3542', run);
+    expect(r).toMatchObject({ healed: false, issue: null, reason: 'no-branch-token' });
+    expect(state.worktree).toBeNull(); // nothing authoritative to bind to
+  });
+});
+
 // ── Integration: real git worktrees prove cross-worktree isolation ──
 
 describe('integration: real worktrees do not leak bindings', () => {
@@ -231,5 +268,54 @@ describe('integration: real worktrees do not leak bindings', () => {
     bindIssue(777, runA);
     expect(readBoundIssue(runA)).toBe(777);
     expect(readBoundIssue(runB)).toBe(1111);
+  });
+});
+
+describe('integration: selfHealBinding heals a leaked worktree (#1113)', () => {
+  let root: string;
+  let mainRepo: string;
+  let wt: string;
+
+  const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf-8' });
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'kaizen-selfheal-'));
+    mainRepo = join(root, 'main');
+    git(root, ['init', '-q', 'main']);
+    git(mainRepo, ['config', 'user.email', 'test@example.com']);
+    git(mainRepo, ['config', 'user.name', 'Test']);
+    writeFileSync(join(mainRepo, 'f.txt'), 'hi\n');
+    git(mainRepo, ['add', '.']);
+    git(mainRepo, ['commit', '-q', '-m', 'init']);
+    // A prior run leaked a binding into shared config.
+    git(mainRepo, ['config', 'kaizen.issue', '1106']);
+    wt = join(root, 'wt');
+    git(mainRepo, ['worktree', 'add', '-q', '-b', 'case/260626-k1113-x', wt]);
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('binds the worktree to its branch token, overriding the inherited leak', () => {
+    const run = makeGitRun(wt);
+    expect(readBoundIssue(run)).toBe(1106); // inherited leak before heal
+    expect(detectLeak('case/260626-k1113-x', run).leaked).toBe(true);
+
+    const r = selfHealBinding('case/260626-k1113-x', run);
+    expect(r).toMatchObject({ healed: true, issue: 1113 });
+
+    // After heal: worktree owns 1113, merged read is 1113, shared stays 1106,
+    // and a sibling that read shared is undisturbed.
+    expect(worktreeScopedIssue(run)).toBe(1113);
+    expect(readBoundIssue(run)).toBe(1113);
+    expect(sharedIssue(run)).toBe(1106);
+    expect(detectLeak('case/260626-k1113-x', run).leaked).toBe(false);
+  });
+
+  it('is idempotent — a second heal is a no-op', () => {
+    const run = makeGitRun(wt);
+    const r = selfHealBinding('case/260626-k1113-x', run);
+    expect(r).toMatchObject({ healed: false, issue: 1113, reason: 'already-bound' });
   });
 });

--- a/src/issue-binding.ts
+++ b/src/issue-binding.ts
@@ -179,3 +179,51 @@ export function currentBranch(run: GitRun): string {
   const r = run(['rev-parse', '--abbrev-ref', 'HEAD']);
   return r.code === 0 ? r.stdout : '';
 }
+
+export interface SelfHealResult {
+  /** True when this call wrote a new worktree-scoped binding. */
+  healed: boolean;
+  /** The issue bound after this call, or null when none could be derived. */
+  issue: number | null;
+  /** Why no heal happened (only set when `healed` is false). */
+  reason?: 'already-bound' | 'no-branch-token';
+  /** Whether enabling `extensions.worktreeConfig` was part of the heal. */
+  enabledWorktreeConfig?: boolean;
+}
+
+/**
+ * The L3 escalation of the #1111 advisory (#1113): instead of *warning* that a
+ * worktree would read a leaked inherited binding, set the correct per-worktree
+ * binding mechanically — before the first edit, with no manual step.
+ *
+ * The authoritative source is the canonical case branch: `case/<date>-k<N>-*`
+ * carries the issue token the #1106 edit-time hook already trusts as a
+ * cross-check, so binding *to* that token is exactly what a correct provisioning
+ * step would do. Behaviour:
+ *
+ *   - Worktree already owns a binding  → no-op (`already-bound`). An explicit
+ *     worktree-scoped value is never overridden; a mismatch there is the #1106
+ *     hook's domain, not a provisioning artifact.
+ *   - Canonical case branch, no binding → bind to the branch token (`healed`).
+ *     This also overrides any *inherited* shared value (the leak), because the
+ *     worktree-scoped value wins the merged read.
+ *   - Tokenless branch (e.g. a `worktree-*` run worktree) → no-op
+ *     (`no-branch-token`): nothing authoritative to derive the issue from. The
+ *     caller may fall back to the advisory warning.
+ *
+ * Touches only worktree scope — never shared config — so it is safe under
+ * concurrency: it cannot clobber a sibling worktree's binding.
+ */
+export function selfHealBinding(branch: string, run: GitRun): SelfHealResult {
+  const worktreeScoped = worktreeScopedIssue(run);
+  if (worktreeScoped != null) {
+    return { healed: false, issue: worktreeScoped, reason: 'already-bound' };
+  }
+  const tokenRaw = extractCaseIssueFromBranch(branch);
+  const branchToken = tokenRaw ? Number(tokenRaw) : null;
+  if (branchToken == null) {
+    return { healed: false, issue: null, reason: 'no-branch-token' };
+  }
+  const { enabledWorktreeConfig } = bindIssue(branchToken, run);
+  return { healed: true, issue: branchToken, enabledWorktreeConfig };
+}


### PR DESCRIPTION
## The problem

`kaizen.issue` answers "which issue is THIS worktree's work for?" — an inherently
per-worktree fact. #1111/#1112 made the binding per-worktree and shipped two things:
a leak-proof `bind` CLI, and a SessionStart **advisory** that *warns* when a worktree
would read a leaked inherited value. But the advisory is where it stopped. Nothing
**mechanically** binds at provisioning. A fresh case worktree still started life with
no binding of its own, and the agent (or harness) had to remember to run `bind` by
hand before the first edit — or trip the #1106 edit-time block on a stale value.

That's a half-finished feature: the detection landed, the mechanism didn't.

## The discovery

The binding doesn't need a manual step at all. On a canonical `case/<date>-k<N>-*`
branch, the branch token **is** the authoritative issue — it's the very token the
#1106 edit-time hook already trusts as a cross-check. And there's already a choke
point that runs in every worktree before the first edit: the
`kaizen-worktree-setup.sh` SessionStart hook. So the correct issue can be derived
and bound mechanically, with zero human action.

## The solution

Escalate the #1111 advisory to an L3 mechanism (#1113):

- **`selfHealBinding(branch, run)`** (`src/issue-binding.ts`) — the canonical mechanism.
  - Worktree already owns a binding → no-op (`already-bound`); an explicit value is
    never overridden — that mismatch is the #1106 hook's domain.
  - Canonical case branch, no binding → bind to the branch token (`healed`). The
    worktree-scoped value wins the merged read, so this also **overrides any leaked
    inherited value**.
  - Tokenless branch (e.g. a `worktree-*` run worktree) → no-op (`no-branch-token`);
    nothing authoritative to derive from.
  - Touches **only** worktree scope — never shared config — so it is concurrency-safe.
- **`auto-bind` CLI subcommand** (`src/cli-issue-binding.ts`) — the same mechanism for
  the programmatic / harness path (#1113 step 2).
- **`kaizen-worktree-setup.sh`** — advisory → mechanism. Case branches self-heal (info
  line); tokenless worktrees keep the advisory warning. Implemented as a fast bash
  mirror so SessionStart pays no node startup.

## Evidence

`Test Plan` and `Validation` sections below. 32 tests green:
- 20 TS unit/integration in `issue-binding.test.ts` (incl. a real-worktree test that
  heals a leaked worktree and proves `detectLeak` returns clean afterward, and an
  idempotency test).
- 12 cases in `test-worktree-setup-leak.sh` rewritten to assert auto-bind on case
  branches (the `--worktree kaizen.issue` value is actually set) and advisory-only on
  tokenless worktrees.

Two unrelated `test_hooks.py` cases (`kaizen-reflect-ts.sh` post-hook) failed under
fleet load (harness timeout — the hook itself outputs `KAIZEN` and exits 0 when run
directly, and both pass on clean `main`). My diff touches neither reflect nor
post-hooks.

## Impact

Every case worktree now arrives at its first edit already bound to the right issue,
with no manual step and no stale-value block — the categorical L3 form of the #1106
problem at the provisioning choke point.

## Acceptance (from #1113)

- [x] A freshly created case worktree has `git config --worktree --get kaizen.issue`
  already set to its own issue, with no manual step.
- [x] `cli-issue-binding check-leak` returns clean immediately after provisioning.

## Test Plan (behaviors × levels)

| Behavior | Unit | Integration | System |
|---|:-:|:-:|:-:|
| `selfHealBinding` binds from case-branch token when unbound | ✅ | | |
| `selfHealBinding` no-op when worktree already bound (never overrides) | ✅ | | |
| `selfHealBinding` no-op on tokenless branch (run worktree) | ✅ | | |
| `selfHealBinding` overrides a leaked inherited value (real worktrees) | | ✅ | |
| SessionStart hook auto-binds a fresh case worktree | | | ✅ |
| SessionStart hook warns (no auto-bind) on tokenless leaked worktree | | | ✅ |

## Scope

- **In this PR:** the self-heal mechanism, the `auto-bind` CLI, the SessionStart
  escalation, and the tests above.
- **Deferred (follow-up):** run-worktree harness binding (#1113 step 2 — the harness
  must call `auto-bind`/`bind`); one-time fleet `unset-shared` migration (#1113 step 3
  — risky during a live 200+ worktree batch; with auto-bind the shared value is
  already harmless for case worktrees).

Closes #1113
Refs: #1111, #1106, #842

Run tag: sticky-lark/run-1
