### PR TITLE
feat(doctor): add Codex readiness check

### DIFF
--- a/scripts/kaizen-doctor.test.ts
+++ b/scripts/kaizen-doctor.test.ts
@@ -9,6 +9,7 @@ import {
   checkRestartNeeded,
   checkHookExecSmoke,
   checkSingleRegistrationPath,
+  checkCodexReadiness,
   runAllChecks,
   exitCodeFor,
   buildSnapshot,
@@ -339,12 +340,187 @@ describe('checkSingleRegistrationPath (#1063)', () => {
   });
 });
 
+describe('checkCodexReadiness (#1151)', () => {
+  const supportedFeatures = [
+    'shell_tool stable true',
+    'unified_exec stable true',
+    'hooks stable true',
+    'apply_patch removed false',
+  ].join('\n');
+
+  const subscriptionDoctorJson = JSON.stringify({
+    codexVersion: '0.142.3',
+    overallStatus: 'ok',
+    checks: {
+      'auth.credentials': {
+        status: 'ok',
+        details: {
+          'stored API key': 'false',
+          'stored ChatGPT tokens': 'true',
+          'stored auth mode': 'chatgpt',
+        },
+      },
+      'config.load': {
+        status: 'ok',
+        details: {
+          'enabled feature flags': 'shell_tool, unified_exec, hooks',
+        },
+      },
+    },
+  });
+
+  const runner = (responses: Record<string, string | Error>) =>
+    (cmd: string, args: readonly string[]): string => {
+      const key = `${cmd} ${args.join(' ')}`;
+      const value = responses[key];
+      if (value instanceof Error) throw value;
+      if (value == null) throw new Error(`unexpected command: ${key}`);
+      return value;
+    };
+
+  it('WARNs with machine-readable unavailable state when the Codex CLI is missing', () => {
+    const r = checkCodexReadiness({
+      run: runner({ 'codex --version': new Error('ENOENT') }),
+    });
+
+    expect(r.status).toBe('WARN');
+    expect(r.name).toBe('codex-readiness');
+    expect(r.data).toMatchObject({
+      available: false,
+      accepted_path_available: false,
+      subscription_compatible: false,
+    });
+  });
+
+  it('reports codex-cli 0.142.3 as supported and subscription-compatible', () => {
+    const r = checkCodexReadiness({
+      run: runner({
+        'codex --version': 'codex-cli 0.142.3\n',
+        'codex doctor --json': subscriptionDoctorJson,
+        'codex features list': supportedFeatures,
+      }),
+    });
+
+    expect(r.status).toBe('PASS');
+    expect(r.data).toMatchObject({
+      available: true,
+      version: '0.142.3',
+      supported_version: true,
+      auth_mode: 'chatgpt',
+      subscription_compatible: true,
+      api_token_only: false,
+      accepted_path_available: true,
+    });
+  });
+
+  it('reports unsupported old versions as present but not accepted', () => {
+    const r = checkCodexReadiness({
+      run: runner({
+        'codex --version': 'codex-cli 0.90.0\n',
+        'codex doctor --json': subscriptionDoctorJson,
+        'codex features list': supportedFeatures,
+      }),
+    });
+
+    expect(r.status).toBe('WARN');
+    expect(r.data).toMatchObject({
+      available: true,
+      version: '0.90.0',
+      supported_version: false,
+      accepted_path_available: false,
+    });
+  });
+
+  it('keeps version/auth readiness when feature probing fails', () => {
+    const r = checkCodexReadiness({
+      run: runner({
+        'codex --version': 'codex-cli 0.142.3\n',
+        'codex doctor --json': subscriptionDoctorJson,
+        'codex features list': new Error('not supported'),
+      }),
+    });
+
+    expect(r.status).toBe('PASS');
+    expect(r.data).toMatchObject({
+      available: true,
+      supported_version: true,
+      feature_probe: 'unavailable',
+      accepted_path_available: true,
+    });
+  });
+
+  it('does not accept readiness when a required Codex feature is disabled', () => {
+    const r = checkCodexReadiness({
+      run: runner({
+        'codex --version': 'codex-cli 0.142.3\n',
+        'codex doctor --json': subscriptionDoctorJson,
+        'codex features list': [
+          'shell_tool stable true',
+          'unified_exec stable false',
+          'hooks stable true',
+        ].join('\n'),
+      }),
+    });
+
+    expect(r.status).toBe('WARN');
+    expect(r.data).toMatchObject({
+      required_features: { unified_exec: false },
+      accepted_path_available: false,
+    });
+  });
+
+  it('does not accept API-token-only auth as subscription-compatible readiness', () => {
+    const apiTokenDoctorJson = JSON.stringify({
+      codexVersion: '0.142.3',
+      checks: {
+        'auth.credentials': {
+          status: 'ok',
+          details: {
+            'stored API key': 'true',
+            'stored ChatGPT tokens': 'false',
+            'stored auth mode': 'api-key',
+          },
+        },
+      },
+    });
+    const r = checkCodexReadiness({
+      run: runner({
+        'codex --version': 'codex-cli 0.142.3\n',
+        'codex doctor --json': apiTokenDoctorJson,
+        'codex features list': supportedFeatures,
+      }),
+    });
+
+    expect(r.status).toBe('WARN');
+    expect(r.data).toMatchObject({
+      available: true,
+      api_token_only: true,
+      subscription_compatible: false,
+      accepted_path_available: false,
+    });
+  });
+
+  it('serializes readiness data for JSON doctor output', () => {
+    const r = checkCodexReadiness({
+      run: runner({
+        'codex --version': 'codex-cli 0.142.3\n',
+        'codex doctor --json': subscriptionDoctorJson,
+        'codex features list': supportedFeatures,
+      }),
+    });
+
+    expect(JSON.parse(JSON.stringify({ results: [r] })).results[0].data).toMatchObject({
+      accepted_path_available: true,
+    });
+  });
+});
+
 describe('runAllChecks + exitCodeFor', () => {
   let proj: string, home: string;
   beforeEach(() => { proj = makeProject(); home = makeHome(); });
   afterEach(() => { rmSync(proj, { recursive: true, force: true }); rmSync(home, { recursive: true, force: true }); });
 
-  it('returns 6 checks in defined order', () => {
+  it('returns checks in defined order', () => {
     const results = runAllChecks({ projectRoot: proj, homeDir: home });
     expect(results.map(r => r.name)).toEqual([
       'single-registration-path',
@@ -353,6 +529,7 @@ describe('runAllChecks + exitCodeFor', () => {
       'stale-plugin-cache',
       'restart-needed',
       'hook-exec-smoke',
+      'codex-readiness',
     ]);
   });
 

--- a/scripts/kaizen-doctor.ts
+++ b/scripts/kaizen-doctor.ts
@@ -26,6 +26,7 @@ import {
   constants as fsConstants,
   accessSync,
 } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { dirname } from 'node:path';
 import { join, resolve, isAbsolute } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -37,6 +38,7 @@ export interface CheckResult {
   name: string;
   status: CheckStatus;
   detail: string;
+  data?: unknown;
 }
 
 export interface DoctorOpts {
@@ -45,7 +47,32 @@ export interface DoctorOpts {
   pluginName?: string;
 }
 
+export type CommandRunner = (cmd: string, args: readonly string[]) => string;
+
+export interface CodexReadiness {
+  available: boolean;
+  version: string | null;
+  supported_version: boolean;
+  min_version: string;
+  auth_mode: string | null;
+  subscription_compatible: boolean;
+  api_token_only: boolean;
+  accepted_path_available: boolean;
+  feature_probe: 'available' | 'unavailable';
+  doctor_probe: 'available' | 'unavailable';
+  required_features: Record<string, boolean | null>;
+  unsupported_reasons: string[];
+  experimental_capabilities: string[];
+}
+
+export interface CodexReadinessOpts {
+  run?: CommandRunner;
+  minVersion?: string;
+}
+
 const DEFAULT_PLUGIN = 'kaizen@kaizen';
+const MIN_CODEX_VERSION = '0.142.3';
+const REQUIRED_CODEX_FEATURES = ['shell_tool', 'unified_exec', 'hooks'] as const;
 
 function safeReadJson(path: string): unknown | null {
   try {
@@ -421,6 +448,166 @@ export function checkHookExecSmoke(opts: DoctorOpts): CheckResult {
   };
 }
 
+function defaultRun(cmd: string, args: readonly string[]): string {
+  return execFileSync(cmd, [...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 10_000,
+  });
+}
+
+function parseVersion(output: string): string | null {
+  return output.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null;
+}
+
+function compareVersion(a: string, b: string): number {
+  const aa = a.split('.').map((x) => Number.parseInt(x, 10));
+  const bb = b.split('.').map((x) => Number.parseInt(x, 10));
+  for (let i = 0; i < Math.max(aa.length, bb.length); i++) {
+    const av = aa[i] ?? 0;
+    const bv = bb[i] ?? 0;
+    if (av !== bv) return av - bv;
+  }
+  return 0;
+}
+
+function asRecord(x: unknown): Record<string, unknown> {
+  return x && typeof x === 'object' ? x as Record<string, unknown> : {};
+}
+
+function detailValue(details: Record<string, unknown>, key: string): string | null {
+  const v = details[key];
+  return typeof v === 'string' ? v : null;
+}
+
+function parseFeatureList(output: string): Record<string, { stage: string; enabled: boolean }> {
+  const features: Record<string, { stage: string; enabled: boolean }> = {};
+  for (const raw of output.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || /^Name\s+/i.test(line) || /^-+\s+/.test(line)) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 3) continue;
+    const enabledRaw = parts[parts.length - 1];
+    if (enabledRaw !== 'true' && enabledRaw !== 'false') continue;
+    const name = parts[0];
+    const stage = parts.slice(1, -1).join(' ');
+    features[name] = { stage, enabled: enabledRaw === 'true' };
+  }
+  return features;
+}
+
+/**
+ * #1151 — Codex readiness for subscription-compatible auto-dent paths.
+ * Best-effort by design: absence or unsupported shape is WARN, not FAIL, so
+ * non-Codex users can still use kaizen-doctor without breaking setup.
+ */
+export function checkCodexReadiness(opts: CodexReadinessOpts = {}): CheckResult {
+  const run = opts.run ?? defaultRun;
+  const minVersion = opts.minVersion ?? MIN_CODEX_VERSION;
+  const base: CodexReadiness = {
+    available: false,
+    version: null,
+    supported_version: false,
+    min_version: minVersion,
+    auth_mode: null,
+    subscription_compatible: false,
+    api_token_only: false,
+    accepted_path_available: false,
+    feature_probe: 'unavailable',
+    doctor_probe: 'unavailable',
+    required_features: Object.fromEntries(REQUIRED_CODEX_FEATURES.map((f) => [f, null])),
+    unsupported_reasons: [],
+    experimental_capabilities: [],
+  };
+
+  let versionOutput = '';
+  try {
+    versionOutput = run('codex', ['--version']);
+  } catch {
+    return {
+      name: 'codex-readiness',
+      status: 'WARN',
+      detail: 'Codex CLI not found; Codex auto-dent path is unavailable.',
+      data: {
+        ...base,
+        unsupported_reasons: ['codex CLI missing'],
+      },
+    };
+  }
+
+  const version = parseVersion(versionOutput);
+  const readiness: CodexReadiness = {
+    ...base,
+    available: true,
+    version,
+    supported_version: version != null && compareVersion(version, minVersion) >= 0,
+  };
+
+  if (!readiness.supported_version) {
+    readiness.unsupported_reasons.push(
+      version ? `codex ${version} is older than supported minimum ${minVersion}` : 'could not parse codex version',
+    );
+  }
+
+  try {
+    const doctor = asRecord(JSON.parse(run('codex', ['doctor', '--json'])));
+    readiness.doctor_probe = 'available';
+    const checks = asRecord(doctor.checks);
+    const auth = asRecord(checks['auth.credentials']);
+    const authDetails = asRecord(auth.details);
+    const authMode = detailValue(authDetails, 'stored auth mode');
+    const storedApiKey = detailValue(authDetails, 'stored API key') === 'true';
+    const storedChatgpt = detailValue(authDetails, 'stored ChatGPT tokens') === 'true';
+    readiness.auth_mode = authMode;
+    readiness.api_token_only = storedApiKey && !storedChatgpt;
+    readiness.subscription_compatible = storedChatgpt && !readiness.api_token_only;
+    if (!readiness.subscription_compatible) {
+      readiness.unsupported_reasons.push(
+        readiness.api_token_only
+          ? 'Codex auth is API-token-only; accepted auto-dent path requires subscription CLI auth'
+          : 'Codex subscription auth was not detected',
+      );
+    }
+  } catch {
+    readiness.unsupported_reasons.push('codex doctor --json unavailable; auth mode could not be verified');
+  }
+
+  try {
+    const features = parseFeatureList(run('codex', ['features', 'list']));
+    readiness.feature_probe = 'available';
+    for (const f of REQUIRED_CODEX_FEATURES) {
+      readiness.required_features[f] = features[f]?.enabled ?? null;
+      if (features[f]?.enabled !== true) {
+        const stage = features[f]?.stage ?? 'unknown';
+        readiness.experimental_capabilities.push(`${f}: ${stage}`);
+        readiness.unsupported_reasons.push(`required Codex feature ${f} is not enabled (${stage})`);
+      }
+    }
+  } catch {
+    // Feature probing is useful color, but Codex 0.142.3 has `codex doctor --json`
+    // as the stronger readiness source; don't reject a run solely for this.
+    readiness.feature_probe = 'unavailable';
+  }
+
+  readiness.accepted_path_available =
+    readiness.available &&
+    readiness.supported_version &&
+    readiness.subscription_compatible &&
+    readiness.unsupported_reasons.length === 0;
+
+  const status: CheckStatus = readiness.accepted_path_available ? 'PASS' : 'WARN';
+  const detail = readiness.accepted_path_available
+    ? `Codex ${readiness.version} ready for subscription-compatible auto-dent path (auth=${readiness.auth_mode ?? 'unknown'}).`
+    : `Codex present but not ready for accepted auto-dent path: ${readiness.unsupported_reasons.join('; ') || 'unknown reason'}.`;
+
+  return {
+    name: 'codex-readiness',
+    status,
+    detail,
+    data: readiness,
+  };
+}
+
 export function runAllChecks(opts: DoctorOpts): CheckResult[] {
   return [
     checkSingleRegistrationPath(opts),
@@ -429,6 +616,7 @@ export function runAllChecks(opts: DoctorOpts): CheckResult[] {
     checkStalePluginCache(opts),
     checkRestartNeeded(opts),
     checkHookExecSmoke(opts),
+    checkCodexReadiness(),
   ];
 }
 


### PR DESCRIPTION
## Problem

Auto-dent can now reason about providers and process evidence, but operators still need a preflight answer before launching a Codex-backed batch: is Codex installed, authenticated through the subscription-compatible path, and exposing the local features the accepted path depends on?

## Discovery

The existing `scripts/kaizen-doctor.ts` already provides machine-readable setup diagnostics and human-readable checks for kaizen/plugin health. Local Codex 0.142.3 exposes `codex --version`, `codex doctor --json`, and `codex features list`, which are enough for a best-effort readiness signal without requiring API-token calls.

## Solution

Adds the #1151 Codex readiness check to kaizen-doctor:

- Adds `checkCodexReadiness()` with an injectable command runner for deterministic tests.
- Reports CLI availability, parsed version, supported-version status, auth mode, subscription compatibility, API-token-only rejection, feature-probe status, and accepted-path availability.
- Uses `codex doctor --json` for auth/config readiness and `codex features list` for required local feature checks.
- Treats missing/unsupported Codex as `WARN`, not `FAIL`, so non-Codex users can still run kaizen-doctor.
- Includes the structured readiness payload in `--json` output through the existing doctor results list.

Closes #1151
Parent: #1134

## Verification

- `npx vitest run scripts/kaizen-doctor.test.ts scripts/auto-dent-provider.test.ts`
- `npm run typecheck`
