### PR TITLE
feat(auto-dent): provider capability/billing model — Phase 1 of Codex epic (Closes #1141, #1142, #1143)

### DIFF
--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -72,6 +72,11 @@ export interface RunCompleteEvent extends BaseEvent {
   review_verdict?: 'pass' | 'fail' | 'skipped';
   /** Review battery cost (USD) */
   review_cost_usd?: number;
+  /**
+   * Provider + billing mode per lifecycle phase (#1143, epic #1134).
+   * Absent on older events. Keyed by phase → { provider, billing }.
+   */
+  phase_providers?: Record<string, { provider: string; billing: string }>;
 }
 
 export interface BatchReflectEvent extends BaseEvent {

--- a/scripts/auto-dent-provider.test.ts
+++ b/scripts/auto-dent-provider.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CAPABILITY_INVENTORY,
+  PHASES,
+  PROVIDERS,
+  SUBSCRIPTION_COMPATIBLE_BILLING,
+  renderCapabilityMatrix,
+  validateProviderPlan,
+  defaultPhaseProviders,
+  type ProviderCapability,
+  type ProviderPlan,
+} from './auto-dent-provider.js';
+
+describe('capability inventory (#1141)', () => {
+  it('validates inventory shape — every entry is well-formed', () => {
+    const fits = new Set(['best', 'works', 'avoid']);
+    const billings = new Set(['subscription-cli', 'local-only', 'api-token']);
+    for (const c of CAPABILITY_INVENTORY) {
+      expect(PROVIDERS).toContain(c.provider);
+      expect(PHASES).toContain(c.phase);
+      expect(billings.has(c.billingMode)).toBe(true);
+      expect(fits.has(c.fit)).toBe(true);
+      expect(typeof c.acceptedForUnattended).toBe('boolean');
+      expect(c.rationale.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers claude-best, codex-best, and provider-independent capabilities', () => {
+    const has = (p: string, fit: string) =>
+      CAPABILITY_INVENTORY.some((c) => c.provider === p && c.fit === fit && c.acceptedForUnattended);
+    expect(has('claude', 'best')).toBe(true);
+    expect(has('codex', 'best')).toBe(true);
+    expect(
+      CAPABILITY_INVENTORY.some(
+        (c) => c.provider === 'provider-independent' && c.acceptedForUnattended,
+      ),
+    ).toBe(true);
+  });
+
+  it('records api-token paths as documented but NOT accepted (subscription constraint)', () => {
+    const apiToken = CAPABILITY_INVENTORY.filter((c) => c.billingMode === 'api-token');
+    expect(apiToken.length).toBeGreaterThan(0);
+    for (const c of apiToken) {
+      expect(c.acceptedForUnattended).toBe(false);
+    }
+  });
+});
+
+describe('renderCapabilityMatrix (#1141)', () => {
+  it('names every phase', () => {
+    const out = renderCapabilityMatrix();
+    for (const phase of PHASES) {
+      expect(out).toContain(`## ${phase}`);
+    }
+  });
+
+  it('honors an explicitly-passed inventory override', () => {
+    const custom: ProviderCapability[] = [
+      { provider: 'codex', phase: 'implementation', billingMode: 'subscription-cli', fit: 'best', acceptedForUnattended: true, rationale: 'custom only' },
+    ];
+    const out = renderCapabilityMatrix(custom);
+    expect(out).toContain('custom only');
+    expect(out).not.toContain('Claude Code plans');
+  });
+});
+
+describe('validateProviderPlan (#1142)', () => {
+  it('accepts a subscription-only plan', () => {
+    const plan: ProviderPlan = {
+      planning: 'claude',
+      implementation: 'codex',
+      review: 'claude',
+      fix: 'codex',
+      reflection: 'claude',
+      validation: 'provider-independent',
+    };
+    const result = validateProviderPlan(plan);
+    expect(result.ok).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('accepts an empty plan (no phases to violate)', () => {
+    expect(validateProviderPlan({}).ok).toBe(true);
+  });
+
+  it('rejects a plan whose phase only has api-token capability, with a clear reason', () => {
+    // Custom inventory: codex/review is ONLY available via api-token.
+    const inventory: ProviderCapability[] = [
+      { provider: 'codex', phase: 'review', billingMode: 'api-token', fit: 'avoid', acceptedForUnattended: false, rationale: 'api-token only' },
+    ];
+    const result = validateProviderPlan({ review: 'codex' }, inventory);
+    expect(result.ok).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].phase).toBe('review');
+    expect(result.violations[0].provider).toBe('codex');
+    expect(result.violations[0].reason).toContain('api-token');
+    expect(result.violations[0].reason).toContain('subscription-compatible');
+  });
+
+  it('rejects a phase with no accepted capability at all, with a distinct reason', () => {
+    const result = validateProviderPlan({ planning: 'codex' }, []);
+    expect(result.ok).toBe(false);
+    expect(result.violations[0].reason).toContain('no accepted subscription-compatible capability');
+  });
+
+  it('only subscription-cli and local-only count as subscription-compatible', () => {
+    expect([...SUBSCRIPTION_COMPATIBLE_BILLING].sort()).toEqual(['local-only', 'subscription-cli']);
+    expect(SUBSCRIPTION_COMPATIBLE_BILLING).not.toContain('api-token');
+  });
+});
+
+describe('defaultPhaseProviders (#1143)', () => {
+  it('maps agent phases to Claude under subscription and validation to provider-independent', () => {
+    const d = defaultPhaseProviders();
+    for (const phase of ['planning', 'implementation', 'review', 'fix', 'reflection'] as const) {
+      expect(d[phase]).toEqual({ provider: 'claude', billing: 'subscription-cli' });
+    }
+    expect(d.validation).toEqual({ provider: 'provider-independent', billing: 'local-only' });
+  });
+
+  it('produces a plan that passes validateProviderPlan', () => {
+    const plan: ProviderPlan = {};
+    for (const [phase, pp] of Object.entries(defaultPhaseProviders())) {
+      plan[phase as keyof ProviderPlan] = pp!.provider;
+    }
+    expect(validateProviderPlan(plan).ok).toBe(true);
+  });
+});

--- a/scripts/auto-dent-provider.ts
+++ b/scripts/auto-dent-provider.ts
@@ -1,0 +1,249 @@
+/**
+ * auto-dent-provider — Provider capability / billing model for auto-dent.
+ *
+ * Phase 1 of epic #1134 (Codex-powered auto-dent). This module is the single
+ * source of truth for *provider awareness*: which agent provider can safely
+ * perform each lifecycle phase, under which billing mode, and whether that
+ * combination is accepted for unattended batches.
+ *
+ * It deliberately holds NO orchestration logic and changes NO run behavior. It
+ * exposes a typed inventory plus two consumers:
+ *   - #1141 renderCapabilityMatrix() — print the provider × phase × billing matrix.
+ *   - #1142 validateProviderPlan()   — reject API-token-only (subscription-
+ *           incompatible) provider plans with a clear reason.
+ *   - #1143 defaultPhaseProviders()  — the provider/billing reality each run
+ *           records today (Claude under subscription for the agent phases,
+ *           provider-independent for validation), so run metrics are auditable.
+ *
+ * Billing constraint (epic #1134): the accepted path must work under normal
+ * Claude/Codex *subscription* (CLI) usage. API-token strategies may be
+ * documented but cannot be required, so they are recorded with
+ * acceptedForUnattended=false and rejected by validateProviderPlan.
+ */
+
+/** Agent providers auto-dent can reason about. */
+export type Provider = 'claude' | 'codex' | 'provider-independent';
+
+/** Lifecycle phases where a provider choice is meaningful (epic #1134 vocabulary). */
+export type Phase =
+  | 'planning'
+  | 'implementation'
+  | 'review'
+  | 'fix'
+  | 'reflection'
+  | 'validation';
+
+/** How a capability is billed. Only subscription-compatible modes are accepted. */
+export type BillingMode = 'subscription-cli' | 'local-only' | 'api-token';
+
+/** How well a provider fits a phase. */
+export type Fit = 'best' | 'works' | 'avoid';
+
+/** Canonical phase order — drives matrix layout and ensures every phase is named. */
+export const PHASES: readonly Phase[] = [
+  'planning',
+  'implementation',
+  'review',
+  'fix',
+  'reflection',
+  'validation',
+] as const;
+
+/** Providers in canonical display order. */
+export const PROVIDERS: readonly Provider[] = ['claude', 'codex', 'provider-independent'] as const;
+
+/**
+ * Billing modes that are compatible with the hard subscription-only constraint.
+ * `api-token` is intentionally excluded — it may be documented but never required.
+ */
+export const SUBSCRIPTION_COMPATIBLE_BILLING: readonly BillingMode[] = [
+  'subscription-cli',
+  'local-only',
+] as const;
+
+/** One row of the capability matrix: a (provider, phase) cell with its properties. */
+export interface ProviderCapability {
+  provider: Provider;
+  phase: Phase;
+  billingMode: BillingMode;
+  fit: Fit;
+  /** Whether this capability is accepted for unattended auto-dent batches. */
+  acceptedForUnattended: boolean;
+  /** One-line human rationale for the fit/accepted decision. */
+  rationale: string;
+}
+
+/**
+ * Hand-authored capability inventory. Reflects today's reality plus the Codex
+ * direction of epic #1134. The api-token rows are documentation of optional
+ * future paths — they are NOT accepted for unattended batches, which is what
+ * validateProviderPlan enforces.
+ */
+export const CAPABILITY_INVENTORY: readonly ProviderCapability[] = [
+  // --- Claude (subscription CLI) — the proven path today ---
+  { provider: 'claude', phase: 'planning', billingMode: 'subscription-cli', fit: 'best', acceptedForUnattended: true, rationale: 'Claude Code plans the kaizen lifecycle natively under subscription.' },
+  { provider: 'claude', phase: 'implementation', billingMode: 'subscription-cli', fit: 'best', acceptedForUnattended: true, rationale: 'Claude Code edits in a case worktree with hook enforcement.' },
+  { provider: 'claude', phase: 'review', billingMode: 'subscription-cli', fit: 'best', acceptedForUnattended: true, rationale: 'Adversarial multi-dimension review battery is Claude-driven.' },
+  { provider: 'claude', phase: 'fix', billingMode: 'subscription-cli', fit: 'works', acceptedForUnattended: true, rationale: 'Review-fix loop runs under subscription; Codex is often faster here.' },
+  { provider: 'claude', phase: 'reflection', billingMode: 'subscription-cli', fit: 'best', acceptedForUnattended: true, rationale: 'Reflection/contemplation modes are Claude-native.' },
+  { provider: 'claude', phase: 'validation', billingMode: 'subscription-cli', fit: 'works', acceptedForUnattended: true, rationale: 'Claude can validate, but provider-independent checks are authoritative.' },
+
+  // --- Codex (subscription CLI) — the epic #1134 target ---
+  { provider: 'codex', phase: 'planning', billingMode: 'subscription-cli', fit: 'works', acceptedForUnattended: true, rationale: 'Codex can plan via `codex exec` under subscription; Claude usually richer.' },
+  { provider: 'codex', phase: 'implementation', billingMode: 'subscription-cli', fit: 'best', acceptedForUnattended: true, rationale: 'Codex is strong at focused code generation via the CLI.' },
+  { provider: 'codex', phase: 'review', billingMode: 'subscription-cli', fit: 'works', acceptedForUnattended: true, rationale: 'Codex can review but lacks the structured kaizen review battery.' },
+  { provider: 'codex', phase: 'fix', billingMode: 'subscription-cli', fit: 'best', acceptedForUnattended: true, rationale: 'Tight edit/fix iterations suit Codex exec well.' },
+  { provider: 'codex', phase: 'reflection', billingMode: 'subscription-cli', fit: 'works', acceptedForUnattended: true, rationale: 'Codex can reflect but kaizen reflection is Claude-tuned.' },
+
+  // --- Provider-independent — git/GitHub facts need no agent at all ---
+  { provider: 'provider-independent', phase: 'validation', billingMode: 'local-only', fit: 'best', acceptedForUnattended: true, rationale: 'Plan/PR/test/review evidence is read from git+GitHub, not self-report.' },
+
+  // --- API-token paths: documented, optional, NOT accepted (subscription constraint) ---
+  { provider: 'claude', phase: 'review', billingMode: 'api-token', fit: 'avoid', acceptedForUnattended: false, rationale: 'API-token review works but violates the subscription-only constraint.' },
+  { provider: 'codex', phase: 'implementation', billingMode: 'api-token', fit: 'avoid', acceptedForUnattended: false, rationale: 'API-token implementation is an optional future path, not required.' },
+];
+
+/** A provider plan: which provider runs each phase (phases may be omitted). */
+export type ProviderPlan = Partial<Record<Phase, Provider>>;
+
+/** A single reason a provider plan was rejected. */
+export interface PlanViolation {
+  phase: Phase;
+  provider: Provider;
+  reason: string;
+}
+
+/** Result of validating a provider plan against the capability inventory. */
+export interface PlanValidation {
+  ok: boolean;
+  violations: PlanViolation[];
+}
+
+/**
+ * Is this (phase, provider) runnable under the subscription-only constraint?
+ * True iff the inventory has an accepted capability for it with a
+ * subscription-compatible billing mode.
+ */
+function hasSubscriptionCompatibleCapability(
+  phase: Phase,
+  provider: Provider,
+  inventory: readonly ProviderCapability[],
+): boolean {
+  return inventory.some(
+    (c) =>
+      c.phase === phase &&
+      c.provider === provider &&
+      c.acceptedForUnattended &&
+      SUBSCRIPTION_COMPATIBLE_BILLING.includes(c.billingMode),
+  );
+}
+
+/**
+ * #1142 — Reject provider plans that would require API-token billing.
+ *
+ * For every phase assigned in the plan, the chosen provider must have an
+ * accepted, subscription-compatible capability. If a provider can only perform
+ * a phase via `api-token` (or has no accepted capability for it at all), the
+ * plan is rejected with a clear, human-readable reason. Subscription plans pass.
+ */
+export function validateProviderPlan(
+  plan: ProviderPlan,
+  inventory: readonly ProviderCapability[] = CAPABILITY_INVENTORY,
+): PlanValidation {
+  const violations: PlanViolation[] = [];
+
+  for (const phase of PHASES) {
+    const provider = plan[phase];
+    if (!provider) continue; // phase not assigned — nothing to validate
+
+    if (hasSubscriptionCompatibleCapability(phase, provider, inventory)) continue;
+
+    // Distinguish "only api-token exists" from "no capability at all" for a clearer reason.
+    const apiTokenOnly = inventory.some(
+      (c) => c.phase === phase && c.provider === provider && c.billingMode === 'api-token',
+    );
+    const reason = apiTokenOnly
+      ? `phase "${phase}" with provider "${provider}" requires api-token billing, which is not subscription-compatible`
+      : `phase "${phase}" has no accepted subscription-compatible capability for provider "${provider}"`;
+
+    violations.push({ phase, provider, reason });
+  }
+
+  return { ok: violations.length === 0, violations };
+}
+
+/** Provider + billing recorded for a single phase of a run (#1143). */
+export interface PhaseProvider {
+  provider: Provider;
+  billing: BillingMode;
+}
+
+/** Per-phase provider/billing record stored on run metrics (#1143). */
+export type PhaseProviderRecord = Partial<Record<Phase, PhaseProvider>>;
+
+/**
+ * #1143 — The provider/billing reality of an auto-dent run today.
+ *
+ * Claude under subscription performs planning/implementation/review/fix/reflection;
+ * validation is provider-independent (git/GitHub facts). Recording this makes every
+ * run auditable for provider usage and billing mode without changing behavior.
+ */
+export function defaultPhaseProviders(): PhaseProviderRecord {
+  const claude: PhaseProvider = { provider: 'claude', billing: 'subscription-cli' };
+  return {
+    planning: claude,
+    implementation: claude,
+    review: claude,
+    fix: claude,
+    reflection: claude,
+    validation: { provider: 'provider-independent', billing: 'local-only' },
+  };
+}
+
+/**
+ * #1141 — Render the capability matrix as deterministic text. Every phase is
+ * named (one section per phase), so a snapshot/string test can assert coverage.
+ */
+export function renderCapabilityMatrix(
+  inventory: readonly ProviderCapability[] = CAPABILITY_INVENTORY,
+): string {
+  const lines: string[] = [];
+  lines.push('Auto-dent provider capability matrix');
+  lines.push('(fit | billing | accepted-for-unattended)');
+  lines.push('');
+
+  for (const phase of PHASES) {
+    lines.push(`## ${phase}`);
+    const rows = inventory.filter((c) => c.phase === phase);
+    if (rows.length === 0) {
+      lines.push('  (no capabilities recorded)');
+      lines.push('');
+      continue;
+    }
+    for (const c of rows) {
+      const accepted = c.acceptedForUnattended ? 'accepted' : 'NOT-accepted';
+      lines.push(`  - ${c.provider}: ${c.fit} | ${c.billingMode} | ${accepted} — ${c.rationale}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+// CLI entry point: `npx tsx scripts/auto-dent-provider.ts matrix [--json]`
+if (
+  process.argv[1]?.endsWith('auto-dent-provider.ts') ||
+  process.argv[1]?.endsWith('auto-dent-provider.js')
+) {
+  const cmd = process.argv[2] ?? 'matrix';
+  if (cmd === 'matrix') {
+    if (process.argv.includes('--json')) {
+      console.log(JSON.stringify(CAPABILITY_INVENTORY, null, 2));
+    } else {
+      console.log(renderCapabilityMatrix());
+    }
+  } else {
+    console.error(`Unknown command: ${cmd}\nUsage: npx tsx scripts/auto-dent-provider.ts matrix [--json]`);
+    process.exit(1);
+  }
+}

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -46,6 +46,7 @@ import {
   readBatchOutcomesFromGithub,
   computeSteeringRecommendations,
 } from './batch-outcome.js';
+import { defaultPhaseProviders, type PhaseProviderRecord } from './auto-dent-provider.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -229,6 +230,13 @@ export interface RunMetrics {
   review_verdict?: 'pass' | 'fail' | 'skipped';
   /** Review battery cost (USD) */
   review_cost_usd?: number;
+  /**
+   * Provider + billing mode used for each lifecycle phase (#1143, epic #1134).
+   * Absent on older runs (treated as unknown). Defaults to Claude-under-subscription
+   * for the agent phases and provider-independent for validation — see
+   * `defaultPhaseProviders()` in scripts/auto-dent-provider.ts.
+   */
+  phase_providers?: PhaseProviderRecord;
 }
 
 export interface RunResult {
@@ -2036,6 +2044,7 @@ async function main(): Promise<void> {
       lifecycle_critical: lifecycleCriticalCount,
       review_verdict: reviewVerdict,
       review_cost_usd: reviewCostUsd,
+      phase_providers: defaultPhaseProviders(),
       outcome,
       mode: runMode,
     });
@@ -2197,6 +2206,7 @@ async function main(): Promise<void> {
     lifecycle_health: lifecycleHealth,
     review_verdict: reviewVerdict,
     review_cost_usd: reviewCostUsd,
+    phase_providers: defaultPhaseProviders(),
   };
   // Classify failure: wall-clock timeout is authoritative (#686), then heuristics.
   // Feed the run log so the log-based branch (hook_rejection, infrastructure,

--- a/scripts/batch-summary.test.ts
+++ b/scripts/batch-summary.test.ts
@@ -382,3 +382,55 @@ describe('formatPlainLanguage', () => {
     expect(text).not.toContain('Single-mode batch');
   });
 });
+
+describe('provider-per-phase distribution (#1143)', () => {
+  const claudePhases = {
+    planning: { provider: 'claude', billing: 'subscription-cli' },
+    implementation: { provider: 'claude', billing: 'subscription-cli' },
+    validation: { provider: 'provider-independent', billing: 'local-only' },
+  };
+
+  it('formats a legacy run with no provider metadata without crashing', () => {
+    const summary = summarizeEvents([makeCompleteEvent({ run_num: 1 })]);
+    expect(summary.phase_provider_distribution).toEqual({});
+    const text = formatPlainLanguage(summary);
+    expect(text).not.toContain('Provider per Phase');
+    expect(text).toContain('Batch Summary');
+  });
+
+  it('aggregates a Claude-only run into the phase distribution', () => {
+    const summary = summarizeEvents([
+      makeCompleteEvent({ run_num: 1, phase_providers: claudePhases }),
+    ]);
+    expect(summary.phase_provider_distribution.planning).toEqual({ 'claude (subscription-cli)': 1 });
+    expect(summary.phase_provider_distribution.validation).toEqual({
+      'provider-independent (local-only)': 1,
+    });
+    const text = formatPlainLanguage(summary);
+    expect(text).toContain('### Provider per Phase');
+    expect(text).toContain('**planning:** claude (subscription-cli): 1');
+  });
+
+  it('aggregates a hybrid Claude/Codex/provider-independent batch', () => {
+    const summary = summarizeEvents([
+      makeCompleteEvent({ run_num: 1, phase_providers: {
+        implementation: { provider: 'claude', billing: 'subscription-cli' },
+        validation: { provider: 'provider-independent', billing: 'local-only' },
+      } }),
+      makeCompleteEvent({ run_num: 2, phase_providers: {
+        implementation: { provider: 'codex', billing: 'subscription-cli' },
+        validation: { provider: 'provider-independent', billing: 'local-only' },
+      } }),
+    ]);
+    expect(summary.phase_provider_distribution.implementation).toEqual({
+      'claude (subscription-cli)': 1,
+      'codex (subscription-cli)': 1,
+    });
+    expect(summary.phase_provider_distribution.validation).toEqual({
+      'provider-independent (local-only)': 2,
+    });
+    const text = formatPlainLanguage(summary);
+    expect(text).toContain('### Provider per Phase');
+    expect(text).toContain('**implementation:**');
+  });
+});

--- a/scripts/batch-summary.ts
+++ b/scripts/batch-summary.ts
@@ -47,6 +47,12 @@ export interface BatchSummary {
   mode_distribution: Record<string, number>;
   /** Outcome breakdown by cognitive mode — which modes produce PRs vs failures */
   mode_outcomes: Record<string, ModeOutcome>;
+  /**
+   * Provider + billing usage per lifecycle phase (#1143, epic #1134).
+   * phase → "provider (billing)" → count of runs. Empty when no run recorded
+   * provider metadata (legacy batches), so old history formats without crashing.
+   */
+  phase_provider_distribution: Record<string, Record<string, number>>;
 }
 
 export interface ModeOutcome {
@@ -153,6 +159,20 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
     else if (e.event.outcome === 'stop') mo.stop++;
   }
 
+  // Provider + billing usage per lifecycle phase (#1143). Runs without
+  // phase_providers (legacy events) contribute nothing — the map stays sparse.
+  const phaseProviderDistribution: Record<string, Record<string, number>> = {};
+  for (const e of completeEvents) {
+    const phaseProviders = e.event.phase_providers;
+    if (!phaseProviders) continue;
+    for (const [phase, pp] of Object.entries(phaseProviders)) {
+      if (!pp) continue;
+      const key = `${pp.provider} (${pp.billing})`;
+      const byProvider = (phaseProviderDistribution[phase] ??= {});
+      byProvider[key] = (byProvider[key] ?? 0) + 1;
+    }
+  }
+
   const runCount = completeEvents.length || 1;
   const totalDurationMinutes = Math.round(totalDurationMs / 60000 * 10) / 10;
 
@@ -181,8 +201,19 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
     area_distribution: areaDistribution,
     mode_distribution: modeDistribution,
     mode_outcomes: modeOutcomes,
+    phase_provider_distribution: phaseProviderDistribution,
   };
 }
+
+/** Lifecycle phase display order for the provider-per-phase summary block (#1143). */
+const PHASE_DISPLAY_ORDER = [
+  'planning',
+  'implementation',
+  'review',
+  'fix',
+  'reflection',
+  'validation',
+];
 
 /**
  * Format a BatchSummary as plain-language text suitable for posting
@@ -269,6 +300,25 @@ export function formatPlainLanguage(summary: BatchSummary): string {
     if (modeEntries.length === 1) {
       lines.push('');
       lines.push('*Single-mode batch — consider enabling mode diversity for strategic balance.*');
+    }
+  }
+
+  // Provider per phase (#1143, epic #1134) — auditable provider/billing usage.
+  // Backward compatible: legacy batches have an empty distribution and skip this block.
+  const providerPhases = Object.keys(summary.phase_provider_distribution ?? {});
+  if (providerPhases.length > 0) {
+    lines.push('');
+    lines.push('### Provider per Phase');
+    const ordered = [
+      ...PHASE_DISPLAY_ORDER.filter((p) => providerPhases.includes(p)),
+      ...providerPhases.filter((p) => !PHASE_DISPLAY_ORDER.includes(p)).sort(),
+    ];
+    for (const phase of ordered) {
+      const byProvider = summary.phase_provider_distribution[phase];
+      const parts = Object.entries(byProvider)
+        .sort((a, b) => b[1] - a[1])
+        .map(([key, count]) => `${key}: ${count}`);
+      lines.push(`- **${phase}:** ${parts.join(', ')}`);
     }
   }
 


### PR DESCRIPTION
## The problem

auto-dent's whole operating model is coupled to one agent surface (Claude) and to
Claude-specific behavior. Epic #1134 wants auto-dent to run **Codex** — and hybrid
runs — while preserving the kaizen lifecycle and a hard *subscription-only* billing
constraint. But before any orchestration can become provider-aware, the harness needs
something it doesn't have today: an explicit, testable model of **which provider can
do which phase, under which billing mode, and whether that's acceptable unattended.**

Without that model, three gaps stay open:
- Hidden Claude coupling is invisible — nobody can say what's actually possible per phase.
- Nothing stops a "Codex via API token" strategy that quietly breaks the subscription constraint.
- Batch summaries can't tell you who did the planning, implementation, review, or validation.

## The discovery

These are exactly the three Phase-1 "Foundation and guardrails" sub-issues of #1134 —
and they aren't independent. #1142 (reject API-token-only plans) and #1143 (record
provider per phase) both *consume the inventory* that #1141 defines. Splitting them
across PRs would mean shipping a guardrail with nothing to guard and a metric with
nothing to populate it. So they ship as one cohesive unit.

## The solution

A new module — `scripts/auto-dent-provider.ts` — that is the single source of truth for
provider awareness. It holds **no orchestration logic and changes no run behavior**; it's
purely the model the later epic phases (Codex exec provider, provider-aware review, the
external validator) will build on.

- **#1141 — capability inventory.** `CAPABILITY_INVENTORY` is a `provider × phase ×
  billing-mode` matrix; each cell records `fit` (best/works/avoid), `acceptedForUnattended`,
  and a one-line rationale. `renderCapabilityMatrix()` prints it (one section per phase);
  `npx tsx scripts/auto-dent-provider.ts matrix` exposes it on the CLI. API-token paths are
  documented but recorded **NOT-accepted** — encoding the subscription constraint as data.
- **#1142 — the guardrail.** `validateProviderPlan(plan)` rejects any plan whose phase can
  only run via `api-token` (or has no accepted subscription-compatible capability), each
  violation carrying a clear, human-readable reason. Subscription/hybrid plans pass.
- **#1143 — auditability.** `RunMetrics` and `RunCompleteEvent` gain `phase_providers`; every
  run now records `defaultPhaseProviders()` — Claude-under-subscription for the agent phases,
  provider-independent for validation — so today's reality is captured without changing it.
  `batch-summary` aggregates a `phase_provider_distribution` and renders a **"Provider per
  Phase"** block. Legacy runs without the field format without crashing.

## The evidence

`scripts/auto-dent-provider.test.ts` (new) + `scripts/batch-summary.test.ts` extensions —
**43 tests pass**; dependent suites (`auto-dent-run`, `auto-dent-events`, `batch-trends`)
**323 tests pass**; `npm run build` (tsc) clean.

### Behaviors × levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Inventory entries are well-formed (schema) | ✅ | – | – | – | – |
| Inventory covers Claude-best, Codex-best, provider-independent | ✅ | – | – | – | – |
| API-token paths are documented but NOT accepted | ✅ | – | – | – | – |
| `renderCapabilityMatrix` names every phase | ✅ | – | – | – | – |
| Matrix honors an explicit inventory override | ✅ | – | – | – | – |
| `validateProviderPlan` accepts subscription/hybrid/empty plans | ✅ | – | – | – | – |
| `validateProviderPlan` rejects api-token-only plan with reason | ✅ | – | – | – | – |
| `validateProviderPlan` rejects no-capability phase (distinct reason) | ✅ | – | – | – | – |
| `defaultPhaseProviders` reflects today + passes validation | ✅ | – | – | – | – |
| batch-summary aggregates Claude-only / hybrid distributions | ✅ | ✅ | – | – | – |
| batch-summary formats legacy (no provider metadata) without crashing | ✅ | ✅ | – | – | – |
| `matrix` CLI renders the full inventory | – | – | ✅ | – | – |

## Impact

Phase 1 of #1134 is complete: the harness now has an auditable, testable provider model,
a subscription-constraint guardrail, and provider-per-phase observability in every batch
summary — the foundation the Codex exec provider, provider-aware review battery, and
external validator (later epic phases) all build on. No existing run behavior changes.

Closes #1141
Closes #1142
Closes #1143
Parent: #1134

Run tag: powerful-capybara/run-4
