### PR TITLE
feat(auto-dent): thematic plan coordination — bunch related issues into coordinated bundles (Closes #941)

### DIFF
--- a/prompts/plan-prepass.md
+++ b/prompts/plan-prepass.md
@@ -55,6 +55,16 @@ PRs already created (avoid overlapping work): {{prs}}
 
 7. For each selected item, write a one-sentence approach.
 
+8. **Group related items into coordinated themes (aim for 3-5 items per theme).**
+   Issues that share a root cause, a file/subsystem, or a parent epic belong
+   together so the batch drives a coherent body of work to completion instead
+   of hopping across unrelated issues by score. Give each theme a kebab-case
+   `id`, a human `title`, a one-line `rationale`, and the member issue refs.
+   Stamp each item with its `theme` id. Leave genuinely unrelated singletons
+   out of themes. (If you omit `themes`, auto-dent derives them
+   deterministically from shared epics + title overlap — but your semantic
+   grouping is better, so prefer providing them.)
+
 ## Output
 
 You MUST output a single JSON code block with this exact structure:
@@ -70,7 +80,8 @@ You MUST output a single JSON code block with this exact structure:
       "score": 0.0,
       "approach": "one sentence describing the implementation approach",
       "status": "pending",
-      "item_type": "leaf"
+      "item_type": "leaf",
+      "theme": "theme-id"
     },
     {
       "issue": "#NNN",
@@ -82,6 +93,14 @@ You MUST output a single JSON code block with this exact structure:
       "parent_epic": "#NNN"
     }
   ],
+  "themes": [
+    {
+      "id": "theme-id",
+      "title": "Short theme title",
+      "rationale": "why these issues belong together (shared root cause / file / epic)",
+      "issues": ["#NNN", "#NNN"]
+    }
+  ],
   "wip_excluded": ["#NNN (reason)"],
   "epics_scanned": ["#NNN title"],
   "decomposition_candidates": ["#NNN title — reason it needs decomposition"]
@@ -91,5 +110,10 @@ You MUST output a single JSON code block with this exact structure:
 Notes on `item_type`:
 - `"leaf"` — a concrete issue ready for implementation
 - `"decompose"` — an abstract item (epic/PRD/horizon) that needs to be broken into concrete issues first. The agent should file 1-3 child issues, then implement the most actionable one.
