### PR TITLE
feat(auto-dent): UCB1 bandit mode scheduler — principled exploit/explore (Closes #1136)

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -26,7 +26,10 @@ import {
   formatPlanAsMarkdown,
   selectMode,
   checkSignalOverrides,
-  computeAdaptiveWeights,
+  computeBanditWeights,
+  SCHEDULABLE_MODES,
+  DEFAULT_BANDIT_C,
+  banditExplorationC,
   modeSuccess,
   weightedModeSelect,
   computeModeDistribution,
@@ -2234,119 +2237,172 @@ describe('checkSignalOverrides', () => {
   });
 });
 
-describe('computeAdaptiveWeights', () => {
+describe('computeBanditWeights', () => {
+  /** Build a history where each schedulable mode is played `plays[mode]` times,
+   *  each play credited with `reward[mode]` units of that mode's OWN success metric
+   *  (so modeSuccess === reward for every mode, not just exploit). */
+  function makeHistory(plays: Record<string, number>, reward: Record<string, number> = {}): RunMetrics[] {
+    const out: RunMetrics[] = [];
+    let i = 0;
+    const credit = (mode: string, r: number): Partial<RunMetrics> => {
+      const ids = Array.from({ length: r }, (_, j) => `#${j}`);
+      switch (mode) {
+        case 'exploit': return { prs: Array.from({ length: r }, (_, j) => `pr-${j}`) };
+        case 'explore':
+        case 'reflect': return { issues_filed: ids };
+        case 'subtract': return { lines_deleted: r * 100, issues_pruned: 0 };
+        default: return { prs: Array.from({ length: r }, (_, j) => `pr-${j}`) };
+      }
+    };
+    for (const mode of SCHEDULABLE_MODES) {
+      const n = plays[mode] ?? 0;
+      const r = reward[mode] ?? 0;
+      for (let k = 0; k < n; k++) {
+        out.push(makeRunMetrics({ run: i++, mode, cost_usd: 1.0, ...credit(mode, r) }));
+      }
+    }
+    return out;
+  }
+
   it('returns null when history has fewer than minRuns', () => {
     const history = Array.from({ length: 9 }, (_, i) =>
       makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr-1'] }),
     );
-    expect(computeAdaptiveWeights(history, 10)).toBeNull();
+    expect(computeBanditWeights(history, { minRuns: 10 })).toBeNull();
   });
 
   it('returns null when no runs have mode data', () => {
-    const history = Array.from({ length: 15 }, (_, i) =>
-      makeRunMetrics({ run: i }),
-    );
-    // mode is undefined on all — filtered out
-    expect(computeAdaptiveWeights(history)).toBeNull();
+    const history = Array.from({ length: 15 }, (_, i) => makeRunMetrics({ run: i }));
+    expect(computeBanditWeights(history)).toBeNull();
   });
 
   it('returns weights that sum to 1.0 with sufficient data', () => {
-    const history: RunMetrics[] = [];
-    for (let i = 0; i < 12; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: i < 8 ? ['pr'] : [], cost_usd: 1.5 }));
-    }
-    history.push(makeRunMetrics({ run: 12, mode: 'explore', prs: ['pr'], cost_usd: 2.0 }));
-    history.push(makeRunMetrics({ run: 13, mode: 'reflect', prs: [], cost_usd: 1.0 }));
-    history.push(makeRunMetrics({ run: 14, mode: 'subtract', prs: ['pr'], cost_usd: 0.5 }));
-
-    const weights = computeAdaptiveWeights(history, 10);
-    expect(weights).not.toBeNull();
-    const sum = Object.values(weights!).reduce((s, v) => s + v, 0);
+    const history = makeHistory(
+      { exploit: 9, explore: 1, reflect: 1, subtract: 1 },
+      { exploit: 1, explore: 1, subtract: 1 },
+    );
+    const result = computeBanditWeights(history, { minRuns: 10 });
+    expect(result).not.toBeNull();
+    const sum = Object.values(result!.weights).reduce((s, v) => s + v, 0);
     expect(sum).toBeCloseTo(1.0, 5);
+    expect(result!.details).toHaveLength(SCHEDULABLE_MODES.length);
   });
 
-  it('gives higher weight to modes with better success rates', () => {
-    const history: RunMetrics[] = [];
-    // exploit: 7 runs, 6 with PRs (high success)
-    for (let i = 0; i < 7; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: i < 6 ? ['pr'] : [], cost_usd: 1.0 }));
-    }
-    // explore: 3 runs, 0 issues filed (low success for explore)
-    for (let i = 7; i < 10; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'explore', prs: [], issues_filed: [], cost_usd: 2.0 }));
-    }
-    // reflect and subtract: 1 run each
-    history.push(makeRunMetrics({ run: 10, mode: 'reflect', issues_filed: ['#1'], cost_usd: 1.0 }));
-    history.push(makeRunMetrics({ run: 11, mode: 'subtract', prs: ['pr'], lines_deleted: 200, cost_usd: 0.5 }));
-
-    const weights = computeAdaptiveWeights(history, 10);
-    expect(weights).not.toBeNull();
-    // exploit should dominate since it has high base weight AND high success
-    expect(weights!.exploit).toBeGreaterThan(weights!.explore);
+  it('EXPLOITATION: with equal plays, the higher-reward mode gets more weight', () => {
+    // exploit and explore both played 5x; exploit earns 2/play, explore 0/play.
+    const history = makeHistory(
+      { exploit: 5, explore: 5 },
+      { exploit: 2, explore: 0 },
+    );
+    const result = computeBanditWeights(history, { minRuns: 10 })!;
+    expect(result.weights.exploit).toBeGreaterThan(result.weights.explore);
   });
 
