### PR TITLE
feat(auto-dent): observability accuracy — reconcile issues-closed from merged PRs + one-line stream rendering (Closes #1173, #1170)

### DIFF
--- a/scripts/auto-dent-github.test.ts
+++ b/scripts/auto-dent-github.test.ts
@@ -16,6 +16,7 @@ import {
   extractAllLinkedIssues,
   syncEpicChecklists,
   verifyIssuesClosed,
+  reconcileBatchClosedIssues,
 } from './auto-dent-github.js';
 import { makeRunResult } from './auto-dent-test-helpers.js';
 
@@ -846,5 +847,114 @@ describe('verifyIssuesClosed', () => {
       'owner/repo',
     );
     expect(results).toEqual([]);
+  });
+});
+
+describe('reconcileBatchClosedIssues (#1173)', () => {
+  beforeEach(() => {
+    mockSpawnSync.mockReset();
+  });
+
+  it('counts verified auto-closures, not just force-closures', () => {
+    // The undercount bug: a merged PR whose Closes #N GitHub already auto-closed
+    // must be counted. Previously only force-closed issues were recorded back.
+    mockSpawnSync.mockImplementation(((_bin: string, args: string[]) => {
+      const cmdStr = args.join(' ');
+      if (cmdStr.includes('pr view')) {
+        return ok(JSON.stringify({ state: 'MERGED', body: 'Closes #5\nFixes #6' }));
+      }
+      if (cmdStr.includes('issue view')) {
+        return ok(JSON.stringify({ state: 'CLOSED' }));
+      }
+      return ok('');
+    }) as any);
+
+    const closed = reconcileBatchClosedIssues(
+      ['https://github.com/owner/repo/pull/1'],
+      'owner/repo',
+    );
+    expect(closed).toEqual(['#5', '#6']);
+  });
+
+  it('unions verified and force-closed sets', () => {
+    mockSpawnSync.mockImplementation(((_bin: string, args: string[]) => {
+      const cmdStr = args.join(' ');
+      if (cmdStr.includes('pr view')) {
+        return ok(JSON.stringify({ state: 'MERGED', body: 'Closes #5\nFixes #6' }));
+      }
+      if (cmdStr.includes('issue view 5')) {
+        return ok(JSON.stringify({ state: 'CLOSED' }));
+      }
+      if (cmdStr.includes('issue view 6')) {
+        return ok(JSON.stringify({ state: 'OPEN' }));
+      }
+      if (cmdStr.includes('issue close')) return ok('ok');
+      return ok('');
+    }) as any);
+
+    const closed = reconcileBatchClosedIssues(
+      ['https://github.com/owner/repo/pull/1'],
+      'owner/repo',
+    );
+    expect(closed).toEqual(['#5', '#6']);
+  });
+
+  it('dedupes issues closed by more than one batch PR (no double count)', () => {
+    // verifyIssuesClosed re-runs over ALL batch PRs each run; if two PRs both
+    // reference #7 the reconciled set must contain it once, not twice.
+    mockSpawnSync.mockImplementation(((_bin: string, args: string[]) => {
+      const cmdStr = args.join(' ');
+      if (cmdStr.includes('pr view')) {
+        return ok(JSON.stringify({ state: 'MERGED', body: 'Closes #7' }));
+      }
+      if (cmdStr.includes('issue view')) {
+        return ok(JSON.stringify({ state: 'CLOSED' }));
+      }
+      return ok('');
+    }) as any);
+
+    const closed = reconcileBatchClosedIssues(
+      [
+        'https://github.com/owner/repo/pull/1',
+        'https://github.com/owner/repo/pull/2',
+      ],
+      'owner/repo',
+    );
+    expect(closed).toEqual(['#7']);
+  });
+
+  it('excludes issues from PRs that are not merged', () => {
+    mockSpawnSync.mockImplementation(((_bin: string, args: string[]) => {
+      const cmdStr = args.join(' ');
+      if (cmdStr.includes('pr view')) {
+        return ok(JSON.stringify({ state: 'OPEN', body: 'Closes #9' }));
+      }
+      return ok('');
+    }) as any);
+
+    const closed = reconcileBatchClosedIssues(
+      ['https://github.com/owner/repo/pull/1'],
+      'owner/repo',
+    );
+    expect(closed).toEqual([]);
+  });
+
+  it('returns refs sorted by issue number', () => {
+    mockSpawnSync.mockImplementation(((_bin: string, args: string[]) => {
+      const cmdStr = args.join(' ');
+      if (cmdStr.includes('pr view')) {
+        return ok(JSON.stringify({ state: 'MERGED', body: 'Closes #30\nFixes #4\nResolves #12' }));
+      }
+      if (cmdStr.includes('issue view')) {
+        return ok(JSON.stringify({ state: 'CLOSED' }));
+      }
+      return ok('');
+    }) as any);
+
+    const closed = reconcileBatchClosedIssues(
+      ['https://github.com/owner/repo/pull/1'],
+      'owner/repo',
+    );
+    expect(closed).toEqual(['#4', '#12', '#30']);
   });
 });