+
+Notes on `themes`:
+- Optional but strongly preferred — it is the mechanism that lets the batch
+  finish a related cluster of issues as one coordinated effort (#941).
+- Every issue ref in a theme's `issues` array should also appear as an item.
 
 Do NOT include any text outside the JSON code block. The output will be parsed programmatically.

--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -5,15 +5,31 @@ import { tmpdir } from 'os';
 import {
   extractPlanJson,
   validatePlan,
+  validateThemes,
   readPlan,
   claimNextItem,
+  selectNextItem,
   markItem,
   resetAssignedItems,
   formatPlanSummary,
   buildPlanPrompt,
+  titleTokens,
+  deriveThemes,
+  ensureThemes,
+  themeProgress,
   type BatchPlan,
   type PlanItem,
 } from './auto-dent-plan.js';
+
+function mkItem(overrides: Partial<PlanItem> & { issue: string; title: string }): PlanItem {
+  return {
+    score: 5,
+    approach: '',
+    status: 'pending',
+    item_type: 'leaf',
+    ...overrides,
+  };
+}
 
 function makePlan(overrides: Partial<BatchPlan> = {}): BatchPlan {
   return {
@@ -490,5 +506,387 @@ describe('buildPlanPrompt', () => {
     const prompt = buildPlanPrompt(state);
     expect(prompt).toContain('decomposition');
     expect(prompt).toContain('item_type');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Thematic plan coordination (#941)
+// ---------------------------------------------------------------------------
+
+describe('titleTokens', () => {
+  it('lowercases, splits, and drops short/stopwords', () => {
+    const t = titleTokens('Fix the L2 hook performance observability');
+    expect(t.has('hook')).toBe(true);
+    expect(t.has('performance')).toBe(true);
+    expect(t.has('observability')).toBe(true);
+    // stopwords / domain noise removed
+    expect(t.has('the')).toBe(false);
+    expect(t.has('fix')).toBe(false);
+    expect(t.has('l2')).toBe(false);
+  });
+
+  it('splits on hyphens', () => {
+    const t = titleTokens('cross-batch steering');
+    expect(t.has('cross')).toBe(true);
+    expect(t.has('batch')).toBe(true);
+    expect(t.has('steering')).toBe(true);
+  });
+});
+
+describe('deriveThemes', () => {
+  it('groups items sharing a parent_epic into one theme', () => {
+    const items = [
+      mkItem({ issue: '#1', title: 'alpha widget', parent_epic: '#900' }),
+      mkItem({ issue: '#2', title: 'beta gadget', parent_epic: '#900' }),
+      mkItem({ issue: '#3', title: 'lone thing', parent_epic: '#999' }),
+    ];
+    const themes = deriveThemes(items);
+    expect(themes).toHaveLength(1);
+    expect(themes[0].issues.sort()).toEqual(['#1', '#2']);
+    expect(themes[0].title).toContain('#900');
+  });
+
+  it('groups items sharing >=2 significant title tokens', () => {
+    const items = [
+      mkItem({ issue: '#1', title: 'hook performance observability' }),
+      mkItem({ issue: '#2', title: 'hook performance timing instrumentation' }),
+      mkItem({ issue: '#3', title: 'worktree cleanup logic' }),
+    ];
+    const themes = deriveThemes(items);
+    expect(themes).toHaveLength(1);
+    expect(themes[0].issues.sort()).toEqual(['#1', '#2']);
+  });
+
+  it('does NOT group on a single shared token', () => {
+    const items = [
+      mkItem({ issue: '#1', title: 'hook reliability gate' }),
+      mkItem({ issue: '#2', title: 'hook is unrelated entirely otherwise distinct' }),
+    ];
+    // only "hook" is shared (1 token) → not related
+    const themes = deriveThemes(items);
+    expect(themes).toHaveLength(0);
+  });
+
+  it('leaves singletons themeless (no theme produced)', () => {
+    const items = [
+      mkItem({ issue: '#1', title: 'alpha unique words' }),
+      mkItem({ issue: '#2', title: 'beta different terms' }),
+    ];
+    expect(deriveThemes(items)).toHaveLength(0);
+  });
+
+  it('clusters transitively via union-find (A~B, B~C => one theme)', () => {
+    const items = [
+      mkItem({ issue: '#1', title: 'batch steering recommendations' }),
+      mkItem({ issue: '#2', title: 'batch steering memory' }), // shares batch+steering with #1
+      mkItem({ issue: '#3', title: 'batch memory observability' }), // shares batch+memory with #2
+    ];
+    const themes = deriveThemes(items);
+    expect(themes).toHaveLength(1);
+    expect(themes[0].issues.sort()).toEqual(['#1', '#2', '#3']);
+  });
+
+  it('is deterministic — same input yields same ids/order', () => {
+    const build = () => [
+      mkItem({ issue: '#1', title: 'hook performance observability' }),
+      mkItem({ issue: '#2', title: 'hook performance timing' }),
+    ];
+    expect(deriveThemes(build())).toEqual(deriveThemes(build()));
+  });
+
+  it('produces unique theme ids when labels collide', () => {
+    const items = [
+      mkItem({ issue: '#1', title: 'review battery dimension', parent_epic: '#100' }),
+      mkItem({ issue: '#2', title: 'review battery loop', parent_epic: '#100' }),
+      mkItem({ issue: '#3', title: 'review battery coverage', parent_epic: '#200' }),
+      mkItem({ issue: '#4', title: 'review battery fix', parent_epic: '#200' }),
+    ];
+    const themes = deriveThemes(items);
+    const ids = themes.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('ensureThemes', () => {
+  it('derives themes and stamps item.theme when absent', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      items: [
+        mkItem({ issue: '#1', title: 'hook performance observability' }),
+        mkItem({ issue: '#2', title: 'hook performance timing' }),
+        mkItem({ issue: '#3', title: 'unrelated singleton work' }),
+      ],
+    };
+    ensureThemes(plan);
+    expect(plan.themes!.length).toBe(1);
+    expect(plan.items[0].theme).toBe(plan.themes![0].id);
+    expect(plan.items[1].theme).toBe(plan.themes![0].id);
+    expect(plan.items[2].theme).toBeUndefined();
+  });
+
+  it('is idempotent', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      items: [
+        mkItem({ issue: '#1', title: 'batch steering memory' }),
+        mkItem({ issue: '#2', title: 'batch steering recommendations' }),
+      ],
+    };
+    ensureThemes(plan);
+    const first = JSON.stringify(plan);
+    ensureThemes(plan);
+    expect(JSON.stringify(plan)).toBe(first);
+  });
+
+  it('respects LLM-provided themes instead of overwriting', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      themes: [{ id: 'llm-theme', title: 'LLM Theme', rationale: 'r', issues: ['#1', '#2'] }],
+      items: [
+        mkItem({ issue: '#1', title: 'totally unrelated alpha' }),
+        mkItem({ issue: '#2', title: 'totally unrelated beta' }),
+      ],
+    };
+    ensureThemes(plan);
+    expect(plan.themes!.map((t) => t.id)).toEqual(['llm-theme']);
+    expect(plan.items[0].theme).toBe('llm-theme');
+    expect(plan.items[1].theme).toBe('llm-theme');
+  });
+});
+
+describe('validateThemes', () => {
+  it('keeps well-formed themes', () => {
+    const themes = validateThemes([
+      { id: 't1', title: 'T1', rationale: 'r', issues: ['#1', '#2'] },
+    ]);
+    expect(themes).toHaveLength(1);
+    expect(themes[0].issues).toEqual(['#1', '#2']);
+  });
+
+  it('drops malformed themes (missing fields / empty issues)', () => {
+    const themes = validateThemes([
+      { id: 't1', title: 'ok', issues: ['#1'] },
+      { id: 't2', issues: ['#3'] }, // missing title
+      { id: 't3', title: 'empty', issues: [] }, // empty issues
+      null,
+    ]);
+    expect(themes.map((t) => t.id)).toEqual(['t1']);
+  });
+
+  it('returns [] for non-array', () => {
+    expect(validateThemes(undefined)).toEqual([]);
+    expect(validateThemes('nope')).toEqual([]);
+  });
+
+  it('de-duplicates an issue appearing in multiple themes (first wins)', () => {
+    const themes = validateThemes([
+      { id: 't1', title: 'T1', rationale: '', issues: ['#1', '#2'] },
+      { id: 't2', title: 'T2', rationale: '', issues: ['#2', '#3'] },
+    ]);
+    expect(themes.find((t) => t.id === 't1')!.issues).toEqual(['#1', '#2']);
+    expect(themes.find((t) => t.id === 't2')!.issues).toEqual(['#3']);
+  });
+
+  it('drops a theme that becomes empty after dedup', () => {
+    const themes = validateThemes([
+      { id: 't1', title: 'T1', rationale: '', issues: ['#1'] },
+      { id: 't2', title: 'T2', rationale: '', issues: ['#1'] },
+    ]);
+    expect(themes.map((t) => t.id)).toEqual(['t1']);
+  });
+});
+
+describe('validatePlan with themes', () => {
+  it('preserves per-item theme and a validated themes array', () => {
+    const raw = {
+      items: [
+        { issue: '#1', title: 'one', score: 5, theme: 'alpha' },
+        { issue: '#2', title: 'two', score: 4, theme: 'alpha' },
+      ],
+      themes: [{ id: 'alpha', title: 'Alpha', rationale: 'r', issues: ['#1', '#2'] }],
+    };
+    const plan = validatePlan(raw);
+    expect(plan!.items[0].theme).toBe('alpha');
+    expect(plan!.themes).toHaveLength(1);
+    expect(plan!.themes![0].id).toBe('alpha');
+  });
+
+  it('omits themes when none provided (no themes key)', () => {
+    const plan = validatePlan({ items: [{ issue: '#1', title: 'one', score: 5 }] });
+    expect(plan!.themes).toBeUndefined();
+  });
+});
+
+describe('selectNextItem — coordination', () => {
+  it('theme-less plan: returns first pending (legacy behavior)', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      items: [
+        mkItem({ issue: '#1', title: 'a', score: 3 }),
+        mkItem({ issue: '#2', title: 'b', score: 9 }),
+      ],
+    };
+    // Even though #2 has higher score, legacy behavior takes first pending.
+    expect(selectNextItem(plan)!.issue).toBe('#1');
+  });
+
+  it('continues an in-progress theme even when a higher-score item exists elsewhere', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      themes: [
+        { id: 'T1', title: 'T1', rationale: '', issues: ['#1', '#2'] },
+        { id: 'T2', title: 'T2', rationale: '', issues: ['#3'] },
+      ],
+      items: [
+        mkItem({ issue: '#1', title: 'a', score: 5, theme: 'T1', status: 'done' }),
+        mkItem({ issue: '#2', title: 'b', score: 4, theme: 'T1', status: 'pending' }),
+        mkItem({ issue: '#3', title: 'c', score: 9, theme: 'T2', status: 'pending' }),
+      ],
+    };
+    // T1 is in progress (#1 done) and has pending #2 → claim #2, not higher-score #3.
+    expect(selectNextItem(plan)!.issue).toBe('#2');
+  });
+
+  it('within an in-progress theme, picks the highest-score pending', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      themes: [{ id: 'T1', title: 'T1', rationale: '', issues: ['#1', '#2', '#3'] }],
+      items: [
+        mkItem({ issue: '#1', title: 'a', score: 5, theme: 'T1', status: 'assigned' }),
+        mkItem({ issue: '#2', title: 'b', score: 4, theme: 'T1', status: 'pending' }),
+        mkItem({ issue: '#3', title: 'c', score: 7, theme: 'T1', status: 'pending' }),
+      ],
+    };
+    expect(selectNextItem(plan)!.issue).toBe('#3');
+  });
+
+  it('with no theme in progress, starts the strongest theme (highest-score item)', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      themes: [
+        { id: 'T1', title: 'T1', rationale: '', issues: ['#1'] },
+        { id: 'T2', title: 'T2', rationale: '', issues: ['#2'] },
+      ],
+      items: [
+        mkItem({ issue: '#1', title: 'a', score: 5, theme: 'T1', status: 'pending' }),
+        mkItem({ issue: '#2', title: 'b', score: 9, theme: 'T2', status: 'pending' }),
+      ],
+    };
+    expect(selectNextItem(plan)!.issue).toBe('#2');
+  });
+
+  it('moves to a fresh theme once the in-progress one is exhausted', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      themes: [
+        { id: 'T1', title: 'T1', rationale: '', issues: ['#1'] },
+        { id: 'T2', title: 'T2', rationale: '', issues: ['#2'] },
+      ],
+      items: [
+        mkItem({ issue: '#1', title: 'a', score: 5, theme: 'T1', status: 'done' }),
+        mkItem({ issue: '#2', title: 'b', score: 9, theme: 'T2', status: 'pending' }),
+      ],
+    };
+    // T1 done & exhausted → fall to strongest fresh pending = #2
+    expect(selectNextItem(plan)!.issue).toBe('#2');
+  });
+
+  it('returns null when nothing is pending', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      items: [mkItem({ issue: '#1', title: 'a', status: 'done' })],
+    };
+    expect(selectNextItem(plan)).toBeNull();
+  });
+});
+
+describe('claimNextItem theme-aware persistence', () => {
+  let tmpDir: string;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'plan-theme-test-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('claims the continuation of an in-progress theme and persists assigned', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      themes: [
+        { id: 'T1', title: 'T1', rationale: '', issues: ['#1', '#2'] },
+        { id: 'T2', title: 'T2', rationale: '', issues: ['#3'] },
+      ],
+      items: [
+        mkItem({ issue: '#1', title: 'a', score: 5, theme: 'T1', status: 'done' }),
+        mkItem({ issue: '#2', title: 'b', score: 4, theme: 'T1', status: 'pending' }),
+        mkItem({ issue: '#3', title: 'c', score: 9, theme: 'T2', status: 'pending' }),
+      ],
+    };
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+    const claimed = claimNextItem(tmpDir);
+    expect(claimed!.issue).toBe('#2');
+    const updated = readPlan(tmpDir)!;
+    expect(updated.items.find((i) => i.issue === '#2')!.status).toBe('assigned');
+    expect(updated.items.find((i) => i.issue === '#3')!.status).toBe('pending');
+  });
+});
+
+describe('themeProgress', () => {
+  it('counts statuses per theme', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      themes: [{ id: 'T1', title: 'Hooks', rationale: '', issues: ['#1', '#2', '#3'] }],
+      items: [
+        mkItem({ issue: '#1', title: 'a', theme: 'T1', status: 'done' }),
+        mkItem({ issue: '#2', title: 'b', theme: 'T1', status: 'pending' }),
+        mkItem({ issue: '#3', title: 'c', theme: 'T1', status: 'assigned' }),
+      ],
+    };
+    const tp = themeProgress(plan);
+    expect(tp).toHaveLength(1);
+    expect(tp[0]).toMatchObject({ id: 'T1', total: 3, done: 1, pending: 1, assigned: 1, skipped: 0 });
+  });
+
+  it('returns [] when no themes', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      items: [mkItem({ issue: '#1', title: 'a' })],
+    };
+    expect(themeProgress(plan)).toEqual([]);
+  });
+});
+
+describe('formatPlanSummary with themes', () => {
+  it('renders a Themes section with done/total markers', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      themes: [{ id: 'hooks', title: 'Hooks', rationale: '', issues: ['#1', '#2'] }],
+      items: [
+        mkItem({ issue: '#1', title: 'a', theme: 'hooks', status: 'done' }),
+        mkItem({ issue: '#2', title: 'b', theme: 'hooks', status: 'pending' }),
+      ],
+    };
+    const summary = formatPlanSummary(plan);
+    expect(summary).toContain('Themes (1 coordinated bundle)');
+    expect(summary).toContain('Hooks [1/2]');
+  });
+
+  it('omits the Themes section when there are no themes', () => {
+    const plan: BatchPlan = {
+      created_at: 'x', guidance: 'g', wip_excluded: [], epics_scanned: [],
+      items: [mkItem({ issue: '#1', title: 'a' })],
+    };
+    expect(formatPlanSummary(plan)).not.toContain('Themes (');
+  });
+});
+
+describe('plan-prepass template includes theme instructions', () => {
+  it('buildPlanPrompt mentions themes', () => {
+    const state = {
+      batch_id: 'b', batch_start: 0, guidance: 'g', max_runs: 10, cooldown: 30,
+      budget: '3.00', max_failures: 3, kaizen_repo: 'Garsson-io/kaizen',
+      host_repo: 'Garsson-io/kaizen', run: 0, prs: [], issues_filed: [],
+      issues_closed: [], cases: [], consecutive_failures: 0, current_cooldown: 30,
+      stop_reason: '', last_issue: '', last_pr: '', last_case: '', last_branch: '',
+      last_worktree: '',
+    };
+    const prompt = buildPlanPrompt(state);
+    expect(prompt.toLowerCase()).toContain('theme');
   });
 });

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -35,6 +35,20 @@ export interface PlanItem {
   status: 'pending' | 'assigned' | 'done' | 'skipped';
   item_type?: 'leaf' | 'decompose';
   parent_epic?: string;
+  /** Theme id this item belongs to (a coordinated cluster of related issues). */
+  theme?: string;
+}
+
+/**
+ * A coordinated cluster of related work items — the unit of "bunching" that
+ * lets a batch drive 3-5 related PRs to completion before switching topics,
+ * instead of hopping across unrelated issues by score (#941).
+ */
+export interface PlanTheme {
+  id: string;
+  title: string;
+  rationale: string;
+  issues: string[];
 }
 
 export interface BatchPlan {
@@ -44,6 +58,8 @@ export interface BatchPlan {
   wip_excluded: string[];
   epics_scanned: string[];
   decomposition_candidates?: string[];
+  /** Coordinated clusters of related items (#941). Derived if not LLM-provided. */
+  themes?: PlanTheme[];
 }
 
 function readState(stateFile: string): BatchState {
@@ -128,9 +144,12 @@ export function validatePlan(raw: any): BatchPlan | null {
       approach: String(item.approach || ''),
       status: 'pending' as const,
       ...(item.item_type === 'decompose' ? { item_type: 'decompose' as const, parent_epic: item.parent_epic ? String(item.parent_epic) : undefined } : { item_type: 'leaf' as const }),
+      ...(item.theme ? { theme: String(item.theme) } : {}),
     }));
 
   if (items.length === 0) return null;
