### PR TITLE
feat(auto-dent): add durable process verdict

### DIFF
--- a/scripts/auto-dent-events.test.ts
+++ b/scripts/auto-dent-events.test.ts
@@ -128,6 +128,9 @@ describe('EventEmitter', () => {
       stop_requested: false,
       failure_class: undefined,
       lifecycle_violations: 0,
+      process_verdict: 'process-incomplete',
+      process_issue_count: 2,
+      process_summary: 'process-incomplete: plan and test evidence missing',
       outcome: 'success',
     });
 
@@ -137,6 +140,8 @@ describe('EventEmitter', () => {
       outcome: 'success',
       cost_usd: 1.5,
       prs_created: 1,
+      process_verdict: 'process-incomplete',
+      process_issue_count: 2,
     });
   });
 

--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -17,6 +17,7 @@
 
 import { appendFileSync } from 'fs';
 import { resolve } from 'path';
+import type { ProcessVerdict } from './auto-dent-lifecycle.js';
 
 // Event type definitions
 
@@ -65,6 +66,12 @@ export interface RunCompleteEvent extends BaseEvent {
   lifecycle_health?: 'clean' | 'degraded' | 'critical';
   /** Count of critical lifecycle findings (gaps + phantom phases) (#1103) */
   lifecycle_critical?: number;
+  /** Durable process-evidence verdict (#1149) */
+  process_verdict?: ProcessVerdict;
+  /** Count of failed/warning process evidence checks (#1149) */
+  process_issue_count?: number;
+  /** Compact human-readable process evidence summary (#1149) */
+  process_summary?: string;
   outcome: 'success' | 'empty_success' | 'failure' | 'stop';
   /** Cognitive mode used, for context in analysis */
   mode?: string;

--- a/scripts/auto-dent-lifecycle.test.ts
+++ b/scripts/auto-dent-lifecycle.test.ts
@@ -6,12 +6,15 @@ import {
   validateRunLifecycle,
   summarizeLifecycle,
   verifyLifecycleEvidence,
+  validateProcessEvidence,
   foldEvidenceIntoHealth,
   summarizeEvidence,
+  summarizeProcessValidation,
   LIFECYCLE_ORDER,
   REQUIRED_PREDECESSORS,
   type LifecycleValidation,
   type LifecycleEvidence,
+  type ProcessEvidence,
 } from './auto-dent-lifecycle.js';
 
 /**
@@ -363,5 +366,120 @@ describe('summarizeEvidence', () => {
     expect(s).toMatch(/incomplete/i);
     expect(s).toContain('0 PRs');
     expect(s).toContain('no issues were filed');
+  });
+});
+
+describe('validateProcessEvidence — durable kaizen evidence verdict (#1149)', () => {
+  const validationWith = (phasesPresent: string[]): LifecycleValidation => ({
+    valid: true,
+    phasesPresent,
+    phasesMissing: [],
+    violations: [],
+    criticalGaps: [],
+    phantomPhases: [],
+    health: 'clean',
+  });
+
+  const fullEvidence = (over: Partial<ProcessEvidence> = {}): ProcessEvidence => ({
+    planEvidence: true,
+    implementationEvidence: true,
+    prEvidence: true,
+    testEvidence: true,
+    reviewEvidence: true,
+    reflectionEvidence: true,
+    mergeReadiness: 'ready',
+    ...over,
+  });
+
+  it('returns process-incomplete when a PR claim lacks implementation evidence', () => {
+    const result = validateProcessEvidence(
+      validationWith(['PICK', 'EVALUATE', 'PR']),
+      fullEvidence({ implementationEvidence: false, prEvidence: true }),
+    );
+    expect(result.verdict).toBe('process-incomplete');
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      id: 'implementation',
+      status: 'fail',
+    }));
+  });
+
+  it('returns process-incomplete when tests are claimed green without test evidence', () => {
+    const result = validateProcessEvidence(
+      validationWith(['IMPLEMENT', 'TEST', 'PR']),
+      fullEvidence({ testEvidence: false }),
+    );
+    expect(result.verdict).toBe('process-incomplete');
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      id: 'test',
+      status: 'fail',
+    }));
+  });
+
+  it('checks for missing durable plan evidence', () => {
+    const result = validateProcessEvidence(
+      validationWith(['PICK', 'EVALUATE', 'IMPLEMENT']),
+      fullEvidence({ planEvidence: false }),
+    );
+    expect(result.verdict).toBe('process-incomplete');
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      id: 'plan',
+      status: 'fail',
+    }));
+  });
+
+  it('checks for missing review evidence when a PR exists', () => {
+    const result = validateProcessEvidence(
+      validationWith(['IMPLEMENT', 'TEST', 'PR']),
+      fullEvidence({ reviewEvidence: false }),
+    );
+    expect(result.verdict).toBe('process-incomplete');
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      id: 'review',
+      status: 'fail',
+    }));
+  });
+
+  it('checks for missing reflection evidence when reflection is claimed', () => {
+    const result = validateProcessEvidence(
+      validationWith(['IMPLEMENT', 'TEST', 'PR', 'REFLECT']),
+      fullEvidence({ reflectionEvidence: false }),
+    );
+    expect(result.verdict).toBe('process-incomplete');
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      id: 'reflection',
+      status: 'fail',
+    }));
+  });
+
+  it('returns fail-open-warning when merge readiness is explicitly not ready', () => {
+    const result = validateProcessEvidence(
+      validationWith(['IMPLEMENT', 'TEST', 'PR', 'MERGE']),
+      fullEvidence({ mergeReadiness: 'not-ready' }),
+    );
+    expect(result.verdict).toBe('fail-open-warning');
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      id: 'merge-readiness',
+      status: 'warning',
+    }));
+  });
+
+  it('can pass with durable plan, implementation, PR, test, review, reflection, and merge-readiness evidence', () => {
+    const result = validateProcessEvidence(
+      validationWith(['PICK', 'EVALUATE', 'IMPLEMENT', 'TEST', 'PR', 'MERGE', 'REFLECT']),
+      fullEvidence(),
+    );
+    expect(result.verdict).toBe('pass');
+    expect(result.checks.filter((check) => check.status === 'fail')).toEqual([]);
+  });
+
+  it('summarizes failed checks as steering-ready text', () => {
+    const result = validateProcessEvidence(
+      validationWith(['IMPLEMENT', 'TEST', 'PR']),
+      fullEvidence({ planEvidence: false, testEvidence: false }),
+    );
+    const summary = summarizeProcessValidation(result);
+    expect(summary).toContain('process-incomplete');
+    expect(summary).toContain('plan');
+    expect(summary).toContain('test');
   });
 });

--- a/scripts/auto-dent-lifecycle.ts
+++ b/scripts/auto-dent-lifecycle.ts
@@ -165,6 +165,171 @@ export interface EvidenceVerification {
   processComplete: boolean;
 }
 
+export type ProcessVerdict = 'pass' | 'process-incomplete' | 'fail-open-warning';
+export type ProcessCheckStatus = 'pass' | 'fail' | 'warning' | 'not-applicable';
+export type MergeReadinessEvidence = 'ready' | 'not-ready' | 'unknown' | 'not-applicable';
+
+export interface ProcessEvidence {
+  /** Durable plan or claimed-plan assignment evidence exists. */
+  planEvidence?: boolean;
+  /** Durable implementation evidence exists (case/worktree or equivalent). */
+  implementationEvidence?: boolean;
+  /** Durable PR evidence exists. */
+  prEvidence?: boolean;
+  /** Durable test evidence exists. */
+  testEvidence?: boolean;
+  /** Review-battery verdict exists (pass/fail both count as evidence). */
+  reviewEvidence?: boolean;
+  /** Durable reflection output exists. */
+  reflectionEvidence?: boolean;
+  /** Merge readiness signal for PR-producing runs. */
+  mergeReadiness?: MergeReadinessEvidence;
+}
+
+export interface ProcessCheck {
+  id: 'plan' | 'implementation' | 'pr' | 'test' | 'review' | 'reflection' | 'merge-readiness';
+  status: ProcessCheckStatus;
+  reason: string;
+  remediation?: string;
+}
+
+export interface ProcessValidation {
+  verdict: ProcessVerdict;
+  checks: ProcessCheck[];
+  failedChecks: ProcessCheck[];
+  warningChecks: ProcessCheck[];
+}
+
+function addCheck(
+  checks: ProcessCheck[],
+  id: ProcessCheck['id'],
+  required: boolean,
+  present: boolean | undefined,
+  failReason: string,
+  passReason: string,
+  remediation?: string,
+): void {
+  if (!required) {
+    checks.push({ id, status: 'not-applicable', reason: 'not required for this run' });
+    return;
+  }
+  if (present === true) {
+    checks.push({ id, status: 'pass', reason: passReason });
+    return;
+  }
+  checks.push({ id, status: 'fail', reason: failReason, remediation });
+}
+
+/**
+ * Validate durable process evidence for a run. This is the richer #1149 layer:
+ * marker claims describe what the worker says happened; `ProcessEvidence`
+ * describes what the harness can corroborate through durable artifacts.
+ */
+export function validateProcessEvidence(
+  validation: LifecycleValidation,
+  evidence: ProcessEvidence,
+): ProcessValidation {
+  const present = new Set(validation.phasesPresent);
+  const checks: ProcessCheck[] = [];
+  const hasWorkClaim =
+    present.has('EVALUATE') ||
+    present.has('IMPLEMENT') ||
+    present.has('TEST') ||
+    present.has('PR') ||
+    present.has('MERGE') ||
+    present.has('REFLECT') ||
+    evidence.implementationEvidence === true ||
+    evidence.prEvidence === true;
+
+  const needsImplementation =
+    present.has('IMPLEMENT') || present.has('TEST') || present.has('PR') || present.has('MERGE') || evidence.prEvidence === true;
+  const needsPr = present.has('PR') || present.has('MERGE') || evidence.prEvidence === true;
+  const needsTest = present.has('TEST') || present.has('PR') || present.has('MERGE') || evidence.prEvidence === true;
+  const needsReview = present.has('PR') || present.has('MERGE') || evidence.prEvidence === true;
+  const needsReflection = present.has('REFLECT');
+  const needsMergeReadiness = present.has('PR') || present.has('MERGE') || evidence.prEvidence === true;
+
+  addCheck(
+    checks,
+    'plan',
+    hasWorkClaim,
+    evidence.planEvidence,
+    'work was claimed or produced without durable plan evidence',
+    'durable plan evidence exists',
+    'store or claim a concrete plan before implementation',
+  );
+  addCheck(
+    checks,
+    'implementation',
+    needsImplementation,
+    evidence.implementationEvidence,
+    'implementation/PR progress was claimed without durable implementation evidence',
+    'durable implementation evidence exists',
+    'create or record the case/worktree or other implementation artifact before claiming implementation',
+  );
+  addCheck(
+    checks,
+    'pr',
+    needsPr,
+    evidence.prEvidence,
+    'PR/MERGE was claimed but no durable PR evidence exists',
+    'durable PR evidence exists',
+    'create the PR or avoid claiming PR/MERGE',
+  );
+  addCheck(
+    checks,
+    'test',
+    needsTest,
+    evidence.testEvidence,
+    'tests were claimed or a PR was produced without durable test evidence',
+    'durable test evidence exists',
+    'run tests and record a non-empty test result before claiming TEST/PR success',
+  );
+  addCheck(
+    checks,
+    'review',
+    needsReview,
+    evidence.reviewEvidence,
+    'a PR exists or was claimed without review evidence',
+    'review evidence exists',
+    'run the review battery and store a pass/fail verdict',
+  );
+  addCheck(
+    checks,
+    'reflection',
+    needsReflection,
+    evidence.reflectionEvidence,
+    'REFLECT was claimed without durable reflection output',
+    'durable reflection evidence exists',
+    'file/close the follow-up issue or record the durable reflection artifact',
+  );
+
+  if (!needsMergeReadiness) {
+    checks.push({ id: 'merge-readiness', status: 'not-applicable', reason: 'no PR-producing phase required merge readiness' });
+  } else if (evidence.mergeReadiness === 'ready') {
+    checks.push({ id: 'merge-readiness', status: 'pass', reason: 'merge readiness evidence is ready' });
+  } else if (evidence.mergeReadiness === 'not-applicable') {
+    checks.push({ id: 'merge-readiness', status: 'not-applicable', reason: 'merge readiness not applicable' });
+  } else {
+    const state = evidence.mergeReadiness ?? 'unknown';
+    checks.push({
+      id: 'merge-readiness',
+      status: 'warning',
+      reason: `merge readiness is ${state}`,
+      remediation: 'treat as fail-open steering and re-check PR merge readiness next run',
+    });
+  }
+
+  const failedChecks = checks.filter((check) => check.status === 'fail');
+  const warningChecks = checks.filter((check) => check.status === 'warning');
+  const verdict: ProcessVerdict =
+    failedChecks.length > 0 ? 'process-incomplete'
+      : warningChecks.length > 0 ? 'fail-open-warning'
+        : 'pass';
+
+  return { verdict, checks, failedChecks, warningChecks };
+}
+
 /**
  * Cross-check a run's claimed lifecycle phases against the external outcomes the
  * harness extracted. Returns the unsupported claims (process gaps). Conservative
@@ -237,6 +402,13 @@ export function foldEvidenceIntoHealth(
 export function summarizeEvidence(v: EvidenceVerification): string {
   if (v.processComplete) return 'process complete (claims corroborated by outcomes)';
   return `process-incomplete: ${v.processGaps.map((g) => g.reason).join('; ')}`;
+}
+
+/** One-line summary of the #1149 durable process verdict, for logs and steering. */
+export function summarizeProcessValidation(v: ProcessValidation): string {
+  if (v.verdict === 'pass') return 'process verdict pass (durable evidence complete)';
+  const actionable = [...v.failedChecks, ...v.warningChecks];
+  return `${v.verdict}: ${actionable.map((check) => `${check.id}: ${check.reason}`).join('; ')}`;
 }
 
 /**

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -1489,10 +1489,14 @@ describe('RunMetrics type', () => {
       issues_closed: ['#451'],
       cases: ['260322-1200-k451-hook-fix'],
       stop_requested: false,
+      process_verdict: 'pass',
+      process_issue_count: 0,
+      process_summary: 'process verdict pass (durable evidence complete)',
     };
     expect(metrics.run).toBe(1);
     expect(metrics.cost_usd).toBe(2.5);
     expect(metrics.prs).toHaveLength(1);
+    expect(metrics.process_verdict).toBe('pass');
   });
 
   it('supports run_history in BatchState', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -109,8 +109,10 @@ export {
   validateRunLifecycle,
   summarizeLifecycle,
   verifyLifecycleEvidence,
+  validateProcessEvidence,
   foldEvidenceIntoHealth,
   summarizeEvidence,
+  summarizeProcessValidation,
   LIFECYCLE_ORDER,
   FLOATING_PHASES,
   REQUIRED_PREDECESSORS,
@@ -119,6 +121,7 @@ export {
   type LifecycleEvidence,
   type EvidenceVerification,
   type ProcessGap,
+  type ProcessVerdict,
 } from './auto-dent-lifecycle.js';
 
 // Import for internal use
@@ -145,10 +148,14 @@ import {
   validateRunLifecycle,
   summarizeLifecycle,
   verifyLifecycleEvidence,
+  validateProcessEvidence,
   foldEvidenceIntoHealth,
   summarizeEvidence,
+  summarizeProcessValidation,
   type LifecycleHealth,
   type LifecycleEvidence,
+  type ProcessEvidence,
+  type ProcessVerdict,
 } from './auto-dent-lifecycle.js';
 
 // Types
@@ -226,6 +233,12 @@ export interface RunMetrics {
   lifecycle_violations?: number;
   /** Lifecycle health: clean (ok) | degraded (ordering) | critical (gaps/phantoms) (#1103) */
   lifecycle_health?: LifecycleHealth;
