### PR TITLE
feat(skills): test-plan discipline — cheap System ≠ expensive E2E + no circular deferral (Closes #1014)

### DIFF
--- a/.agents/skills/kaizen-evaluate/SKILL.md
+++ b/.agents/skills/kaizen-evaluate/SKILL.md
@@ -236,6 +236,8 @@ You may only recommend reduced scope if you also provide **at least one** of:
 
 **If none of these three exist, you must not reduce scope.** Either solve the full problem in the current case, or include building the signal infrastructure as part of the current scope.
 
+**No circular deferral (kaizen #1014):** the follow-up issue in (3) must be an *independent* mechanism — not a symptom of the issue you are currently evaluating. Deferring a test level to an issue that exists *because that very test level is missing* (e.g., deferring System/E2E coverage to the open "no E2E coverage" issue that is itself listed among this issue's symptoms) is circular: it defers the fix to the problem. If the only candidate deferral target is a symptom of the current work, the work is in scope.
+
 **Why this matters:** "Do less now, more later" without a mechanism is just "do less." The "later" never arrives because there's no signal that triggers it. The reduced scope becomes the final scope, and the problem persists silently. This has happened repeatedly in kaizen evaluations — agents propose L1 with "escalate to L2 if needed" but provide no way to detect when L1 has failed.
 
 **This gate applies to:**
@@ -310,6 +312,8 @@ SEAM: [the injection point that isolates this for testing]
 ```
 
 If you cannot name the seam, the behavior is not testable in isolation. Add an extraction task before the implementation task. Red flags requiring extraction: the target location has more than 5 imports, the location is a CLI entry point or script's global scope, or testing it would require mocking more than 3 modules. Extract first, implement second — this is never the optional step.
+
+**COST NOTE — "session-level" ≠ "expensive E2E" (kaizen #1014):** when a seam names `SessionSimulator`, `src/e2e/hook-runner.ts`, `synthetic-workflow.test.ts`, or `spawnSync` on a hook script, that is a **System** test that fires real hooks/CLIs in a subprocess with **zero LLM/API calls** — deterministic, ~$0, <1s. Only real `claude -p` tests carry LLM cost. Never downgrade such a seam to unit-only or defer it to a follow-up on cost grounds. A seam map that names `SessionSimulator` followed by a unit-only test plan is a contradiction — resolve it before storing the plan.
 
 **Write the plan.** With all five steps complete, write the plan using this structure:
 

--- a/.agents/skills/kaizen-write-plan/SKILL.md
+++ b/.agents/skills/kaizen-write-plan/SKILL.md
@@ -176,6 +176,8 @@ When proposing to do less than the full solution, you must provide **at least on
 
 **Without one of these three, do not reduce scope.**
 
+**No circular deferral (kaizen #1014):** the follow-up issue in (3) must be an *independent* mechanism — not a symptom of the issue you are currently planning. Deferring a test level to an issue that exists *because that very test level is missing* (e.g., deferring E2E/System coverage to the open "no E2E coverage" issue that is itself listed among this issue's symptoms) is circular: it defers the fix to the problem. If the only candidate deferral target is a symptom of the current work, the work is **in scope** — write the test now.
+
 ---
 
 ## Phase 4: Critique the spec (if one exists)
@@ -284,6 +286,8 @@ For each behavior, determine the minimum test level needed to avoid false confid
   - **Agentic** — result depends on real LLM non-determinism or a real AI/ML model call (e.g., classification, scoring, generation APIs). This includes: does the test verify that an AI agent makes the right DECISION (e.g., choosing to use a tool, following instructions, reading output correctly)? Agent decisions are LLM-dependent.
   - **Workflow** — multiple agentic steps in sequence, or a full agent pipeline
 
+- **COST NOTE — System ≠ expensive E2E (kaizen #1014):** "Session-level" or "lifecycle" does NOT mean "expensive LLM test." Subprocess-based hook and session tests — `SessionSimulator`, `src/e2e/hook-runner.ts`, `spawnSync` on a hook script, `synthetic-workflow.test.ts` — are **System** level: they fire real hooks/CLIs in a subprocess with **zero LLM/API calls**, so they are deterministic, cost ~$0, and run in <1s. Only **Agentic/Workflow** tests (real `claude -p`) carry per-run LLM cost. Therefore: never downgrade a session/hook seam to `Unit`, and never defer it to a follow-up issue, on cost grounds. If Step 5 named `SessionSimulator`/`hook-runner` as the seam, the level is at least **System** and the test ships in this PR.
+
 - **KEY-QUESTIONS** per behavior:
   - **MOCK-MISS**: Does THIS SPECIFIC BEHAVIOR describe a failure that only appears when multiple modules interact — not just a failure that could theoretically exist somewhere in the feature? If the behavior tests one function's logic, parsing, or algorithm, Unit is acceptable only when higher-level checks add no new reality signal. If the bug appears when local modules hand off data/state, elevate to Integration. Then still apply REAL-INFRA, LLM-DEP, and MULTI-STEP.
     Do not escalate based on generic "could miss wiring" language alone. Escalation requires behavior-text evidence of a concrete handoff/contract/order/state-boundary failure (for example: cross-module state propagation, ordering guarantees, durability/persistence boundary).
@@ -349,8 +353,10 @@ Rejected because: ...
 | 1 | ... | code | Unit | ... | ... |
 | 2 | ... | agent | Agentic | ... | ... |
 
-[For deferred behaviors (e.g., Agentic tests out of scope), state what they are, why they're deferred, and which issue tracks them.]
+[For deferred behaviors (e.g., Agentic tests out of scope), state what they are, why they're deferred, and which issue tracks them. The deferral target must satisfy the Scope Reduction Discipline gate — in particular, **No circular deferral**: it may not be a symptom of this issue.]
 ```
+
+**Seam-map coverage gate (kaizen #1014):** before storing the plan, scan every `BEHAVIOR` from Step 5. Each must appear as a row in the table above at the level Step 6 assigned it. A seam named in Step 5 (e.g., `SessionSimulator`) that has no row — or appears only at `Unit` when Step 6 said System/Agentic — is a contradiction between the seam map and the test plan. Resolve it (add the row at the right level, or apply COST NOTE) before storing. A correct seam map plus a unit-only test plan in the same document is exactly the #1014 failure.
 
 Store the plan on the issue. The plan MUST contain a `## Seam Map & Test Plan` section — review dimensions retrieve it from there automatically.
 

--- a/src/e2e/skill-change.test.ts
+++ b/src/e2e/skill-change.test.ts
@@ -238,6 +238,91 @@ describe("kaizen-evaluate — Phase 4.5: Plan Formation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// kaizen-write-plan / kaizen-evaluate — Test-plan discipline (kaizen #1014)
+// ---------------------------------------------------------------------------
+// Problem the old skills had: Phase 4.5 could produce a CORRECT seam map (naming
+//   SessionSimulator as the seam for session-level behavior) yet a WRONG test plan
+//   that downgraded it to unit-only and deferred "E2E" to #944 — an issue that is
+//   itself a symptom of the current meta-issue (#1010). Two heuristic errors:
+//     (1) conflating cheap subprocess System tests with expensive LLM E2E ("defer on cost"), and
+//     (2) circular deferral — deferring a missing test level to the very issue that
+//         exists because that test level is missing.
+// What the new skills add:
+//     - COST NOTE: SessionSimulator/hook-runner are System level, $0, never deferred on cost.
+//     - No circular deferral: a deferral target may not be a symptom of the current issue.
+//     - Seam-map coverage gate (write-plan): every Step-5 seam must appear at its assigned level.
+// ---------------------------------------------------------------------------
+
+describe("kaizen-write-plan — test-plan discipline (#1014)", () => {
+  it("SKILL.md names cheap System hook/session tests and forbids cost-deferral", () => {
+    const skill = loadSkill("kaizen-write-plan");
+    expect(skill).toContain("COST NOTE");
+    expect(skill).toContain("SessionSimulator");
+    // The level for a subprocess hook/session seam is at least System, not deferrable on cost.
+    expect(skill).toMatch(/never defer[^.]*cost/i);
+  });
+
+  it("SKILL.md forbids circular deferral to a symptom of the current issue", () => {
+    const skill = loadSkill("kaizen-write-plan");
+    expect(skill).toContain("No circular deferral");
+    expect(skill).toContain("symptom");
+  });
+
+  it("SKILL.md has a seam-map coverage gate tying Step 5 seams to test-plan rows", () => {
+    const skill = loadSkill("kaizen-write-plan");
+    expect(skill).toContain("Seam-map coverage gate");
+  });
+
+  it.skipIf(!isLive)(
+    "keeps a SessionSimulator seam at System level and rejects circular deferral to a symptom issue",
+    async () => {
+      // Reproduces the #1014 scenario directly. With the new guidance, the correct
+      // answer is: System level (not deferred on cost) AND the deferral to #944 is
+      // circular because #944 is a listed symptom of the meta-issue being planned.
+      const prompt = [
+        "You are applying the kaizen-write-plan Step 6 (Assign test levels) and Scope",
+        "Reduction Discipline rules below:",
+        "",
+        "RULE A (COST NOTE): Subprocess-based hook/session tests — SessionSimulator,",
+        "hook-runner.ts, spawnSync on a hook script — are System level: real hooks in a",
+        "subprocess, ZERO LLM/API calls, deterministic, ~$0, <1s. Only real `claude -p`",
+        "tests carry LLM cost. Never downgrade or defer a session/hook seam on cost grounds.",
+        "RULE B (No circular deferral): a deferral target issue must be an independent",
+        "mechanism, not a symptom of the issue you are currently planning.",
+        "",
+        "Scenario: You are planning meta-issue #1010 (worktree-lifecycle cluster). Its",
+        "listed symptoms include #944 ('zero E2E tests for worktree lifecycle').",
+        "Step 5 named the seam for the lifecycle behavior as: SEAM: spawnSync on",
+        "kaizen-worktree-setup.sh via SessionSimulator.",
+        "",
+        "A teammate proposes: 'test plan = unit tests only; defer the session test to #944.'",
+        "",
+        "Apply the rules. State (a) the minimum test LEVEL for the SessionSimulator-based",
+        "behavior (one word: Unit/Integration/System/Agentic/Workflow), and (b) whether",
+        "deferring it to #944 is acceptable. End with one line: 'LEVEL: <level>' and one",
+        "line: 'DEFERRAL: <acceptable|circular>'.",
+      ].join("\n");
+
+      const output = runSkill(prompt, { maxBudget: 0.1 });
+      // New guidance must drive both decisions: System level, circular deferral.
+      expect(output).toMatch(/LEVEL:\s*System/i);
+      expect(output).toMatch(/DEFERRAL:\s*circular/i);
+    },
+    90_000,
+  );
+});
+
+describe("kaizen-evaluate — test-plan discipline (#1014)", () => {
+  it("SKILL.md mirrors the cheap-System cost note and anti-circular deferral", () => {
+    const skill = loadSkill("kaizen-evaluate");
+    expect(skill).toContain("COST NOTE");
+    expect(skill).toContain("SessionSimulator");
+    expect(skill).toContain("No circular deferral");
+    expect(skill).toContain("symptom");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Behavioral smoke test — dry dimension detects known DRY violation (kaizen #952)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The Problem

Issue #1014 captured a precise, reproducible category error in the planning step. During Phase 4.5 grounding for the worktree-lifecycle meta-issue #1010, the agent produced a **correct seam map** — it named `SessionSimulator` as the seam for the session-level behavior — and then, in the very next section, wrote a **wrong test plan**: unit tests only, with "E2E deferred to #944."

Two things made that wrong:

1. **#944 is a *symptom* of #1010.** It's the open issue "zero E2E tests for worktree lifecycle," listed among the bugs #1010 exists to fix. Deferring the missing test level to the issue that exists *because that test level is missing* is circular — it defers the fix to the problem.
2. **`SessionSimulator` is not expensive.** It fires real hooks in a subprocess with zero LLM calls: deterministic, ~$0, <1s. But "session-level" got pattern-matched to "behavioral LLM test" → "expensive" → "defer." The seam map was right; the cost heuristic overrode it.

## The Discovery

Re-examining the current planning skills against reality: the chain has moved to `kaizen-write-plan`, whose Step 6 already assigns per-behavior test levels (MOCK-MISS / REAL-INFRA / LLM-DEP / REJECTION-GATE) — this is **stronger** than #1014's proposed "Fix 1" cross-check, and already shipped. So Fix 1 was effectively done.

What remained were the two heuristics that actually caused the incident, and they were absent from **both** planning entry points (`kaizen-write-plan` and the still-invokable `kaizen-evaluate`):

- no statement that subprocess hook/session tests are cheap **System** level, and
- no rule against circular deferral.

## The Solution

Categorical fix in both planning skills:

- **COST NOTE — System ≠ expensive E2E.** `SessionSimulator`, `hook-runner.ts`, `synthetic-workflow.test.ts`, `spawnSync` on a hook script are **System** level: real hooks, zero LLM/API calls, ~$0, <1s. Only real `claude -p` carries LLM cost. Never downgrade or defer a session/hook seam on cost grounds.
- **No circular deferral.** A deferral target must be an *independent* mechanism, not a symptom of the issue being planned. If the only candidate is a symptom of the current work, the work is in scope — write the test now.
- **Seam-map coverage gate** (`kaizen-write-plan`): before storing the plan, every `BEHAVIOR` from Step 5 must appear as a test-plan row at the level Step 6 assigned. A seam named in Step 5 that has no row, or sits at `Unit` when Step 6 said System, is the #1014 contradiction — resolve it first.

## The Evidence

`src/e2e/skill-change.test.ts` (the canonical before/after harness for skill changes, I22):

- **4 structural assertions** — the cost note (naming `SessionSimulator`), the anti-circular clause, and the seam-map coverage gate are present in both skills. Run in normal CI.
- **1 live `claude -p` behavioral test** (gated `KAIZEN_SKILL_TEST=1`, haiku ~$0.01). Fed the exact #1014 scenario with the new guidance, the model now outputs `LEVEL: System` and `DEFERRAL: circular` — the old default was unit-only + defer. **Verified passing live** in this session (13.6s).

```
$ KAIZEN_SKILL_TEST=1 npx vitest run src/e2e/skill-change.test.ts -t "keeps a SessionSimulator seam"
  Tests  1 passed | 15 skipped (16)
$ npx vitest run src/e2e/skill-change.test.ts src/skill-metadata.test.ts src/policy-docs.test.ts
  Tests  76 passed | 5 skipped
```

## Behaviors × Test Levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| write-plan SKILL.md carries cost note + anti-circular + coverage gate | ✅ | | | | |
| evaluate SKILL.md mirrors cost note + anti-circular | ✅ | | | | |
| New guidance flips the #1014 decision (System, not deferred) under a real model | | | | ✅ (`claude -p`) | |

The Agentic test ships in this PR — not deferred. Per its own new rule, it is cheap (haiku, ~$0.01, gated off default CI), so there is no cost ground to defer it.

## Impact

The planning step now refuses the two moves that turned a correct seam map into a unit-only test plan. The next time grounding names a `SessionSimulator` seam, the test plan keeps it — at System level, in this PR, not deferred to the symptom that named the gap.

Closes #1014
Refs: #1010, #944, #968, #747

Run tag: sticky-lark/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