+
+  const themes = validateThemes(raw.themes);
 
   return {
     created_at: raw.created_at || new Date().toISOString(),
@@ -139,7 +158,186 @@ export function validatePlan(raw: any): BatchPlan | null {
     wip_excluded: Array.isArray(raw.wip_excluded) ? raw.wip_excluded : [],
     epics_scanned: Array.isArray(raw.epics_scanned) ? raw.epics_scanned : [],
     decomposition_candidates: Array.isArray(raw.decomposition_candidates) ? raw.decomposition_candidates : [],
+    ...(themes.length > 0 ? { themes } : {}),
   };
+}
+
+/**
+ * Validate and normalize an LLM-provided themes array. Drops malformed
+ * entries (missing id/title or empty issue list) and de-duplicates issues
+ * across themes (first theme to claim an issue wins) so an item is never
+ * stamped with two themes — which would make {@link themeProgress} miscount.
+ */
+export function validateThemes(raw: any): PlanTheme[] {
+  if (!Array.isArray(raw)) return [];
+  const claimed = new Set<string>();
+  const out: PlanTheme[] = [];
+  for (const t of raw) {
+    if (!t || !t.id || !t.title || !Array.isArray(t.issues)) continue;
+    const issues = t.issues
+      .map((i: any) => String(i))
+      .filter((i: string) => !claimed.has(i));
+    if (issues.length === 0) continue;
+    for (const i of issues) claimed.add(i);
+    out.push({
+      id: String(t.id),
+      title: String(t.title),
+      rationale: String(t.rationale || ''),
+      issues,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Thematic clustering (#941) — group related issues into coordinated bundles.
+// ---------------------------------------------------------------------------
+
+const TITLE_STOPWORDS = new Set([
+  'the', 'a', 'an', 'of', 'to', 'and', 'or', 'for', 'in', 'on', 'with', 'is',
+  'are', 'be', 'not', 'no', 'as', 'at', 'by', 'from', 'into', 'via', 'auto',
+  'dent', 'kaizen', 'fix', 'add', 'l1', 'l2', 'l3', 'meta', 'epic', 'feat',
+  'should', 'when', 'this', 'that', 'it', 'its', 'but', 'use', 'using',
+]);
+
+/** Tokenize a title into significant lowercase tokens (stopwords removed). */
+export function titleTokens(title: string): Set<string> {
+  const tokens = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/[\s-]+/)
+    .filter((t) => t.length >= 3 && !TITLE_STOPWORDS.has(t));
+  return new Set(tokens);
+}
+
+/** True when two items belong in the same coordinated theme. */
+function itemsRelated(a: PlanItem, b: PlanItem): boolean {
+  if (a.parent_epic && b.parent_epic && a.parent_epic === b.parent_epic) return true;
+  const ta = titleTokens(a.title);
+  const tb = titleTokens(b.title);
+  let shared = 0;
+  for (const t of ta) if (tb.has(t)) shared++;
+  return shared >= 2;
+}
+
+/** Slugify a string into a stable theme id. */
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'theme';
+}
+
+/**
+ * Derive coordinated themes from a flat item list using connected components
+ * over the {@link itemsRelated} predicate (union-find). Components of size >= 2
+ * become themes; singletons stay themeless so they are claimed last.
+ *
+ * Pure and deterministic: input order in → stable theme ids/order out. No
+ * Date/random — safe under auto-dent's resume constraints.
+ */
+export function deriveThemes(items: PlanItem[]): PlanTheme[] {
+  const n = items.length;
+  const parent = Array.from({ length: n }, (_, i) => i);
+  const find = (x: number): number => {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]];
+      x = parent[x];
+    }
+    return x;
+  };
+  const union = (x: number, y: number) => {
+    const rx = find(x);
+    const ry = find(y);
+    if (rx !== ry) parent[Math.max(rx, ry)] = Math.min(rx, ry);
+  };
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      if (itemsRelated(items[i], items[j])) union(i, j);
+    }
+  }
+
+  // Group indices by component root, preserving first-seen order.
+  const groups = new Map<number, number[]>();
+  for (let i = 0; i < n; i++) {
+    const root = find(i);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root)!.push(i);
+  }
+
+  const themes: PlanTheme[] = [];
+  const usedIds = new Set<string>();
+  for (const idxs of groups.values()) {
+    if (idxs.length < 2) continue; // singletons stay themeless
+    const members = idxs.map((i) => items[i]);
+    // Theme label: shared parent_epic, else most common significant token.
+    const epic = members[0].parent_epic;
+    const sameEpic = epic && members.every((m) => m.parent_epic === epic);
+    let label: string;
+    if (sameEpic) {
+      label = `epic ${epic}`;
+    } else {
+      const freq = new Map<string, number>();
+      for (const m of members) for (const t of titleTokens(m.title)) freq.set(t, (freq.get(t) || 0) + 1);
+      const best = [...freq.entries()].sort((x, y) => y[1] - x[1] || x[0].localeCompare(y[0]))[0];
+      label = best ? best[0] : members[0].issue;
+    }
+    let id = slugify(label);
+    let suffix = 2;
+    while (usedIds.has(id)) id = `${slugify(label)}-${suffix++}`;
+    usedIds.add(id);
+    themes.push({
+      id,
+      title: label,
+      rationale: `${members.length} related items grouped by ${sameEpic ? 'shared parent epic' : 'shared topic'}`,
+      issues: members.map((m) => m.issue),
+    });
+  }
+  return themes;
+}
+
+/**
+ * Ensure a plan has themes and that each item is stamped with its theme id.
+ * If the plan already carries LLM-provided themes, they are respected and
+ * used to stamp items; otherwise themes are derived deterministically.
+ * Idempotent.
+ */
+export function ensureThemes(plan: BatchPlan): BatchPlan {
+  const themes = plan.themes && plan.themes.length > 0 ? plan.themes : deriveThemes(plan.items);
+  const issueToTheme = new Map<string, string>();
+  for (const t of themes) for (const issue of t.issues) issueToTheme.set(issue, t.id);
+  for (const item of plan.items) {
+    const tid = issueToTheme.get(item.issue);
+    if (tid) item.theme = tid;
+  }
+  plan.themes = themes;
+  return plan;
+}
+
+/** Per-theme completion counts for observability and steering. */
+export interface ThemeProgress {
+  id: string;
+  title: string;
+  total: number;
+  done: number;
+  pending: number;
+  assigned: number;
+  skipped: number;
+}
+
+export function themeProgress(plan: BatchPlan): ThemeProgress[] {
+  const themes = plan.themes || [];
+  return themes.map((t) => {
+    const members = plan.items.filter((i) => i.theme === t.id);
+    const count = (s: PlanItem['status']) => members.filter((m) => m.status === s).length;
+    return {
+      id: t.id,
+      title: t.title,
+      total: members.length,
+      done: count('done'),
+      pending: count('pending'),
+      assigned: count('assigned'),
+      skipped: count('skipped'),
+    };
+  });
 }
 
 /**
@@ -237,14 +435,50 @@ export function readPlan(logDir: string): BatchPlan | null {
 }
 
 /**
- * Get the next pending item from a plan.
- * Marks it as 'assigned' in the plan file.
+ * Choose the next pending item from a plan, preferring coordination:
+ *
+ * - If a theme is already in progress (has an `assigned`/`done`/`skipped`
+ *   member) and still has `pending` members, claim the highest-score pending
+ *   item from THAT theme — drive the bundle to completion before switching.
+ * - Otherwise claim the highest-score pending item overall, which naturally
+ *   starts the strongest theme first.
+ *
+ * When the plan carries no themes, this reduces to the legacy behavior
+ * (first pending item in plan/array order) — a strict no-op for theme-less plans.
+ */
+export function selectNextItem(plan: BatchPlan): PlanItem | null {
+  const pending = plan.items.filter((i) => i.status === 'pending');
+  if (pending.length === 0) return null;
+
+  const themes = plan.themes || [];
+  if (themes.length > 0) {
+    const inProgress = new Set(
+      plan.items
+        .filter((i) => i.theme && i.status !== 'pending')
+        .map((i) => i.theme as string),
+    );
+    if (inProgress.size > 0) {
+      const continuable = pending
+        .filter((i) => i.theme && inProgress.has(i.theme))
+        .sort((a, b) => b.score - a.score);
+      if (continuable.length > 0) return continuable[0];
+    }
+    // No in-progress theme has pending work — start the strongest theme.
+    return [...pending].sort((a, b) => b.score - a.score)[0];
+  }
+
+  // Theme-less plan: legacy behavior — first pending in existing order.
+  return pending[0];
+}
+
+/**
+ * Get the next item to work from a plan and mark it 'assigned' in the file.
  */
 export function claimNextItem(logDir: string): PlanItem | null {
   const plan = readPlan(logDir);
   if (!plan) return null;
 
-  const next = plan.items.find((item) => item.status === 'pending');
+  const next = selectNextItem(plan);
   if (!next) return null;
 
   next.status = 'assigned';
@@ -320,6 +554,13 @@ export function formatPlanSummary(plan: BatchPlan): string {
   if (plan.decomposition_candidates && plan.decomposition_candidates.length > 0) {
     lines.push(`  Decomposition candidates: ${plan.decomposition_candidates.length}`);
   }
+  const progress = themeProgress(plan);
+  if (progress.length > 0) {
+    lines.push(`  Themes (${progress.length} coordinated bundle${progress.length === 1 ? '' : 's'}):`);
+    for (const t of progress) {
+      lines.push(`    - ${t.title} [${t.done}/${t.total}] ${t.id}`);
+    }
+  }
   return lines.join('\n');
 }
 
@@ -346,6 +587,7 @@ async function main(): Promise<void> {
     process.exit(0); // Non-fatal: batch continues without a plan
   }
 
+  ensureThemes(plan);
   const planFile = resolve(logDir, 'plan.json');
   writeFileSync(planFile, JSON.stringify(plan, null, 2) + '\n');
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -27,7 +27,7 @@ import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
 import { firstHookReason } from './hook-signals.js';
-import { claimNextItem, markItem, resetAssignedItems } from './auto-dent-plan.js';
+import { claimNextItem, markItem, resetAssignedItems, readPlan, themeProgress } from './auto-dent-plan.js';
 import { writeAttachment, addSection } from '../src/section-editor.js';
 import {
   reviewBattery,
@@ -386,8 +386,19 @@ export function buildTemplateVars(
           lines.push(`- **Parent epic:** ${planItem.parent_epic}`);
         }
       }
+      // Surface theme membership so the run knows it is continuing a
+      // coordinated bundle of related work, not a one-off issue (#941).
+      if (planItem.theme) {
+        const plan = readPlan(logDir);
+        const tp = plan ? themeProgress(plan).find((t) => t.id === planItem.theme) : undefined;
+        if (tp) {
+          lines.push(
+            `- **Theme:** ${tp.title} (${tp.done}/${tp.total} complete) — part of a coordinated bundle of related issues; keep this PR scoped to the theme and prefer finishing the theme before switching topics`,
+          );
+        }
+      }
       planAssignment = lines.join('\n');
-      console.log(`  [plan] assigned ${planItem.issue}: ${planItem.title}${planItem.item_type === 'decompose' ? ' [DECOMPOSE]' : ''}`);
+      console.log(`  [plan] assigned ${planItem.issue}: ${planItem.title}${planItem.item_type === 'decompose' ? ' [DECOMPOSE]' : ''}${planItem.theme ? ` [theme:${planItem.theme}]` : ''}`);
     }
 
     // Load reflection insights from prior mid-batch reflection (#603)