+  /** Durable process-evidence verdict (#1149) */
+  process_verdict?: ProcessVerdict;
+  /** Count of failed/warning process evidence checks (#1149) */
+  process_issue_count?: number;
+  /** Compact process evidence summary (#1149) */
+  process_summary?: string;
   /** Review battery verdict for PRs created in this run */
   review_verdict?: 'pass' | 'fail' | 'skipped';
   /** Review battery cost (USD) */
@@ -1928,6 +1941,9 @@ async function main(): Promise<void> {
   let lifecycleHealth: LifecycleHealth = 'clean';
   let lifecycleCriticalCount = 0;
   let lifecycleSteeringNote: string | null = null;
+  let processVerdict: ProcessVerdict = 'fail-open-warning';
+  let processIssueCount = 0;
+  let processSummary = 'fail-open-warning: process validator did not run';
   try {
     const lifecycle = validateRunLifecycle(logFile);
 
@@ -1944,11 +1960,36 @@ async function main(): Promise<void> {
       reviewVerdict: result.reviewVerdict,
     };
     const evidenceCheck = verifyLifecycleEvidence(lifecycle, evidence);
+    const phaseSet = new Set(lifecycle.phasesPresent);
+    const hasDurableTestMarker = phaseSet.has('TEST') && lifecycle.phantomPhases.every((p) => p.phase !== 'TEST');
+    const mergeStatuses = result.prs.map((pr) => checkMergeStatus(pr));
+    const mergeReadiness: ProcessEvidence['mergeReadiness'] =
+      result.prs.length === 0 ? 'not-applicable'
+        : mergeStatuses.some((status) => status === 'unknown') ? 'unknown'
+          : mergeStatuses.some((status) => status === 'closed') ? 'not-ready'
+            : mergeStatuses.every((status) => status === 'merged' || status === 'auto_queued') ? 'ready'
+              : 'unknown';
+    const processEvidence: ProcessEvidence = {
+      planEvidence: Boolean(promptMeta.claimedPlanIssue),
+      implementationEvidence: result.cases.length > 0,
+      prEvidence: result.prs.length > 0,
+      testEvidence: hasDurableTestMarker,
+      reviewEvidence: result.reviewVerdict != null && result.reviewVerdict !== 'skipped',
+      reflectionEvidence: result.issuesFiled.length + result.issuesClosed.length > 0,
+      mergeReadiness,
+    };
+    const processValidation = validateProcessEvidence(lifecycle, processEvidence);
 
     lifecycleViolationCount = lifecycle.violations.length;
     lifecycleHealth = foldEvidenceIntoHealth(lifecycle.health, evidenceCheck);
     lifecycleCriticalCount = lifecycle.criticalGaps.length + lifecycle.phantomPhases.length;
     const summary = summarizeLifecycle(lifecycle);
+    processVerdict = processValidation.verdict;
+    processIssueCount = processValidation.failedChecks.length + processValidation.warningChecks.length;
+    processSummary = summarizeProcessValidation(processValidation);
+    if (processVerdict !== 'pass' && lifecycleHealth !== 'critical') {
+      lifecycleHealth = 'degraded';
+    }
 
     // Surface process-completeness for observability/telemetry regardless of health.
     appendFileSync(
@@ -1963,6 +2004,13 @@ async function main(): Promise<void> {
       lifecycleSteeringNote =
         `Prior run was PROCESS-INCOMPLETE (${evidenceSummary}). ` +
         `Don't emit a lifecycle phase you didn't actually complete — auto-dent verifies claims against real PRs, cases, filed issues, and the review verdict, not against your markers.`;
+    }
+    appendFileSync(logFile, `process_verdict=${processVerdict}: ${processSummary}\n`);
+    if (processVerdict !== 'pass') {
+      console.log(`  ${color.yellow('[process]')} ${processSummary}`);
+      lifecycleSteeringNote =
+        `Prior run had process verdict ${processVerdict} (${processSummary}). ` +
+        `Back claims with durable plan, implementation, PR, test, review, reflection, and merge-readiness evidence.`;
     }
 
     if (lifecycle.health === 'critical') {
@@ -1986,7 +2034,14 @@ async function main(): Promise<void> {
       );
     }
   } catch {
-    // Log file unreadable — skip lifecycle check
+    // Log file unreadable — classify fail-open so telemetry does not claim pass.
+    processVerdict = 'fail-open-warning';
+    processIssueCount = 1;
+    processSummary = 'fail-open-warning: process validator could not read the run log';
+    lifecycleHealth = lifecycleHealth === 'critical' ? 'critical' : 'degraded';
+    lifecycleSteeringNote =
+      `Prior run had process verdict fail-open-warning (${processSummary}). ` +
+      `Ensure the run log is durable so auto-dent can validate process evidence.`;
   }
 
   // Cost anomaly detection (#585)
@@ -2042,6 +2097,9 @@ async function main(): Promise<void> {
       lifecycle_violations: lifecycleViolationCount,
       lifecycle_health: lifecycleHealth,
       lifecycle_critical: lifecycleCriticalCount,
+      process_verdict: processVerdict,
+      process_issue_count: processIssueCount,
+      process_summary: processSummary,
       review_verdict: reviewVerdict,
       review_cost_usd: reviewCostUsd,
       phase_providers: defaultPhaseProviders(),
@@ -2204,6 +2262,9 @@ async function main(): Promise<void> {
     prompt_hash: promptMeta.hash,
     lifecycle_violations: lifecycleViolationCount,
     lifecycle_health: lifecycleHealth,
+    process_verdict: processVerdict,
+    process_issue_count: processIssueCount,
+    process_summary: processSummary,
     review_verdict: reviewVerdict,
     review_cost_usd: reviewCostUsd,
     phase_providers: defaultPhaseProviders(),

--- a/scripts/batch-summary.test.ts
+++ b/scripts/batch-summary.test.ts
@@ -383,6 +383,43 @@ describe('formatPlainLanguage', () => {
   });
 });
 
+describe('process verdict distribution (#1149)', () => {
+  it('keeps legacy events without process verdicts sparse', () => {
+    const summary = summarizeEvents([makeCompleteEvent({ run_num: 1 })]);
+    expect(summary.process_verdict_distribution).toEqual({});
+
+    const text = formatPlainLanguage(summary);
+    expect(text).not.toContain('Process Verdicts');
+  });
+
+  it('aggregates process verdicts from run.complete events', () => {
+    const summary = summarizeEvents([
+      makeCompleteEvent({ run_num: 1, process_verdict: 'pass' }),
+      makeCompleteEvent({ run_num: 2, process_verdict: 'process-incomplete' }),
+      makeCompleteEvent({ run_num: 3, process_verdict: 'process-incomplete' }),
+      makeCompleteEvent({ run_num: 4, process_verdict: 'fail-open-warning' }),
+    ]);
+
+    expect(summary.process_verdict_distribution).toEqual({
+      pass: 1,
+      'process-incomplete': 2,
+      'fail-open-warning': 1,
+    });
+  });
+
+  it('includes process verdict distribution in the plain-language summary', () => {
+    const summary = summarizeEvents([
+      makeCompleteEvent({ run_num: 1, process_verdict: 'pass' }),
+      makeCompleteEvent({ run_num: 2, process_verdict: 'process-incomplete' }),
+    ]);
+    const text = formatPlainLanguage(summary);
+
+    expect(text).toContain('### Process Verdicts');
+    expect(text).toContain('pass: 1 run');
+    expect(text).toContain('process-incomplete: 1 run');
+  });
+});
+
 describe('provider-per-phase distribution (#1143)', () => {
   const claudePhases = {
     planning: { provider: 'claude', billing: 'subscription-cli' },

--- a/scripts/batch-summary.ts
+++ b/scripts/batch-summary.ts
@@ -16,6 +16,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import type { EventEnvelope, RunCompleteEvent, RunIssuePickedEvent, RunPrCreatedEvent } from './auto-dent-events.js';
+import type { ProcessVerdict } from './auto-dent-lifecycle.js';
 
 export interface BatchSummary {
   batch_id: string;
@@ -53,6 +54,11 @@ export interface BatchSummary {
    * provider metadata (legacy batches), so old history formats without crashing.
    */
   phase_provider_distribution: Record<string, Record<string, number>>;
+  /**
+   * Durable process-evidence verdict distribution (#1149).
+   * Empty for legacy events that do not record process verdicts.
+   */
+  process_verdict_distribution: Partial<Record<ProcessVerdict, number>>;
 }
 
 export interface ModeOutcome {
@@ -173,6 +179,13 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
     }
   }
 
+  const processVerdictDistribution: Partial<Record<ProcessVerdict, number>> = {};
+  for (const e of completeEvents) {
+    const verdict = e.event.process_verdict;
+    if (!verdict) continue;
+    processVerdictDistribution[verdict] = (processVerdictDistribution[verdict] ?? 0) + 1;
+  }
+
   const runCount = completeEvents.length || 1;
   const totalDurationMinutes = Math.round(totalDurationMs / 60000 * 10) / 10;
 
@@ -202,6 +215,7 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
     mode_distribution: modeDistribution,
     mode_outcomes: modeOutcomes,
     phase_provider_distribution: phaseProviderDistribution,
+    process_verdict_distribution: processVerdictDistribution,
   };
 }
 
@@ -319,6 +333,15 @@ export function formatPlainLanguage(summary: BatchSummary): string {
         .sort((a, b) => b[1] - a[1])
         .map(([key, count]) => `${key}: ${count}`);
       lines.push(`- **${phase}:** ${parts.join(', ')}`);
+    }
+  }
+
+  const processEntries = Object.entries(summary.process_verdict_distribution ?? {});
+  if (processEntries.length > 0) {
+    lines.push('');
+    lines.push('### Process Verdicts');
+    for (const [verdict, count] of processEntries.sort((a, b) => b[1] - a[1])) {
+      lines.push(`- ${verdict}: ${count} run${count > 1 ? 's' : ''}`);
     }
   }
 


### PR DESCRIPTION
## Problem

Auto-dent already validates lifecycle phase markers and checks some external outcomes, but those signals stop short of a durable process verdict. A run can still look successful in batch metrics while missing evidence that the kaizen workflow actually happened: plan, implementation artifact, tests, review, reflection, or merge readiness.

## Discovery

Current `validateRunLifecycle()` classifies marker ordering, critical gaps, and phantom test claims. `verifyLifecycleEvidence()` adds a small PR/case/review/reflection corroboration layer, and `auto-dent-run.ts` folds that into lifecycle health. Batch telemetry records lifecycle health and provider usage, but not a process verdict that can be summarized across runs.

## Solution

This PR adds the #1149 external process validator MVP:

- Adds a pure `validateProcessEvidence()` API with verdicts: `pass`, `process-incomplete`, and `fail-open-warning`.
- Checks durable plan, implementation, PR, test, review, reflection, and merge-readiness evidence against lifecycle claims.
- Records `process_verdict`, `process_issue_count`, and `process_summary` in `RunMetrics` and `run.complete` events.
- Adds process verdict aggregation to batch summaries while keeping legacy event logs sparse and compatible.
- Emits steering text for non-pass verdicts and validator failures without hard-stopping unattended batches.

Closes #1149
Parent: #1134

## Verification

- `npx vitest run scripts/auto-dent-lifecycle.test.ts scripts/batch-summary.test.ts scripts/auto-dent-events.test.ts scripts/auto-dent-run.test.ts`
- `npx vitest run scripts/auto-dent-plan.test.ts scripts/auto-dent-lifecycle.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-provider.test.ts scripts/batch-summary.test.ts scripts/auto-dent-events.test.ts`
- `npm run typecheck`