-  it('ensures every mode gets at least 5% of its base weight', () => {
-    const history: RunMetrics[] = [];
-    // exploit: 10 runs, all with PRs
-    for (let i = 0; i < 10; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr'], cost_usd: 1.0 }));
-    }
-    // explore: 3 runs, 0 PRs, high cost
-    for (let i = 10; i < 13; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'explore', prs: [], cost_usd: 5.0 }));
-    }
-
-    const weights = computeAdaptiveWeights(history, 10);
-    expect(weights).not.toBeNull();
-    // explore should still have some weight (not zero)
-    expect(weights!.explore).toBeGreaterThan(0);
+  it('EXPLORATION: with equal reward, the less-played mode gets more weight (uncertainty bonus)', () => {
+    // Both earn the same reward/play, but exploit has been played far more.
+    // The old heuristic could not express this; UCB1 must favor the rarer mode.
+    const history = makeHistory(
+      { exploit: 9, explore: 2, reflect: 0, subtract: 0 },
+      { exploit: 1, explore: 1 },
+    );
+    const result = computeBanditWeights(history, { minRuns: 10 })!;
+    expect(result.weights.explore).toBeGreaterThan(result.weights.exploit);
   });
 
-  it('uses base weight for modes with no runs', () => {
-    const history: RunMetrics[] = [];
-    // Only exploit runs
-    for (let i = 0; i < 12; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr'], cost_usd: 1.0 }));
-    }
-    const weights = computeAdaptiveWeights(history, 10);
-    expect(weights).not.toBeNull();
-    // Modes with no data should still get some weight
-    expect(weights!.explore).toBeGreaterThan(0);
-    expect(weights!.reflect).toBeGreaterThan(0);
-    expect(weights!.subtract).toBeGreaterThan(0);
+  it('NO STARVATION: a never-played schedulable mode still gets substantial weight', () => {
+    const history = makeHistory(
+      { exploit: 12, explore: 0, reflect: 0, subtract: 0 },
+      { exploit: 2 },
+    );
+    const result = computeBanditWeights(history, { minRuns: 10 })!;
+    expect(result.weights.reflect).toBeGreaterThan(0);
+    // An unplayed mode (max bonus, zero exploit term) must be competitive with a
+    // heavily-exploited one — guaranteeing re-exploration, not a token sliver.
+    expect(result.weights.reflect).toBeGreaterThan(result.weights.exploit * 0.5);
   });
 
-  it('uses issues_filed for explore mode success (not PRs)', () => {
-    const history: RunMetrics[] = [];
-    // exploit: 7 runs, all with PRs
-    for (let i = 0; i < 7; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr'], cost_usd: 1.0 }));
-    }
-    // explore: 5 runs, 0 PRs but filed issues
-    for (let i = 7; i < 12; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'explore', prs: [], issues_filed: ['#1', '#2'], cost_usd: 1.5 }));
-    }
-
-    const weights = computeAdaptiveWeights(history, 10);
-    expect(weights).not.toBeNull();
-    // explore should get meaningful weight since it filed issues
-    expect(weights!.explore).toBeGreaterThan(0.01);
+  it('KNOB c=0 is greedy: the best-reward mode dominates and weights collapse to exploit', () => {
+    const history = makeHistory(
+      { exploit: 5, explore: 5, reflect: 1, subtract: 1 },
+      { exploit: 3, explore: 0 },
+    );
+    const greedy = computeBanditWeights(history, { minRuns: 10, explorationC: 0 })!;
+    // With no exploration bonus, only the best mean reward carries weight.
+    expect(greedy.weights.exploit).toBeCloseTo(1.0, 5);
+    expect(greedy.weights.explore).toBeCloseTo(0, 5);
   });
 
-  it('uses lines_deleted for subtract mode success', () => {
-    const history: RunMetrics[] = [];
-    for (let i = 0; i < 10; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr'], cost_usd: 1.0 }));
-    }
-    // subtract: 3 runs, 0 PRs but deleted lines
-    for (let i = 10; i < 13; i++) {
-      history.push(makeRunMetrics({ run: i, mode: 'subtract', prs: [], lines_deleted: 300, issues_pruned: 2, cost_usd: 0.8 }));
-    }
+  it('KNOB: larger c flattens the weight distribution toward uniform', () => {
+    const history = makeHistory(
+      { exploit: 5, explore: 5, reflect: 2, subtract: 2 },
+      { exploit: 3, explore: 0 },
+    );
+    const spread = (r: BanditResultLike) => {
+      const w = Object.values(r.weights);
+      return Math.max(...w) - Math.min(...w);
+    };
+    const low = computeBanditWeights(history, { minRuns: 10, explorationC: 0.5 })!;
+    const high = computeBanditWeights(history, { minRuns: 10, explorationC: 50 })!;
+    // More exploration ⇒ weights pulled toward uniform ⇒ smaller max-min spread.
+    expect(spread(high)).toBeLessThan(spread(low));
+  });
 
-    const weights = computeAdaptiveWeights(history, 10);
-    expect(weights).not.toBeNull();
-    // subtract should get meaningful weight since it deleted lines
-    expect(weights!.subtract).toBeGreaterThan(0.01);
+  it('details: exploreBonus strictly decreases as plays increase (holding N fixed)', () => {
+    const history = makeHistory(
+      { exploit: 6, explore: 3, reflect: 2, subtract: 1 },
+      { exploit: 1, explore: 1, reflect: 1, subtract: 1 },
+    );
+    const result = computeBanditWeights(history, { minRuns: 10 })!;
+    const byMode = Object.fromEntries(result.details.map(d => [d.mode, d]));
+    // exploit(6p) < explore(3p) < reflect(2p) < subtract(1p) in plays ⇒ inverse for bonus.
+    expect(byMode.exploit.exploreBonus).toBeLessThan(byMode.explore.exploreBonus);
+    expect(byMode.explore.exploreBonus).toBeLessThan(byMode.reflect.exploreBonus);
+    expect(byMode.reflect.exploreBonus).toBeLessThan(byMode.subtract.exploreBonus);
+    expect(result.totalPlays).toBe(12);
+    expect(result.explorationC).toBe(DEFAULT_BANDIT_C);
+  });
+
+  it('reward semantics: explore credited by issues_filed, subtract by lines/pruned', () => {
+    const history: RunMetrics[] = [];
+    for (let i = 0; i < 8; i++) history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: [], cost_usd: 1 }));
+    // explore files lots of issues (its reward), subtract deletes lines.
+    history.push(makeRunMetrics({ run: 8, mode: 'explore', issues_filed: ['#1', '#2', '#3'], cost_usd: 1 }));
+    history.push(makeRunMetrics({ run: 9, mode: 'explore', issues_filed: ['#4', '#5', '#6'], cost_usd: 1 }));
+    history.push(makeRunMetrics({ run: 10, mode: 'subtract', lines_deleted: 400, issues_pruned: 2, cost_usd: 1 }));
+    const result = computeBanditWeights(history, { minRuns: 10 })!;
+    const byMode = Object.fromEntries(result.details.map(d => [d.mode, d]));
+    // explore's mean reward reflects issues filed (3/play), not its zero PRs.
+    expect(byMode.explore.meanReward).toBeCloseTo(3, 5);
+    expect(byMode.subtract.meanReward).toBeGreaterThan(0);
+    // exploit produced zero PRs ⇒ zero mean reward.
+    expect(byMode.exploit.meanReward).toBe(0);
+  });
+});
+
+type BanditResultLike = { weights: Record<string, number> };
+
+describe('banditExplorationC', () => {
+  const orig = process.env.KAIZEN_BANDIT_C;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.KAIZEN_BANDIT_C;
+    else process.env.KAIZEN_BANDIT_C = orig;
+  });
+
+  it('defaults to DEFAULT_BANDIT_C when unset', () => {
+    delete process.env.KAIZEN_BANDIT_C;
+    expect(banditExplorationC()).toBe(DEFAULT_BANDIT_C);
+  });
+
+  it('reads a valid non-negative number from the environment', () => {
+    process.env.KAIZEN_BANDIT_C = '3.5';
+    expect(banditExplorationC()).toBe(3.5);
+  });
+
+  it('falls back to default on invalid or negative input', () => {
+    process.env.KAIZEN_BANDIT_C = 'not-a-number';
+    expect(banditExplorationC()).toBe(DEFAULT_BANDIT_C);
+    process.env.KAIZEN_BANDIT_C = '-2';
+    expect(banditExplorationC()).toBe(DEFAULT_BANDIT_C);
   });
 });
 