### PR DESCRIPTION
## The Problem

Auto-dent's planning pre-pass (`auto-dent-plan.ts`) produced a **flat, score-ranked queue**. `claimNextItem()` simply took the first `pending` item, so each run picked whatever scored highest next — with no memory of what the previous run worked on. The result is the failure mode #941 names directly: a batch of **40 isolated single-issue fixes** instead of a handful of coordinated efforts. The user's guidance for this batch put it plainly: *"find the most meaningful tasks, bunch them together into one bigger useful task, finish it to completion perfectly."* The planner had no way to bunch.

## The Discovery

The cross-batch *steering* loop (#940 Phase 1+2, #1116) already landed — batches now read prior outcomes and steer. The missing piece was *intra-batch* coordination (#940 Phase 2c / #941): the plan had no concept of a related cluster, and `claimNextItem` had no notion of "keep going on what we started." Both #941 (coordinate into themes) and #960 (detect issue clusters) want the same primitive — a way to recognize that several issues belong together.

## The Solution

A **theme layer** on the batch plan:

- **Model:** `PlanTheme { id, title, rationale, issues[] }` + an optional per-item `theme`. `validatePlan` preserves both and de-duplicates an issue that appears in multiple LLM-provided themes (first theme wins) so `themeProgress` never miscounts.
- **`deriveThemes()`** — deterministic union-find clustering: two items relate if they share a `parent_epic` or ≥2 significant title tokens (stopword-filtered). Connected components of size ≥2 become themes; singletons stay themeless. No `Date`/`Math.random` — safe under auto-dent's resume constraints.
- **`ensureThemes()`** — respects LLM-provided themes when present, derives them otherwise, and stamps every item. Idempotent.
- **Theme-aware claiming** — `selectNextItem()`/`claimNextItem()` now prefer continuing an **in-progress theme** (highest-score pending member) before switching topics. Critically, this is a **strict no-op for theme-less plans**: the legacy first-pending behavior is preserved byte-for-byte, so existing batches and the 35 prior tests are unaffected.
- **Observability** — `themeProgress()` and a Themes section in `formatPlanSummary` (`Hooks [1/2]`).
- **Prompt wiring** — `plan-prepass.md` instructs the planner to emit 3–5 coordinated themes; `auto-dent-run.ts` surfaces theme membership + completion in `{{plan_assignment}}` so each run knows it is continuing a coordinated bundle and should keep its PR scoped to the theme.

## The Evidence

- **29 new unit tests** covering clustering (parent-epic grouping, ≥2-token grouping, single-token rejection, transitive union-find, determinism, unique ids), `ensureThemes` (derive/stamp/idempotent/respect-LLM), theme-aware claim (continue in-progress, highest-score-within-theme, start strongest theme, exhaustion fallback, **backward-compat no-op**), `themeProgress`, and `validateThemes` cross-theme dedup.
- All **66** `auto-dent-plan.test.ts` tests pass; full `scripts/` suite (**40 files, 1210 tests**) green; `tsc --noEmit` clean.
- Adversarial review (union-find validity, claiming-loop safety, themeless-singleton edge, determinism, backward-compat trace) found no high/medium bugs; both LOW findings (misleading comment, cross-theme dedup) were fixed in this PR.

## The Impact

Auto-dent can now drive a *theme* — a coordinated cluster of 3–5 related issues — to completion before switching topics, instead of scattering effort across the backlog by score. This is the concrete realization of "bunch the most meaningful tasks into one bigger useful task," and it lays the clustering primitive that #960 (category detection) builds on.

## Test Plan

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Clustering correctness (`deriveThemes`) | ✅ | — | — | — | — |
| Theme stamping (`ensureThemes`, LLM vs derived) | ✅ | — | — | — | — |
| Theme-aware claim coordination | ✅ | — | — | — | — |
| Backward-compat (theme-less = legacy) | ✅ | — | — | — | — |
| `validateThemes` dedup/robustness | ✅ | — | — | — | — |
| Progress + summary rendering | ✅ | — | — | — | — |
| Planner prompt emits themes | ✅ (template) | — | — | ⬜ (live planner judgment, fallback guarantees themes) | — |

Closes #941
Parent: #940
Refs: #960

Run tag: powerful-capybara/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