--- a/scripts/auto-dent-github.ts
+++ b/scripts/auto-dent-github.ts
@@ -605,3 +605,33 @@ export function verifyIssuesClosed(
 
   return results;
 }
+
+/**
+ * Authoritative batch-level set of issues actually closed by a batch's merged PRs.
+ *
+ * The per-run `issues_closed` metric is scraped from the agent's live text stream
+ * and undercounts: it misses closures the agent didn't narrate verbatim, and it
+ * never sees the `verified` set that GitHub auto-closed from a merged PR's
+ * `Closes #N` (only force-closures were ever recorded back). Summing those
+ * per-run scrapes is also wrong in the other direction, since this verification
+ * re-runs over ALL batch PRs every run and would double-count.
+ *
+ * This derives the truth once at finalize from the merged PR bodies: the deduped
+ * union of `verified ∪ forceClosed` across every merged PR in the batch. Same
+ * "measure outcomes from the authoritative source, not scraped narration" rule
+ * as #1153 / #943. Returns sorted `#N` refs. (#1173)
+ */
+export function reconcileBatchClosedIssues(
+  prUrls: string[],
+  repo: string,
+): string[] {
+  const results = verifyIssuesClosed(prUrls, repo);
+  const closed = new Set<string>();
+  for (const r of results) {
+    for (const ref of r.verified) closed.add(ref);
+    for (const ref of r.forceClosed) closed.add(ref);
+  }
+  return [...closed].sort(
+    (a, b) => Number(a.replace('#', '')) - Number(b.replace('#', '')),
+  );
+}

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -61,6 +61,7 @@ export {
   fetchIssueLabels,
   syncEpicChecklists,
   verifyIssuesClosed,
+  reconcileBatchClosedIssues,
   type MergeStatus,
   type DriveStatus,
   type DriveReason,
@@ -133,6 +134,7 @@ import {
   queueAutoMerge,
   fetchIssueLabels,
   verifyIssuesClosed,
+  reconcileBatchClosedIssues,
   syncEpicChecklists,
 } from './auto-dent-github.js';
 import {
@@ -1284,6 +1286,22 @@ export function closeBatchProgressIssue(
 
   const batchScore = scoreBatch(state.run_history || []);
 
+  // Authoritative "issues closed" count (#1173): the per-run sum in batchScore is
+  // scraped from agent narration and undercounts (it never saw GitHub's verified
+  // auto-closures). Reconcile once here from the merged PR bodies — the deduped
+  // union of verified ∪ force-closed — so the summary, score table, and
+  // batch-outcome attachment all report the true count instead of the scrape.
+  // Best-effort: a gh failure must never block batch close.
+  let reconciledClosed: string[] = [];
+  if (state.prs.length > 0) {
+    try {
+      reconciledClosed = reconcileBatchClosedIssues(state.prs, kaizenRepo);
+      batchScore.reconciled_issues_closed = reconciledClosed.length;
+    } catch (err) {
+      console.log(`  [intelligence] issues-closed reconcile skipped: ${(err as Error).message}`);
+    }
+  }
+
   // Post-hoc: check final merge status for all PRs
   if (state.prs.length > 0) {
     const postHoc = runPostHocScoring(state.prs, batchScore.total_cost_usd);
@@ -1300,7 +1318,7 @@ export function closeBatchProgressIssue(
     '',
     `**PRs:** ${state.prs.length > 0 ? state.prs.join(', ') : 'none'}`,
     `**Issues filed:** ${state.issues_filed.length > 0 ? state.issues_filed.join(', ') : 'none'}`,
-    `**Issues closed:** ${state.issues_closed.length > 0 ? state.issues_closed.join(' ') : 'none'}`,
+    `**Issues closed:** ${reconciledClosed.length > 0 ? reconciledClosed.join(' ') : state.issues_closed.length > 0 ? state.issues_closed.join(' ') : 'none'}`,
   ].join('\n');
 
   ghExec(

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -25,7 +25,7 @@ import { createHash } from 'crypto';
 import { readFileSync, writeFileSync, appendFileSync, existsSync, renameSync, copyFileSync } from 'fs';
 import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
-import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
+import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, formatIssuesClosedLine, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
 import { firstHookReason } from './hook-signals.js';
 import { claimNextItem, markItem, resetAssignedItems, readPlan, themeProgress } from './auto-dent-plan.js';
 import { writeAttachment, addSection } from '../src/section-editor.js';
@@ -1292,7 +1292,9 @@ export function closeBatchProgressIssue(
   // union of verified ∪ force-closed — so the summary, score table, and
   // batch-outcome attachment all report the true count instead of the scrape.
   // Best-effort: a gh failure must never block batch close.
-  let reconciledClosed: string[] = [];
+  // null until reconcile runs; an empty array means "reconcile ran, nothing
+  // closed" (authoritative) — distinct from null ("reconcile did not run").
+  let reconciledClosed: string[] | null = null;
   if (state.prs.length > 0) {
     try {
       reconciledClosed = reconcileBatchClosedIssues(state.prs, kaizenRepo);
@@ -1318,7 +1320,7 @@ export function closeBatchProgressIssue(
     '',
     `**PRs:** ${state.prs.length > 0 ? state.prs.join(', ') : 'none'}`,
     `**Issues filed:** ${state.issues_filed.length > 0 ? state.issues_filed.join(', ') : 'none'}`,
-    `**Issues closed:** ${reconciledClosed.length > 0 ? reconciledClosed.join(' ') : state.issues_closed.length > 0 ? state.issues_closed.join(' ') : 'none'}`,
+    `**Issues closed:** ${formatIssuesClosedLine(reconciledClosed, state.issues_closed)}`,
   ].join('\n');
 
   ghExec(

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -8,6 +8,7 @@ import {
   computeBatchTrend,
   formatRunScoreLine,
   formatBatchScoreTable,
+  effectiveIssuesClosed,
   formatModeBreakdown,
   postHocScoreBatch,
   formatPostHocLine,
@@ -1345,5 +1346,49 @@ describe('formatFailureDistribution', () => {
 
   it('returns empty string for empty array', () => {
     expect(formatFailureDistribution([])).toBe('');
+  });
+});
+
+describe('effectiveIssuesClosed / reconciled count (#1173)', () => {
+  // Minimal score; only the two issue-closed fields matter for these assertions.
+  const baseScore = (): BatchScore => ({
+    total_runs: 2,
+    successful_runs: 2,
+    success_rate: 1,
+    total_cost_usd: 4,
+    total_prs: 2,
+    total_issues_closed: 2, // per-run scraped sum (undercount)
+    total_duration_seconds: 100,
+    total_lines_deleted: 0,
+    total_issues_pruned: 0,
+    avg_cost_per_success: 2,
+    avg_duration_seconds: 50,
+    overall_efficiency: 0.5,
+    runs: [],
+    mode_breakdown: [],
+    cost_anomaly_count: 0,
+    mode_diversity: 0,
+    trend: null,
+  });
+
+  it('prefers the reconciled count when present', () => {
+    const score = { ...baseScore(), reconciled_issues_closed: 6 };
+    expect(effectiveIssuesClosed(score)).toBe(6);
+  });
+
+  it('falls back to the per-run sum when reconciled is absent', () => {
+    expect(effectiveIssuesClosed(baseScore())).toBe(2);
+  });
+
+  it('treats a reconciled value of 0 as authoritative (not falling back)', () => {
+    const score = { ...baseScore(), reconciled_issues_closed: 0 };
+    expect(effectiveIssuesClosed(score)).toBe(0);
+  });
+
+  it('formatBatchScoreTable shows the reconciled count, not the scraped sum', () => {
+    const score = { ...baseScore(), reconciled_issues_closed: 6 };
+    const table = formatBatchScoreTable(score);
+    expect(table).toContain('| **Issues closed** | 6 |');
+    expect(table).not.toContain('| **Issues closed** | 2 |');
   });
 });

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -9,6 +9,7 @@ import {
   formatRunScoreLine,
   formatBatchScoreTable,
   effectiveIssuesClosed,
+  formatIssuesClosedLine,
   formatModeBreakdown,
   postHocScoreBatch,
   formatPostHocLine,
@@ -1390,5 +1391,25 @@ describe('effectiveIssuesClosed / reconciled count (#1173)', () => {
     const table = formatBatchScoreTable(score);
     expect(table).toContain('| **Issues closed** | 6 |');
     expect(table).not.toContain('| **Issues closed** | 2 |');
+  });
+});
+
+describe('formatIssuesClosedLine (#1173 display wiring)', () => {
+  it('uses reconciled refs when reconcile ran', () => {
+    expect(formatIssuesClosedLine(['#5', '#6'], ['#5'])).toBe('#5 #6');
+  });
+
+  it('shows "none" when reconcile ran and returned empty — does NOT fall back to scraped', () => {
+    // The divergence bug: an empty authoritative result must override the
+    // scraped set, not be overridden by it.
+    expect(formatIssuesClosedLine([], ['#12', '#34'])).toBe('none');
+  });
+
+  it('falls back to scraped refs only when reconcile did not run (null)', () => {
+    expect(formatIssuesClosedLine(null, ['#12', '#34'])).toBe('#12 #34');
+  });
+
+  it('shows "none" when reconcile did not run and there are no scraped refs', () => {
+    expect(formatIssuesClosedLine(null, [])).toBe('none');
   });
 });

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -172,8 +172,15 @@ export interface BatchScore {
   total_cost_usd: number;
   /** Total PRs created */
   total_prs: number;
-  /** Total issues closed */
+  /** Total issues closed (per-run sum of stream-scraped closures — best-effort) */
   total_issues_closed: number;
+  /**
+   * Authoritative count of issues actually closed by the batch's merged PRs,
+   * deduped across the whole batch (reconciled from PR bodies at finalize, #1173).
+   * Preferred over `total_issues_closed` for display/observability when present;
+   * absent until finalize so per-run scoring stays backward-compatible.
+   */
+  reconciled_issues_closed?: number;
   /** Total duration in seconds */
   total_duration_seconds: number;
   /** Total net lines deleted across all runs */
@@ -486,6 +493,14 @@ export function formatRunScoreLine(score: RunScore): string {
   return parts.join(' | ');
 }
 
+/**
+ * The count to report for "issues closed": the authoritative reconciled count
+ * when finalize has computed it (#1173), else the per-run scraped sum.
+ */
+export function effectiveIssuesClosed(score: BatchScore): number {
+  return score.reconciled_issues_closed ?? score.total_issues_closed;
+}
+
 /** Format a BatchScore as a multi-line summary table. */
 export function formatBatchScoreTable(score: BatchScore): string {
   // Compute mode distribution from per-run scores
@@ -504,7 +519,7 @@ export function formatBatchScoreTable(score: BatchScore): string {
     `| **Success rate** | ${(score.success_rate * 100).toFixed(0)}% |`,
     `| **Total cost** | $${score.total_cost_usd.toFixed(2)} |`,
     `| **Total PRs** | ${score.total_prs} |`,
-    `| **Issues closed** | ${score.total_issues_closed} |`,
+    `| **Issues closed** | ${effectiveIssuesClosed(score)} |`,
     `| **Lines deleted** | ${score.total_lines_deleted} |`,
     `| **Issues pruned** | ${score.total_issues_pruned} |`,
     `| **Avg cost/success** | ${isNaN(score.avg_cost_per_success) ? 'N/A' : '$' + score.avg_cost_per_success.toFixed(2)} |`,

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -501,6 +501,22 @@ export function effectiveIssuesClosed(score: BatchScore): number {
   return score.reconciled_issues_closed ?? score.total_issues_closed;
 }
 
+/**
+ * The "Issues closed:" display line for the batch summary. When reconciliation
+ * ran (#1173), its result is authoritative even when empty — an empty
+ * authoritative set means "no issues were actually closed", which must NOT fall
+ * back to the scraped refs (that would reintroduce the scrape-vs-truth divergence
+ * this fix removes). Only fall back to the scraped set when reconcile did not run
+ * (`reconciledRefs === null`, e.g. no PRs or a gh failure).
+ */
+export function formatIssuesClosedLine(
+  reconciledRefs: string[] | null,
+  scrapedRefs: string[],
+): string {
+  const refs = reconciledRefs ?? scrapedRefs;
+  return refs.length > 0 ? refs.join(' ') : 'none';
+}
+
 /** Format a BatchScore as a multi-line summary table. */
 export function formatBatchScoreTable(score: BatchScore): string {
   // Compute mode distribution from per-run scores

--- a/scripts/auto-dent-stream.test.ts
+++ b/scripts/auto-dent-stream.test.ts
@@ -6,6 +6,7 @@ import {
   prettifyPath,
   stripCdPrefix,
   formatToolUse,
+  collapseWhitespace,
   type StreamContext,
 } from './auto-dent-stream.js';
 import * as github from './auto-dent-github.js';
@@ -198,5 +199,37 @@ describe('formatToolUse (#1157 semantic budget)', () => {
 
   it('Bash falls back to description when no command, with prefix handling', () => {
     expect(formatToolUse('Bash', { description: 'run tests' })).toBe('$ run tests');
+  });
+
+  // #1170 — one tool event must render as exactly one stream line. A heredoc /
+  // multiline script body previously spilled onto following lines with no
+  // timestamp/tool prefix, so it looked like separate auto-dent events.
+  it('Bash: collapses a multiline heredoc command to a single line', () => {
+    const cmd = `cat > /tmp/analyze.sh << 'EOF'\n#!/bin/bash\n\n# get files\nall=$(find src -name '*.ts')\nEOF`;
+    const out = formatToolUse('Bash', { command: cmd });
+    expect(out).not.toContain('\n');
+    expect(out.startsWith('$ ')).toBe(true);
+  });
+
+  it('formatToolUse output never contains a newline for any free-text field', () => {
+    const multiline = 'line one\nline two\n\tindented';
+    for (const [name, input] of [
+      ['Bash', { command: multiline }],
+      ['Grep', { pattern: multiline }],
+      ['Agent', { description: multiline }],
+      ['TaskCreate', { subject: multiline }],
+    ] as const) {
+      expect(formatToolUse(name, input)).not.toContain('\n');
+    }
+  });
+});
+
+describe('collapseWhitespace (#1170)', () => {
+  it('collapses newlines, tabs, and runs of spaces to a single space and trims', () => {
+    expect(collapseWhitespace('  a\n\nb\t c   d  ')).toBe('a b c d');
+  });
+
+  it('leaves a single-line string unchanged', () => {
+    expect(collapseWhitespace('sed -n 1,40p scripts/x.ts')).toBe('sed -n 1,40p scripts/x.ts');
   });
 });

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -52,7 +52,23 @@ function formatElapsed(startMs: number): string {
 }
 
 function truncate(s: string, max: number): string {
-  return s.length > max ? s.slice(0, max - 1) + '\u2026' : s;
+  // Collapse first so the one-event-one-line stream contract holds for ANY
+  // free-text field (#1170), not just Bash commands, and so the length budget
+  // is spent on visible content rather than on whitespace we'd drop anyway.
+  const oneLine = collapseWhitespace(s);
+  return oneLine.length > max ? oneLine.slice(0, max - 1) + '\u2026' : oneLine;
+}
+
+/**
+ * Collapse internal whitespace \u2014 newlines, tabs, runs of spaces \u2014 to a single
+ * space and trim (#1170). The live terminal stream's contract is one tool event
+ * per readable line; a multiline command (heredoc, script body) otherwise spills
+ * its body onto following lines with no timestamp/tool prefix, so the body looks
+ * like separate auto-dent events. Display-only: the machine-readable logs keep
+ * the original command verbatim.
+ */
+export function collapseWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
 }
 
 // Semantic line budget (#1157)
@@ -108,7 +124,7 @@ export function formatToolUse(
     case 'Write':
       return `Write ${truncate(prettifyPath(input?.file_path || '?'), 60)}`;
     case 'Bash':
-      return `$ ${truncate(prettifyPath(stripCdPrefix(input?.command || input?.description || '?')), 90)}`;
+      return `$ ${truncate(prettifyPath(stripCdPrefix(collapseWhitespace(input?.command || input?.description || '?'))), 90)}`;
     case 'Grep':
       return `Grep "${truncate(input?.pattern || '?', 30)}" ${prettifyPath(input?.path || '')}`;
     case 'Glob':

--- a/scripts/batch-outcome.test.ts
+++ b/scripts/batch-outcome.test.ts
@@ -102,6 +102,21 @@ describe('buildBatchOutcome — pure derivation', () => {
     expect(outcome.prs).toEqual(['https://github.com/Garsson-io/kaizen/pull/1108']);
   });
 
+  it('sources issues_closed from the reconciled count when present (#1173)', () => {
+    // The scraped per-run sum (total_issues_closed) undercounts; the durable
+    // record must carry the authoritative reconciled count, not the scrape.
+    const score = makeScore({ total_issues_closed: 2, reconciled_issues_closed: 6 });
+    const outcome = buildBatchOutcome(makeState(), score, 1_600);
+    expect(outcome.totals.issues_closed).toBe(6);
+  });
+
+  it('falls back to the per-run sum when no reconciled count (backward compat)', () => {
+    const score = makeScore({ total_issues_closed: 2 });
+    expect(score.reconciled_issues_closed).toBeUndefined();
+    const outcome = buildBatchOutcome(makeState(), score, 1_600);
+    expect(outcome.totals.issues_closed).toBe(2);
+  });
+
   it('defaults stop_reason to "completed" when blank', () => {
     expect(buildBatchOutcome(makeState({ stop_reason: '' }), makeScore(), 1_600).stop_reason).toBe('completed');
   });

--- a/scripts/batch-outcome.ts
+++ b/scripts/batch-outcome.ts
@@ -18,7 +18,7 @@ import { z } from 'zod';
 import { writeAttachment, readAttachment } from '../src/section-editor.js';
 import { gh } from '../src/lib/gh-exec.js';
 import type { BatchState } from './auto-dent-run.js';
-import type { BatchScore } from './auto-dent-score.js';
+import { type BatchScore, effectiveIssuesClosed } from './auto-dent-score.js';
 
 /** Named-attachment key on the progress issue. Stable contract with Phase 2 readers. */
 export const BATCH_OUTCOME_ATTACHMENT = 'batch-outcome';
@@ -121,7 +121,7 @@ export function buildBatchOutcome(
       runs: score.total_runs,
       successful_runs: score.successful_runs,
       prs: score.total_prs,
-      issues_closed: score.total_issues_closed,
+      issues_closed: effectiveIssuesClosed(score),
       issues_filed: state.issues_filed.length,
       cost_usd: finite(score.total_cost_usd),
       duration_seconds: finite(score.total_duration_seconds),


### PR DESCRIPTION
## Problem

Auto-dent's cross-batch intelligence (#940/#842) is only as good as the numbers it records. Two of those numbers were wrong in the same way.

A batch-loop reflection (powerful-capybara) reported the batch summary showing **"issues closed: 2"** while the batch's merged PRs actually carried **6 `Closes #N` linkages** — a 3× undercount steering future batches on bad data. Separately, after PR #1162 the live stream was still hard to read: a heredoc or multiline script body spilled its lines into the stream with no timestamp/tool prefix, so **one tool event looked like several auto-dent events** (#1170).

## Discovery

Both bugs have the *same root cause*: **auto-dent measures and renders from scraped agent narration / raw command text instead of authoritative or normalized sources.**

- **Issues-closed (#1173):** `total_issues_closed` is a per-run *sum* of `result.issuesClosed`, which `extractArtifacts` scrapes from the agent's live text with a `closes? #N` regex. It misses closures the agent didn't narrate verbatim. Meanwhile `verifyIssuesClosed()` *already* computes the authoritative set from each merged PR body (`verified` = GitHub auto-closed, `forceClosed` = we closed it) — but at finalize **only `forceClosed` was recorded back**; `verified` was dropped. And because verification re-runs over *all* batch PRs every run, a naive "just add verified" fix would double-count.
- **Stream (#1170):** `formatToolUse` truncated a multiline Bash command to 90 chars but left embedded newlines intact, breaking the one-event-one-line contract.

## Solution

Derive each metric once, from the authoritative/normalized source.

- **`reconcileBatchClosedIssues(prUrls, repo)`** (`auto-dent-github.ts`): the deduped union of `verified ∪ forceClosed` across all merged batch PRs — computed once at finalize, so it fixes the undercount (counts verified) *and* avoids the double-count (deduped union, not a per-run sum).
- **`closeBatchProgressIssue`** sets `BatchScore.reconciled_issues_closed`; the score table, the "Issues closed:" summary line, and the `batch-outcome` attachment all prefer it via the new **`effectiveIssuesClosed()`** helper (falls back to the scraped sum when reconciliation hasn't run — backward compatible).
- **`collapseWhitespace()`** (`auto-dent-stream.ts`): `truncate` now collapses newlines/tabs/space-runs to a single space *before* cutting, enforcing one-event-one-line for **every** free-text field. Display-only — machine logs keep the verbatim command.

## Evidence

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Reconcile counts verified auto-closures (not just force-closed) | ✅ | | | | |
| Reconcile unions verified+forceClosed, dedupes across PRs, excludes unmerged, sorts | ✅ | | | | |
| `effectiveIssuesClosed` prefers reconciled (incl. value 0), falls back to sum | ✅ | | | | |
| Score table shows reconciled count, not scraped sum | ✅ | | | | |
| `formatToolUse` collapses heredoc/multiline to one line (the #1170 repro) | ✅ | | | | |
| One-line invariant holds for Bash/Grep/Agent/Task free-text | ✅ | | | | |
| `batch-outcome` attachment sources reconciled count | | ✅ | | | |

- New/affected suites green: `auto-dent-github.test.ts`, `auto-dent-score.test.ts`, `auto-dent-stream.test.ts` (233), plus `batch-outcome.test.ts` + `auto-dent-run.test.ts` (314) for no regressions. `npm run build` clean.
- Live repro confirmed: the exact `cat > … << 'EOF'` command from #1170 now renders `$ cat > /tmp/analyze_imports.sh << 'EOF' #!/bin/bash …` on a single line (no newline).

## Impact

Cross-batch observability now reports what the batch *actually did* (true `Closes #` linkage), not what the agent happened to narrate — the same "measure outcomes, not markers" discipline as #1153/#943. The live operator view regains its one-event-one-line contract. Both are small, surgical, well-tested fixes in the auto-dent stream/metrics layer.

Closes #1173
Closes #1170
Refs #940, #842, #1153, #943

Run tag: powerful-capybara/run-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
