### PR TITLE
feat(setup): thin-wrapper pre-push dispatch — host hook self-updates on plugin update (Closes #1086)

### DIFF
--- a/docs/git-hooks-design.md
+++ b/docs/git-hooks-design.md
@@ -83,7 +83,7 @@ The detection order in `src/setup-git-hooks.ts`:
 
 ### Framework-specific injection
 
-In every case, kaizen writes `.kaizen-hooks/pre-push` (the host-side entry script, see below) to the host project root, then registers it with whichever framework is present.
+In every case, kaizen writes `.kaizen-hooks/pre-push` (a **thin wrapper** that execs the plugin-resident entry — see below) to the host project root, then registers it with whichever framework is present.
 
 **pre-commit** (PRIMARY):
 
@@ -131,15 +131,25 @@ pre-push:
 
 All injection is **idempotent**: running `/kaizen-setup install-git-hooks` twice detects the `KAIZEN_CHAIN_START` marker (or hook `id: kaizen-pre-push` for structured configs) and skips.
 
-### The `.kaizen-hooks/pre-push` entry script
+### The `.kaizen-hooks/pre-push` thin wrapper (#1086)
 
-A thin shell script installed in the host repo. It:
+`/kaizen-setup install-git-hooks` writes a **thin wrapper** (~25–35 lines) into the host repo at `.kaizen-hooks/pre-push`. It is NOT a copy of the gate logic — it only:
 
-1. Runs the agent-env gate (exit 0 for humans).
-2. Resolves `$CLAUDE_PLUGIN_ROOT` (baked in at install time; falls back to `$HOME/.claude/plugins/cache` search).
-3. Execs `npx tsx "$CLAUDE_PLUGIN_ROOT/src/hooks/pre-push.ts"` with stdin and args passed through.
+1. Resolves the kaizen plugin root: `$CLAUDE_PLUGIN_ROOT` → baked-in install path → `$HOME/.claude/plugins/cache` search → fail-open.
+2. Exports the resolved root as `$CLAUDE_PLUGIN_ROOT`.
+3. `exec`s the **plugin-resident** `$KAIZEN_ROOT/src/hooks/kaizen-host-entry.sh` with stdin and args passed through.
 
-The source template lives at `src/hooks/kaizen-host-entry.sh` in the kaizen plugin.
+`kaizen-host-entry.sh` (inside the plugin) then runs the agent-env gate, resolves the runtime, and dispatches to `src/hooks/pre-push.ts`.
+
+**Why a wrapper, not a copy (the self-updating property).** The earlier design wrote a ~66-line *copy* of `kaizen-host-entry.sh` into the host repo. That froze the host's pre-push logic at the kaizen version present when setup last ran — a gate fix learned from an incident could not reach the host until it re-ran `/kaizen-setup`, which most collaborators never do. The opposite of kaizen's continuous-improvement loop. With the wrapper, **all version-sensitive logic lives in the plugin**, so a plugin update reaches every host automatically. The wrapper is so minimal it almost never changes.
+
+**No agent-env gate in the wrapper — deliberate.** `kaizen-host-entry.sh` already gates on the agent-env vars as its first action, and `src/hooks/agent-env-agreement.test.ts` pins that var list against `pre-push.ts` so it can't drift. Adding the gate to the wrapper would create a *third* copy of that list to keep in sync — the exact drift hazard the agreement test exists to prevent. In the common case the baked-in path resolves without a cache scan, so a human push still exits fast once it reaches the entry's gate.
+
+**Migration is automatic.** `writeEntryScript` overwrites `.kaizen-hooks/pre-push` on every setup run, so the next `/kaizen-setup` on an existing host swaps the stale copy for the wrapper. No `.kaizen-hooks/` removal needed.
+
+Builder: `buildThinWrapper(pluginRoot)` in `src/setup-git-hooks.ts`. The dispatch target template lives at `src/hooks/kaizen-host-entry.sh` in the kaizen plugin.
+
+> Remote-repo hook references (pre-commit `repo:`/lefthook `remotes:`, #1087) would remove host-side code entirely. That is a larger architecture change tracked separately; the thin wrapper is the categorical fix for the *staleness* of the host-side file today.
 
 ## Worktree semantics
 

--- a/src/kaizen-setup.ts
+++ b/src/kaizen-setup.ts
@@ -19,7 +19,7 @@ import { execSync } from "child_process";
 import { join } from "path";
 import { parseArgs } from "util";
 import { loadAllSkillMetadata, validateSkillDependencies, validateSkillVersions } from "./skill-metadata.js";
-import { installGitHooks, type InstallResult } from "./setup-git-hooks.js";
+import { installGitHooks, buildThinWrapper, type InstallResult } from "./setup-git-hooks.js";
 
 // ── Types ──
 
@@ -494,23 +494,27 @@ if (process.argv[1]?.endsWith("kaizen-setup.ts") || process.argv[1]?.endsWith("k
       // Epic #1059: install kaizen's pre-push hook into host project.
       // Option C: detect host framework; inject into theirs; raw fallback if none.
       const pluginRoot = values["plugin-root"] ?? process.env.CLAUDE_PLUGIN_ROOT;
-      const entryTemplatePath = pluginRoot
+      // The host's `.kaizen-hooks/pre-push` is a THIN WRAPPER (#1086) that execs
+      // the plugin-resident canonical entry — it does not copy the entry's logic.
+      // Verify the entry exists in the plugin so a broken/missing install fails
+      // fast here rather than silently fail-opening at push time.
+      const entryPath = pluginRoot
         ? join(pluginRoot, "src/hooks/kaizen-host-entry.sh")
         : null;
 
-      if (!entryTemplatePath || !existsSync(entryTemplatePath)) {
+      if (!entryPath || !existsSync(entryPath)) {
         console.log(JSON.stringify({
           step: "install-git-hooks",
           status: "error",
-          error: `entry template not found: ${entryTemplatePath ?? "(plugin-root not set)"}`,
+          error: `kaizen entry not found in plugin: ${entryPath ?? "(plugin-root not set)"}`,
         }));
         process.exit(1);
       }
 
-      const template = readFileSync(entryTemplatePath, "utf-8");
-      // Substitute plugin root so the entry script can locate kaizen at runtime.
-      // See src/hooks/kaizen-host-entry.sh: __KAIZEN_PLUGIN_ROOT__ is the placeholder.
-      const entryContent = template.replace(/__KAIZEN_PLUGIN_ROOT__/g, pluginRoot ?? "");
+      // Build the thin wrapper, baking in the plugin root as the secondary
+      // fallback. All version-sensitive logic stays in the plugin entry, so a
+      // plugin update reaches the host without re-running /kaizen-setup.
+      const entryContent = buildThinWrapper(pluginRoot ?? "");
       const runPostInstall = values["run-post-install"] === "true";
 
       const result: InstallResult = installGitHooks({ cwd, entryScriptContent: entryContent, runPostInstall });

--- a/src/setup-git-hooks.test.ts
+++ b/src/setup-git-hooks.test.ts
@@ -19,11 +19,13 @@ import {
   injectIntoRaw,
   installGitHooks,
   installStandalone,
+  buildThinWrapper,
   KAIZEN_CHAIN_MARKER,
   KAIZEN_HOOK_ID,
   KAIZEN_ENTRY_PATH,
   writeEntryScript,
 } from './setup-git-hooks.js';
+import { AGENT_ENV_VARS } from './hooks/pre-push.js';
 
 // ── Fixture helpers ───────────────────────────────────────────────────
 
@@ -107,6 +109,67 @@ describe('writeEntryScript', () => {
   it('creates the directory if absent', () => {
     writeEntryScript(tmpDir, 'x');
     expect(fs.statSync(path.join(tmpDir, '.kaizen-hooks')).isDirectory()).toBe(true);
+  });
+});
+
+// ── buildThinWrapper (#1086) ──────────────────────────────────────────
+
+describe('buildThinWrapper — host pre-push is a wrapper, not a copy', () => {
+  const PLUGIN_ROOT = '/home/me/.claude/plugins/cache/kaizen';
+
+  it('bakes the plugin root in as the secondary fallback', () => {
+    const w = buildThinWrapper(PLUGIN_ROOT);
+    // env var first, then the baked-in install path.
+    expect(w).toContain('KAIZEN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"');
+    expect(w).toContain(`KAIZEN_ROOT="${PLUGIN_ROOT}"`);
+  });
+
+  it('execs the plugin-resident canonical entry (does not inline its logic)', () => {
+    const w = buildThinWrapper(PLUGIN_ROOT);
+    expect(w).toContain('ENTRY="$KAIZEN_ROOT/src/hooks/kaizen-host-entry.sh"');
+    expect(w).toContain('exec bash "$ENTRY" "$@"');
+  });
+
+  it('exports CLAUDE_PLUGIN_ROOT so the entry re-resolves to the same plugin', () => {
+    const w = buildThinWrapper(PLUGIN_ROOT);
+    expect(w).toContain('export CLAUDE_PLUGIN_ROOT="$KAIZEN_ROOT"');
+  });
+
+  it('has the full env -> baked-in -> cache -> fail-open resolution chain', () => {
+    const w = buildThinWrapper(PLUGIN_ROOT);
+    expect(w).toContain('.claude/plugins/cache'); // cache search
+    expect(w).toContain('plugin.json');
+    // Fail-open guards: never block a push if kaizen / entry can't be located.
+    expect(w).toContain('[ -d "$KAIZEN_ROOT" ] || exit 0');
+    expect(w).toContain('[ -f "$ENTRY" ] || exit 0');
+  });
+
+  it('is THIN — carries none of the version-sensitive dispatch logic', () => {
+    const w = buildThinWrapper(PLUGIN_ROOT);
+    // These live only in kaizen-host-entry.sh / pre-push.ts. If they leak into
+    // the wrapper, the host has copied logic that goes stale again (#1086).
+    expect(w).not.toContain('pre-push.ts');
+    expect(w).not.toContain('tsx');
+    expect(w).not.toContain('npx');
+    // A wrapper, not a 66-line snapshot.
+    expect(w.split('\n').length).toBeLessThan(40);
+  });
+
+  it('adds NO new copy of the agent-env var list (single-source via entry)', () => {
+    // agent-env-agreement.test.ts pins the var list across pre-push.ts and the
+    // two shell wrappers. The thin wrapper must not introduce a third copy —
+    // the entry it execs already gates. Assert none of the canonical vars are
+    // gated inside the wrapper.
+    const w = buildThinWrapper(PLUGIN_ROOT);
+    for (const v of AGENT_ENV_VARS) {
+      expect(w).not.toContain(`-z "${'$'}{${v}:-}"`);
+    }
+  });
+
+  it('starts with a bash shebang and set -eu', () => {
+    const w = buildThinWrapper(PLUGIN_ROOT);
+    expect(w.startsWith('#!/usr/bin/env bash')).toBe(true);
+    expect(w).toContain('set -eu');
   });
 });
 
@@ -351,5 +414,32 @@ describe('installGitHooks — end-to-end', () => {
     expect(result2.action).toBe('already_installed');
     expect(read('.pre-commit-config.yaml')).toBe(firstConfig);
     expect(read('.kaizen-hooks/pre-push')).toBe(firstEntry);
+  });
+
+  it('install with the thin wrapper writes a wrapper, not a copy of entry logic (#1086)', () => {
+    write('.pre-commit-config.yaml', 'repos: []\n');
+    const wrapper = buildThinWrapper('/plugins/cache/kaizen');
+    installGitHooks({ cwd: tmpDir, entryScriptContent: wrapper });
+    const installed = read('.kaizen-hooks/pre-push');
+    expect(installed).toContain('exec bash "$ENTRY" "$@"');
+    expect(installed).not.toContain('pre-push.ts');
+  });
+
+  it('migration: re-install overwrites a stale 66-line copy with the thin wrapper (#1086)', () => {
+    write('.pre-commit-config.yaml', 'repos: []\n');
+    // Simulate a host that previously installed the old full COPY of the entry.
+    const stale = '#!/usr/bin/env bash\n# stale copy\n' +
+      'HOOK_TS="$KAIZEN_ROOT/src/hooks/pre-push.ts"\n' +
+      'exec npx --no-install tsx "$HOOK_TS" "$@"\n';
+    writeEntryScript(tmpDir, stale);
+    expect(read('.kaizen-hooks/pre-push')).toContain('pre-push.ts');
+
+    // Next /kaizen-setup run installs the thin wrapper.
+    const wrapper = buildThinWrapper('/plugins/cache/kaizen');
+    installGitHooks({ cwd: tmpDir, entryScriptContent: wrapper });
+
+    const migrated = read('.kaizen-hooks/pre-push');
+    expect(migrated).toContain('exec bash "$ENTRY" "$@"');
+    expect(migrated).not.toContain('pre-push.ts'); // stale dispatch logic gone
   });
 });

--- a/src/setup-git-hooks.ts
+++ b/src/setup-git-hooks.ts
@@ -161,6 +161,78 @@ export function detectHostFramework(cwd: string): HostDetectionResult {
   return { framework: 'none' };
 }
 
+// ── Thin wrapper builder ──────────────────────────────────────────────
+
+/**
+ * Build the host-side `.kaizen-hooks/pre-push` content as a THIN WRAPPER
+ * that dispatches to the plugin-resident `kaizen-host-entry.sh` (#1086).
+ *
+ * Why a wrapper and not a copy: the previous design wrote a ~66-line *copy*
+ * of `kaizen-host-entry.sh` into the host repo with `__KAIZEN_PLUGIN_ROOT__`
+ * substituted. That copy froze the host's pre-push logic at the kaizen
+ * version present when setup last ran — bug fixes to the gate never reached
+ * the host until it re-ran `/kaizen-setup`. That is the opposite of kaizen's
+ * continuous-improvement loop: an incident that teaches us something about
+ * pre-push couldn't propagate.
+ *
+ * The wrapper holds ONLY the version-stable plumbing — resolve the plugin
+ * root, then `exec` the canonical entry inside the plugin. All logic that
+ * changes version-to-version (agent-env gate, tsx resolution, dispatch to
+ * `pre-push.ts`) lives in `kaizen-host-entry.sh` inside the plugin, so a
+ * plugin update reaches every host automatically.
+ *
+ * Resolution order mirrors `kaizen-host-entry.sh`:
+ *   1. `$CLAUDE_PLUGIN_ROOT` (set by Claude Code at invocation time)
+ *   2. the baked-in install-time path (`pluginRoot` arg)
+ *   3. a search of the Claude plugin cache
+ *   4. fail-open (never block a push if kaizen can't be located)
+ *
+ * Deliberately NO agent-env gate here. `kaizen-host-entry.sh` already gates
+ * on the agent-env vars as its first action, and `agent-env-agreement.test.ts`
+ * pins that var list against `pre-push.ts` so it can't drift. Duplicating the
+ * gate into the wrapper would add a third copy of that list to keep in sync —
+ * the exact drift hazard the agreement test exists to prevent. In the common
+ * case the baked-in path resolves without a cache scan, so a human push still
+ * exits fast once it reaches the entry's gate. The resolved root is exported
+ * as `CLAUDE_PLUGIN_ROOT` so the entry re-resolves to the same plugin.
+ */
+export function buildThinWrapper(pluginRoot: string): string {
+  return `#!/usr/bin/env bash
+# Kaizen host-project pre-push wrapper (installed by /kaizen-setup, #1086).
+#
+# THIN WRAPPER — do not add logic here. This file resolves the kaizen plugin
+# root and execs the canonical entry inside the plugin. All version-sensitive
+# behavior (agent-env gate, runtime resolution, hook dispatch) lives in
+# \$KAIZEN_ROOT/src/hooks/kaizen-host-entry.sh, so a plugin update reaches this
+# host automatically — no need to re-run /kaizen-setup.
+
+set -eu
+
+# Resolve kaizen plugin root: env -> baked-in install path -> cache -> fail-open.
+KAIZEN_ROOT="\${CLAUDE_PLUGIN_ROOT:-}"
+if [ ! -d "\$KAIZEN_ROOT" ]; then
+  KAIZEN_ROOT="${pluginRoot}"
+fi
+if [ ! -d "\$KAIZEN_ROOT" ]; then
+  CACHE_ROOT="\${HOME}/.claude/plugins/cache"
+  if [ -d "\$CACHE_ROOT" ]; then
+    CANDIDATE=\$(find "\$CACHE_ROOT" -maxdepth 5 -name "plugin.json" -path "*kaizen*" 2>/dev/null | head -1 || true)
+    [ -n "\$CANDIDATE" ] && KAIZEN_ROOT=\$(dirname "\$(dirname "\$CANDIDATE")")
+  fi
+fi
+
+# Fail-open: never block a push if kaizen can't be located.
+[ -d "\$KAIZEN_ROOT" ] || exit 0
+
+ENTRY="\$KAIZEN_ROOT/src/hooks/kaizen-host-entry.sh"
+[ -f "\$ENTRY" ] || exit 0
+
+# Export the resolved root so the entry re-resolves to the same plugin.
+export CLAUDE_PLUGIN_ROOT="\$KAIZEN_ROOT"
+exec bash "\$ENTRY" "\$@"
+`;
+}
+
 // ── Entry script writer ───────────────────────────────────────────────
 
 export function writeEntryScript(cwd: string, content: string): string {


### PR DESCRIPTION
## The problem

`/kaizen-setup install-git-hooks` wrote `.kaizen-hooks/pre-push` into the host repo as a **~66-line copy** of `kaizen-host-entry.sh`, with `__KAIZEN_PLUGIN_ROOT__` substituted at install time and then committed to the host's git history.

The consequence: the host's pre-push logic **froze at the kaizen version present when setup last ran.** A gate fix learned from an incident — exactly the kind of thing kaizen's continuous-improvement loop is supposed to propagate — could not reach the host until it re-ran `/kaizen-setup`. Most collaborators never do that, so they run stale hook logic indefinitely. The deployment surface was the one place kaizen *couldn't* improve itself.

## The discovery

The fix the host repo *needs* is the same one kaizen preaches everywhere else: **single source of truth.** The host shouldn't carry a copy of logic it doesn't own. `kaizen-host-entry.sh` already resolves the plugin root and dispatches; the host file only needs to *find* the plugin and hand off.

A subtlety surfaced while wiring it: the plugin-resident `kaizen-host-entry.sh` re-resolves the root from scratch (its own `__KAIZEN_PLUGIN_ROOT__` is the literal, unsubstituted placeholder). So the wrapper must **export** the root it resolved, or the entry could re-resolve differently. The wrapper sets `CLAUDE_PLUGIN_ROOT` before `exec`.

A second decision: should the wrapper carry the agent-env gate? No. `kaizen-host-entry.sh` already gates as its first action, and `agent-env-agreement.test.ts` pins that var list against `pre-push.ts` so it can't drift. A gate in the wrapper would be a **third copy** of that list — the exact drift hazard the agreement test exists to prevent.

## The solution

`buildThinWrapper(pluginRoot)` (in `src/setup-git-hooks.ts`) emits a ~33-line wrapper that:

1. Resolves the plugin root: `$CLAUDE_PLUGIN_ROOT` → baked-in install path → `$HOME/.claude/plugins/cache` search → **fail-open** (never block a push).
2. Exports the resolved root as `$CLAUDE_PLUGIN_ROOT`.
3. `exec`s the plugin-resident `$KAIZEN_ROOT/src/hooks/kaizen-host-entry.sh "$@"`.

`/kaizen-setup install-git-hooks` (`src/kaizen-setup.ts`) now builds the wrapper instead of copy-and-substitute — still verifying the plugin entry exists so a broken install fails fast. **Migration is automatic:** `writeEntryScript` already overwrites `.kaizen-hooks/pre-push` on every setup run, so the next `/kaizen-setup` on an existing host swaps the stale copy for the wrapper.

The result: all version-sensitive logic lives in the plugin. **A plugin update reaches every host automatically — no re-running setup.**

## The evidence

- **Unit** (`buildThinWrapper`, 7 tests): bakes the root, execs the canonical entry, exports `CLAUDE_PLUGIN_ROOT`, full env→baked-in→cache→fail-open chain, and is genuinely *thin* — asserts no `pre-push.ts`/`tsx`/`npx` dispatch logic leaked in, `<40` lines, and **no new copy of the agent-env var list** (checked against `AGENT_ENV_VARS`).
- **Integration** (`installGitHooks`, 2 tests): install writes a wrapper not a copy; re-install over a simulated stale 66-line copy migrates it to the wrapper.
- **Real bash smoke test**: human push exits 0 silently via the entry's gate; bad root + no cache fail-opens to 0; env-unset resolves via the baked-in path and execs the entry. (33-line wrapper vs old 66-line copy.)
- `agent-env-agreement.test.ts` still green (2/2) — single-sourcing intact. `npm run build` clean.

## Impact

Converts kaizen's host-side pre-push hook from *frozen-at-install* to *self-updating-on-plugin-update*. The continuous-improvement loop now reaches the deployment surface it previously couldn't.

> **Scope note:** Remote-repo hook references (pre-commit `repo:` / lefthook `remotes:`, #1087) would remove host-side code entirely — a larger architecture change tracked separately. This PR is the categorical fix for the *staleness* of the host-side file today.

Closes #1086
Refs: #1087, #1090, #1085

Run tag: sticky-lark/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
