### PR TITLE
feat(auto-dent): add provider capability inventory

### DIFF
--- a/scripts/auto-dent-provider-capabilities.test.ts
+++ b/scripts/auto-dent-provider-capabilities.test.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import {
+  AUTO_DENT_PHASES,
+  PROVIDER_CAPABILITIES,
+  buildProviderCapabilityMatrix,
+  renderProviderCapabilityMatrix,
+  validateProviderCapabilityInventory,
+} from './auto-dent-provider-capabilities.js';
+
+describe('auto-dent provider capability inventory', () => {
+  it('covers every #1141 phase', () => {
+    expect(AUTO_DENT_PHASES).toEqual([
+      'planning',
+      'implementation',
+      'review',
+      'fix',
+      'reflection',
+      'validation',
+    ]);
+
+    const matrix = buildProviderCapabilityMatrix();
+    for (const phase of AUTO_DENT_PHASES) {
+      expect(matrix.phases).toContain(phase);
+      expect(matrix.rows.some((row) => row.phaseFit[phase] !== 'not-applicable')).toBe(true);
+    }
+  });
+
+  it('represents Claude, Codex, and provider-independent capabilities', () => {
+    const providers = new Set(PROVIDER_CAPABILITIES.map((cap) => cap.provider));
+    expect(providers).toEqual(new Set(['claude', 'codex', 'provider-independent']));
+
+    expect(PROVIDER_CAPABILITIES).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'claude-kaizen-skills',
+          provider: 'claude',
+          billingMode: 'subscription-cli',
+        }),
+        expect.objectContaining({
+          id: 'codex-structured-exec',
+          provider: 'codex',
+          billingMode: 'subscription-cli',
+        }),
+        expect.objectContaining({
+          id: 'external-lifecycle-evidence',
+          provider: 'provider-independent',
+          billingMode: 'local-only',
+        }),
+      ]),
+    );
+  });
+
+  it('validates schema and rejects unattended API-token-only capabilities', () => {
+    expect(validateProviderCapabilityInventory(PROVIDER_CAPABILITIES)).toEqual([]);
+
+    for (const capability of PROVIDER_CAPABILITIES) {
+      expect(capability.id).toMatch(/^[a-z0-9-]+$/);
+      expect(['subscription-cli', 'local-only', 'api-token']).toContain(capability.billingMode);
+      if (capability.billingMode === 'api-token') {
+        expect(capability.acceptedForUnattended).toBe(false);
+      }
+    }
+  });
+
+  it('renders a stable matrix naming every phase and provider class', () => {
+    const rendered = renderProviderCapabilityMatrix(buildProviderCapabilityMatrix());
+    expect(rendered).toContain('| Capability | Provider | Billing | Unattended | Planning | Implementation | Review | Fix | Reflection | Validation | Notes |');
+    expect(rendered).toContain('Claude');
+    expect(rendered).toContain('Codex');
+    expect(rendered).toContain('Provider-independent');
+
+    for (const phase of ['Planning', 'Implementation', 'Review', 'Fix', 'Reflection', 'Validation']) {
+      expect(rendered).toContain(`| ${phase} `);
+    }
+  });
+
+  it('prints the rendered matrix from the CLI entry point', () => {
+    const output = execFileSync(
+      'npx',
+      ['tsx', 'scripts/auto-dent-provider-capabilities.ts'],
+      { encoding: 'utf8' },
+    );
+
+    expect(output).toBe(renderProviderCapabilityMatrix(buildProviderCapabilityMatrix()) + '\n');
+  });
+});

--- a/scripts/auto-dent-provider-capabilities.test.ts
+++ b/scripts/auto-dent-provider-capabilities.test.ts
@@ -75,6 +75,30 @@ describe('auto-dent provider capability inventory', () => {
     }
   });
 
