### PR TITLE
feat(auto-dent): semantic line budget for live terminal stream (Closes #1157)

### DIFF
--- a/scripts/auto-dent-stream.test.ts
+++ b/scripts/auto-dent-stream.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   postInFlightUpdate,
   buildInFlightComment,
+  relativizeWorktreePath,
+  prettifyPath,
+  stripCdPrefix,
+  formatToolUse,
   type StreamContext,
 } from './auto-dent-stream.js';
 import * as github from './auto-dent-github.js';
@@ -106,5 +110,93 @@ describe('buildInFlightComment', () => {
     const comment = buildInFlightComment(1, Date.now(), result, ctx);
 
     expect(comment).toContain('https://github.com/o/r/pull/1');
+  });
+});
+
+// #1157 — semantic line budget for the live terminal stream.
+const WT = '/home/aviad/projects/kaizen/.claude/worktrees/2606271151-c55d';
+
+describe('relativizeWorktreePath', () => {
+  it('collapses a worktree-absolute path to its repo-relative remainder', () => {
+    expect(relativizeWorktreePath(`${WT}/scripts/foo.ts`)).toBe('scripts/foo.ts');
+  });
+
+  it('collapses a bare worktree root to "."', () => {
+    expect(relativizeWorktreePath(WT)).toBe('.');
+  });
+
+  it('leaves non-worktree paths unchanged', () => {
+    expect(relativizeWorktreePath('/usr/local/bin/node')).toBe('/usr/local/bin/node');
+    expect(relativizeWorktreePath('src/cli.ts')).toBe('src/cli.ts');
+  });
+
+  it('relativizes a worktree path embedded inside a larger command string', () => {
+    expect(relativizeWorktreePath(`sed -n 1,5p ${WT}/docs/x.md`)).toBe('sed -n 1,5p docs/x.md');
+  });
+
+  it('is a no-op on empty input', () => {
+    expect(relativizeWorktreePath('')).toBe('');
+  });
+});
+
+describe('prettifyPath', () => {
+  it('collapses /home/<user>/ to ~/ for non-worktree absolute paths', () => {
+    expect(prettifyPath('/home/aviad/projects/kaizen/src/cli.ts')).toBe(
+      '~/projects/kaizen/src/cli.ts',
+    );
+  });
+
+  it('prefers worktree-relative over home-collapse for worktree paths', () => {
+    expect(prettifyPath(`${WT}/scripts/foo.ts`)).toBe('scripts/foo.ts');
+  });
+});
+
+describe('stripCdPrefix', () => {
+  it('removes a leading "cd <path>;" prefix', () => {
+    expect(stripCdPrefix(`cd ${WT}; sed -n 1,5p file.ts`)).toBe('sed -n 1,5p file.ts');
+  });
+
+  it('removes a leading "cd <path> &&" prefix', () => {
+    expect(stripCdPrefix(`cd ${WT} && npm test`)).toBe('npm test');
+  });
+
+  it('leaves commands without a cd prefix untouched', () => {
+    expect(stripCdPrefix('npm run build')).toBe('npm run build');
+    expect(stripCdPrefix('grep -n cd file.ts')).toBe('grep -n cd file.ts');
+  });
+});
+
+describe('formatToolUse (#1157 semantic budget)', () => {
+  it('Bash: renders the meaningful tail, not the worktree cd prefix', () => {
+    const out = formatToolUse('Bash', {
+      command: `cd ${WT}; sed -n 1,40p ${WT}/scripts/auto-dent-stream.ts`,
+    });
+    expect(out).toBe('$ sed -n 1,40p scripts/auto-dent-stream.ts');
+    expect(out).not.toContain('worktrees');
+    expect(out).not.toContain('cd ');
+  });
+
+  it('Read/Edit/Write: render worktree-absolute paths repo-relative', () => {
+    expect(formatToolUse('Read', { file_path: `${WT}/scripts/foo.ts` })).toBe(
+      'Read scripts/foo.ts',
+    );
+    expect(formatToolUse('Edit', { file_path: `${WT}/src/cli.ts` })).toBe('Edit src/cli.ts');
+    expect(formatToolUse('Write', { file_path: `${WT}/docs/x.md` })).toBe('Write docs/x.md');
+  });
+
+  it('Grep: relativizes the search path', () => {
+    expect(formatToolUse('Grep', { pattern: 'foo', path: `${WT}/scripts` })).toBe(
+      'Grep "foo" scripts',
+    );
+  });
+
+  it('preserves existing rendering for non-path tools', () => {
+    expect(formatToolUse('Skill', { skill_name: 'kaizen-reflect' })).toBe('Skill /kaizen-reflect');
+    expect(formatToolUse('Agent', { description: 'do a thing' })).toBe('Agent: do a thing');
+    expect(formatToolUse('ExitWorktree', {})).toBe('ExitWorktree');
+  });
+
+  it('Bash falls back to description when no command, with prefix handling', () => {
+    expect(formatToolUse('Bash', { description: 'run tests' })).toBe('$ run tests');
   });
 });

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -55,6 +55,45 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 1) + '\u2026' : s;
 }
 
