### PR TITLE
feat(hooks): enforce plan/test-plan substance at first edit, not just at PR (Closes #1035)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -57,7 +57,7 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 | `src/cli-structured-data.ts` | CLI for structured data — the primary interface for skills |
 | `src/section-editor.ts` | Low-level: sections (## in bodies) + attachments (marker comments) — CRUD primitives |
 | `src/case-system.ts` | **Case FE** — single gateway for plan gate (I3, I8). Pluggable `CaseBackend`: `GitHubCaseBackend` today, Linear/custom tomorrow. Hooks and skills go through this, never call BE directly |
-| `src/hooks/enforce-plan-stored.ts` | PreToolUse hook enforcing I3/I8: Edit/Write/NotebookEdit require a stored plan on `git config kaizen.issue`; `gh pr create` adds a substance check. Cross-checks the declared issue against the canonical case-branch token (`case/<date>-k<N>-*`) and fails closed on mismatch — a stale/inherited `kaizen.issue` can't sail through the plan gate for the wrong issue (#1106; the #943/#950 command-vs-outcome category). |
+| `src/hooks/enforce-plan-stored.ts` | PreToolUse hook enforcing I3/I8: Edit/Write/NotebookEdit require a stored **and substantive** plan + test plan on `git config kaizen.issue`, and `gh pr create` applies the SAME substance bar. The substance heuristic (`checkSubstance`) runs at BOTH choke points — a rubber-stamp stub is rejected at the FIRST source edit, not deferred to PR time (#1035). Same bar both places → no new false positives, only earlier feedback. Cross-checks the declared issue against the canonical case-branch token (`case/<date>-k<N>-*`) and fails closed on mismatch — a stale/inherited `kaizen.issue` can't sail through the plan gate for the wrong issue (#1106; the #943/#950 command-vs-outcome category). |
 | `src/hooks/pre-push.ts` | **Git pre-push hook** (epic #1059) — mechanistic L3 gate: agent-env gate + merged-branch block (I7) + needs_review gate creation. Replaces fragile Bash parsing path for push detection (#909, #1057). See `docs/git-hooks-design.md`. |
 | `src/hooks/prehook-no-verify.ts` | PreToolUse hook blocking `git push --no-verify` — prevents agents from bypassing the pre-push gate |
 | `src/setup-git-hooks.ts` | `/kaizen-setup install-git-hooks` implementation — detects host framework (pre-commit/husky/lefthook/raw/none) and injects kaizen's pre-push hook idempotently |
@@ -92,6 +92,8 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 | `/kaizen-update` | Pull updates from kaizen repo |
 
 ## Mandatory Practices
+
+**Substantive test plan before implementation**: An issue MUST have a stored, *substantive* plan AND test plan (`retrieve-testplan` ≠ null and it passes the substance heuristic) before any source code is written — not just before the PR. A one-sentence stub cannot guide implementation, which is the whole point of writing it first. The `enforce-plan-stored` hook (I3/I8) enforces this at the FIRST source edit *and* at `gh pr create` with the identical substance bar; do not retrofit the plan at PR time. If the gate blocks you, run `/kaizen-write-plan` — don't reach for the stub. (#1035)
 
 **PR bodies**: Always use `/kaizen-write-pr` when creating or editing PR descriptions. Never write a bare `gh pr create --body` with a few bullet points. The Story Spine narrative makes PRs reviewable without reading the diff.
 

--- a/src/hooks/enforce-plan-stored.test.ts
+++ b/src/hooks/enforce-plan-stored.test.ts
@@ -178,6 +178,46 @@ describe('checkPlanBeforeEdit', () => {
     expect(result.reason).toContain('Wait for the skill to COMPLETE');
   });
 
+  // ── #1035: substance enforced at edit time, not just PR time ──────
+  describe('substance at edit time (#1035)', () => {
+    const STUB_PLAN = '## Plan\n\nDo the thing.';
+    const STUB_TEST_PLAN = '## Test Plan\nno table';
+
+    it('B1: DENIES first source edit when plan exists but is a rubber-stamp', () => {
+      const result = checkPlanBeforeEdit('src/thing.ts', makeDeps({ retrievePlan: () => STUB_PLAN }));
+      expect(result.allowed).toBe(false);
+      expect(result.missing).toContain('substance');
+      expect(result.reason).toContain('not substantive');
+    });
+
+    it('B2: DENIES first source edit when test plan exists but is a rubber-stamp', () => {
+      const result = checkPlanBeforeEdit('src/thing.ts', makeDeps({ retrieveTestPlan: () => STUB_TEST_PLAN }));
+      expect(result.allowed).toBe(false);
+      expect(result.missing).toContain('substance');
+    });
+
+    it('B3: ALLOWS first source edit when plan AND test plan are both substantive', () => {
+      expect(checkPlanBeforeEdit('src/thing.ts', makeDeps()).allowed).toBe(true);
+    });
+
+    it('B6: substance deny reason is the same at the edit gate and the PR gate', () => {
+      const editReason = checkPlanBeforeEdit('src/thing.ts', makeDeps({ retrievePlan: () => STUB_PLAN })).reason ?? '';
+      const prReason = checkPlanBeforePr(ghPrCreate('Closes #1055'), makeDeps({ retrievePlan: () => STUB_PLAN })).reason ?? '';
+      // Same heuristic, same message body — one substance bar at both choke points.
+      expect(editReason).toContain('not substantive');
+      expect(prReason).toContain('not substantive');
+      expect(editReason).toContain('Plan substance failures');
+      expect(prReason).toContain('Plan substance failures');
+    });
+
+    it('does not falsely block when both are substantive (no new false positives)', () => {
+      // Any plan that passes at PR time must pass at edit time — same heuristic.
+      const deps = makeDeps();
+      expect(checkPlanBeforeEdit('src/thing.ts', deps).allowed).toBe(true);
+      expect(checkPlanBeforePr(ghPrCreate('Closes #1055'), deps).allowed).toBe(true);
+    });
+  });
+
   // ── #1106: stale/inherited kaizen.issue cross-check ───────────────
   describe('stale kaizen.issue (#1106)', () => {
     it('BLOCKS when a case branch (k950) disagrees with declared issue (1108) — live repro', () => {

--- a/src/hooks/enforce-plan-stored.ts
+++ b/src/hooks/enforce-plan-stored.ts
@@ -187,6 +187,46 @@ export function checkTestPlanSubstance(testPlanText: string): string[] {
   return failures;
 }
 
+/**
+ * Run the substance heuristic over the already-fetched gate text. Returns a
+ * BLOCKED result if either the plan or the test plan is a rubber-stamp, else
+ * null. Shared by BOTH choke points (first source edit AND `gh pr create`) so
+ * there is ONE substance bar — the gates can never drift to different bars
+ * (#1035). `planText`/`testPlanText` are guarded for null: existence is already
+ * enforced upstream, so a null here means "nothing to substance-check" → no
+ * failure, never a false denial.
+ */
+export function checkSubstance(
+  issueNum: string,
+  planText: string | null | undefined,
+  testPlanText: string | null | undefined,
+): PlanCheckResult | null {
+  const planIssues = planText ? checkPlanSubstance(planText) : [];
+  const testPlanIssues = testPlanText ? checkTestPlanSubstance(testPlanText) : [];
+  if (planIssues.length === 0 && testPlanIssues.length === 0) return null;
+
+  const parts: string[] = [];
+  if (planIssues.length > 0) {
+    parts.push(`Plan substance failures:\n${planIssues.map(i => `  - ${i}`).join('\n')}`);
+  }
+  if (testPlanIssues.length > 0) {
+    parts.push(`Test plan substance failures:\n${testPlanIssues.map(i => `  - ${i}`).join('\n')}`);
+  }
+  return {
+    allowed: false,
+    missing: ['substance'],
+    reason: `BLOCKED: Plan exists but is not substantive (rubber-stamp check).
+
+${parts.join('\n\n')}
+
+A one-sentence stub passes the existence gate but cannot guide implementation —
+which is the whole point of writing it first (#1035). Fix it NOW, before the code:
+Run /kaizen-write-plan to produce a proper plan with Success Criteria,
+Design Alternatives, and a Seam Map & Test Plan with test levels.
+  Skill({ skill: "kaizen-write-plan", args: "#${issueNum}" })`,
+  };
+}
+
 // ── Gate 1: Edit/Write — block source edits without a plan ──────────
 
 export function checkPlanBeforeEdit(
@@ -267,6 +307,14 @@ IMPORTANT: Wait for the skill to COMPLETE. Do not retry Write until the skill is
     };
   }
 
+  // Existence passed — now enforce SUBSTANCE at the FIRST source edit, using the
+  // already-fetched gate text (no refetch). This is the same heuristic the PR
+  // gate applies, just earlier: a rubber-stamp plan is caught before any code is
+  // written, not after (#1035). Same bar at both choke points → no new false
+  // positives, only earlier feedback.
+  const substanceResult = checkSubstance(issueNum, gate.planText, gate.testPlanText);
+  if (substanceResult) return substanceResult;
+
   return { allowed: true };
 }
 
@@ -326,31 +374,11 @@ Run /kaizen-write-plan — the skill knows how to create and store the plan corr
     };
   }
 
-  // Substance check: plan must be substantive (not a rubber stamp).
-  // Reuse text from gate (PlanGateResult carries it — no refetch).
-  const planIssues = gate.planText ? checkPlanSubstance(gate.planText) : [];
-  const testPlanIssues = gate.testPlanText ? checkTestPlanSubstance(gate.testPlanText) : [];
-
-  if (planIssues.length > 0 || testPlanIssues.length > 0) {
-    const parts: string[] = [];
-    if (planIssues.length > 0) {
-      parts.push(`Plan substance failures:\n${planIssues.map(i => `  - ${i}`).join('\n')}`);
-    }
-    if (testPlanIssues.length > 0) {
-      parts.push(`Test plan substance failures:\n${testPlanIssues.map(i => `  - ${i}`).join('\n')}`);
-    }
-    return {
-      allowed: false,
-      missing: ['substance'],
-      reason: `BLOCKED: Plan exists but is not substantive (rubber-stamp check).
-
-${parts.join('\n\n')}
-
-Run /kaizen-write-plan to produce a proper plan with Success Criteria,
-Design Alternatives, and a Seam Map & Test Plan with test levels.
-  Skill({ skill: "kaizen-write-plan", args: "#${issueNum}" })`,
-    };
-  }
+  // Substance check: plan must be substantive (not a rubber stamp). Reuse text
+  // from gate (PlanGateResult carries it — no refetch). Same helper as the edit
+  // gate → one substance bar at both choke points (#1035).
+  const substanceResult = checkSubstance(issueNum, gate.planText, gate.testPlanText);
+  if (substanceResult) return substanceResult;
 
   return { allowed: true };
 }


### PR DESCRIPTION
## Once upon a time

Kaizen's plan gate (`enforce-plan-stored.ts`) guards two choke points: the **first source edit** (`checkPlanBeforeEdit`) and **`gh pr create`** (`checkPlanBeforePr`). Both require a stored plan *and* test plan on the declared issue (`passed = hasPlan && hasTestPlan`). The idea: you write the plan first, and it guides the implementation.

## Every day

That mostly worked — agents couldn't start coding without *some* plan attached. The gate fired, the plan existed, everyone moved on.

## One day

But the **substance** check — the heuristic that distinguishes a real plan from a one-sentence stub (`checkPlanSubstance` / `checkTestPlanSubstance`) — ran **only** at `gh pr create`. The edit gate checked *existence* only. So an agent could attach a 1-char rubber-stamp ("`## Plan\n\nDo the thing.`"), sail past the first source edit, write the **entire** implementation, and only discover at PR time that the plan was empty.

That is exactly the failure #1035 names:

> "The plan gets retrofitted at PR time — too late to guide implementation choices."

PR #1084's own added hook message admits it in passing: *"a one-sentence stub passes the gate but fails substance checks on `gh pr create`."* The defense existed — it was just wired to the **last** choke point instead of the **first**.

## Because of that

The substance functions already existed, and the edit gate **already fetched the plan text** (`PlanGateResult` carries `planText`/`testPlanText` — no refetch needed). The fix is small and surgical:

- Extract the substance-deny formatting into one shared helper `checkSubstance(issueNum, planText, testPlanText)`.
- Call it from **both** gates: in `checkPlanBeforeEdit` right after the existence gate passes (on the already-fetched text — zero extra fetch), and in `checkPlanBeforePr` (replacing the inline copy).

A rubber-stamp is now rejected at the **first source edit**, with an actionable message:

```
BLOCKED: Plan exists but is not substantive (rubber-stamp check).

Plan substance failures:
  - Plan is too short (22 chars, need 200+)
  - Plan needs structured headings (1 found, need 2+)
  - Plan has too few steps/items (0, need 3+)
...
A one-sentence stub passes the existence gate but cannot guide implementation —
which is the whole point of writing it first (#1035). Fix it NOW, before the code:
  Skill({ skill: "kaizen-write-plan", args: "#1035" })
```

## The key safety argument

This is the **identical** heuristic already gating PR creation. **Any plan that passes at PR time passes at edit time.** So there is **no new false-positive surface** — only strictly *earlier* feedback. DRY: one helper, one substance bar; the two choke points can never drift apart.

**Dual failure mode** (per the behavioral-constraint discipline):
- *Absent* → stub plans guide nothing and the gap is discovered after all the code is written (the original bug).
- *Present* → could in theory block an edit on a thin-but-legitimate plan — but since it's the same check as PR-time, anything that would be blocked here was already going to be blocked at PR. Present-mode over-correction is **nil**.

## Until finally

TDD, RED→GREEN. Dogfood evidence (real `checkSubstance` output):
- Stub plan + stub test plan → **BLOCKED**, `missing: ["substance"]`, message lists every failure.
- Substantive plan + test plan → **allowed** (`checkSubstance` returns `null`).

`756` hook tests pass across 36 files; `tsc` clean.

## And ever since

The "test plan" is now a real precondition for "execution" in the **feature → plan → test-plan → execution → review** lifecycle. The plan guides implementation as intended, instead of being a formality retrofitted after the code is already written.

---

## What's in this PR

| File | Change |
|------|--------|
| `src/hooks/enforce-plan-stored.ts` | New shared `checkSubstance` helper; `checkPlanBeforeEdit` now substance-checks after existence; `checkPlanBeforePr` refactored to use the helper (behavior unchanged) |
| `src/hooks/enforce-plan-stored.test.ts` | B1/B2/B3/B6 + false-positive guard tests (edit-time substance) |
| `.agents/AGENTS.md` | Key Files row updated; new "Substantive test plan before implementation" Mandatory Practice (#1035 L1 acceptance) |

## Design decisions

| Decision | Why | Tradeoff |
|----------|-----|----------|
| One shared `checkSubstance` helper for both gates | Two heuristics could drift, reintroducing "passes one gate, fails the other" | Slightly more indirection than inline checks |
| Reuse already-fetched `gate.planText`/`testPlanText` | Zero extra I/O at edit time | Relies on `PlanGateResult` carrying the text (it does) |
| Guard `planText`/`testPlanText` null → no failure | Existence is already enforced upstream; avoid any false denial | Belt-and-suspenders branch that can't fire in practice |
| Block (not warn) at edit time | Consistent with the existing PR-time deny; truly enforces lifecycle ordering | Same false-positive profile as PR-time (i.e., none new) |

## Test Plan (Behaviors × Levels)

| # | Behavior | Level | Status |
|---|----------|-------|--------|
| B1 | `checkPlanBeforeEdit` DENIES when plan is a stub | Unit | ✅ |
| B2 | `checkPlanBeforeEdit` DENIES when test plan is a stub | Unit | ✅ |
| B3 | `checkPlanBeforeEdit` ALLOWS when both are substantive | Unit | ✅ |
| B4 | `checkPlanBeforeEdit` still DENIES when plan absent (existence regression) | Unit | ✅ (existing) |
| B5 | `checkPlanBeforePr` substance behavior unchanged after refactor | Unit | ✅ (existing) |
| B6 | Shared helper yields the same deny message at both gates (category-prevention) | Unit | ✅ |

All behaviors are pure functions over an injected `PlanCheckDeps` — local logic with no cross-module handoff, OS/network, or LLM dependence, so Unit is the correct reality-check level.

## Validation

- ✅ `npx vitest run src/hooks/enforce-plan-stored.test.ts` — 48 pass
- ✅ `npx vitest run src/hooks` — 756 pass (36 files)
- ✅ `npx tsc --noEmit` — clean
- ✅ Dogfood: stub → blocked with actionable message; substantive → allowed

## Known limitations

- The substance heuristic is unchanged (same thresholds); this PR only changes *where* it fires. Tuning the heuristic is out of scope.
- Raw-shell source writes (`cat > file.ts`) remain out of scope for the edit gate, as documented in the file — unchanged here.

Closes #1035
Refs: #857 (plan-before-code hook — already resolved by #1055's edit gate; being closed separately with evidence)

Run-tag: sticky-lark/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)