+  it('escapes Markdown table metacharacters in rendered cells', () => {
+    const rendered = renderProviderCapabilityMatrix(buildProviderCapabilityMatrix([
+      {
+        id: 'escape-test',
+        label: 'Pipe | Backslash \\',
+        provider: 'provider-independent',
+        billingMode: 'local-only',
+        acceptedForUnattended: true,
+        phaseFit: {
+          planning: 'not-applicable',
+          implementation: 'not-applicable',
+          review: 'not-applicable',
+          fix: 'not-applicable',
+          reflection: 'not-applicable',
+          validation: 'best',
+        },
+        notes: 'line one\nline | two \\',
+      },
+    ]));
+
+    expect(rendered).toContain('Pipe \\| Backslash \\\\');
+    expect(rendered).toContain('line one line \\| two \\\\');
+  });
+
   it('prints the rendered matrix from the CLI entry point', () => {
     const output = execFileSync(
       'npx',

--- a/scripts/auto-dent-provider-capabilities.ts
+++ b/scripts/auto-dent-provider-capabilities.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env npx tsx
+/**
+ * Provider capability inventory for auto-dent.
+ *
+ * This is descriptive metadata only. It does not select providers or change
+ * runtime behavior; later provider-aware phases can consume the same inventory.
+ */
+
+export const AUTO_DENT_PHASES = [
+  'planning',
+  'implementation',
+  'review',
+  'fix',
+  'reflection',
+  'validation',
+] as const;
+
+export type AutoDentPhase = typeof AUTO_DENT_PHASES[number];
+export type AgentProvider = 'claude' | 'codex' | 'provider-independent';
+export type BillingMode = 'subscription-cli' | 'local-only' | 'api-token';
+export type PhaseFit = 'best' | 'supported' | 'partial' | 'avoid' | 'not-applicable';
+
+export interface ProviderCapability {
+  id: string;
+  label: string;
+  provider: AgentProvider;
+  billingMode: BillingMode;
+  acceptedForUnattended: boolean;
+  phaseFit: Record<AutoDentPhase, PhaseFit>;
+  notes: string;
+}
+
+export interface ProviderCapabilityMatrix {
+  phases: AutoDentPhase[];
+  rows: ProviderCapability[];
+}
+
+const NONE: Record<AutoDentPhase, PhaseFit> = {
+  planning: 'not-applicable',
+  implementation: 'not-applicable',
+  review: 'not-applicable',
+  fix: 'not-applicable',
+  reflection: 'not-applicable',
+  validation: 'not-applicable',
+};
+
+function fit(overrides: Partial<Record<AutoDentPhase, PhaseFit>>): Record<AutoDentPhase, PhaseFit> {
+  return { ...NONE, ...overrides };
+}
+
+export const PROVIDER_CAPABILITIES: ProviderCapability[] = [
+  {
+    id: 'claude-kaizen-skills',
+    label: 'Claude kaizen skills',
+    provider: 'claude',
+    billingMode: 'subscription-cli',
+    acceptedForUnattended: true,
+    phaseFit: fit({
+      planning: 'best',
+      implementation: 'supported',
+      review: 'best',
+      fix: 'supported',
+      reflection: 'best',
+    }),
+    notes: 'Current mature path for existing /kaizen-* workflows and Claude hook observability.',
+  },
+  {
+    id: 'claude-auto-dent-runner',
+    label: 'Claude auto-dent runner',
+    provider: 'claude',
+    billingMode: 'subscription-cli',
+    acceptedForUnattended: true,
+    phaseFit: fit({
+      planning: 'best',
+      implementation: 'best',
+      review: 'supported',
+      fix: 'partial',
+      reflection: 'supported',
+    }),
+    notes: 'Existing batch path uses claude stream-json and max-budget-usd.',
+  },
+  {
+    id: 'codex-structured-exec',
+    label: 'Codex structured exec',
+    provider: 'codex',
+    billingMode: 'subscription-cli',
+    acceptedForUnattended: true,
+    phaseFit: fit({
+      planning: 'partial',
+      implementation: 'best',
+      review: 'partial',
+      fix: 'partial',
+      reflection: 'partial',
+    }),
+    notes: 'Target subscription-compatible CLI path for JSONL execution and schema-constrained summaries.',
+  },
+  {
+    id: 'codex-review-command',
+    label: 'Codex review command',
+    provider: 'codex',
+    billingMode: 'subscription-cli',
+    acceptedForUnattended: true,
+    phaseFit: fit({
+      review: 'partial',
+    }),
+    notes: 'Candidate review surface; must still produce structured kaizen review evidence before replacing existing dimensions.',
+  },
+  {
+    id: 'external-lifecycle-evidence',
+    label: 'External lifecycle evidence',
+    provider: 'provider-independent',
+    billingMode: 'local-only',
+    acceptedForUnattended: true,
+    phaseFit: fit({
+      validation: 'best',
+    }),
+    notes: 'GitHub, git state, stored plans, review attachments, and lifecycle evidence judge worker claims.',
+  },
+  {
+    id: 'git-github-safeguards',
+    label: 'Git/GitHub safeguards',
+    provider: 'provider-independent',
+    billingMode: 'local-only',
+    acceptedForUnattended: true,
+    phaseFit: fit({
+      implementation: 'supported',
+      review: 'supported',
+      fix: 'supported',
+      validation: 'best',
+    }),
+    notes: 'Provider-neutral checks for branches, dirty worktrees, PR links, checks, and merge readiness.',
+  },
+  {
+    id: 'direct-api-orchestration',
+    label: 'Direct API orchestration',
+    provider: 'codex',
+    billingMode: 'api-token',
+    acceptedForUnattended: false,
+    phaseFit: fit({
+      planning: 'avoid',
+      implementation: 'avoid',
+      review: 'avoid',
+      fix: 'avoid',
+      reflection: 'avoid',
+      validation: 'avoid',
+    }),
+    notes: 'Out of scope for accepted #1134 path because it requires API-token billing rather than subscription CLI access.',
+  },
+];
+
+export function buildProviderCapabilityMatrix(
+  capabilities: ProviderCapability[] = PROVIDER_CAPABILITIES,
+): ProviderCapabilityMatrix {
+  return {
+    phases: [...AUTO_DENT_PHASES],
+    rows: [...capabilities].sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+export function validateProviderCapabilityInventory(
+  capabilities: ProviderCapability[] = PROVIDER_CAPABILITIES,
+): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+  for (const cap of capabilities) {
+    if (!/^[a-z0-9-]+$/.test(cap.id)) errors.push(`${cap.id}: id must be kebab-case`);
+    if (ids.has(cap.id)) errors.push(`${cap.id}: duplicate id`);
+    ids.add(cap.id);
+    if (cap.billingMode === 'api-token' && cap.acceptedForUnattended) {
+      errors.push(`${cap.id}: api-token capabilities cannot be accepted for unattended batches`);
+    }
+    for (const phase of AUTO_DENT_PHASES) {
+      if (!cap.phaseFit[phase]) errors.push(`${cap.id}: missing phase fit for ${phase}`);
+    }
+  }
+  return errors;
+}
+
+export function renderProviderCapabilityMatrix(matrix: ProviderCapabilityMatrix): string {
+  const lines = [
+    '# Auto-dent Provider Capability Matrix',
+    '',
+    '| Capability | Provider | Billing | Unattended | Planning | Implementation | Review | Fix | Reflection | Validation | Notes |',
+    '|---|---|---|---:|---|---|---|---|---|---|---|',
+  ];
+
+  for (const row of matrix.rows) {
+    lines.push([
+      row.label,
+      providerLabel(row.provider),
+      row.billingMode,
+      row.acceptedForUnattended ? 'yes' : 'no',
+      row.phaseFit.planning,
+      row.phaseFit.implementation,
+      row.phaseFit.review,
+      row.phaseFit.fix,
+      row.phaseFit.reflection,
+      row.phaseFit.validation,
+      row.notes,
+    ].map(escapeCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  return lines.join('\n');
+}
+
+function providerLabel(provider: AgentProvider): string {
+  switch (provider) {
+    case 'claude':
+      return 'Claude';
+    case 'codex':
+      return 'Codex';
+    case 'provider-independent':
+      return 'Provider-independent';
+  }
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+const isDirectRun = process.argv[1]?.endsWith('auto-dent-provider-capabilities.ts') ||
+  process.argv[1]?.endsWith('auto-dent-provider-capabilities.js');
+
+if (isDirectRun) {
+  const errors = validateProviderCapabilityInventory();
+  if (errors.length > 0) {
+    console.error(errors.join('\n'));
+    process.exit(1);
+  }
+  console.log(renderProviderCapabilityMatrix(buildProviderCapabilityMatrix()));
+}

--- a/scripts/auto-dent-provider-capabilities.ts
+++ b/scripts/auto-dent-provider-capabilities.ts
@@ -215,7 +215,10 @@ function providerLabel(provider: AgentProvider): string {
 }
 
 function escapeCell(value: string): string {
-  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ');
 }
 
 const isDirectRun = process.argv[1]?.endsWith('auto-dent-provider-capabilities.ts') ||


### PR DESCRIPTION
## Story

Once upon a time, #1134 needed Codex support for auto-dent without weakening the kaizen lifecycle. The current harness could run unattended batches, review PRs, score runs, and validate lifecycle evidence, but provider capability was still implicit in code paths.

Every day, planning, implementation, review, and repair used Claude-specific surfaces while validation increasingly moved toward provider-independent evidence. That was workable for the Claude-only world, but it made Codex planning risky because the harness had no inspectable map of what each provider could safely do per phase.

One day, #1141 carved out the first foundation step: build the inventory before changing orchestration. The issue explicitly asks for a command or helper that renders a provider capability matrix, records billing mode, and keeps runtime behavior unchanged.

Because of that, this PR adds a pure TypeScript provider capability inventory plus a CLI renderer. The matrix names Claude, Codex, provider-independent checks, billing mode, unattended acceptance, and phase fit across planning, implementation, review, fix, reflection, and validation.

Because of that, API-token-only orchestration is represented as an explicit avoided capability, not as an accepted path. That keeps the #1134 subscription-only constraint visible in code before #1142 adds stronger guardrails.

Until finally, tests prove the matrix covers every #1141 phase, includes representative Claude/Codex/provider-independent capabilities, rejects unattended API-token-only entries, and prints stable CLI output.

And ever since, later #1134 work can consume a typed inventory instead of rediscovering provider capability from scattered Claude/Codex implementation details.

## Architecture

```text
scripts/auto-dent-provider-capabilities.ts
  -> AUTO_DENT_PHASES
  -> PROVIDER_CAPABILITIES
  -> buildProviderCapabilityMatrix()
  -> validateProviderCapabilityInventory()
  -> renderProviderCapabilityMatrix()
  -> CLI: npx tsx scripts/auto-dent-provider-capabilities.ts
```

This is descriptive metadata only. It does not select a provider, change the batch runner, or alter auto-dent execution.

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Standalone script/module | #1141 asks for an inventory/report with no behavior change. | Future PRs must deliberately wire consumers to this module. |
| Explicit phase-fit columns | Makes planning, implementation, review, fix, reflection, and validation visible in one rendered artifact. | Some entries are necessarily coarse until later empirical provider work lands. |
| Include direct API orchestration as avoided | Keeps the subscription-only constraint visible before #1142. | It is an out-of-scope negative capability, not a supported implementation path. |
| Use Unit tests plus a CLI subprocess check | Inventory is pure data/rendering; subprocess proves the command path works. | No Agentic test is needed because no LLM decision path changes. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-provider-capabilities.ts` | Typed phase/provider/billing capability inventory, validator, Markdown renderer, and CLI entry point. |
| `scripts/auto-dent-provider-capabilities.test.ts` | Tests phase coverage, provider coverage, schema/guardrail invariants, stable renderer output, and CLI output. |

## Validation

- [x] TDD red: `npx vitest run scripts/auto-dent-provider-capabilities.test.ts` failed because `./auto-dent-provider-capabilities.js` did not exist.
- [x] `npx vitest run scripts/auto-dent-provider-capabilities.test.ts` — 6/6 pass, including CodeQL regression coverage for backslash/table escaping.
- [x] `npx tsx scripts/auto-dent-provider-capabilities.ts` — prints the provider capability matrix.
- [x] `npx vitest run scripts/auto-dent-plan.test.ts scripts/auto-dent-lifecycle.test.ts scripts/auto-dent-run.test.ts` — 381/381 pass.
- [x] `npm run typecheck` — pass.

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration | System | Agentic | Evidence |
|---|:-:|:-:|:-:|:-:|---|
| Inventory includes every #1141 phase | yes |  |  |  | `auto-dent-provider-capabilities.test.ts` |
| Entries expose provider, billing, phase fit, and unattended acceptance | yes |  |  |  | `auto-dent-provider-capabilities.test.ts` |
| Claude-best, Codex-best, and provider-independent capabilities are represented | yes |  |  |  | `auto-dent-provider-capabilities.test.ts` |
| API-token-only capabilities are not accepted for unattended batches | yes |  |  |  | `auto-dent-provider-capabilities.test.ts` |
| Renderer names each phase and provider class | yes |  |  |  | `auto-dent-provider-capabilities.test.ts` |
| CLI/report prints the matrix |  |  | yes |  | `execFileSync('npx', ['tsx', 'scripts/auto-dent-provider-capabilities.ts'])` |

## Known Limitations

- The matrix is descriptive in this PR. #1142/#1143 should consume it for guardrails and metrics rather than duplicate it.
- Phase fit is intentionally conservative. Provider comparison and synthetic Codex runs later in #1134 should update the matrix with measured evidence.

Closes #1141
Parent: #1134