### PR TITLE
feat(auto-dent): add synthetic Codex provider

### DIFF
--- a/scripts/auto-dent-codex.test.ts
+++ b/scripts/auto-dent-codex.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCodexExecArgs,
+  parseCodexJsonl,
+  extractCodexPhaseMarkers,
+} from './auto-dent-codex.js';
+
+describe('buildCodexExecArgs (#1144)', () => {
+  it('constructs codex exec argv for externally sandboxed synthetic runs', () => {
+    const args = buildCodexExecArgs('/repo/worktree');
+
+    expect(args).toEqual([
+      'exec',
+      '--json',
+      '--cd',
+      '/repo/worktree',
+      '--sandbox',
+      'danger-full-access',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--color',
+      'never',
+      '-',
+    ]);
+  });
+});
+
+describe('parseCodexJsonl (#1144)', () => {
+  it('extracts final text and text chunks from Codex JSONL', () => {
+    const parsed = parseCodexJsonl([
+      JSON.stringify({ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'AUTO_DENT_PHASE: PICK | issue=#1' }] }),
+      JSON.stringify({ type: 'final_message', message: 'AUTO_DENT_PHASE: TEST | result=pass | count=1' }),
+    ].join('\n'));
+
+    expect(parsed.events).toHaveLength(2);
+    expect(parsed.text).toContain('AUTO_DENT_PHASE: PICK');
+    expect(parsed.finalText).toContain('AUTO_DENT_PHASE: TEST');
+    expect(parsed.malformedLines).toEqual([]);
+  });
+
+  it('keeps malformed lines without throwing', () => {
+    const parsed = parseCodexJsonl([
+      '{"type":"message","content":"ok"}',
+      '{not json',
+    ].join('\n'));
+
+    expect(parsed.events).toHaveLength(1);
+    expect(parsed.malformedLines).toEqual(['{not json']);
+  });
+
+  it('recovers AUTO_DENT_PHASE markers from parsed Codex text', () => {
+    const parsed = parseCodexJsonl(JSON.stringify({
+      type: 'final_message',
+      message: [
+        'done',
+        'AUTO_DENT_PHASE: IMPLEMENT | case=synthetic',
+        'AUTO_DENT_PHASE: PR | url=https://example.test/pull/1',
+      ].join('\n'),
+    }));
+
+    expect(extractCodexPhaseMarkers(parsed)).toEqual([
+      'AUTO_DENT_PHASE: IMPLEMENT | case=synthetic',
+      'AUTO_DENT_PHASE: PR | url=https://example.test/pull/1',
+    ]);
+  });
+});

--- a/scripts/auto-dent-codex.ts
+++ b/scripts/auto-dent-codex.ts
@@ -1,0 +1,90 @@
+/**
+ * auto-dent-codex — synthetic Codex provider helpers (#1144).
+ *
+ * This module deliberately contains no batch orchestration. It builds the
+ * subscription-CLI Codex argv and parses Codex JSONL into text/marker evidence
+ * that the existing auto-dent lifecycle validator can consume.
+ */
+
+export interface ParsedCodexJsonl {
+  events: unknown[];
+  text: string;
+  finalText: string;
+  malformedLines: string[];
+}
+
+export function buildCodexExecArgs(repoRoot: string): string[] {
+  return [
+    'exec',
+    '--json',
+    '--cd',
+    repoRoot,
+    '--sandbox',
+    'danger-full-access',
+    '--dangerously-bypass-approvals-and-sandbox',
+    '--color',
+    'never',
+    '-',
+  ];
+}
+
+function collectText(value: unknown, out: string[]): void {
+  if (typeof value === 'string') {
+    out.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectText(item, out);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  const obj = value as Record<string, unknown>;
+  for (const key of ['text', 'message', 'content', 'output', 'final_message']) {
+    if (key in obj) collectText(obj[key], out);
+  }
+}
+
+function isFinalEvent(event: unknown): boolean {
+  if (!event || typeof event !== 'object') return false;
+  const type = String((event as Record<string, unknown>).type ?? '').toLowerCase();
+  return type.includes('final') || type === 'result';
+}
+
+export function parseCodexJsonl(jsonl: string): ParsedCodexJsonl {
+  const events: unknown[] = [];
+  const textChunks: string[] = [];
+  const finalChunks: string[] = [];
+  const malformedLines: string[] = [];
+
+  for (const raw of jsonl.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line) as unknown;
+      events.push(event);
+      const chunks: string[] = [];
+      collectText(event, chunks);
+      textChunks.push(...chunks);
+      if (isFinalEvent(event)) finalChunks.push(...chunks);
+    } catch {
+      malformedLines.push(raw);
+    }
+  }
+
+  return {
+    events,
+    text: textChunks.join('\n'),
+    finalText: finalChunks.join('\n'),
+    malformedLines,
+  };
+}
+
+export function extractCodexPhaseMarkers(parsed: ParsedCodexJsonl): string[] {
+  return [parsed.text, parsed.finalText]
+    .join('\n')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line, index, lines) =>
+      line.startsWith('AUTO_DENT_PHASE:') && lines.indexOf(line) === index,
+    );
+}

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -1544,6 +1544,17 @@ describe('RunMetrics type', () => {
   });
 });
 
