### PR TITLE
fix(structured-data): make comment fetch gh-version-robust (Closes #1082)

### DIFF
--- a/src/section-editor.test.ts
+++ b/src/section-editor.test.ts
@@ -293,6 +293,37 @@ describe('readAttachment', () => {
   });
 });
 
+// Regression for #1082: retrievePlan/retrieveTestPlan crashed (TypeError) on any
+// issue with comments when running against an older gh CLI, because the issue
+// fetch path relied on a `url` field that older `gh issue view --json comments`
+// does not emit. Both prevention tests below FAIL before the categorical fix:
+//   1. the issue path must use the stable REST API (like the PR path), not `gh issue view`;
+//   2. extractCommentId must null-guard so a missing url degrades to '' instead of throwing.
+describe('#1082 — comment fetch is gh-version-robust', () => {
+  beforeEach(() => { vi.clearAllMocks(); clearCommentCache(); });
+
+  it('fetches issue comments via the stable REST API (not gh issue view), with --paginate', () => {
+    ghReturns(JSON.stringify({ url: 'https://...#issuecomment-1', body: 'a comment' }));
+    listAttachments(issueAttach);
+    const args = mockGh.mock.calls[0][1] as string[];
+    expect(args).toContain('api');
+    expect(args.some(a => a.includes(`/issues/${issueAttach.number}/comments`))).toBe(true);
+    expect(args).toContain('--paginate');
+    // Must NOT use the version-fragile `gh issue view` path for comments.
+    expect(args).not.toContain('view');
+  });
+
+  it('does not throw on a comment whose url is null (old-gh shape), degrades commentId to ""', () => {
+    // Real shape from older `gh issue view --json comments`: no html_url → url is null.
+    ghReturns(JSON.stringify({ url: null, body: '<!-- kaizen:plan -->\n## Plan\n\n1. Do X' }));
+    let a: ReturnType<typeof readAttachment> = null;
+    expect(() => { a = readAttachment(issueAttach, 'plan'); }).not.toThrow();
+    expect(a).not.toBeNull();
+    expect(a!.content).toContain('Do X');
+    expect(a!.commentId).toBe('');
+  });
+});
+
 describe('writeAttachment', () => {
   beforeEach(() => { vi.clearAllMocks(); clearCommentCache(); });
 

--- a/src/section-editor.ts
+++ b/src/section-editor.ts
@@ -208,8 +208,13 @@ export interface Attachment {
 
 const MARKER_RE = /^<!-- kaizen:(\S+) -->/;
 
-/** Extract comment ID from GitHub URL (#issuecomment-123 or #discussion_r123 → ID) */
-function extractCommentId(url: string): string {
+/**
+ * Extract comment ID from a GitHub comment URL (#issuecomment-123 or comments/123 → ID).
+ * Null-guards a missing/empty url (e.g. a gh CLI version that omits the field) so callers
+ * degrade to '' instead of crashing on `null.match(...)` — see #1082.
+ */
+function extractCommentId(url: string | null | undefined): string {
+  if (!url) return '';
   return url.match(/#issuecomment-(\d+)/)?.[1]
     ?? url.match(/comments\/(\d+)/)?.[1]
     ?? '';
@@ -245,20 +250,16 @@ function fetchComments(target: AttachmentTarget): Array<{ url: string; body: str
     if (cached) return cached;
   }
   try {
-    let raw: string;
-    if (target.kind === 'issue') {
-      raw = gh([
-        'issue', 'view', target.number, '--repo', target.repo,
-        '--json', 'comments',
-        '--jq', '.comments[] | {url: .url, body: .body} | @json',
-      ]);
-    } else {
-      // PR comments via the issues API (PRs are issues in GitHub's model)
-      raw = gh([
-        'api', `repos/${target.repo}/issues/${target.number}/comments`,
-        '--jq', '.[] | {url: .html_url, body: .body} | @json',
-      ]);
-    }
+    // One stable code path for BOTH issues and PRs (PRs are issues in GitHub's
+    // model). The REST API exposes `html_url` on every gh CLI version; the older
+    // `gh issue view --json comments` path omitted `url` on pre-2.x gh, which
+    // crashed extractCommentId on any commented issue (#1082). `--paginate`
+    // preserves the previous "all comments" behavior (raw REST caps at 30/page).
+    const raw = gh([
+      'api', `repos/${target.repo}/issues/${target.number}/comments`,
+      '--paginate',
+      '--jq', '.[] | {url: .html_url, body: .body} | @json',
+    ]);
     if (!raw) return [];
     const results: Array<{ url: string; body: string }> = [];
     for (const line of raw.split('\n')) {


### PR DESCRIPTION
## The Problem

`retrieve-plan` and `retrieve-testplan` crashed with
`TypeError: Cannot read properties of null (reading 'match')` on **any issue that
had at least one comment**. The crash propagated into the plan gate: because
`enforce-plan-stored` → `CaseSystem#checkPlanGate` calls the same retrieve path,
`gh pr create` was blocked with *"Issue #N is missing: implementation plan, test
plan"* — even 30 seconds after `store-plan` had succeeded. The install's own bug
blocked the PR that ships the install (#1082, hit while running `/kaizen-setup`
on a host repo).

## The Discovery

`section-editor.ts#fetchComments` had **two divergent code paths**:

- **Issue path** — `gh issue view --json comments --jq '.comments[] | {url: .url, …}'`
- **PR path** — `gh api repos/<repo>/issues/<N>/comments --jq '.[] | {url: .html_url, …}'`

The `url` field on issue comments only appears in recent `gh` CLI versions. On
older gh (host projects, the langsmith-cli repro), `gh issue view --json comments`
emits **no `url` field**, so `.url` is `null` for every comment and
`extractCommentId(null)` throws. The PR path never hit this because the REST API
exposes `html_url` on every gh version. This is the **#1083 category**: newer code
silently assumes gh-CLI JSON fields that older gh lacks.

The green test suite hid it: the existing mocks fed comment JSON *with* a `url`
field — the synthetic-shape blind spot called out by #1102/#1115.

## The Fix

Categorical, not a patch:

1. **One stable code path for both issues and PRs.** Fetch comments via
   `gh api repos/<repo>/issues/<N>/comments --paginate` for both kinds (PRs are
   issues in GitHub's model). The REST API's `html_url` exists on every gh version,
   so there's no version-fragile field and no shape divergence left to drift apart.
   `--paginate` preserves the issue path's prior "all comments" behavior (raw REST
   caps at 30/page; `gh issue view` returned all).
2. **Null-guard `extractCommentId`.** A missing/empty url now degrades to `''`
   instead of crashing — defense in depth for any future caller.

## The Evidence

Two prevention tests, written red-first against the **real old-gh shape** (not the
synthetic one that masked the bug):

- The issue path must call the REST API (`api` + `/issues/<N>/comments` +
  `--paginate`, never `gh issue view`).
- A comment with `url: null` must not throw; `commentId` degrades to `''` and the
  attachment is still found by its marker.

Both failed before the fix (the second reproduced the exact reported TypeError),
both pass after. Full `section-editor` (41) and `structured-data` (30) suites green;
`tsc` clean; live `retrieve-plan` against a commented issue now returns the plan.

## The Impact

The feature → plan → test-plan → execution pipeline no longer breaks on real host
environments running older gh. The plan gate stops falsely blocking `gh pr create`
right after a plan is stored, and one less gh-version assumption is baked into the
structured-data layer.

Closes #1082
Refs: #1083 (gh CLI version assumptions), #1102 / #1115 (synthetic-shape test blind spot)

Run tag: sticky-lark/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
