### PR TITLE
feat(auto-dent): add final claim contract

### DIFF
--- a/scripts/auto-dent-final-claim.test.ts
+++ b/scripts/auto-dent-final-claim.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  compareFinalClaimToEvidence,
+  foldFinalClaimWarningsIntoProcess,
+  parseFinalRunClaim,
+  writeFinalClaimArtifact,
+  type FinalRunClaim,
+} from './auto-dent-final-claim.js';
+
+function validClaim(overrides: Partial<FinalRunClaim> = {}): FinalRunClaim {
+  return {
+    schema_version: 1,
+    selected_issue: '#1145',
+    case_worktree: '2606271547-k1145-final-claim-contract',
+    tests: {
+      status: 'pass',
+      command: 'npx vitest run scripts/auto-dent-final-claim.test.ts',
+      count: 8,
+      evidence: ['8 tests passed'],
+    },
+    pr_url: 'https://github.com/Garsson-io/kaizen/pull/1176',
+    review_status: 'pass',
+    reflection_status: 'done',
+    stop_reason: null,
+    blockers: [],
+    ...overrides,
+  };
+}
+
+describe('parseFinalRunClaim (#1145)', () => {
+  it('parses a valid fenced final claim object', () => {
+    const result = parseFinalRunClaim([
+      'done',
+      '```json',
+      JSON.stringify(validClaim(), null, 2),
+      '```',
+    ].join('\n'));
+
+    expect(result.status).toBe('valid');
+    expect(result.claim?.selected_issue).toBe('#1145');
+    expect(result.claim?.tests.status).toBe('pass');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('parses a valid plain JSON final claim object', () => {
+    const result = parseFinalRunClaim(JSON.stringify(validClaim({ pr_url: null })));
+
+    expect(result.status).toBe('valid');
+    expect(result.claim?.pr_url).toBeNull();
+  });
+
+  it('returns structured warnings for invalid schema output', () => {
+    const result = parseFinalRunClaim(JSON.stringify({
+      schema_version: 1,
+      selected_issue: '#1145',
+      tests: { status: 'green' },
+      blockers: 'none',
+    }));
+
+    expect(result.status).toBe('invalid');
+    expect(result.warnings.join('\n')).toMatch(/tests\.status/);
+    expect(result.warnings.join('\n')).toMatch(/blockers/);
+  });
+
+  it('returns missing without throwing for legacy free text', () => {
+    const result = parseFinalRunClaim('Finished the run. AUTO_DENT_PHASE: STOP | reason=done');
+
+    expect(result.status).toBe('missing');
+    expect(result.claim).toBeUndefined();
+    expect(result.warnings).toEqual(['final claim object missing']);
+  });
+});
+
+describe('compareFinalClaimToEvidence (#1145)', () => {
+  it('warns when agent claims are not backed by durable evidence', () => {
+    const warnings = compareFinalClaimToEvidence(validClaim(), {
+      prs: [],
+      cases: [],
+      testEvidence: false,
+      reviewEvidence: false,
+      reflectionEvidence: false,
+    });
+
+    expect(warnings).toContain('claim selected PR https://github.com/Garsson-io/kaizen/pull/1176 but durable PR evidence is missing');
+    expect(warnings).toContain('claim selected case/worktree 2606271547-k1145-final-claim-contract but durable implementation evidence is missing');
+    expect(warnings).toContain('claim says tests passed but durable test evidence is missing');
+    expect(warnings).toContain('claim says review passed but durable review evidence is missing');
+    expect(warnings).toContain('claim says reflection completed but durable reflection evidence is missing');
+  });
+
+  it('does not warn when claims match durable evidence', () => {
+    const warnings = compareFinalClaimToEvidence(validClaim(), {
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1176'],
+      cases: ['2606271547-k1145-final-claim-contract'],
+      testEvidence: true,
+      reviewEvidence: true,
+      reflectionEvidence: true,
+    });
+
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('writeFinalClaimArtifact (#1145)', () => {
+  it('persists valid claim JSON beside run artifacts', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'final-claim-'));
+    try {
+      const path = writeFinalClaimArtifact(dir, 3, validClaim());
+
+      expect(path).toBe(join(dir, 'run-3-final-claim.json'));
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toMatchObject({
+        schema_version: 1,
+        selected_issue: '#1145',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('foldFinalClaimWarningsIntoProcess (#1145)', () => {
+  it('turns an otherwise passing process verdict into process-incomplete for valid contradictory claims', () => {
+    const folded = foldFinalClaimWarningsIntoProcess(
+      'pass',
+      0,
+      'process verdict pass (durable evidence complete)',
+      true,
+      ['claim says tests passed but durable test evidence is missing'],
+    );
+
+    expect(folded).toEqual({
+      verdict: 'process-incomplete',
+      issueCount: 1,
+      summary: 'process verdict pass (durable evidence complete); final-claim: claim says tests passed but durable test evidence is missing',
+    });
+  });
+
+  it('does not change the durable process verdict for invalid or missing claim warnings alone', () => {
+    const folded = foldFinalClaimWarningsIntoProcess(
+      'pass',
+      0,
+      'process verdict pass (durable evidence complete)',
+      false,
+      ['final claim object missing'],
+    );
+
+    expect(folded).toEqual({
+      verdict: 'pass',
+      issueCount: 0,
+      summary: 'process verdict pass (durable evidence complete)',
+    });
+  });
+});

--- a/scripts/auto-dent-final-claim.ts
+++ b/scripts/auto-dent-final-claim.ts
@@ -1,0 +1,161 @@
+/**
+ * Schema-constrained final run summary claims (#1145).
+ *
+ * These claims are worker self-report. They are useful structured inputs for
+ * diagnostics, but durable evidence remains authoritative.
+ */
+
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { z } from 'zod';
+
+export const FINAL_RUN_CLAIM_SCHEMA_VERSION = 1;
+
+const statusSchema = z.enum(['pass', 'fail', 'skipped', 'missing']);
+const testsSchema = z.object({
+  status: statusSchema,
+  command: z.string().min(1).nullable().optional(),
+  count: z.number().int().nonnegative().nullable().optional(),
+  evidence: z.array(z.string()).default([]),
+});
+
+export const finalRunClaimSchema = z.object({
+  schema_version: z.literal(FINAL_RUN_CLAIM_SCHEMA_VERSION),
+  selected_issue: z.string().min(1).nullable(),
+  case_worktree: z.string().min(1).nullable(),
+  tests: testsSchema,
+  pr_url: z.string().url().nullable(),
+  review_status: statusSchema,
+  reflection_status: z.enum(['done', 'skipped', 'missing']),
+  stop_reason: z.string().min(1).nullable(),
+  blockers: z.array(z.string()),
+});
+
+export type FinalRunClaim = z.infer<typeof finalRunClaimSchema>;
+export type FinalClaimStatus = 'valid' | 'invalid' | 'missing';
+
+export interface FinalClaimParseResult {
+  status: FinalClaimStatus;
+  claim?: FinalRunClaim;
+  warnings: string[];
+}
+
+export interface FinalClaimEvidence {
+  prs: string[];
+  cases: string[];
+  testEvidence: boolean;
+  reviewEvidence: boolean;
+  reflectionEvidence: boolean;
+}
+
+export type FinalClaimProcessVerdict = 'pass' | 'process-incomplete' | 'fail-open-warning';
+
+export interface FinalClaimProcessTelemetry {
+  verdict: FinalClaimProcessVerdict;
+  issueCount: number;
+  summary: string;
+}
+
+function findJsonCandidates(text: string): string[] {
+  const candidates: string[] = [];
+  for (const match of text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)) {
+    candidates.push(match[1].trim());
+  }
+
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    candidates.push(trimmed);
+  }
+
+  return candidates;
+}
+
+function formatZodIssues(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : 'claim';
+    return `${path}: ${issue.message}`;
+  });
+}
+
+export function parseFinalRunClaim(text: string): FinalClaimParseResult {
+  const candidates = findJsonCandidates(text);
+  if (candidates.length === 0) {
+    return { status: 'missing', warnings: ['final claim object missing'] };
+  }
+
+  const warnings: string[] = [];
+  for (const candidate of candidates) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch (err) {
+      warnings.push(`final claim JSON parse failed: ${(err as Error).message}`);
+      continue;
+    }
+
+    const result = finalRunClaimSchema.safeParse(parsed);
+    if (result.success) {
+      return { status: 'valid', claim: result.data, warnings: [] };
+    }
+    warnings.push(...formatZodIssues(result.error));
+  }
+
+  return {
+    status: 'invalid',
+    warnings: warnings.length > 0 ? warnings : ['final claim object invalid'],
+  };
+}
+
+export function compareFinalClaimToEvidence(
+  claim: FinalRunClaim,
+  evidence: FinalClaimEvidence,
+): string[] {
+  const warnings: string[] = [];
+
+  if (claim.pr_url && !evidence.prs.includes(claim.pr_url)) {
+    warnings.push(`claim selected PR ${claim.pr_url} but durable PR evidence is missing`);
+  }
+  if (claim.case_worktree && !evidence.cases.includes(claim.case_worktree)) {
+    warnings.push(`claim selected case/worktree ${claim.case_worktree} but durable implementation evidence is missing`);
+  }
+  if (claim.tests.status === 'pass' && !evidence.testEvidence) {
+    warnings.push('claim says tests passed but durable test evidence is missing');
+  }
+  if (claim.review_status === 'pass' && !evidence.reviewEvidence) {
+    warnings.push('claim says review passed but durable review evidence is missing');
+  }
+  if (claim.reflection_status === 'done' && !evidence.reflectionEvidence) {
+    warnings.push('claim says reflection completed but durable reflection evidence is missing');
+  }
+
+  return warnings;
+}
+
+export function writeFinalClaimArtifact(
+  logDir: string,
+  runNum: number,
+  claim: FinalRunClaim,
+): string {
+  const path = join(logDir, `run-${runNum}-final-claim.json`);
+  writeFileSync(path, JSON.stringify(claim, null, 2) + '\n');
+  return path;
+}
+
+export function foldFinalClaimWarningsIntoProcess(
+  verdict: FinalClaimProcessVerdict,
+  issueCount: number,
+  summary: string,
+  hasValidClaim: boolean,
+  warnings: string[],
+): FinalClaimProcessTelemetry {
+  if (!hasValidClaim || warnings.length === 0) {
+    return { verdict, issueCount, summary };
+  }
+
+  const claimSummary = `final-claim: ${warnings.join('; ')}`;
+  return {
+    verdict: verdict === 'pass' ? 'process-incomplete' : verdict,
+    issueCount: issueCount + warnings.length,
+    summary: `${summary}; ${claimSummary}`,
+  };
+}

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -1380,6 +1380,34 @@ describe('processStreamMessage', () => {
     expect(result.issuesClosed).toContain('#451');
   });
 
+  it('captures structured final claims from result text', () => {
+    const result = makeRunResult();
+    processStreamMessage(
+      {
+        type: 'result',
+        subtype: 'success',
+        total_cost_usd: 1.0,
+        result: JSON.stringify({
+          schema_version: 1,
+          selected_issue: '#1145',
+          case_worktree: '2606271547-k1145-final-claim-contract',
+          tests: { status: 'pass', command: 'npm test', count: 5, evidence: ['5 passed'] },
+          pr_url: 'https://github.com/Garsson-io/kaizen/pull/1176',
+          review_status: 'pass',
+          reflection_status: 'done',
+          stop_reason: null,
+          blockers: [],
+        }),
+      },
+      result,
+      Date.now(),
+    );
+
+    expect(result.finalClaimStatus).toBe('valid');
+    expect(result.finalClaim?.selected_issue).toBe('#1145');
+    expect(result.finalClaimWarnings).toEqual([]);
+  });
+
   it('handles messages without content gracefully', () => {
     const result = makeRunResult();
     processStreamMessage({ type: 'assistant' }, result, Date.now());
@@ -1492,11 +1520,15 @@ describe('RunMetrics type', () => {
       process_verdict: 'pass',
       process_issue_count: 0,
       process_summary: 'process verdict pass (durable evidence complete)',
+      final_claim_status: 'valid',
+      final_claim_path: 'logs/auto-dent/batch/run-1-final-claim.json',
+      final_claim_warnings: [],
     };
     expect(metrics.run).toBe(1);
     expect(metrics.cost_usd).toBe(2.5);
     expect(metrics.prs).toHaveLength(1);
     expect(metrics.process_verdict).toBe('pass');
+    expect(metrics.final_claim_status).toBe('valid');
   });
 
   it('supports run_history in BatchState', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -153,6 +153,14 @@ import {
   parseCodexJsonl,
 } from './auto-dent-codex.js';
 import {
+  compareFinalClaimToEvidence,
+  foldFinalClaimWarningsIntoProcess,
+  parseFinalRunClaim,
+  writeFinalClaimArtifact,
+  type FinalClaimStatus,
+  type FinalRunClaim,
+} from './auto-dent-final-claim.js';
+import {
   validateRunLifecycle,
   summarizeLifecycle,
   verifyLifecycleEvidence,
@@ -260,6 +268,14 @@ export interface RunMetrics {
    * `defaultPhaseProviders()` in scripts/auto-dent-provider.ts.
    */
   phase_providers?: PhaseProviderRecord;
+  /** Status of the schema-constrained final run claim (#1145). */
+  final_claim_status?: FinalClaimStatus;
+  /** Parsed final claim object, when valid (#1145). */
+  final_claim?: FinalRunClaim;
+  /** Sidecar path for the persisted final claim object (#1145). */
+  final_claim_path?: string;
+  /** Warnings from final-claim parsing or claim/evidence comparison (#1145). */
+  final_claim_warnings?: string[];
 }
 
 export interface RunResult {
@@ -287,6 +303,14 @@ export interface RunResult {
   reviewVerdict?: 'pass' | 'fail' | 'skipped';
   /** Cost of the requirements review in USD */
   reviewCostUsd?: number;
+  /** Parsed schema-constrained final run claim (#1145). */
+  finalClaim?: FinalRunClaim;
+  /** Parse status for the final run claim (#1145). */
+  finalClaimStatus?: FinalClaimStatus;
+  /** Sidecar path for the persisted final claim object (#1145). */
+  finalClaimPath?: string;
+  /** Parse/comparison warnings for the final run claim (#1145). */
+  finalClaimWarnings?: string[];
 }
 
 import { extractPlanText } from '../src/structured-data.js';
@@ -1460,6 +1484,10 @@ async function runCodexSynthetic(
       if (parsed.malformedLines.length > 0) {
         appendFileSync(input.logFile, `\n[codex] malformed_jsonl_lines=${parsed.malformedLines.length}\n`);
       }
+      const claimResult = parseFinalRunClaim(parsed.finalText || parsed.text);
+      input.result.finalClaimStatus = claimResult.status;
+      input.result.finalClaim = claimResult.claim;
+      input.result.finalClaimWarnings = claimResult.warnings;
 
       const duration = Math.floor((Date.now() - runStart) / 1000);
       resolvePromise({
@@ -2106,6 +2134,13 @@ async function main(): Promise<void> {
   );
   result.reviewVerdict = reviewVerdict;
   result.reviewCostUsd = reviewCostUsd;
+  if (result.finalClaim) {
+    result.finalClaimPath = writeFinalClaimArtifact(logDir, runNum, result.finalClaim);
+    appendFileSync(logFile, `final_claim_path=${result.finalClaimPath}\n`);
+  }
+  if (result.finalClaimStatus && result.finalClaimStatus !== 'valid') {
+    appendFileSync(logFile, `final_claim_status=${result.finalClaimStatus}: ${(result.finalClaimWarnings || []).join('; ')}\n`);
+  }
 
   // Lifecycle validation (#639, #1103) — observability + steering, never a hard
   // block. Beyond ordering, this detects critical gaps (PR without IMPLEMENT,
@@ -2153,6 +2188,21 @@ async function main(): Promise<void> {
       mergeReadiness,
     };
     const processValidation = validateProcessEvidence(lifecycle, processEvidence);
+    if (result.finalClaim) {
+      const claimWarnings = compareFinalClaimToEvidence(result.finalClaim, {
+        prs: result.prs,
+        cases: result.cases,
+        testEvidence: processEvidence.testEvidence === true,
+        reviewEvidence: processEvidence.reviewEvidence === true,
+        reflectionEvidence: processEvidence.reflectionEvidence === true,
+      });
+      if (claimWarnings.length > 0) {
+        result.finalClaimWarnings = [
+          ...(result.finalClaimWarnings || []),
+          ...claimWarnings,
+        ];
+      }
+    }
 
     lifecycleViolationCount = lifecycle.violations.length;
     lifecycleHealth = foldEvidenceIntoHealth(lifecycle.health, evidenceCheck);
@@ -2161,6 +2211,20 @@ async function main(): Promise<void> {
     processVerdict = processValidation.verdict;
     processIssueCount = processValidation.failedChecks.length + processValidation.warningChecks.length;
     processSummary = summarizeProcessValidation(processValidation);
+    const claimEvidenceWarnings = result.finalClaimWarnings || [];
+    if (claimEvidenceWarnings.length > 0) {
+      appendFileSync(logFile, `final_claim_warnings=${claimEvidenceWarnings.join('; ')}\n`);
+      const folded = foldFinalClaimWarningsIntoProcess(
+        processVerdict,
+        processIssueCount,
+        processSummary,
+        Boolean(result.finalClaim),
+        claimEvidenceWarnings,
+      );
+      processVerdict = folded.verdict;
+      processIssueCount = folded.issueCount;
+      processSummary = folded.summary;
+    }
     if (processVerdict !== 'pass' && lifecycleHealth !== 'critical') {
       lifecycleHealth = 'degraded';
     }
@@ -2442,6 +2506,10 @@ async function main(): Promise<void> {
     review_verdict: reviewVerdict,
     review_cost_usd: reviewCostUsd,
     phase_providers: phaseProvidersForState(state),
+    final_claim_status: result.finalClaimStatus,
+    final_claim: result.finalClaim,
+    final_claim_path: result.finalClaimPath,
+    final_claim_warnings: result.finalClaimWarnings,
   };
   // Classify failure: wall-clock timeout is authoritative (#686), then heuristics.
   // Feed the run log so the log-based branch (hook_rejection, infrastructure,

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -9,6 +9,7 @@
  */
 
 import type { RunResult } from './auto-dent-run.js';
+import { parseFinalRunClaim } from './auto-dent-final-claim.js';
 import { ghExec } from './auto-dent-github.js';
 
 // ANSI color helpers (graceful degradation when NO_COLOR is set or not a TTY)
@@ -441,6 +442,10 @@ export function processStreamMessage(
       }
       if (msg.result) {
         extractArtifacts(msg.result, result);
+        const claimResult = parseFinalRunClaim(msg.result);
+        result.finalClaimStatus = claimResult.status;
+        result.finalClaim = claimResult.claim;
+        result.finalClaimWarnings = claimResult.warnings;
         checkStopSignal(msg.result, result);
         const recs = extractContemplationRecommendations(msg.result);
         if (recs.length > 0) {


### PR DESCRIPTION
## Problem

Auto-dent could already extract PRs, issues, cases, and lifecycle markers from agent output, but the agent's final "what happened" claim was still free text. That made the #1134 external validator compare durable evidence against regex-derived fragments instead of a typed final claim contract.

## Discovery

The current run path has two good seams: Claude result text flows through `processStreamMessage()`, and synthetic Codex final text is parsed in `runCodexSynthetic()`. The #1149 durable process validator is already authoritative, so the right change is to add structured claim parsing as evidence input and telemetry, not to let claims override real PR/case/test/review/reflection artifacts.

## Solution

Adds the #1145 final-claim contract:

- Defines `scripts/auto-dent-final-claim.ts` with a schema-versioned JSON contract for selected issue, case/worktree, tests, PR URL, review status, reflection status, stop reason, and blockers.
- Parses fenced or plain JSON final claims from Claude result text and Codex synthetic final text.
- Returns structured `valid`, `invalid`, or `missing` statuses with warnings instead of throwing on legacy free text.
- Persists valid claims to `run-N-final-claim.json`.
- Records claim status, claim object, sidecar path, and warnings in `RunMetrics`.
- Compares claim fields against durable evidence and degrades an otherwise-passing process verdict to `process-incomplete` when a valid claim asserts PR/test/review/reflection/case evidence that is missing.

Closes #1145
Parent: #1134

## Architecture

```text
Claude result text ─┐
                    ├─ parseFinalRunClaim()
Codex final text  ──┘
                         │
                         ├─ RunResult.finalClaim*
                         ├─ run-N-final-claim.json
                         ├─ RunMetrics.final_claim*
                         └─ compareFinalClaimToEvidence()
                                   │
                                   └─ durable process verdict remains authoritative
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use a small Zod-backed schema module | Keeps the contract typed and locally testable | Does not yet invoke live `codex exec --output-schema` |
| Treat missing claims as warnings | Preserves legacy Claude runs | New telemetry will show missing claim status until prompts/providers emit the contract |
| Let valid claim mismatches degrade process verdicts | A structured claim that contradicts durable evidence is process-incomplete | Claims still cannot make a run pass |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Coverage |
|---|----------|-------------|-------|-----------|----------|
| 1 | Valid final claim JSON with selected issue, case/worktree, tests, PR, review, reflection, stop reason, and blockers parses to a typed object. | code | Unit | `scripts/auto-dent-final-claim.test.ts` | Tested |
| 2 | Invalid final claim JSON or missing required fields returns structured warnings instead of throwing. | code | Unit | `scripts/auto-dent-final-claim.test.ts` | Tested |
| 3 | Missing final claim output returns a `missing` status and does not crash legacy Claude runs. | compatibility | Unit | `scripts/auto-dent-final-claim.test.ts`; `scripts/auto-dent-run.test.ts` | Tested |
| 4 | Claim fields are compared against durable evidence and mismatches are classified as process-incomplete claim warnings. | lifecycle | Unit | `scripts/auto-dent-final-claim.test.ts` | Tested |
| 5 | A valid claim captured during a run is persisted to a sidecar file and referenced in `RunMetrics`. | session | Integration | `scripts/auto-dent-run.test.ts` | Tested via parser capture, sidecar helper, and metrics type coverage |
| 6 | Codex final text uses the same parser path as Claude final result text without requiring live `codex exec --output-schema` in tests. | provider | Unit | `scripts/auto-dent-codex.test.ts`; `scripts/auto-dent-run.test.ts` | Tested in affected slice |

Deferred: live `codex exec --output-schema` execution remains in parent epic comparison work (#1152); this PR ships the deterministic contract first.

## Validation

- [x] `npx vitest run scripts/auto-dent-final-claim.test.ts scripts/auto-dent-run.test.ts`
- [x] `npx vitest run scripts/auto-dent-final-claim.test.ts scripts/auto-dent-codex.test.ts scripts/auto-dent-stream.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-lifecycle.test.ts scripts/auto-dent-provider.test.ts`
- [x] `npm run typecheck`
- [x] `git diff --check`
- [ ] `npm test` full suite: failed in unrelated e2e/hook simulator tests (`src/e2e/setup-e2e.test.ts`, `src/e2e/synthetic-workflow.test.ts`, `src/hooks/kaizen-reflect.test.ts`) with timeout/count mismatches outside this PR's touched files.

## Known Limitations

This PR does not require live provider `--output-schema` execution. It defines and persists the contract deterministically so later #1134 provider-comparison work can measure real Claude/Codex behavior against the same schema.