+describe('BatchState provider field (#1144)', () => {
+  it('supports synthetic Codex provider state while preserving optional default', () => {
+    const codexState = makeBatchState({ test_task: true, provider: 'codex' });
+    const legacyState = makeBatchState({});
+
+    expect(codexState.provider).toBe('codex');
+    expect(codexState.test_task).toBe(true);
+    expect(legacyState.provider).toBeUndefined();
+  });
+});
+
 describe('truncateAtWord', () => {
   it('returns short text unchanged', () => {
     expect(truncateAtWord('hello world', 50)).toBe('hello world');

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -20,7 +20,7 @@
  *   - auto-dent-stream.ts  — Stream processing (phase markers, artifacts, display)
  */
 
-import { spawn, execSync } from 'child_process';
+import { spawn, execFileSync, execSync } from 'child_process';
 import { createHash } from 'crypto';
 import { readFileSync, writeFileSync, appendFileSync, existsSync, renameSync, copyFileSync } from 'fs';
 import { createInterface } from 'readline';
@@ -137,6 +137,7 @@ import {
 } from './auto-dent-github.js';
 import {
   color,
+  extractArtifacts,
   processStreamMessage,
   parsePhaseMarkers,
   postInFlightUpdate,
@@ -144,6 +145,11 @@ import {
   IN_FLIGHT_UPDATE_INTERVAL_MS,
   type StreamContext,
 } from './auto-dent-stream.js';
+import {
+  buildCodexExecArgs,
+  extractCodexPhaseMarkers,
+  parseCodexJsonl,
+} from './auto-dent-codex.js';
 import {
   validateRunLifecycle,
   summarizeLifecycle,
@@ -188,6 +194,8 @@ export interface BatchState {
   progress_issue?: string;
   test_task?: boolean;
   experiment?: boolean;
+  /** Agent provider. Defaults to claude for older state files. Codex is synthetic-only (#1144). */
+  provider?: 'claude' | 'codex';
   last_heartbeat?: number;
   max_run_seconds?: number;
   run_history?: RunMetrics[];
@@ -1345,6 +1353,113 @@ const POST_RESULT_GRACE_MS = 60_000;
 // Grace period after SIGTERM before SIGKILL
 const SIGKILL_GRACE_MS = 10_000;
 
+interface ProviderRunResult {
+  exitCode: number;
+  duration: number;
+  result: RunResult;
+  mode: string;
+  modeReason: string;
+  promptMeta: PromptMetadata;
+}
+
+async function runCodexSynthetic(
+  input: {
+    state: BatchState;
+    runNum: number;
+    logFile: string;
+    repoRoot: string;
+    stateFile: string;
+    prompt: string;
+    promptMeta: PromptMetadata;
+    mode: string;
+    modeReason: string;
+    result: RunResult;
+  },
+): Promise<ProviderRunResult> {
+  const logDir = dirname(input.stateFile);
+  const rawFile = `${logDir}/run-${input.runNum}-codex.jsonl`;
+  const runStart = Date.now();
+  const maxRunMs = (input.state.max_run_seconds || DEFAULT_MAX_RUN_SECONDS) * 1000;
+
+  let version = 'unknown';
+  try {
+    version = execFileSync('codex', ['--version'], { encoding: 'utf8' }).trim();
+  } catch {
+    // Missing version detail should not hide the primary spawn error below.
+  }
+
+  appendFileSync(input.logFile, `[provider] codex synthetic test-task\n`);
+  appendFileSync(input.logFile, `[provider] version=${version}\n`);
+  appendFileSync(input.logFile, `[provider] raw_jsonl=${rawFile}\n`);
+  writeFileSync(rawFile, '');
+
+  return new Promise((resolvePromise) => {
+    let processExited = false;
+    let raw = '';
+    const child = spawn('codex', buildCodexExecArgs(input.repoRoot), {
+      cwd: input.repoRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    child.stdin?.end(input.prompt);
+
+    const wallTimer = setTimeout(() => {
+      if (!processExited) {
+        input.result.timedOut = true;
+        appendFileSync(input.logFile, `\n[watchdog] codex wall-time timeout (${maxRunMs / 1000}s) — sending SIGTERM\n`);
+        child.kill('SIGTERM');
+        setTimeout(() => {
+          if (!processExited) child.kill('SIGKILL');
+        }, SIGKILL_GRACE_MS);
+      }
+    }, maxRunMs);
+
+    child.stdout?.on('data', (data: Buffer) => {
+      const s = data.toString();
+      raw += s;
+      appendFileSync(rawFile, s);
+    });
+
+    child.stderr?.on('data', (data: Buffer) => {
+      appendFileSync(input.logFile, data.toString());
+    });
+
+    const finish = (exitCode: number) => {
+      if (processExited) return;
+      processExited = true;
+      clearTimeout(wallTimer);
+      const parsed = parseCodexJsonl(raw);
+      input.result.toolCalls = parsed.events.length;
+      extractArtifacts([parsed.text, parsed.finalText].join('\n'), input.result);
+
+      appendFileSync(input.logFile, `\n--- codex final text ---\n${parsed.finalText || parsed.text}\n`);
+      const markers = extractCodexPhaseMarkers(parsed);
+      if (markers.length > 0) {
+        appendFileSync(input.logFile, `\n--- codex lifecycle markers ---\n${markers.join('\n')}\n`);
+      }
+      if (parsed.malformedLines.length > 0) {
+        appendFileSync(input.logFile, `\n[codex] malformed_jsonl_lines=${parsed.malformedLines.length}\n`);
+      }
+
+      const duration = Math.floor((Date.now() - runStart) / 1000);
+      resolvePromise({
+        exitCode,
+        duration,
+        result: input.result,
+        mode: input.mode,
+        modeReason: input.modeReason,
+        promptMeta: input.promptMeta,
+      });
+    };
+
+    child.on('close', (code) => finish(code ?? 1));
+    child.on('error', (err) => {
+      appendFileSync(input.logFile, `\nCodex process error: ${err.message}\n`);
+      finish(1);
+    });
+  });
+}
+
 async function runClaude(
   state: BatchState,
   runNum: number,
@@ -1385,6 +1500,32 @@ async function runClaude(
   // Save rendered prompt for observability (#602)
   const promptFile = `${logDir}/run-${runNum}-prompt.md`;
   writeFileSync(promptFile, prompt + '\n');
+
+  if (state.provider === 'codex') {
+    if (!state.test_task) {
+      appendFileSync(logFile, '[provider] codex requested for non-synthetic run; refusing\n');
+      return {
+        exitCode: 1,
+        duration: 0,
+        result,
+        mode: modeSelection.mode,
+        modeReason: modeSelection.reason,
+        promptMeta,
+      };
+    }
+    return runCodexSynthetic({
+      state,
+      runNum,
+      logFile,
+      repoRoot,
+      stateFile,
+      prompt,
+      promptMeta,
+      mode: modeSelection.mode,
+      modeReason: modeSelection.reason,
+      result,
+    });
+  }
 
   const nonce = `${new Date()
     .toISOString()
@@ -1618,6 +1759,19 @@ function printRunSummary(
     `  \u2514${'─'.repeat(54)}`,
   );
   console.log('');
+}
+
+function phaseProvidersForState(state: BatchState): PhaseProviderRecord {
+  if (state.provider !== 'codex') return defaultPhaseProviders();
+  const codex = { provider: 'codex' as const, billing: 'subscription-cli' as const };
+  return {
+    planning: codex,
+    implementation: codex,
+    review: { provider: 'claude', billing: 'subscription-cli' },
+    fix: codex,
+    reflection: codex,
+    validation: { provider: 'provider-independent', billing: 'local-only' },
+  };
 }
 
 // Lifecycle validation — implementation lives in ./auto-dent-lifecycle.ts.
@@ -2102,7 +2256,7 @@ async function main(): Promise<void> {
       process_summary: processSummary,
       review_verdict: reviewVerdict,
       review_cost_usd: reviewCostUsd,
-      phase_providers: defaultPhaseProviders(),
+      phase_providers: phaseProvidersForState(state),
       outcome,
       mode: runMode,
     });
@@ -2267,7 +2421,7 @@ async function main(): Promise<void> {
     process_summary: processSummary,
     review_verdict: reviewVerdict,
     review_cost_usd: reviewCostUsd,
-    phase_providers: defaultPhaseProviders(),
+    phase_providers: phaseProvidersForState(state),
   };
   // Classify failure: wall-clock timeout is authoritative (#686), then heuristics.
   // Feed the run log so the log-based branch (hook_rejection, infrastructure,

--- a/scripts/auto-dent.test.ts
+++ b/scripts/auto-dent.test.ts
@@ -27,6 +27,7 @@ const baseOpts: AutoDentOptions = {
   testTask: false,
   experiment: false,
   noPlan: false,
+  provider: 'claude',
   guidance: 'focus on hooks',
 };
 
@@ -100,6 +101,22 @@ describe('parseAutoDentArgs', () => {
     expect(parseAutoDentArgs(['--test-task']).guidance).toBe('synthetic pipeline test');
   });
 
+  it('defaults provider to claude', () => {
+    expect(parseAutoDentArgs(['focus']).provider).toBe('claude');
+  });
+
+  it('accepts codex provider only for test-task mode', () => {
+    const opts = parseAutoDentArgs(['--provider', 'codex', '--test-task']);
+    expect(opts.provider).toBe('codex');
+    expect(opts.testTask).toBe(true);
+  });
+
+  it('rejects codex provider for non-synthetic batches', () => {
+    expect(() => parseAutoDentArgs(['--provider', 'codex', 'real work'])).toThrow(
+      'Codex provider is restricted to --test-task synthetic runs',
+    );
+  });
+
   it('rejects unknown options', () => {
     expect(() => parseAutoDentArgs(['--wat'])).toThrow('Unknown option: --wat');
   });
@@ -130,6 +147,21 @@ describe('createInitialState', () => {
     expect(state.test_task).toBe(true);
     expect(state.experiment).toBe(true);
     expect(state.max_run_seconds).toBe(600);
+    expect(state.provider).toBe('claude');
+  });
+
+  it('stores selected provider in initial state for dry-run inspection', () => {
+    const state = createInitialState('batch-1', 'synthetic', 1, {
+      ...baseOpts,
+      testTask: true,
+      provider: 'codex',
+    }, {
+      kaizenRepo: 'Garsson-io/kaizen',
+      hostRepo: 'Garsson-io/kaizen',
+    });
+
+    expect(state.provider).toBe('codex');
+    expect(state.test_task).toBe(true);
   });
 });
 

--- a/scripts/auto-dent.ts
+++ b/scripts/auto-dent.ts
@@ -29,6 +29,7 @@ export interface AutoDentOptions {
   testTask: boolean;
   experiment: boolean;
   noPlan: boolean;
+  provider: 'claude' | 'codex';
   guidance: string;
 }
 
@@ -59,6 +60,7 @@ const DEFAULT_OPTIONS: AutoDentOptions = {
   testTask: false,
   experiment: false,
   noPlan: false,
+  provider: 'claude',
   guidance: '',
 };
 
@@ -79,6 +81,7 @@ Options:
   --max-failures N     Stop after N consecutive failures (default: 3)
   --max-run-seconds N  Wall-time timeout per run in seconds (default: 1200 = 20min)
   --no-plan            Skip planning pre-pass (use discovery mode)
+  --provider NAME      Agent provider: claude (default) or codex (synthetic --test-task only)
   --dry-run            Show what would run without executing
   --test-task          Use synthetic fast task instead of /kaizen-deep-dive
   --experiment         Enable extra pipeline diagnostics
@@ -150,6 +153,15 @@ export function parseAutoDentArgs(argv: string[]): AutoDentOptions {
         opts.noPlan = true;
         i += 1;
         break;
+      case '--provider': {
+        const provider = requiredValue(argv, i);
+        if (provider !== 'claude' && provider !== 'codex') {
+          throw new Error(`Unknown provider: ${provider}`);
+        }
+        opts.provider = provider;
+        i += 2;
+        break;
+      }
       case '--experiment':
         opts.experiment = true;
         i += 1;
@@ -165,6 +177,9 @@ export function parseAutoDentArgs(argv: string[]): AutoDentOptions {
 
   opts.guidance = positional.join(' ');
   if (!opts.guidance && opts.testTask) opts.guidance = 'synthetic pipeline test';
+  if (opts.provider === 'codex' && !opts.testTask) {
+    throw new Error('Codex provider is restricted to --test-task synthetic runs');
+  }
   return opts;
 }
 
@@ -233,6 +248,7 @@ export function createInitialState(
     progress_issue: '',
     test_task: opts.testTask,
     experiment: opts.experiment,
+    provider: opts.provider,
     max_run_seconds: opts.maxRunSeconds,
     last_heartbeat: 0,
   };
@@ -568,6 +584,7 @@ async function main(): Promise<void> {
   if (opts.dryRun) {
     console.log('[dry-run] Would execute per run:');
     console.log(`  npx tsx ${join(repoRoot, 'scripts', 'auto-dent-run.ts')} ${stateFile}`);
+    console.log(`[dry-run] Provider: ${opts.provider}${opts.provider === 'codex' ? ' (synthetic test-task only)' : ''}`);
     console.log('');
     console.log('[dry-run] State file:');
     console.log(readFileSync(stateFile, 'utf8').trimEnd());


### PR DESCRIPTION
## Problem

Auto-dent has provider capability metadata and Codex readiness checks, but it still cannot run a controlled Codex subprocess to observe real Codex JSONL output and lifecycle-marker behavior.

## Discovery

The current single-run path hardcodes Claude stream-json execution. Codex 0.142.3 supports the needed synthetic path through `codex exec --json`, `--cd`, `--sandbox danger-full-access`, and approval bypass flags. The safest first integration point is `--test-task` only, so real autonomous batches remain Claude-only until later issues expand the contract.

## Solution

Adds the #1144 synthetic Codex provider path:

- Adds `scripts/auto-dent-codex.ts` for deterministic Codex argv construction and JSONL parsing.
- Adds `--provider claude|codex` to `auto-dent`, defaulting to Claude.
- Rejects `--provider codex` unless `--test-task` is set.
- Persists provider selection in batch state for dry-run inspection and single-run execution.
- Runs `codex exec --json` only for synthetic test-task state, writing raw JSONL beside the normal run log.
- Appends parsed final text and recovered `AUTO_DENT_PHASE` markers into the normal run log so existing lifecycle validation can inspect the run.
- Records Codex subscription provider metadata for synthetic Codex runs while leaving Claude defaults unchanged.

Closes #1144
Parent: #1134

## Verification

- `npx vitest run scripts/auto-dent-codex.test.ts scripts/auto-dent.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-provider.test.ts`
- `npm run typecheck`