+// Semantic line budget (#1157)
+//
+// In an auto-dent run worktree every command is prefixed with
+// `cd /home/.../.claude/worktrees/<id>; ...` and every path is absolute under
+// that worktree. That low-signal prefix consumes the truncation budget, pushing
+// the high-value tail (the real command / file) past the cutoff. These pure
+// helpers reclaim the budget for the meaningful part. Display-only: they never
+// touch the machine-readable logs.
+
+/** Matches a `.../.claude/worktrees/<id>` prefix; capture group 1 is the trailing slash, if any. */
+const WORKTREE_PREFIX_RE = /\S*?\/\.claude\/worktrees\/[^/\s;|&]+(\/?)/g;
+
+/**
+ * Render worktree-absolute paths repo-relative. A path *under* the worktree
+ * (trailing slash present) collapses to its remainder (`scripts/x.ts`); a bare
+ * worktree root collapses to `.`. Non-worktree paths are returned unchanged.
+ */
+export function relativizeWorktreePath(s: string): string {
+  if (!s) return s;
+  return s.replace(WORKTREE_PREFIX_RE, (_m, slash) => (slash ? '' : '.'));
+}
+
+/**
+ * Collapse noisy absolute prefixes for display: worktree paths become
+ * repo-relative, then a remaining `/home/<user>/` collapses to `~/`.
+ */
+export function prettifyPath(s: string): string {
+  if (!s) return s;
+  return relativizeWorktreePath(s).replace(/\/home\/[^/\s;|&]+\//g, '~/');
+}
+
+/**
+ * Drop a leading `cd <path>;` / `cd <path> &&` prefix from a command. The
+ * worktree is implied by the run, so the `cd` is pure boilerplate.
+ */
+export function stripCdPrefix(cmd: string): string {
+  return cmd.replace(/^\s*cd\s+\S+\s*(?:;|&&)\s*/, '');
+}
+
 // Tool use formatting
 
 export function formatToolUse(
@@ -63,15 +102,15 @@ export function formatToolUse(
 ): string {
   switch (name) {
     case 'Read':
-      return `Read ${truncate(input?.file_path || '?', 60)}`;
+      return `Read ${truncate(prettifyPath(input?.file_path || '?'), 60)}`;
     case 'Edit':
-      return `Edit ${truncate(input?.file_path || '?', 60)}`;
+      return `Edit ${truncate(prettifyPath(input?.file_path || '?'), 60)}`;
     case 'Write':
-      return `Write ${truncate(input?.file_path || '?', 60)}`;
+      return `Write ${truncate(prettifyPath(input?.file_path || '?'), 60)}`;
     case 'Bash':
-      return `$ ${truncate(input?.command || input?.description || '?', 70)}`;
+      return `$ ${truncate(prettifyPath(stripCdPrefix(input?.command || input?.description || '?')), 90)}`;
     case 'Grep':
-      return `Grep "${truncate(input?.pattern || '?', 30)}" ${input?.path || ''}`;
+      return `Grep "${truncate(input?.pattern || '?', 30)}" ${prettifyPath(input?.path || '')}`;
     case 'Glob':
       return `Glob ${truncate(input?.pattern || '?', 50)}`;
     case 'Skill':


### PR DESCRIPTION
## The problem

While watching auto-dent live during `powerful-capybara/run-4`, the terminal
stream was dominated by low-signal noise. Nearly every line began with a long
worktree path — `cd /home/aviad/projects/kaizen/.claude/worktrees/2606271151-c55d; …`
or `Edit /home/.../worktrees/2606271151-c5…` — and got truncated *before* the
actually useful part became visible:

```text
[0m44s]  $ cd /home/.../worktrees/2606271151-c55d; ls …
[1m00s]  $ cd /home/.../worktrees/2606271151-c55d; sed…
[4m05s]  Edit /home/.../worktrees/2606271151-c5…
[5m41s]  $ cd /home/.../worktrees/2606271151-c55d; gre…
```

The line budget was allocated *mechanically* (truncate at a fixed column)
instead of *semantically* (spend the budget on what the operator needs to see).
The result was a human-observability failure: you couldn't tell which file was
changing, what command was running, or whether the run was making progress —
even though the raw ingredients were all there.

## The discovery

The rendering lives in one place: `formatToolUse` in `auto-dent-stream.ts`. It
truncates `input.command` / `input.file_path` to a fixed width. The noise is
structural and predictable — an auto-dent run worktree means **every** command
carries a `cd <worktree>;` prefix and **every** path is absolute under
`.claude/worktrees/<id>/`. That regularity is exactly what makes it strippable.

## The change

Three pure, exported, unit-tested helpers reclaim the budget for the meaningful tail:

- **`stripCdPrefix`** — drops the implied `cd <wt>;` / `cd <wt> &&` boilerplate.
  The worktree is already implied by the run, so the `cd` carries zero signal.
- **`relativizeWorktreePath`** — renders worktree-absolute paths repo-relative
  (`scripts/x.ts`), a bare worktree root as `.`. Provider-neutral: it matches
  the canonical `.claude/worktrees/<id>` shape, not a specific user/home.
- **`prettifyPath`** — relativizes worktree paths, then collapses a remaining
  `/home/<user>/` to `~/` for non-worktree absolute paths.

These are wired into `formatToolUse` for Read/Edit/Write/Grep/Bash, and the Bash
command budget is widened 70→90 now that the prefix no longer eats it.

Before → after:

```text
$ cd /home/.../worktrees/2606271151-c55d; sed -n 1,40p /home/.../scripts/auto-…
$ sed -n 1,40p scripts/auto-dent-stream.ts
```

This is **display-only (L2)**: the machine-readable logs and phase markers are
untouched. Phase-marker rendering was already high-signal and is left as-is.

## The evidence

| Behavior | Level | Test |
|----------|-------|------|
| `stripCdPrefix` removes `cd <wt>;` and `cd <wt> &&`, leaves bare commands alone | Unit | ✅ |
| `relativizeWorktreePath` collapses worktree paths (with/without remainder); leaves non-worktree paths | Unit | ✅ |
| `prettifyPath` collapses `/home/<user>/` → `~/`; prefers worktree-relative | Unit | ✅ |
| `formatToolUse` Bash renders the tail, not the worktree prefix | Unit | ✅ |
| `formatToolUse` Read/Edit/Write/Grep render repo-relative paths | Unit | ✅ |
| Existing non-path tool rendering (Skill/Agent/ExitWorktree) preserved | Unit | ✅ |

`npx vitest run scripts/auto-dent-stream.test.ts` → 24 passed.
`npx vitest run scripts/auto-dent-{stream,run}.test.ts` → 309 passed.
`npx tsc --noEmit` → clean.

## The impact

The live operator view now answers the operator's questions — what file is
changing, what command is running, what phase the run is in — instead of
drowning them in repeated absolute paths. A small, contained step toward the
broader auto-dent observability goal (#556, #516 remain the larger dashboard work).

Closes #1157

Run-tag: powerful-capybara/run-6