@@ -2433,7 +2489,7 @@ describe('weightedModeSelect', () => {
   });
 });
 
-describe('selectMode adaptive integration', () => {
+describe('selectMode bandit integration', () => {
   function makeVariedHistory(): RunMetrics[] {
     // Mix of modes so signal overrides don't fire (avoids 4+ streak)
     const modes = ['exploit', 'exploit', 'exploit', 'explore', 'exploit', 'exploit', 'exploit', 'reflect', 'exploit', 'exploit', 'subtract', 'exploit'];
@@ -2442,11 +2498,15 @@ describe('selectMode adaptive integration', () => {
     );
   }
 
-  it('uses adaptive selection when history is sufficient', () => {
+  it('uses bandit selection when history is sufficient and exposes the breakdown', () => {
     const state = makeBatchState({ run_history: makeVariedHistory() });
     const result = selectMode(state, 1);
-    expect(result.reason).toBe('adaptive');
+    expect(result.reason).toBe('bandit');
     expect(['exploit', 'explore', 'reflect', 'subtract']).toContain(result.mode);
+    // Observability: the full per-mode breakdown rides along on the selection.
+    expect(result.bandit).toBeDefined();
+    expect(result.bandit!.details).toHaveLength(4);
+    expect(result.bandit!.totalPlays).toBe(12);
   });
 
   it('falls back to fixed schedule when history is insufficient', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -714,14 +714,18 @@ export function computeBanditWeights(
   // Normalize the exploitation term to [0,1] so it is comparable to the bonus.
   const maxMean = Math.max(...SCHEDULABLE_MODES.map(m => meanReward[m]), 0);
 
+  // Compute each mode's UCB once; reuse the exact same terms when building the
+  // breakdown so the reported detail can never diverge from the real decision.
+  const exploitTerm: Record<string, number> = {};
+  const exploreBonus: Record<string, number> = {};
   const ucb: Record<string, number> = {};
   for (const mode of SCHEDULABLE_MODES) {
-    const exploitTerm = maxMean > 0 ? meanReward[mode] / maxMean : 0;
+    exploitTerm[mode] = maxMean > 0 ? meanReward[mode] / maxMean : 0;
     // max(plays,1): a never-chosen mode gets the largest finite bonus, guaranteeing
     // it is revisited rather than starved (the fixed schedule has already seeded
     // every mode once before the bandit activates, so plays>=1 in practice).
-    const exploreBonus = explorationC * Math.sqrt(Math.log(totalPlays + 1) / Math.max(plays[mode], 1));
-    ucb[mode] = exploitTerm + exploreBonus;
+    exploreBonus[mode] = explorationC * Math.sqrt(Math.log(totalPlays + 1) / Math.max(plays[mode], 1));
+    ucb[mode] = exploitTerm[mode] + exploreBonus[mode];
   }
 
   // Normalize UCB scores to selection weights summing to 1.0. exploreBonus > 0
@@ -737,8 +741,8 @@ export function computeBanditWeights(
     mode,
     plays: plays[mode],
     meanReward: meanReward[mode],
-    exploitTerm: maxMean > 0 ? meanReward[mode] / maxMean : 0,
-    exploreBonus: explorationC * Math.sqrt(Math.log(totalPlays + 1) / Math.max(plays[mode], 1)),
+    exploitTerm: exploitTerm[mode],
+    exploreBonus: exploreBonus[mode],
     ucb: ucb[mode],
     weight: weights[mode],
   }));

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -528,8 +528,10 @@ export function loadPromptTemplate(templateName: string): string | null {
 export interface ModeSelection {
   mode: string;
   template: string;
-  /** Why this mode was selected (signal name or 'schedule') */
+  /** Why this mode was selected (signal name, 'schedule', 'guidance', or 'bandit') */
   reason: string;
+  /** Full bandit breakdown when the selection came from the UCB1 policy (reason === 'bandit') */
+  bandit?: BanditResult;
 }
 
 const MODE_TEMPLATES: Record<string, string> = {
@@ -620,28 +622,75 @@ export function modeSuccess(mode: string, metrics: RunMetrics): number {
   }
 }
 
+/** Schedulable cognitive modes (contemplate is an overlay, not bandit-scheduled). */
+export const SCHEDULABLE_MODES = ['exploit', 'explore', 'reflect', 'subtract'] as const;
+
+/** Default UCB1 exploration constant (classic value). Tunable via KAIZEN_BANDIT_C. */
+export const DEFAULT_BANDIT_C = Math.SQRT2;
+
+/** Per-mode breakdown of the bandit's decision, surfaced for observability. */
+export interface BanditDetail {
+  mode: string;
+  /** How many runs have been spent on this mode (its "pulls"). */
+  plays: number;
+  /** Raw average mode-appropriate reward (modeSuccess) over those runs. */
+  meanReward: number;
+  /** Exploitation term: meanReward normalized to [0,1] across modes. */
+  exploitTerm: number;
+  /** Exploration bonus: c · sqrt(ln(N+1) / max(plays,1)) — shrinks as a mode is tried more. */
+  exploreBonus: number;
+  /** Upper confidence bound: exploitTerm + exploreBonus. */
+  ucb: number;
+  /** Final normalized selection weight (sums to 1.0 across modes). */
+  weight: number;
+}
+
+export interface BanditResult {
+  /** Normalized selection weights, summing to 1.0. */
+  weights: Record<string, number>;
+  /** Per-mode breakdown (one entry per schedulable mode). */
+  details: BanditDetail[];
+  /** Total plays across schedulable modes (the bandit's N). */
+  totalPlays: number;
+  /** Exploration constant actually used. */
+  explorationC: number;
+}
+
 /**
- * Compute adaptive mode weights from run history.
+ * Compute cognitive-mode selection weights with a UCB1 multi-armed-bandit policy.
  *
- * For each mode, computes an effectiveness score based on mode-appropriate
- * success metrics (not just PRs). Each mode is measured by its own output:
- *   - exploit → PRs/run, PRs/$
- *   - explore/reflect → issues/run, issues/$
- *   - subtract → (lines_deleted/100 + issues_pruned)/run
- *   - contemplate → fixed baseline
+ * The mode scheduler faces the explore/exploit dilemma directly: keep using the
+ * mode that has paid off, or try one that has been tried less and might pay off
+ * more. UCB1 makes that tradeoff principled instead of an ad-hoc blend:
  *
- * Returns weights normalized so they sum to 1.0, or null if insufficient data.
- * Requires at least `minRuns` total runs with mode data to activate.
+ *   score(m) = exploitTerm(m) + c · sqrt( ln(N + 1) / plays(m) )
+ *
+ * - `exploitTerm(m)` is the mean mode-appropriate reward (`modeSuccess`),
+ *   normalized to [0,1] across modes — what we'd pick if we only exploited.
+ * - The second term is the exploration bonus: it *grows* (relatively) for modes
+ *   left untried and *shrinks* as a mode accumulates plays, so a lucky single
+ *   result can't permanently dominate and a neglected mode is always revisited.
+ *   This is the property the previous heuristic (a flat 5% floor) could not express.
+ * - `c` is the single, visible knob for "how much to explore" (default √2).
+ *
+ * Scores normalize to weights that flow through `weightedModeSelect`, preserving
+ * the existing deterministic, parallel-batch-diverging draw.
+ *
+ * Returns null when there are fewer than `minRuns` mode-tagged runs, leaving the
+ * fixed cold-start schedule in charge (it seeds every mode at least once).
  */
-export function computeAdaptiveWeights(
+export function computeBanditWeights(
   history: RunMetrics[],
-  minRuns: number = 10,
-): Record<string, number> | null {
-  // Only runs with mode data
+  opts: { minRuns?: number; explorationC?: number } = {},
+): BanditResult | null {
+  const minRuns = opts.minRuns ?? 10;
+  const explorationC = opts.explorationC ?? DEFAULT_BANDIT_C;
+
+  // Only runs with mode data count toward bandit statistics.
   const withMode = history.filter(r => r.mode);
   if (withMode.length < minRuns) return null;
 
-  // Group by mode
+  // Group runs by mode.
   const byMode = new Map<string, RunMetrics[]>();
   for (const r of withMode) {
     const group = byMode.get(r.mode!) || [];
@@ -649,48 +698,60 @@ export function computeAdaptiveWeights(
     byMode.set(r.mode!, group);
   }
 
-  // Default schedulable modes (contemplate has its own overlay)
-  const schedulableModes = ['exploit', 'explore', 'reflect', 'subtract'];
-
-  // Base weights (matching the fixed schedule proportions)
-  const baseWeights: Record<string, number> = {
-    exploit: 0.7,
-    explore: 0.1,
-    reflect: 0.1,
-    subtract: 0.1,
-  };
-
-  // Compute raw effectiveness scores using mode-appropriate metrics
-  const scores: Record<string, number> = {};
-  for (const mode of schedulableModes) {
+  // Plays + mean reward per schedulable mode.
+  const plays: Record<string, number> = {};
+  const meanReward: Record<string, number> = {};
+  for (const mode of SCHEDULABLE_MODES) {
     const runs = byMode.get(mode) || [];
-    if (runs.length === 0) {
-      // No data for this mode — use base weight as-is
-      scores[mode] = baseWeights[mode];
-      continue;
-    }
-
-    const totalSuccess = runs.reduce((s, r) => s + modeSuccess(mode, r), 0);
-    const totalCostVal = runs.reduce((s, r) => s + r.cost_usd, 0);
-    const successRate = totalSuccess / runs.length;
-    const efficiency = totalCostVal > 0 ? totalSuccess / totalCostVal : 0;
-
-    // Blend success rate and efficiency, then scale by base weight
-    // This preserves the general shape (exploit dominant) while rewarding performance
-    const rawScore = (successRate * 0.7 + efficiency * 0.3) * baseWeights[mode];
-    // Floor at 5% of base to ensure every mode gets some chance
-    scores[mode] = Math.max(rawScore, baseWeights[mode] * 0.05);
+    plays[mode] = runs.length;
+    meanReward[mode] = runs.length
+      ? runs.reduce((s, r) => s + modeSuccess(mode, r), 0) / runs.length
+      : 0;
   }
 
-  // Normalize to sum to 1.0
-  const total = Object.values(scores).reduce((s, v) => s + v, 0);
-  if (total === 0) return null;
+  // N is the total plays across schedulable modes (the bandit's horizon).
+  const totalPlays = SCHEDULABLE_MODES.reduce((s, m) => s + plays[m], 0);
+  // Normalize the exploitation term to [0,1] so it is comparable to the bonus.
+  const maxMean = Math.max(...SCHEDULABLE_MODES.map(m => meanReward[m]), 0);
 
+  const ucb: Record<string, number> = {};
+  for (const mode of SCHEDULABLE_MODES) {
+    const exploitTerm = maxMean > 0 ? meanReward[mode] / maxMean : 0;
+    // max(plays,1): a never-chosen mode gets the largest finite bonus, guaranteeing
+    // it is revisited rather than starved (the fixed schedule has already seeded
+    // every mode once before the bandit activates, so plays>=1 in practice).
+    const exploreBonus = explorationC * Math.sqrt(Math.log(totalPlays + 1) / Math.max(plays[mode], 1));
+    ucb[mode] = exploitTerm + exploreBonus;
+  }
+
+  // Normalize UCB scores to selection weights summing to 1.0. exploreBonus > 0
+  // for c > 0, so the sum is positive; if c === 0 and all rewards are 0 (no signal
+  // at all), fall back to uniform weights rather than dividing by zero.
+  const totalUcb = SCHEDULABLE_MODES.reduce((s, m) => s + ucb[m], 0);
   const weights: Record<string, number> = {};
-  for (const mode of schedulableModes) {
-    weights[mode] = scores[mode] / total;
+  for (const mode of SCHEDULABLE_MODES) {
+    weights[mode] = totalUcb > 0 ? ucb[mode] / totalUcb : 1 / SCHEDULABLE_MODES.length;
   }
-  return weights;
+
+  const details: BanditDetail[] = SCHEDULABLE_MODES.map(mode => ({
+    mode,
+    plays: plays[mode],
+    meanReward: meanReward[mode],
+    exploitTerm: maxMean > 0 ? meanReward[mode] / maxMean : 0,
+    exploreBonus: explorationC * Math.sqrt(Math.log(totalPlays + 1) / Math.max(plays[mode], 1)),
+    ucb: ucb[mode],
+    weight: weights[mode],
+  }));
+
+  return { weights, details, totalPlays, explorationC };
+}
+
+/** Read the bandit exploration constant from the environment, falling back to the default. */
+export function banditExplorationC(): number {
+  const raw = process.env.KAIZEN_BANDIT_C;
+  if (raw === undefined || raw === '') return DEFAULT_BANDIT_C;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_BANDIT_C;
 }
 
 /**
@@ -735,7 +796,7 @@ export function weightedModeSelect(
  *   2. Test task: always exploit with test template
  *   3. Signal-driven: reactive to batch state (failures, stalls, streaks)
  *   4. Contemplate overlay: every 15th run for strategic assessment
- *   5. Adaptive selection: weighted by mode performance from run history
+ *   5. Bandit selection: UCB1 explore/exploit weighting from run history
  *   6. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
  */
 export function selectMode(state: BatchState, runNum: number): ModeSelection {
@@ -764,11 +825,11 @@ export function selectMode(state: BatchState, runNum: number): ModeSelection {
     return { mode: 'contemplate', template: MODE_TEMPLATES.contemplate, reason: 'schedule' };
   }
 
-  // Adaptive selection: use performance data when available
-  const adaptiveWeights = computeAdaptiveWeights(state.run_history || []);
-  if (adaptiveWeights) {
-    const mode = weightedModeSelect(adaptiveWeights, runNum, state.batch_id);
-    return { mode, template: MODE_TEMPLATES[mode] || MODE_TEMPLATES.exploit, reason: 'adaptive' };
+  // Bandit selection: principled UCB1 explore/exploit weighting when data allows.
+  const bandit = computeBanditWeights(state.run_history || [], { explorationC: banditExplorationC() });
+  if (bandit) {
+    const mode = weightedModeSelect(bandit.weights, runNum, state.batch_id);
+    return { mode, template: MODE_TEMPLATES[mode] || MODE_TEMPLATES.exploit, reason: 'bandit', bandit };
   }
 
   // Fallback: fixed schedule (used for first N runs before enough data)
@@ -1274,6 +1335,14 @@ async function runClaude(
   const modeSelection = selectMode(state, runNum);
   if (modeSelection.mode !== 'exploit' || modeSelection.reason !== 'schedule') {
     console.log(`  [mode] run #${runNum}: ${modeSelection.mode} (${modeSelection.reason}, template: ${modeSelection.template})`);
+  }
+  if (modeSelection.bandit) {
+    // Make the explore/exploit decision auditable: show each mode's UCB breakdown.
+    const b = modeSelection.bandit;
+    const breakdown = b.details
+      .map(d => `${d.mode} w=${d.weight.toFixed(2)} (reward=${d.meanReward.toFixed(2)}/${d.plays}p, +explore=${d.exploreBonus.toFixed(2)})`)
+      .join('  ');
+    console.log(`  [bandit] N=${b.totalPlays} c=${b.explorationC.toFixed(2)}  ${breakdown}`);
   }
   const promptMeta = buildPromptWithMetadata(state, runNum, logDir);
   const prompt = promptMeta.prompt;


### PR DESCRIPTION
## The Problem

Auto-dent's cognitive-mode scheduler is the system's core exploit/explore switch: every run it picks **exploit** (ship a PR), **explore** (find gaps), **reflect**, or **subtract**. After a batch builds ≥10 runs of history, `computeAdaptiveWeights` weighted those modes by past performance — but it folded "how well did this mode do" and "how sure am I" into one point estimate:

```ts
const rawScore = (successRate * 0.7 + efficiency * 0.3) * baseWeights[mode];
scores[mode] = Math.max(rawScore, baseWeights[mode] * 0.05); // flat 5% floor
```

Two failure modes followed: a mode tried **once** with a lucky result earned `successRate = 1.0` and dominated, and a rarely-tried mode was never *systematically* re-explored — its only protection was a **flat** 5% floor that never grows the longer the mode is neglected. The result is premature convergence and over-indexing on whatever looked good early (the exact pattern documented in #815). The "amount of exploration" was an emergent accident of three magic constants, invisible and unsteerable.

## The Discovery

This is the textbook explore/exploit dilemma, and #553 had already named the fix: *"The explore/exploit tradeoff has formal solutions (UCB, Thompson sampling). Our mode scheduler could use them instead of fixed ratios."* The missing ingredient was an explicit **uncertainty term** that decays with how often a mode has actually been chosen.

## The Solution

Model mode selection as a UCB1 multi-armed bandit:

```
score(m) = exploitTerm(m) + c · sqrt( ln(N + 1) / plays(m) )
```

- **`exploitTerm(m)`** — mean mode-appropriate reward (`modeSuccess`, already PR/issue/lines-aware), normalized to `[0,1]` across modes.
- **exploration bonus** — grows for neglected modes, shrinks as a mode accumulates plays. A lucky single result can no longer dominate forever, and a starved mode is always revisited.
- **`c`** — the one *visible* knob for how much to explore (default `√2`, the classic UCB1 value), tunable via `KAIZEN_BANDIT_C`. This is the literal "right amount of exploit/explore switching."

Scores normalize to weights that flow through the **unchanged** `weightedModeSelect`, so deterministic, parallel-batch-diverging draws are preserved. Cold start (<10 runs) keeps the fixed schedule, and signal overrides / contemplate overlay / guidance overrides all keep priority — only the post-warmup weighting math changed.

**Observability** (a primary requirement, not an afterthought): `selectMode` now returns the full per-mode breakdown (plays, mean reward, exploit term, explore bonus, ucb, weight); the run prints it as a `[bandit]` line and `mode_reason` becomes `bandit`. Every mode decision is now auditable from telemetry.

## Evidence

| Behavior | Level | Test |
|---|---|---|
| Cold start (<minRuns) → null, fixed schedule owns warmup | Unit | `returns null when history has fewer than minRuns` |
| Weights normalize to 1.0 | Unit | `returns weights that sum to 1.0` |
| **Exploitation**: equal plays, higher reward → more weight | Unit | `EXPLOITATION: ...` |
| **Exploration**: equal reward, fewer plays → more weight | Unit | `EXPLORATION: ... (uncertainty bonus)` |
| No starvation: unplayed mode stays competitive | Unit | `NO STARVATION: ...` |
| Knob `c=0` → greedy; large `c` → uniform | Unit | `KNOB c=0 is greedy`, `larger c flattens` |
| Bonus strictly decreases with plays | Unit | `details: exploreBonus strictly decreases` |
| Mode-appropriate reward (issues/lines, not just PRs) | Unit | `reward semantics: ...` |
| `KAIZEN_BANDIT_C` parsing (default / valid / invalid) | Unit | `banditExplorationC` block |
| `selectMode` routes to bandit + exposes breakdown | Integration | `selectMode bandit integration` |
| Signal / contemplate / guidance still take priority | Integration | existing `selectMode` tests (green) |

`npx vitest run scripts/auto-dent-run.test.ts` → **285 passed**. `npx tsc --noEmit` clean. Full `npm test` green in isolation (the only red files were `src/e2e/synthetic-workflow.test.ts`, confirmed pre-existing fleet-load flakiness #1120 — pass standalone on both this branch and clean `main`).

## Impact

Auto-dent now steers its own exploit/explore balance with a principled, tunable, observable policy instead of three opaque constants — directly advancing self-steering batches (#940), cognitive modes (#548), and the explore/exploit-formalization idea from #553. The single `c` knob makes "how adventurous should this batch be" a first-class lever.

Closes #1136
Parent: #548
Refs: #553, #815, #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)
