### PR TITLE
feat(auto-dent): external lifecycle evidence verification — judge claims by outcomes (Closes #1138)

### DIFF
--- a/scripts/auto-dent-lifecycle.test.ts
+++ b/scripts/auto-dent-lifecycle.test.ts
@@ -5,8 +5,13 @@ import { tmpdir } from 'os';
 import {
   validateRunLifecycle,
   summarizeLifecycle,
+  verifyLifecycleEvidence,
+  foldEvidenceIntoHealth,
+  summarizeEvidence,
   LIFECYCLE_ORDER,
   REQUIRED_PREDECESSORS,
+  type LifecycleValidation,
+  type LifecycleEvidence,
 } from './auto-dent-lifecycle.js';
 
 /**
@@ -224,5 +229,139 @@ describe('summarizeLifecycle', () => {
     // mentions both the phantom test and the PR-without-IMPLEMENT gap
     expect(s).toMatch(/phantom|TEST/i);
     expect(s).toMatch(/IMPLEMENT/);
+  });
+});
+
+/**
+ * Evidence verification (#1138, epic #1134) is the "auto-dent is the judge" layer:
+ * it cross-checks the agent's claimed phases against the outcomes the harness
+ * extracted independently (PRs, cases, filed/closed issues, the review verdict).
+ * A claimed phase with no corroborating external evidence is process-incomplete.
+ * The verifier reads only phasesPresent + evidence, so it is provider-independent
+ * by construction. Helper builds a minimal validation with a given phase set.
+ */
+describe('verifyLifecycleEvidence — claims vs external outcomes', () => {
+  const validationWith = (phasesPresent: string[]): LifecycleValidation => ({
+    valid: true,
+    phasesPresent,
+    phasesMissing: [],
+    violations: [],
+    criticalGaps: [],
+    phantomPhases: [],
+    health: 'clean',
+  });
+
+  const evidence = (over: Partial<LifecycleEvidence> = {}): LifecycleEvidence => ({
+    prsCreated: 0,
+    casesCreated: 0,
+    issuesFiledOrClosed: 0,
+    reviewVerdict: null,
+    ...over,
+  });
+
+  it('flags PR claimed but zero PRs created', () => {
+    const r = verifyLifecycleEvidence(validationWith(['IMPLEMENT', 'PR']), evidence());
+    expect(r.processComplete).toBe(false);
+    expect(r.processGaps.some((g) => g.phase === 'PR')).toBe(true);
+  });
+
+  it('flags MERGE claimed but zero PRs created', () => {
+    const r = verifyLifecycleEvidence(validationWith(['IMPLEMENT', 'PR', 'MERGE']), evidence());
+    expect(r.processGaps.some((g) => g.phase === 'MERGE')).toBe(true);
+  });
+
+  it('flags IMPLEMENT claimed but no case and no PR', () => {
+    const r = verifyLifecycleEvidence(validationWith(['IMPLEMENT']), evidence());
+    expect(r.processGaps.some((g) => g.phase === 'IMPLEMENT')).toBe(true);
+  });
+
+  it('does NOT flag IMPLEMENT when a case exists (work happened, PR may be next run)', () => {
+    const r = verifyLifecycleEvidence(validationWith(['IMPLEMENT']), evidence({ casesCreated: 1 }));
+    expect(r.processGaps.some((g) => g.phase === 'IMPLEMENT')).toBe(false);
+  });
+
+  it('flags REFLECT claimed but nothing filed or closed', () => {
+    const r = verifyLifecycleEvidence(validationWith(['REFLECT']), evidence());
+    expect(r.processGaps.some((g) => g.phase === 'REFLECT')).toBe(true);
+  });
+
+  it('does NOT flag REFLECT when an issue was closed (durable output)', () => {
+    const r = verifyLifecycleEvidence(validationWith(['REFLECT']), evidence({ issuesFiledOrClosed: 1 }));
+    expect(r.processGaps.some((g) => g.phase === 'REFLECT')).toBe(false);
+  });
+
+  it('flags a created PR with a missing review verdict', () => {
+    const r = verifyLifecycleEvidence(
+      validationWith(['IMPLEMENT', 'PR']),
+      evidence({ prsCreated: 1, reviewVerdict: null }),
+    );
+    expect(r.processGaps.some((g) => g.phase === 'PR' && /review/.test(g.reason))).toBe(true);
+  });
+
+  it('flags a created PR with a skipped review', () => {
+    const r = verifyLifecycleEvidence(
+      validationWith(['IMPLEMENT', 'PR']),
+      evidence({ prsCreated: 1, reviewVerdict: 'skipped' }),
+    );
+    expect(r.processGaps.some((g) => /review/.test(g.reason))).toBe(true);
+  });
+
+  it('a fully corroborated run is process-complete (PR built, reviewed)', () => {
+    const r = verifyLifecycleEvidence(
+      validationWith(['PICK', 'IMPLEMENT', 'TEST', 'PR']),
+      evidence({ prsCreated: 1, casesCreated: 1, reviewVerdict: 'pass' }),
+    );
+    expect(r.processComplete).toBe(true);
+    expect(r.processGaps).toEqual([]);
+  });
+
+  it('a review verdict of fail still counts as review evidence (not a gap)', () => {
+    const r = verifyLifecycleEvidence(
+      validationWith(['IMPLEMENT', 'PR']),
+      evidence({ prsCreated: 1, reviewVerdict: 'fail' }),
+    );
+    expect(r.processGaps.some((g) => /review/.test(g.reason))).toBe(false);
+  });
+
+  it('an explore/reflect-only run with no PR claim and a filed issue is process-complete', () => {
+    const r = verifyLifecycleEvidence(
+      validationWith(['PICK', 'REFLECT']),
+      evidence({ issuesFiledOrClosed: 2 }),
+    );
+    expect(r.processComplete).toBe(true);
+  });
+});
+
+describe('foldEvidenceIntoHealth', () => {
+  it('raises clean to degraded when process-incomplete', () => {
+    expect(foldEvidenceIntoHealth('clean', { processGaps: [{ phase: 'PR', reason: 'x' }], processComplete: false })).toBe('degraded');
+  });
+
+  it('keeps critical as critical when process-incomplete', () => {
+    expect(foldEvidenceIntoHealth('critical', { processGaps: [{ phase: 'PR', reason: 'x' }], processComplete: false })).toBe('critical');
+  });
+
+  it('leaves health untouched when process-complete', () => {
+    expect(foldEvidenceIntoHealth('clean', { processGaps: [], processComplete: true })).toBe('clean');
+    expect(foldEvidenceIntoHealth('degraded', { processGaps: [], processComplete: true })).toBe('degraded');
+  });
+});
+
+describe('summarizeEvidence', () => {
+  it('reports process complete when there are no gaps', () => {
+    expect(summarizeEvidence({ processGaps: [], processComplete: true })).toMatch(/complete/i);
+  });
+
+  it('names each gap reason when process-incomplete', () => {
+    const s = summarizeEvidence({
+      processGaps: [
+        { phase: 'PR', reason: 'claimed PR but the harness extracted 0 PRs from the run' },
+        { phase: 'REFLECT', reason: 'claimed REFLECT but no issues were filed or closed' },
+      ],
+      processComplete: false,
+    });
+    expect(s).toMatch(/incomplete/i);
+    expect(s).toContain('0 PRs');
+    expect(s).toContain('no issues were filed');
   });
 });

--- a/scripts/auto-dent-lifecycle.ts
+++ b/scripts/auto-dent-lifecycle.ts
@@ -118,6 +118,127 @@ export function validateRunLifecycle(logFile: string): LifecycleValidation {
   };
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// External evidence verification (#1138, epic #1134)
+//
+// validateRunLifecycle above classifies a run from the agent's AUTO_DENT_PHASE
+// markers — but those are the *worker's self-report*. Epic #1134's principle is
+// "auto-dent is the judge; the agent is the worker; hooks are useful feedback but
+// not the source of truth." A run can emit PR/MERGE/REFLECT markers with zero
+// corresponding external artifacts and still classify as clean. This is the
+// batch-level instance of "verify outcomes, not commands" (#943, #950).
+//
+// The functions below cross-check claimed phases against evidence the harness
+// extracts INDEPENDENTLY of the agent (PRs, cases, filed/closed issues, the
+// review-battery verdict). They read only external outcomes — never the markers'
+// truthiness — so they judge Claude and Codex identically. They are pure: the
+// caller assembles the evidence (the only impure part), the verifier decides.
+// Like all lifecycle validation, this is observability + steering, never a hard
+// block (#1103).
+
+/**
+ * External outcomes of a run, extracted by the harness independently of the
+ * agent's self-report. This is the judge's evidence. Provider-independent:
+ * assembled the same way whether the worker was Claude or Codex.
+ */
+export interface LifecycleEvidence {
+  /** PRs the harness extracted from the run output. */
+  prsCreated: number;
+  /** Case worktrees the harness extracted. */
+  casesCreated: number;
+  /** Issues filed or closed — durable reflection output. */
+  issuesFiledOrClosed: number;
+  /** Requirements-review verdict computed externally by the review battery. */
+  reviewVerdict: 'pass' | 'fail' | 'skipped' | null | undefined;
+}
+
+/** A claimed phase whose corroborating external evidence is missing. */
+export interface ProcessGap {
+  phase: string;
+  reason: string;
+}
+
+export interface EvidenceVerification {
+  /** Claims that the external outcomes do not corroborate. */
+  processGaps: ProcessGap[];
+  /** true when every claimed phase has corroborating external evidence. */
+  processComplete: boolean;
+}
+
+/**
+ * Cross-check a run's claimed lifecycle phases against the external outcomes the
+ * harness extracted. Returns the unsupported claims (process gaps). Conservative
+ * by design: each rule fires only when a claim is contradicted by a hard,
+ * harness-observed fact, so a false positive is unlikely and — per #1103 — never
+ * halts a batch regardless.
+ */
+export function verifyLifecycleEvidence(
+  validation: LifecycleValidation,
+  evidence: LifecycleEvidence,
+): EvidenceVerification {
+  const present = new Set(validation.phasesPresent);
+  const gaps: ProcessGap[] = [];
+
+  // PR / MERGE claimed but nothing shipped externally.
+  if ((present.has('PR') || present.has('MERGE')) && evidence.prsCreated <= 0) {
+    const claimed = present.has('MERGE') ? 'MERGE' : 'PR';
+    gaps.push({
+      phase: claimed,
+      reason: `claimed ${claimed} but the harness extracted 0 PRs from the run`,
+    });
+  }
+
+  // IMPLEMENT claimed but produced no work artifact (no case worktree, no PR).
+  if (present.has('IMPLEMENT') && evidence.casesCreated <= 0 && evidence.prsCreated <= 0) {
+    gaps.push({
+      phase: 'IMPLEMENT',
+      reason: 'claimed IMPLEMENT but no case worktree and no PR were produced',
+    });
+  }
+
+  // REFLECT claimed but produced no durable output (no issue filed or closed).
+  if (present.has('REFLECT') && evidence.issuesFiledOrClosed <= 0) {
+    gaps.push({
+      phase: 'REFLECT',
+      reason: 'claimed REFLECT but no issues were filed or closed',
+    });
+  }
+
+  // A PR shipped but review evidence is absent — the review battery never
+  // produced a verdict for it. Gated on the external fact (prsCreated > 0), not
+  // on a claim, so it catches PRs the agent never announced too.
+  if (
+    evidence.prsCreated > 0 &&
+    (evidence.reviewVerdict == null || evidence.reviewVerdict === 'skipped')
+  ) {
+    gaps.push({
+      phase: 'PR',
+      reason: `a PR was created but review evidence is ${evidence.reviewVerdict ?? 'missing'}`,
+    });
+  }
+
+  return { processGaps: gaps, processComplete: gaps.length === 0 };
+}
+
+/**
+ * Fold an evidence verification into a marker-derived lifecycle health. A
+ * process-incomplete run is at least `degraded`; an already-`critical` run stays
+ * critical. Evidence gaps never *downgrade* health.
+ */
+export function foldEvidenceIntoHealth(
+  health: LifecycleHealth,
+  verification: EvidenceVerification,
+): LifecycleHealth {
+  if (verification.processComplete) return health;
+  return health === 'critical' ? 'critical' : 'degraded';
+}
+
+/** One-line human summary of an evidence verification, for logs and steering. */
+export function summarizeEvidence(v: EvidenceVerification): string {
+  if (v.processComplete) return 'process complete (claims corroborated by outcomes)';
+  return `process-incomplete: ${v.processGaps.map((g) => g.reason).join('; ')}`;
+}
+
 /**
  * Render a one-line human summary of a lifecycle validation result, suitable for
  * console logs, run logs, and steering insights. Critical findings are named.

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -107,11 +107,17 @@ export {
 export {
   validateRunLifecycle,
   summarizeLifecycle,
+  verifyLifecycleEvidence,
+  foldEvidenceIntoHealth,
+  summarizeEvidence,
   LIFECYCLE_ORDER,
   FLOATING_PHASES,
   REQUIRED_PREDECESSORS,
   type LifecycleValidation,
   type LifecycleHealth,
+  type LifecycleEvidence,
+  type EvidenceVerification,
+  type ProcessGap,
 } from './auto-dent-lifecycle.js';
 
 // Import for internal use
@@ -137,7 +143,11 @@ import {
 import {
   validateRunLifecycle,
   summarizeLifecycle,
+  verifyLifecycleEvidence,
+  foldEvidenceIntoHealth,
+  summarizeEvidence,
   type LifecycleHealth,
+  type LifecycleEvidence,
 } from './auto-dent-lifecycle.js';
 
 // Types
@@ -1912,15 +1922,47 @@ async function main(): Promise<void> {
   let lifecycleSteeringNote: string | null = null;
   try {
     const lifecycle = validateRunLifecycle(logFile);
+
+    // External evidence cross-check (#1138, epic #1134): the markers above are
+    // the agent's self-report; here we judge them against the outcomes the
+    // harness extracted independently (PRs, cases, filed/closed issues, the
+    // review verdict). A run that *claims* PR/MERGE/REFLECT without durable
+    // evidence is process-incomplete. Provider-independent — the same evidence
+    // is assembled for a Codex run.
+    const evidence: LifecycleEvidence = {
+      prsCreated: result.prs.length,
+      casesCreated: result.cases.length,
+      issuesFiledOrClosed: result.issuesFiled.length + result.issuesClosed.length,
+      reviewVerdict: result.reviewVerdict,
+    };
+    const evidenceCheck = verifyLifecycleEvidence(lifecycle, evidence);
+
     lifecycleViolationCount = lifecycle.violations.length;
-    lifecycleHealth = lifecycle.health;
+    lifecycleHealth = foldEvidenceIntoHealth(lifecycle.health, evidenceCheck);
     lifecycleCriticalCount = lifecycle.criticalGaps.length + lifecycle.phantomPhases.length;
     const summary = summarizeLifecycle(lifecycle);
+
+    // Surface process-completeness for observability/telemetry regardless of health.
+    appendFileSync(
+      logFile,
+      `\nlifecycle_process_complete=${evidenceCheck.processComplete}\n`,
+    );
+    if (!evidenceCheck.processComplete) {
+      const evidenceSummary = summarizeEvidence(evidenceCheck);
+      console.log(`  ${color.yellow('[lifecycle]')} ${evidenceSummary}`);
+      appendFileSync(logFile, `lifecycle_evidence: ${evidenceSummary}\n`);
+      // Steer the next run: the agent's narrative wasn't backed by outcomes.
+      lifecycleSteeringNote =
+        `Prior run was PROCESS-INCOMPLETE (${evidenceSummary}). ` +
+        `Don't emit a lifecycle phase you didn't actually complete — auto-dent verifies claims against real PRs, cases, filed issues, and the review verdict, not against your markers.`;
+    }
+
     if (lifecycle.health === 'critical') {
       // Claimed-to-ship-without-building, or claimed-green-but-ran-nothing.
       console.log(`  ${color.red('[lifecycle]')} ${summary}`);
       appendFileSync(logFile, `\nlifecycle_health=critical: ${summary}\n`);
       // Steer the next run: warn the agent that this run's narrative didn't hold.
+      // A critical marker problem takes precedence over an evidence note.
       lifecycleSteeringNote =
         `Prior run had a CRITICAL lifecycle problem (${summary}). ` +
         `Do not emit PR/MERGE without a real IMPLEMENT, and never emit TEST result=pass with count=0 — run the tests.`;


### PR DESCRIPTION
## The problem

auto-dent's lifecycle validator classified each run purely from the agent's self-reported `AUTO_DENT_PHASE` markers. Those markers are the **worker's claims**. A run could emit `PR`, `MERGE`, and `REFLECT` with *zero* corresponding external artifacts and still be classified as a clean, successful run. That is the batch-level instance of the "verify outcomes, not commands" category (#943, #950), and it directly violates epic #1134's load-bearing principle:

> auto-dent is the judge; the agent is the worker; hooks are useful feedback but **not the source of truth**.

## The discovery

The harness already extracts the run's real outcomes independently of the agent — `result.prs`, `result.cases`, `result.issuesFiled`/`issuesClosed`, and the review-battery `reviewVerdict` are all in scope at the lifecycle step. Nothing was cross-checking the agent's *claims* against this ground truth. The judge had the evidence on the table and never looked at it.

## The solution

A pure verifier in `scripts/auto-dent-lifecycle.ts`:

- **`verifyLifecycleEvidence(validation, evidence)`** cross-checks claimed phases against external outcomes and returns the unsupported claims (`processGaps`) plus a `processComplete` boolean. Rules (conservative — each fires only on a hard, harness-observed contradiction):
  - `PR`/`MERGE` claimed but **0 PRs** extracted → gap
  - `IMPLEMENT` claimed but **no case worktree and no PR** → gap
  - `REFLECT` claimed but **nothing filed or closed** → gap
  - a PR was created but the **review verdict is missing/skipped** → gap
- **`foldEvidenceIntoHealth`** raises a process-incomplete run to at least `degraded`; an already-`critical` run stays critical (evidence never downgrades health).
- **`summarizeEvidence`** renders a one-line steering/log summary.

Wired into the lifecycle step in `scripts/auto-dent-run.ts`: it logs `lifecycle_process_complete=<bool>` for observability and, when claims aren't backed by outcomes, steers the next run with the specific gap — *"don't emit a phase you didn't complete; auto-dent verifies against real PRs, cases, filed issues, and the review verdict, not your markers."*

**Provider-independent by construction.** The verifier reads only external outcomes, never the markers' truthiness, so it judges Claude and Codex identically. This is the external-verification spine epic #1134 needs before Codex can be trusted as an auto-dent worker (follow-ups #1139 Codex adapter, #1140 comparison harness).

## Evidence

| Behavior | Level | Test |
|----------|-------|------|
| PR/MERGE claimed but no PR created → gap | Unit | ✅ |
| IMPLEMENT with no case and no PR → gap; case present → no gap | Unit | ✅ |
| REFLECT with nothing filed/closed → gap; issue closed → no gap | Unit | ✅ |
| Created PR with missing/skipped review → gap; `fail` verdict → no gap | Unit | ✅ |
| Fully-corroborated run → `processComplete`; explore/reflect-only run → complete | Unit | ✅ |
| Health fold: clean→degraded, critical stays critical, complete untouched | Unit | ✅ |
| `summarizeEvidence` names each gap | Unit | ✅ |
| run.ts assembles evidence from `RunResult` + wires steering/log | Integration | wiring |

`scripts/auto-dent-lifecycle.test.ts`: 30 passed (14 new). `auto-dent-run` + lifecycle suites: 315 passed. `npm run build` clean. The 4 failures in the full suite are the known fleet-load subprocess timeouts (#1120) in `kaizen-reflect`/`synthetic-workflow`/`setup-e2e` — they don't import the changed modules and pass in isolation.

## Impact

auto-dent can now distinguish a genuinely successful run from an **empty or process-incomplete** one — the headline acceptance criterion of #1134 — and steer the next run on the specific unbacked claim. Existing marker validation (`validateRunLifecycle`) is unchanged (back-compat).

Closes #1138
Parent: #1134
Refs: #1139, #1140

Run-tag: powerful-capybara/run-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)