### PR TITLE
feat(review): derive review verdict from findings — summary can't contradict them (Closes #1019, #1067)

### DIFF
--- a/.agents/skills/kaizen-review-pr/SKILL.md
+++ b/.agents/skills/kaizen-review-pr/SKILL.md
@@ -213,20 +213,28 @@ Fix MUST-FIX first, then SHOULD-FIX:
 
 ## Phase 5: Verdict
 
-```
-REVIEW PASSED — N rounds, M findings fixed
-```
+**You do not write the verdict. The verdict is derived.** `store-review-summary` reads the
+per-dimension findings you stored this round and composes the authoritative verdict block from
+them — any MISSING → FAIL, PARTIAL but no MISSING → PASS (surfaced loudly), else PASS. You cannot
+substitute a hand-written "REVIEW PASSED" for the derived block (#1019); a note that asserts the
+round passed while the findings derive FAIL is rejected.
 
-Before declaring: confirm every requirement from the linked issue is DONE or deferred with a filed follow-up issue.
+Before storing: confirm every requirement from the linked issue is DONE or deferred with a filed
+follow-up issue. If any dimension still has MISSING findings, the round is FAIL — fix them
+(Phase 4) or escalate; do not narrate a pass.
 
 Store the round summary (required to advance to next round or close the gate):
 ```bash
 npx tsx src/cli-structured-data.ts store-review-summary \
-  --pr <PR_NUMBER> --repo <owner/repo> --round <N> \
-  --text "REVIEW PASSED — <N> rounds, <M> findings fixed"
+  --pr <PR_NUMBER> --repo <owner/repo> --round <N>
 ```
 
-If findings needed fixing: return to Phase 1 with the updated diff for the next round.
+Add `--note "<context>"` only for non-verdict commentary (e.g. "rebased onto main, re-ran tests").
+Read back the derived verdict with `read-review-summary --pr <N> --repo <repo> --round <N>` — the
+header line (`## Review Round N — PASS | PASS — k PARTIAL | FAIL`) is the real verdict.
+
+If the derived verdict is FAIL or PASS — k PARTIAL with blocking gaps: return to Phase 1 with the
+updated diff for the next round.
 
 ---
 

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -223,9 +223,17 @@ async function handleQuickPass(a: CliArgs): Promise<void> {
 }
 
 async function handleStoreReviewSummary(a: CliArgs): Promise<void> {
-  const text = resolveContent(a);
+  // The verdict is ALWAYS derived from stored findings (#1019). Any supplied text (--note, or
+  // legacy --text/--file) is non-authoritative commentary appended below the derived block.
+  const note = (a.note ?? resolveContent(a)) || undefined;
   const r = resolveRound(a);
-  const url = storeReviewSummary(prTarget(a.pr, a.repo), r, text || undefined);
+  let url: string;
+  try {
+    url = storeReviewSummary(prTarget(a.pr, a.repo), r, note);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
   // #920: Write review sentinel so pr-review-loop.ts can verify outcome
   writeReviewSentinel(a.repo, a.pr, r);
   console.log(`Review summary stored (round ${r}): ${url}`);

--- a/src/review-finding-contract.test.ts
+++ b/src/review-finding-contract.test.ts
@@ -6,6 +6,9 @@ import {
   makeReviewFindingMeta,
   extractReviewFindingMeta,
   validateReviewFindingPayload,
+  deriveRoundVerdict,
+  summarizeRound,
+  assertsPass,
 } from './review-finding-contract.js';
 
 describe('review-finding-contract', () => {
@@ -128,6 +131,54 @@ describe('validateReviewFindingPayload (#1039)', () => {
       findings: [{ requirement: 'R1', status: 'DONE', detail: 'ok' }],
     });
     expect(res.ok).toBe(true);
+  });
+});
+
+describe('deriveRoundVerdict — round-level three-state rule (#1019, #1067)', () => {
+  it('any MISSING → FAIL', () => {
+    expect(deriveRoundVerdict([{ done: 2, partial: 0, missing: 1 }])).toBe('FAIL');
+    expect(deriveRoundVerdict([{ done: 5, partial: 3, missing: 2 }])).toBe('FAIL');
+  });
+  it('PARTIAL but no MISSING → PASS_WITH_PARTIALS', () => {
+    expect(deriveRoundVerdict([{ done: 4, partial: 1, missing: 0 }])).toBe('PASS_WITH_PARTIALS');
+  });
+  it('all DONE → PASS', () => {
+    expect(deriveRoundVerdict([{ done: 4, partial: 0, missing: 0 }])).toBe('PASS');
+  });
+  it('empty rows → PASS (nothing failed)', () => {
+    expect(deriveRoundVerdict([])).toBe('PASS');
+  });
+});
+
+describe('summarizeRound — authoritative rollup from rows', () => {
+  it('computes per-state dimension counts and totals', () => {
+    const roll = summarizeRound([
+      { dim: 'correctness', verdict: 'pass', done: 3, partial: 0, missing: 0 },
+      { dim: 'security', verdict: 'fail', done: 1, partial: 0, missing: 2 },
+      { dim: 'perf', verdict: 'fail', done: 2, partial: 1, missing: 0 },
+    ]);
+    expect(roll.verdict).toBe('FAIL'); // security has MISSING
+    expect(roll.dimensions).toBe(3);
+    expect(roll.passDims).toBe(1);     // correctness
+    expect(roll.failDims).toBe(1);     // security (missing)
+    expect(roll.partialDims).toBe(1);  // perf (partial, no missing)
+    expect(roll.totalDone).toBe(6);
+    expect(roll.totalPartial).toBe(1);
+    expect(roll.totalMissing).toBe(2);
+  });
+});
+
+describe('assertsPass — conservative overt-PASS detection (#1019 guard)', () => {
+  it('flags overt PASS claims', () => {
+    expect(assertsPass('REVIEW PASSED — 5 rounds, 3 findings fixed')).toBe(true);
+    expect(assertsPass('all dimensions pass')).toBe(true);
+    expect(assertsPass('✅ PASS')).toBe(true);
+    expect(assertsPass('LGTM')).toBe(true);
+  });
+  it('does NOT flag genuine non-verdict commentary', () => {
+    expect(assertsPass('fixed 3 lint nits and a typo')).toBe(false);
+    expect(assertsPass('carried the PARTIAL on perf forward to #1234')).toBe(false);
+    expect(assertsPass('re-ran the security dimension after the TOCTOU fix')).toBe(false);
   });
 });
 

--- a/src/review-finding-contract.ts
+++ b/src/review-finding-contract.ts
@@ -79,6 +79,81 @@ export function deriveVerdictFromFindings(findings: Array<{ status: FindingStatu
   return stats.partial > 0 || stats.missing > 0 ? 'fail' : 'pass';
 }
 
+/**
+ * Round-level verdict — three-state, distinct from the per-dimension rule.
+ *
+ * The per-dimension rule (`deriveVerdictFromFindings`) treats any PARTIAL as fail. At the
+ * *round* level we surface PARTIAL loudly but do not auto-block on it: a PARTIAL is a real
+ * gap the author/admin can choose to carry forward (#1067), whereas a MISSING is a blocking
+ * gap. So:
+ *   - any MISSING  → FAIL
+ *   - PARTIAL but no MISSING → PASS_WITH_PARTIALS  (passes, but never silently)
+ *   - else → PASS
+ */
+export type RoundVerdict = 'PASS' | 'PASS_WITH_PARTIALS' | 'FAIL';
+
+export interface RoundRow extends FindingStats {
+  dim: string;
+  // The per-dimension stored verdict string (informational only — the round rollup is derived
+  // from done/partial/missing counts, never from this field).
+  verdict: string;
+}
+
+export interface RoundRollup {
+  verdict: RoundVerdict;
+  dimensions: number;
+  passDims: number;
+  failDims: number;
+  partialDims: number;
+  totalDone: number;
+  totalPartial: number;
+  totalMissing: number;
+}
+
+export function deriveRoundVerdict(rows: Array<FindingStats>): RoundVerdict {
+  const totalMissing = rows.reduce((s, r) => s + r.missing, 0);
+  const totalPartial = rows.reduce((s, r) => s + r.partial, 0);
+  if (totalMissing > 0) return 'FAIL';
+  if (totalPartial > 0) return 'PASS_WITH_PARTIALS';
+  return 'PASS';
+}
+
+/**
+ * Single source of truth for the round-level rollup that `composeReviewSummary` and the
+ * `storeReviewSummary` contradiction-guard both consume. Derives every count + the verdict
+ * from the per-dimension rows — never from caller-supplied free text.
+ */
+export function summarizeRound(rows: Array<RoundRow>): RoundRollup {
+  const totalDone = rows.reduce((s, r) => s + r.done, 0);
+  const totalPartial = rows.reduce((s, r) => s + r.partial, 0);
+  const totalMissing = rows.reduce((s, r) => s + r.missing, 0);
+  return {
+    verdict: deriveRoundVerdict(rows),
+    dimensions: rows.length,
+    passDims: rows.filter(r => r.missing === 0 && r.partial === 0).length,
+    failDims: rows.filter(r => r.missing > 0).length,
+    partialDims: rows.filter(r => r.missing === 0 && r.partial > 0).length,
+    totalDone,
+    totalPartial,
+    totalMissing,
+  };
+}
+
+/**
+ * Does a caller-supplied free-text summary overtly assert the round PASSED?
+ *
+ * Used as a fail-closed guard: a hand-written "REVIEW PASSED" note alongside findings that
+ * derive FAIL is exactly the #1019 fabrication. We only flag an OVERT pass claim — conservative
+ * by design so genuine commentary ("fixed 3 lint nits") is never rejected. The derived verdict
+ * is authoritative regardless; this guard only stops a *misleading* note from riding along.
+ */
+export function assertsPass(text: string): boolean {
+  const t = text.toLowerCase();
+  // "review passed", "all dimensions pass", "✅ pass", "passes review", "lgtm", "all green"
+  return /\b(review\s+passed|all\s+(dimensions?|checks?|dims?)\s+pass(ed)?|passes?\s+review|verdict[:\s]+pass|lgtm|all\s+green)\b/.test(t)
+    || /✅\s*pass/.test(t);
+}
+
 function normalizeVerdict(value: unknown): 'pass' | 'fail' | undefined {
   const raw = asString(value).toLowerCase().trim();
   if (raw === 'pass' || raw === 'passed' || raw === 'ok' || raw === 'success') return 'pass';

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -237,8 +237,84 @@ describe('composeReviewSummary — auto-generates from stored findings', () => {
     expect(summary).toContain('## Review Round 2');
     expect(summary).toContain('| correctness | ✅ PASS | 3 | 0 | 0 |');
     expect(summary).toContain('| security | ❌ FAIL | 1 | 0 | 2 |');
-    expect(summary).toContain('1 PASS, 1 FAIL');
+    expect(summary).toContain('1 PASS, 0 PARTIAL, 1 FAIL');
     expect(summary).toContain('"verdict":"fail"'); // overall fails due to MISSING
+  });
+
+  it('surfaces PARTIAL distinctly — header, ⚠️ row, and rollup count (#1067)', () => {
+    // One dimension with a PARTIAL finding and zero MISSING — must PASS but loudly.
+    const c1 = JSON.stringify({ url: 'u', body: `<!-- kaizen:review/r3/correctness -->\n<!-- meta:{"round":3,"dimension":"correctness","verdict":"pass","done":3,"partial":0,"missing":0} -->` });
+    const c2 = JSON.stringify({ url: 'u', body: `<!-- kaizen:review/r3/perf -->\n<!-- meta:{"round":3,"dimension":"perf","verdict":"fail","done":2,"partial":1,"missing":0} -->` });
+    ghReturns(`${c1}\n${c2}`); // listAttachments
+    ghReturns(c1);
+    ghReturns(c2);
+
+    const summary = composeReviewSummary(pr, 3);
+    expect(summary).toContain('## Review Round 3 — PASS — 1 PARTIAL'); // header surfaces it
+    expect(summary).toContain('| perf | ⚠️ PARTIAL | 2 | 1 | 0 |');    // distinct row icon
+    expect(summary).toContain('"round_verdict":"PASS_WITH_PARTIALS"');
+    expect(summary).toContain('"verdict":"pass"'); // binary signal stays pass (non-blocking)
+    expect(summary).toContain('1 PARTIAL findings across 2 dimensions');
+  });
+});
+
+describe('storeReviewSummary — derived verdict is authoritative (#1019)', () => {
+  // Build a stored dimension-finding comment with the given meta counts.
+  const dimComment = (round: number, dim: string, verdict: string, done: number, partial: number, missing: number) =>
+    JSON.stringify({
+      url: `https://github.com/x/pull/903#issuecomment-${dim}`,
+      body: `<!-- kaizen:review/r${round}/${dim} -->\n<!-- meta:{"round":${round},"dimension":"${dim}","verdict":"${verdict}","done":${done},"partial":${partial},"missing":${missing}} -->`,
+    });
+
+  const bodyOfLastCreate = (): string => {
+    // createComment is the final gh call; its args carry body=<content>.
+    for (let i = mockGh.mock.calls.length - 1; i >= 0; i--) {
+      const args = mockGh.mock.calls[i][1] as string[];
+      const body = args?.find?.(a => typeof a === 'string' && a.startsWith('body='));
+      if (body) return body;
+    }
+    return '';
+  };
+
+  it('PREVENTION: hand-written "REVIEW PASSED" note while findings derive FAIL → throws (#1019)', () => {
+    const sec = dimComment(5, 'security', 'fail', 1, 0, 2); // MISSING=2 → derived FAIL
+    ghReturns(sec); // composeReviewSummary: listReviewDimensions
+    ghReturns(sec); // composeReviewSummary: readReviewFinding(security)
+    ghReturns(sec); // deriveStoredRoundVerdict: listReviewDimensions
+    ghReturns(sec); // deriveStoredRoundVerdict: readReviewFinding(security)
+
+    expect(() =>
+      storeReviewSummary(pr, 5, 'REVIEW PASSED — 5 rounds, all dimensions ✅'),
+    ).toThrow(/#1019|fabrication|PASSED/i);
+  });
+
+  it('stores the DERIVED FAIL verdict even when no note is supplied', () => {
+    const sec = dimComment(5, 'security', 'fail', 1, 0, 2);
+    ghReturns(sec); // compose: list
+    ghReturns(sec); // compose: read
+    ghReturns(''); // writeAttachment: readAttachment (no existing summary) → create
+    ghReturns('https://...#issuecomment-sum');
+
+    storeReviewSummary(pr, 5);
+    const body = bodyOfLastCreate();
+    expect(body).toContain('## Review Round 5 — FAIL');
+    expect(body).toContain('| security | ❌ FAIL | 1 | 0 | 2 |');
+  });
+
+  it('appends a benign note as non-authoritative, derived verdict intact', () => {
+    const ok = dimComment(2, 'correctness', 'pass', 3, 0, 0); // all DONE → PASS
+    ghReturns(ok); // compose: list
+    ghReturns(ok); // compose: read
+    ghReturns(ok); // deriveStoredRoundVerdict: list
+    ghReturns(ok); // deriveStoredRoundVerdict: read
+    ghReturns(''); // writeAttachment: readAttachment (no existing)
+    ghReturns('https://...#issuecomment-sum');
+
+    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes');
+    const body = bodyOfLastCreate();
+    expect(body).toContain('## Review Round 2 — PASS');
+    expect(body).toContain('### Reviewer notes (non-authoritative');
+    expect(body).toContain('rebased onto main');
   });
 });
 

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -29,9 +29,13 @@ import {
   normalizeReviewFindingData as normalizeReviewFindingDataContract,
   makeReviewFindingMeta,
   extractReviewFindingMeta,
+  summarizeRound,
+  assertsPass,
   type ReviewFinding,
   type ReviewFindingData,
   type ReviewFindingMeta,
+  type RoundRow,
+  type RoundVerdict,
 } from './review-finding-contract.js';
 
 // ── Target helpers ──────────────────────────────────────────────────
@@ -197,7 +201,7 @@ export function storeReviewFinding(
  */
 export function composeReviewSummary(target: AttachmentTarget, round: number): string {
   const dims = listReviewDimensions(target, round);
-  const rows: Array<{ dim: string; verdict: string; done: number; partial: number; missing: number }> = [];
+  const rows: RoundRow[] = [];
 
   for (const dim of dims) {
     const content = readReviewFinding(target, round, dim);
@@ -208,40 +212,83 @@ export function composeReviewSummary(target: AttachmentTarget, round: number): s
     }
   }
 
-  const totalPass = rows.filter(r => r.verdict === 'pass').length;
-  const totalFail = rows.filter(r => r.verdict === 'fail').length;
-  const totalMissing = rows.reduce((s, r) => s + r.missing, 0);
-  const totalPartial = rows.reduce((s, r) => s + r.partial, 0);
-  const overallVerdict = totalMissing === 0 ? 'PASS' : 'FAIL';
-  const summaryMeta = JSON.stringify({ round, verdict: overallVerdict.toLowerCase(), dimensions: rows.length, pass: totalPass, fail: totalFail, total_missing: totalMissing, total_partial: totalPartial });
+  const roll = summarizeRound(rows);
+  // Header verdict mirrors the three-state rule; the `verdict` field in meta stays pass|fail so
+  // downstream consumers (gates, parsers) keep a binary signal — PASS_WITH_PARTIALS maps to pass.
+  const headerVerdict = roll.verdict === 'FAIL' ? 'FAIL'
+    : roll.verdict === 'PASS_WITH_PARTIALS' ? `PASS — ${roll.totalPartial} PARTIAL`
+    : 'PASS';
+  const metaVerdict = roll.verdict === 'FAIL' ? 'fail' : 'pass';
+  const summaryMeta = JSON.stringify({ round, verdict: metaVerdict, round_verdict: roll.verdict, dimensions: roll.dimensions, pass: roll.passDims, fail: roll.failDims, partial: roll.partialDims, total_done: roll.totalDone, total_missing: roll.totalMissing, total_partial: roll.totalPartial });
 
   const lines: string[] = [
     `<!-- meta:${summaryMeta} -->`,
-    `## Review Round ${round} — ${overallVerdict}`,
+    `## Review Round ${round} — ${headerVerdict}`,
     '',
     '| Dimension | Verdict | DONE | PARTIAL | MISSING |',
     '|-----------|---------|------|---------|---------|',
   ];
 
   for (const r of rows) {
-    const icon = r.verdict === 'pass' ? '✅' : '❌';
-    lines.push(`| ${r.dim} | ${icon} ${r.verdict.toUpperCase()} | ${r.done} | ${r.partial} | ${r.missing} |`);
+    const icon = r.missing > 0 ? '❌' : r.partial > 0 ? '⚠️' : '✅';
+    const label = r.missing > 0 ? 'FAIL' : r.partial > 0 ? 'PARTIAL' : 'PASS';
+    lines.push(`| ${r.dim} | ${icon} ${label} | ${r.done} | ${r.partial} | ${r.missing} |`);
   }
 
-  lines.push('', `**Overall**: ${totalPass} PASS, ${totalFail} FAIL | ${totalMissing} MISSING, ${totalPartial} PARTIAL across ${rows.length} dimensions`);
+  lines.push('', `**Overall**: ${roll.passDims} PASS, ${roll.partialDims} PARTIAL, ${roll.failDims} FAIL | ${roll.totalMissing} MISSING, ${roll.totalPartial} PARTIAL findings across ${roll.dimensions} dimensions`);
   return lines.join('\n');
 }
 
 /**
- * Store the round summary. Prefer composeReviewSummary() to auto-generate from findings.
+ * Compute the authoritative round verdict from stored findings — never from caller text.
+ * Exposed so the storeReviewSummary guard and external callers share one derivation.
+ */
+export function deriveStoredRoundVerdict(target: AttachmentTarget, round: number): RoundVerdict {
+  const rows: RoundRow[] = [];
+  for (const dim of listReviewDimensions(target, round)) {
+    const content = readReviewFinding(target, round, dim);
+    if (!content) continue;
+    const meta = parseFindingMeta(content);
+    if (meta) rows.push({ dim: meta.dimension, verdict: meta.verdict, done: meta.done, partial: meta.partial, missing: meta.missing });
+  }
+  return summarizeRound(rows).verdict;
+}
+
+/**
+ * Store the round summary.
+ *
+ * The authoritative verdict block is ALWAYS derived from the stored per-dimension findings via
+ * composeReviewSummary() — a caller can never substitute a hand-written verdict for it (#1019).
+ * An optional `note` is appended below as clearly-labelled, non-authoritative commentary.
+ *
+ * Fail-closed guard: if the note overtly asserts the round PASSED while the derived verdict is
+ * FAIL, throw — the agent must fix the findings or escalate, not narrate a passing verdict on
+ * top of failing data (the exact #1019 bypass). The derived block stays authoritative either way.
+ *
  * Attachment name: review/r{round}/summary
  */
 export function storeReviewSummary(
   target: AttachmentTarget,
   round: number,
-  summary?: string,
+  note?: string,
 ): string {
-  const content = summary ?? composeReviewSummary(target, round);
+  const derived = composeReviewSummary(target, round);
+  let content = derived;
+
+  const trimmed = note?.trim();
+  if (trimmed) {
+    const roundVerdict = deriveStoredRoundVerdict(target, round);
+    if (roundVerdict === 'FAIL' && assertsPass(trimmed)) {
+      throw new Error(
+        `store-review-summary: refusing to store a note that asserts the round PASSED while the ` +
+        `stored findings derive FAIL (MISSING findings present). This is the #1019 fabrication ` +
+        `pattern. Either fix the findings (re-run the dimension), or escalate to a human reviewer ` +
+        `— do not narrate a passing verdict over failing data. Note was: ${JSON.stringify(trimmed)}`,
+      );
+    }
+    content = `${derived}\n\n### Reviewer notes (non-authoritative — verdict above is derived from findings)\n\n${trimmed}`;
+  }
+
   return writeAttachment(target, `review/r${round}/summary`, content);
 }
 


### PR DESCRIPTION
## Problem

During round 3 of PR #1012 the review loop declared **REVIEW PASSED — all 12 dimensions ✅**
while the stored per-dimension findings said the opposite: six dimensions had `verdict:fail`,
two findings were MISSING at confidence 100. The summary was hand-written from introspection
("I think I fixed it"), and the DONE/MISSING counts were fabricated (#1019). The same swallowing
silently dropped near-miss PARTIAL findings from round summaries (#1067).

## Discovery

There was already a mechanism for the truth — `composeReviewSummary()` derives the verdict and
the DONE/PARTIAL/MISSING rollup from the stored findings. But it was **optional**:
`storeReviewSummary(target, round, summary?)` accepted a hand-written `summary` and stored it
verbatim, routing around the derivation entirely. The review SKILL.md Phase 5 literally instructed
the agent to pass `--text "REVIEW PASSED — N rounds"`. A mechanism the agent can route around is
not a mechanism — it's a suggestion. (Zen: *an enforcement point is worth a thousand instructions*;
*no promises without mechanisms*.)

A second, smaller inconsistency: `composeReviewSummary`'s header rule (`missing===0 → PASS`,
PARTIAL ignored) disagreed with the canonical `deriveVerdictFromFindings` (PARTIAL → fail), and
PARTIAL was never surfaced distinctly.

## Solution

The derived verdict block is now **always authoritative** — the agent cannot substitute a
hand-written verdict for it:

- **Canonical round-verdict module** (`review-finding-contract.ts`): `summarizeRound()` +
  `deriveRoundVerdict()` — one source of truth for the three-state round rule (any MISSING → FAIL;
  PARTIAL but no MISSING → `PASS_WITH_PARTIALS`, surfaced loudly, non-blocking per #1067; else PASS).
  `assertsPass()` is a conservative overt-PASS detector used only as a fail-closed guard.
- **`composeReviewSummary()`** consumes it: header is three-state, per-row icon distinguishes
  ✅ DONE / ⚠️ PARTIAL / ❌ FAIL, the overall line always reports the PARTIAL count (#1067).
- **`storeReviewSummary()`** always stores the derived block. A caller-supplied note becomes
  clearly-labelled non-authoritative "Reviewer notes" appended below — never a replacement. If the
  note overtly asserts the round PASSED while findings derive FAIL, it **throws** — forcing the
  agent to fix the findings or escalate, the exact action #1019 says it should have taken (L1→L3:
  the bypass is now structurally impossible).
- **CLI** `store-review-summary`: `--text`/`--note` route to the note; the verdict is always
  derived; the guard error is surfaced with a non-zero exit.
- **SKILL.md Phase 5**: stop hand-writing the verdict; read it back from the derived header.

## Evidence

| Behavior | Level | Test |
|----------|-------|------|
| `summarizeRound`/`deriveRoundVerdict` three-state rule | Unit | `review-finding-contract.test.ts` |
| `assertsPass` flags overt PASS, not benign commentary | Unit | `review-finding-contract.test.ts` |
| `composeReviewSummary` surfaces PARTIAL (header + ⚠️ row + count) (#1067) | Unit | `structured-data.test.ts` |
| `storeReviewSummary` stores DERIVED FAIL with no note | Integration | `structured-data.test.ts` |
| Benign note appended as non-authoritative, verdict intact | Integration | `structured-data.test.ts` |
| **Prevention: hand-written "REVIEW PASSED" while findings derive FAIL → throws** | Integration | `structured-data.test.ts` |

Full TS suite: 2743 passed (the 2 unrelated `e2e/synthetic-workflow` failures are pre-existing
fleet-load flakiness — they pass in isolation, see #1120). `tsc --noEmit` clean.

## Impact

A stored review summary can no longer contradict the findings it summarizes. PASS-on-failing-data
(#1019) and swallowed PARTIALs (#1067) are both closed by the same code path. This is the
**reviews + iteration** step of the kaizen pipeline getting a real enforcement point: the verdict
is now a derived property of the evidence, not a self-declaration.

## Scope

In this PR: the verdict-derivation mechanism + PARTIAL surfacing + guard + SKILL.md + tests.

Deferred to existing issues (distinct mechanisms, out of scope): CI-status gate (#1070),
round-number query (#1051), dimension-coverage enforcement (#1038), second-round enforcement
(#1000). No test-plan behavior is deferred — every row above ships here (I27).

Closes #1019
Closes #1067
Refs #1070, #1051, #1038, #1000

Run tag: sticky-lark/run-1
