### PR TITLE
feat(auto-dent): make planning provider-aware

### DIFF
--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -13,13 +13,19 @@ import {
   resetAssignedItems,
   formatPlanSummary,
   buildPlanPrompt,
+  buildPlanningCommand,
   titleTokens,
   deriveThemes,
   ensureThemes,
+  extractPlanningText,
+  formatPlanningFailure,
+  selectPlanningProvider,
+  withPlanningProvider,
   themeProgress,
   type BatchPlan,
   type PlanItem,
 } from './auto-dent-plan.js';
+import type { BatchState } from './auto-dent-run.js';
 
 function mkItem(overrides: Partial<PlanItem> & { issue: string; title: string }): PlanItem {
   return {
@@ -60,6 +66,131 @@ function makePlanWithDecompose(): BatchPlan {
     decomposition_candidates: ['#506 Auto-Dent Experimentation Framework — no child issues filed'],
   };
 }
+
+function makeState(overrides: Partial<BatchState> = {}): BatchState {
+  return {
+    batch_id: 'batch-260627-1608-k1146',
+    batch_start: 0,
+    guidance: 'provider-aware planning',
+    max_runs: 5,
+    cooldown: 30,
+    budget: '3.00',
+    max_failures: 3,
+    kaizen_repo: 'Garsson-io/kaizen',
+    host_repo: 'Garsson-io/kaizen',
+    run: 0,
+    prs: [],
+    issues_filed: [],
+    issues_closed: [],
+    cases: [],
+    consecutive_failures: 0,
+    current_cooldown: 30,
+    stop_reason: '',
+    last_issue: '',
+    last_pr: '',
+    last_case: '',
+    last_branch: '',
+    last_worktree: '',
+    ...overrides,
+  };
+}
+
+describe('provider-aware planning (#1146)', () => {
+  it('defaults planning to Claude under subscription billing', () => {
+    expect(selectPlanningProvider(makeState())).toEqual({
+      provider: 'claude',
+      billing: 'subscription-cli',
+    });
+  });
+
+  it('selects Codex planning only for explicit synthetic Codex batches', () => {
+    expect(selectPlanningProvider(makeState({ provider: 'codex', test_task: true }))).toEqual({
+      provider: 'codex',
+      billing: 'subscription-cli',
+    });
+    expect(selectPlanningProvider(makeState({ provider: 'codex', test_task: false }))).toEqual({
+      provider: 'claude',
+      billing: 'subscription-cli',
+    });
+  });
+
+  it('builds the existing Claude planning command shape', () => {
+    const command = buildPlanningCommand(
+      { provider: 'claude', billing: 'subscription-cli' },
+      'plan prompt',
+      makeState({ budget: '3.00' }),
+      '/repo',
+    );
+
+    expect(command.command).toBe('claude');
+    expect(command.args).toEqual([
+      '-p',
+      'plan prompt',
+      '--dangerously-skip-permissions',
+      '--output-format',
+      'stream-json',
+      '--max-turns',
+      '5',
+      '--max-budget-usd',
+      '1.00',
+    ]);
+    expect(command.stdin).toBeUndefined();
+  });
+
+  it('builds a Codex exec planning command with prompt on stdin', () => {
+    const command = buildPlanningCommand(
+      { provider: 'codex', billing: 'subscription-cli' },
+      'plan prompt',
+      makeState(),
+      '/repo',
+    );
+
+    expect(command.command).toBe('codex');
+    expect(command.args).toEqual([
+      'exec',
+      '--json',
+      '--cd',
+      '/repo',
+      '--sandbox',
+      'danger-full-access',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--color',
+      'never',
+      '-',
+    ]);
+    expect(command.stdin).toBe('plan prompt');
+  });
+
+  it('extracts provider output text from Claude stream-json and Codex JSONL', () => {
+    const planJson = '{"items":[{"issue":"#1146","title":"Plan","score":5,"approach":"do","status":"pending"}]}';
+    const claudeText = extractPlanningText('claude', [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'prefix ' }] } }),
+      JSON.stringify({ type: 'result', result: `\n${planJson}` }),
+    ].join('\n'));
+    const codexText = extractPlanningText('codex', JSON.stringify({
+      type: 'final_message',
+      message: `prefix\n${planJson}`,
+    }));
+
+    expect(validatePlan(extractPlanJson(claudeText))).not.toBeNull();
+    expect(validatePlan(extractPlanJson(codexText))).not.toBeNull();
+  });
+
+  it('attaches planning provider metadata to created plans', () => {
+    const plan = withPlanningProvider(makePlan(), { provider: 'codex', billing: 'subscription-cli' });
+
+    expect(plan.planning_provider).toEqual({
+      provider: 'codex',
+      billing: 'subscription-cli',
+    });
+  });
+
+  it('formats planning failure messages with provider identity', () => {
+    expect(formatPlanningFailure({ provider: 'codex', billing: 'subscription-cli' }, 'could not extract plan JSON')).toBe(
+      '  [plan:codex] could not extract plan JSON',
+    );
+  });
+});
 
 describe('extractPlanJson', () => {
   it('extracts JSON from fenced code block', () => {

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -26,6 +26,8 @@ import {
   renderTemplate,
   loadPromptTemplate,
 } from './auto-dent-run.js';
+import { buildCodexExecArgs, parseCodexJsonl } from './auto-dent-codex.js';
+import type { PhaseProvider } from './auto-dent-provider.js';
 
 export interface PlanItem {
   issue: string;
@@ -54,12 +56,23 @@ export interface PlanTheme {
 export interface BatchPlan {
   created_at: string;
   guidance: string;
+  /** Provider used by the planning pre-pass (#1146). */
+  planning_provider?: PhaseProvider;
   items: PlanItem[];
   wip_excluded: string[];
   epics_scanned: string[];
   decomposition_candidates?: string[];
   /** Coordinated clusters of related items (#941). Derived if not LLM-provided. */
   themes?: PlanTheme[];
+}
+
+export type PlanningProviderName = 'claude' | 'codex';
+
+export interface PlanningCommand {
+  command: string;
+  args: string[];
+  /** Prompt stdin for providers that read the prompt from stdin. */
+  stdin?: string;
 }
 
 function readState(stateFile: string): BatchState {
@@ -99,6 +112,88 @@ Output a JSON plan with ranked work items. Format:
 \`\`\`json
 {"created_at":"...","guidance":"...","items":[{"issue":"#N","title":"...","score":0,"approach":"...","status":"pending"}],"wip_excluded":[],"epics_scanned":[]}
 \`\`\``;
+}
+
+export function selectPlanningProvider(state: BatchState): PhaseProvider {
+  if (state.provider === 'codex' && state.test_task === true) {
+    return { provider: 'codex', billing: 'subscription-cli' };
+  }
+  return { provider: 'claude', billing: 'subscription-cli' };
+}
+
+function planningProviderName(provider: PhaseProvider): PlanningProviderName {
+  return provider.provider === 'codex' ? 'codex' : 'claude';
+}
+
+export function buildPlanningCommand(
+  provider: PhaseProvider,
+  prompt: string,
+  state: BatchState,
+  repoRoot: string,
+): PlanningCommand {
+  if (planningProviderName(provider) === 'codex') {
+    return {
+      command: 'codex',
+      args: buildCodexExecArgs(repoRoot),
+      stdin: prompt,
+    };
+  }
+
+  const args = [
+    '-p',
+    prompt,
+    '--dangerously-skip-permissions',
+    '--output-format',
+    'stream-json',
+    '--max-turns',
+    '5',
+  ];
+  // Use a small budget for planning (if batch has a budget)
+  if (state.budget) {
+    const planBudget = Math.min(parseFloat(state.budget), 1.0).toFixed(2);
+    args.push('--max-budget-usd', planBudget);
+  }
+
+  return { command: 'claude', args };
+}
+
+export function extractPlanningText(provider: PlanningProviderName, raw: string): string {
+  if (provider === 'codex') {
+    const parsed = parseCodexJsonl(raw);
+    return parsed.finalText || parsed.text;
+  }
+
+  let fullText = '';
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const msg = JSON.parse(line);
+      if (msg.type === 'assistant' && msg.message?.content) {
+        for (const block of msg.message.content) {
+          if (block.type === 'text') {
+            fullText += block.text;
+          }
+        }
+      }
+      if (msg.type === 'result' && msg.result) {
+        fullText += '\n' + msg.result;
+      }
+    } catch {
+      // Non-JSON line
+    }
+  }
+  return fullText;
+}
+
+export function withPlanningProvider(plan: BatchPlan, provider: PhaseProvider): BatchPlan {
+  return {
+    ...plan,
+    planning_provider: provider,
+  };
+}
+
+export function formatPlanningFailure(provider: PhaseProvider, message: string): string {
+  return `  [plan:${planningProviderName(provider)}] ${message}`;
 }
 
 /**
@@ -154,6 +249,7 @@ export function validatePlan(raw: any): BatchPlan | null {
   return {
     created_at: raw.created_at || new Date().toISOString(),
     guidance: raw.guidance || '',
+    ...(raw.planning_provider ? { planning_provider: raw.planning_provider } : {}),
     items,
     wip_excluded: Array.isArray(raw.wip_excluded) ? raw.wip_excluded : [],
     epics_scanned: Array.isArray(raw.epics_scanned) ? raw.epics_scanned : [],
@@ -348,53 +444,28 @@ async function runPlanning(
   repoRoot: string,
 ): Promise<BatchPlan | null> {
   const prompt = buildPlanPrompt(state);
-  let fullText = '';
+  const provider = selectPlanningProvider(state);
+  const providerName = planningProviderName(provider);
+  const command = buildPlanningCommand(provider, prompt, state, repoRoot);
+  let rawOutput = '';
 
   return new Promise((resolve) => {
-    const args = [
-      '-p',
-      prompt,
-      '--dangerously-skip-permissions',
-      '--output-format',
-      'stream-json',
-      '--max-turns',
-      '5',
-    ];
-    // Use a small budget for planning (if batch has a budget)
-    if (state.budget) {
-      const planBudget = Math.min(parseFloat(state.budget), 1.0).toFixed(2);
-      args.push('--max-budget-usd', planBudget);
-    }
-
-    const child = spawn('claude', args, {
+    const child = spawn(command.command, command.args, {
       cwd: repoRoot,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: [command.stdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
     });
+    if (command.stdin) child.stdin?.end(command.stdin);
 
     // 5-minute timeout for planning
     const timer = setTimeout(() => {
-      console.log('  [plan] planning timed out after 5 minutes');
+      console.log(formatPlanningFailure(provider, 'planning timed out after 5 minutes'));
       child.kill('SIGTERM');
       setTimeout(() => child.kill('SIGKILL'), 10_000);
     }, 5 * 60 * 1000);
 
     const rl = createInterface({ input: child.stdout! });
     rl.on('line', (line) => {
-      try {
-        const msg = JSON.parse(line);
-        if (msg.type === 'assistant' && msg.message?.content) {
-          for (const block of msg.message.content) {
-            if (block.type === 'text') {
-              fullText += block.text;
-            }
-          }
-        }
-        if (msg.type === 'result' && msg.result) {
-          fullText += '\n' + msg.result;
-        }
-      } catch {
-        // Non-JSON line
-      }
+      rawOutput += line + '\n';
     });
 
     child.stderr?.on('data', () => {
@@ -403,19 +474,25 @@ async function runPlanning(
 
     child.on('close', () => {
       clearTimeout(timer);
+      const fullText = extractPlanningText(providerName, rawOutput);
       const parsed = extractPlanJson(fullText);
       if (parsed) {
         const plan = validatePlan(parsed);
-        resolve(plan);
+        if (plan) {
+          resolve(withPlanningProvider(plan, provider));
+        } else {
+          console.log(formatPlanningFailure(provider, 'plan JSON failed validation'));
+          resolve(null);
+        }
       } else {
-        console.log('  [plan] could not extract plan JSON from response');
+        console.log(formatPlanningFailure(provider, 'could not extract plan JSON from response'));
         resolve(null);
       }
     });
 
     child.on('error', (err) => {
       clearTimeout(timer);
-      console.log(`  [plan] error: ${err.message}`);
+      console.log(formatPlanningFailure(provider, `error: ${err.message}`));
       resolve(null);
     });
   });
@@ -579,6 +656,8 @@ async function main(): Promise<void> {
 
   console.log('>>> Planning pre-pass starting...');
   console.log(`    Guidance: ${state.guidance}`);
+  const provider = selectPlanningProvider(state);
+  console.log(`    Provider: ${planningProviderName(provider)} (${provider.billing})`);
 
   const plan = await runPlanning(state, repoRoot);
 


### PR DESCRIPTION
## Problem

The auto-dent planning pre-pass still had a hidden Claude-only subprocess boundary. That meant a batch could explicitly choose Codex for synthetic execution while the pre-pass silently planned through Claude, weakening the provider audit trail required by #1134.

## Discovery

The downstream plan format was already provider-neutral: `readPlan()`, `claimNextItem()`, themes, and validation all consume `plan.json`. The provider-specific behavior lived at the command/parsing boundary inside `runPlanning()`, where `claude -p ... --output-format stream-json` was hardcoded.

## Solution

Adds provider-aware planning for #1146:

- Keeps Claude as the default planning provider.
- Selects Codex planning only for explicit synthetic Codex state: `state.provider === "codex" && state.test_task === true`.
- Extracts unit-testable planning command construction for Claude and Codex.
- Reuses `buildCodexExecArgs()` and `parseCodexJsonl()` for Codex planning output.
- Stores `planning_provider` metadata in created `plan.json` artifacts.
- Labels timeout, parse, validation, and process errors with `plan:<provider>`.

Closes #1146
Parent: #1134

## Architecture

```text
state.json
  │
  ├─ selectPlanningProvider()
  │     ├─ claude (default)
  │     └─ codex (synthetic --test-task only)
  │
  ├─ buildPlanningCommand()
  ├─ extractPlanningText()
  └─ validatePlan()
          │
          └─ plan.json + planning_provider
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Gate Codex planning on synthetic Codex state | Preserves #1144's synthetic-only Codex boundary | Real Codex planning remains deferred to comparison work |
| Store provider metadata in `plan.json` | The planning artifact is the durable evidence for the pre-pass | Existing plans lack the field and remain valid |
| Reuse Codex helper functions | Keeps planning command shape aligned with synthetic Codex exec | Codex planning currently shares implementation flags with synthetic execution |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Coverage |
|---|----------|-------------|-------|-----------|----------|
| 1 | Default state selects Claude planning and builds the existing Claude command shape. | code | Unit | `scripts/auto-dent-plan.test.ts` | Tested |
| 2 | Synthetic Codex provider state selects Codex planning and builds `codex exec --json` subscription-CLI args. | provider | Unit | `scripts/auto-dent-plan.test.ts` | Tested |
| 3 | Non-synthetic or legacy state does not select Codex planning. | guardrail | Unit | `scripts/auto-dent-plan.test.ts` | Tested |
| 4 | Provider-generated plan text/JSONL parses through the existing plan validator. | code | Unit | `scripts/auto-dent-plan.test.ts` | Tested |
| 5 | Created plans carry `planning_provider` metadata with provider and billing mode. | artifact | Integration | `scripts/auto-dent-plan.test.ts` | Tested via metadata helper and plan type coverage |
| 6 | Planning failure messages include provider identity. | operator | Unit | `scripts/auto-dent-plan.test.ts` | Tested |

Deferred: live Codex planning runs remain out of scope; parent #1152 covers provider comparison with live synthetic lifecycle data.

## Validation

- [x] `npx vitest run scripts/auto-dent-plan.test.ts scripts/auto-dent-codex.test.ts scripts/auto-dent-provider.test.ts scripts/auto-dent.test.ts scripts/auto-dent-run.test.ts`
- [x] `npm run typecheck`
- [x] `git diff --check`

## Known Limitations

This PR makes the pre-pass provider-aware and synthetic-Codex capable. It does not promote Codex planning to unattended production batches; that remains part of the staged #1134 provider comparison path.
