### PR TITLE
feat(review): record review provider metadata

### DIFF
--- a/src/review-battery.test.ts
+++ b/src/review-battery.test.ts
@@ -17,6 +17,7 @@ import { tmpdir } from 'node:os';
 import {
   parseReviewOutput,
   formatBatteryReport,
+  selectReviewProvider,
   loadReviewPrompt,
   resolvePromptsDir,
   discoverDimensions,
@@ -164,12 +165,27 @@ That concludes my review.`;
 
 // Tier 1: Battery report formatting
 
+describe('selectReviewProvider (#1147)', () => {
+  it('defaults to Claude review under subscription billing', () => {
+    expect(selectReviewProvider()).toEqual({ provider: 'claude', billing: 'subscription-cli' });
+  });
+
+  it('preserves an explicit Claude review provider for hybrid mode', () => {
+    expect(selectReviewProvider({ provider: 'claude', billing: 'subscription-cli' })).toEqual({
+      provider: 'claude',
+      billing: 'subscription-cli',
+    });
+  });
+});
+
 describe('formatBatteryReport', () => {
   it('formats a passing battery', () => {
     const result: BatteryResult = {
+      reviewProvider: { provider: 'claude', billing: 'subscription-cli' },
       dimensions: [{
         dimension: 'requirements',
         verdict: 'pass',
+        provider: { provider: 'claude', billing: 'subscription-cli' },
         findings: [
           { requirement: 'R1', status: 'DONE', detail: 'ok' },
           { requirement: 'R2', status: 'DONE', detail: 'ok' },
@@ -190,6 +206,8 @@ describe('formatBatteryReport', () => {
     expect(report).toContain('[x] **R1**');
     expect(report).toContain('[x] **R2**');
     expect(report).toContain('$0.13');
+    expect(report).toContain('| Review provider | claude (subscription-cli) |');
+    expect(report).toContain('_Provider: claude (subscription-cli)_');
   });
 
   it('formats a failing battery with MISSING items', () => {
@@ -569,8 +587,40 @@ describe('spawnReview', () => {
     const { review, costUsd } = await spawnReview({ dimension: 'requirements', prUrl: 'https://github.com/test/test/pull/1', repo: 'test/test' });
     expect(review).not.toBeNull();
     expect(review!.verdict).toBe('pass');
+    expect(review!.provider).toEqual({ provider: 'claude', billing: 'subscription-cli' });
     expect(review!.findings[0].status).toBe('DONE');
     expect(costUsd).toBeCloseTo(0.12);
+  });
+
+  it('can explicitly request Claude review for hybrid mode', async () => {
+    const text = JSON.stringify({
+      dimension: 'requirements',
+      summary: 'all good',
+      findings: [],
+    });
+    mockClaude(streamJsonPayload(text, 0.06));
+
+    const { review, provider } = await spawnReview({
+      dimension: 'requirements',
+      repo: 'test/test',
+      reviewProvider: { provider: 'claude', billing: 'subscription-cli' },
+    });
+
+    expect(provider).toEqual({ provider: 'claude', billing: 'subscription-cli' });
+    expect(review?.provider).toEqual({ provider: 'claude', billing: 'subscription-cli' });
+  });
+
+  it('classifies explicit Codex review as unsupported without calling Claude', async () => {
+    const { review, provider, failureClass } = await spawnReview({
+      dimension: 'requirements',
+      repo: 'test/test',
+      reviewProvider: { provider: 'codex', billing: 'subscription-cli' },
+    });
+
+    expect(review).toBeNull();
+    expect(provider).toEqual({ provider: 'codex', billing: 'subscription-cli' });
+    expect(failureClass).toBe('codex_review_unsupported');
+    expect(vi.mocked(spawn)).not.toHaveBeenCalled();
   });
 
   it('returns null review when claude exits non-zero', async () => {
@@ -632,6 +682,36 @@ describe('reviewBattery', () => {
       return proc;
     });
   }
+
+  it('defaults the battery review provider to Claude', async () => {
+    const passingOutput = streamJsonPayload(
+      JSON.stringify({ dimension: 'requirements', summary: 'ok', findings: [] }),
+      0.10,
+    );
+    mockClaude([{ stdout: passingOutput }]);
+
+    const result = await reviewBattery({ dimensions: ['requirements'] });
+
+    expect(result.reviewProvider).toEqual({ provider: 'claude', billing: 'subscription-cli' });
+    expect(result.dimensions[0].provider).toEqual({ provider: 'claude', billing: 'subscription-cli' });
+  });
+
+  it('classifies Codex review provider failures separately', async () => {
+    const result = await reviewBattery({
+      dimensions: ['requirements'],
+      reviewProvider: { provider: 'codex', billing: 'subscription-cli' },
+    });
+
+    expect(result.failedDimensions).toEqual(['requirements']);
+    expect(result.failedDimensionFailures).toEqual([
+      {
+        dimension: 'requirements',
+        provider: { provider: 'codex', billing: 'subscription-cli' },
+        failureClass: 'codex_review_unsupported',
+      },
+    ]);
+    expect(result.verdict).toBe('fail');
+  });
 
   const passingOutput = streamJsonPayload(
     JSON.stringify({ dimension: 'requirements', summary: 'ok', findings: [{ requirement: 'R1', status: 'DONE', detail: 'ok' }] }),

--- a/src/review-battery.ts
+++ b/src/review-battery.ts
@@ -50,12 +50,31 @@ export interface DimensionReview {
   findings: ReviewFinding[];
   /** One-line summary of the review */
   summary: string;
+  /** Provider that produced or attempted this review dimension (#1147). */
+  provider?: ReviewProvider;
+}
+
+export type ReviewFailureClass =
+  | 'claude_review_failed'
+  | 'codex_review_unsupported';
+
+export interface ReviewProvider {
+  provider: 'claude' | 'codex';
+  billing: 'subscription-cli';
+}
+
+export interface ReviewDimensionFailure {
+  dimension: string;
+  provider: ReviewProvider;
+  failureClass: ReviewFailureClass;
 }
 
 /** Aggregated result from running multiple review dimensions */
 export interface BatteryResult {
   /** Results per dimension */
   dimensions: DimensionReview[];
+  /** Provider selected for this battery (#1147). */
+  reviewProvider?: ReviewProvider;
   /** Overall: pass only if ALL dimensions pass */
   verdict: 'pass' | 'fail';
   /** Total findings with status MISSING */
@@ -68,6 +87,8 @@ export interface BatteryResult {
   costUsd: number;
   /** Dimensions that returned null (timeout or claude error) */
   failedDimensions: string[];
+  /** Provider-aware failure classification per failed dimension (#1147). */
+  failedDimensionFailures?: ReviewDimensionFailure[];
   /** Dimensions auto-skipped due to missing required data (e.g. no plan text) */
   skippedDimensions: string[];
 }
@@ -89,6 +110,14 @@ export const BUDGET_CAP_USD = 2.0;
  * This matches the verdict logic in reviewBattery().
  */
 export const PASSING_THRESHOLD = { maxMissing: 0 } as const;
+
+export function selectReviewProvider(provider?: ReviewProvider): ReviewProvider {
+  return provider ?? { provider: 'claude', billing: 'subscription-cli' };
+}
+
+function providerLabel(provider: ReviewProvider): string {
+  return `${provider.provider} (${provider.billing})`;
+}
 
 // ── Review Dimensions ───────────────────────────────────────────────
 //
@@ -427,6 +456,8 @@ export interface SpawnReviewOptions {
   cwd?: string;
   /** Timeout in ms (default: 120000) */
   timeoutMs?: number;
+  /** Review provider. Defaults to Claude subscription CLI (#1147). */
+  reviewProvider?: ReviewProvider;
 }
 
 // ── Claude Subprocess Helper ─────────────────────────────────────────
@@ -497,7 +528,25 @@ async function runClaude(
  * Spawn a single review agent via `claude -p`.
  * Returns the parsed DimensionReview, or null if the review failed.
  */
-export async function spawnReview(opts: SpawnReviewOptions): Promise<{ review: DimensionReview | null; costUsd: number; durationMs: number }> {
+export async function spawnReview(opts: SpawnReviewOptions): Promise<{
+  review: DimensionReview | null;
+  costUsd: number;
+  durationMs: number;
+  provider: ReviewProvider;
+  failureClass?: ReviewFailureClass;
+}> {
+  const provider = selectReviewProvider(opts.reviewProvider);
+  if (provider.provider === 'codex') {
+    console.error(`  [review:${provider.provider}] ${opts.dimension}: unsupported review provider`);
+    return {
+      review: null,
+      costUsd: 0,
+      durationMs: 0,
+      provider,
+      failureClass: 'codex_review_unsupported',
+    };
+  }
+
   const vars: Record<string, string> = {
     pr_url: opts.prUrl ?? '',
     issue_num: opts.issueNum ?? '',
@@ -513,7 +562,7 @@ export async function spawnReview(opts: SpawnReviewOptions): Promise<{ review: D
     prompt = loadReviewPrompt(opts.dimension, vars);
   } catch (e: any) {
     console.error(`  [review] failed to load prompt for ${opts.dimension}: ${e.message}`);
-    return { review: null, costUsd: 0, durationMs: 0 };
+    return { review: null, costUsd: 0, durationMs: 0, provider, failureClass: 'claude_review_failed' };
   }
 
   const { text, costUsd, durationMs, exitCode } = await runClaude(prompt, {
@@ -523,11 +572,18 @@ export async function spawnReview(opts: SpawnReviewOptions): Promise<{ review: D
 
   if (exitCode !== 0) {
     console.error(`  [review] claude -p failed for ${opts.dimension}: exit ${exitCode}`);
-    return { review: null, costUsd: 0, durationMs };
+    return { review: null, costUsd: 0, durationMs, provider, failureClass: 'claude_review_failed' };
   }
 
   const review = parseReviewOutput(text, opts.dimension);
-  return { review, costUsd, durationMs };
+  if (review) review.provider = provider;
+  return {
+    review,
+    costUsd,
+    durationMs,
+    provider,
+    failureClass: review ? undefined : 'claude_review_failed',
+  };
 }
 
 // ── Batch Review ─────────────────────────────────────────────────────
@@ -577,7 +633,25 @@ export function groupByDataNeeds(
  */
 export async function spawnBatchReview(
   opts: SpawnBatchReviewOptions,
-): Promise<Array<{ review: DimensionReview | null; costUsd: number; durationMs: number }>> {
+): Promise<Array<{
+  review: DimensionReview | null;
+  costUsd: number;
+  durationMs: number;
+  provider: ReviewProvider;
+  failureClass?: ReviewFailureClass;
+}>> {
+  const provider = selectReviewProvider(opts.reviewProvider);
+  if (provider.provider === 'codex') {
+    console.error(`  [review:${provider.provider}] batch: unsupported review provider`);
+    return opts.dimensions.map(() => ({
+      review: null,
+      costUsd: 0,
+      durationMs: 0,
+      provider,
+      failureClass: 'codex_review_unsupported',
+    }));
+  }
+
   const vars: Record<string, string> = {
     pr_url: opts.prUrl ?? '',
     issue_num: opts.issueNum ?? '',
@@ -600,7 +674,7 @@ export async function spawnBatchReview(
   }
 
   if (prompts.length === 0) {
-    return opts.dimensions.map(() => ({ review: null, costUsd: 0, durationMs: 0 }));
+    return opts.dimensions.map(() => ({ review: null, costUsd: 0, durationMs: 0, provider, failureClass: 'claude_review_failed' }));
   }
 
   const batchPrompt =
@@ -615,17 +689,23 @@ export async function spawnBatchReview(
 
   if (exitCode !== 0) {
     console.error(`  [review] batch claude -p failed: exit ${exitCode}`);
-    return opts.dimensions.map(() => ({ review: null, costUsd: 0, durationMs }));
+    return opts.dimensions.map(() => ({ review: null, costUsd: 0, durationMs, provider, failureClass: 'claude_review_failed' }));
   }
 
   const reviews = parseAllReviewOutputs(text, loadedDims);
   const costPerDim = costUsd / Math.max(loadedDims.length, 1);
 
-  return opts.dimensions.map(dim => ({
-    review: reviews.find(r => r.dimension === dim) ?? null,
-    costUsd: costPerDim,
-    durationMs,
-  }));
+  return opts.dimensions.map(dim => {
+    const review = reviews.find(r => r.dimension === dim) ?? null;
+    if (review) review.provider = provider;
+    return {
+      review,
+      costUsd: costPerDim,
+      durationMs,
+      provider,
+      failureClass: review ? undefined : 'claude_review_failed' as const,
+    };
+  });
 }
 
 // ── Battery Orchestration ───────────────────────────────────────────
@@ -651,6 +731,8 @@ export interface BatteryOptions {
   cwd?: string;
   /** Timeout per review in ms */
   timeoutMs?: number;
+  /** Review provider. Defaults to Claude subscription CLI (#1147). */
+  reviewProvider?: ReviewProvider;
 }
 
 /**
@@ -661,6 +743,7 @@ export interface BatteryOptions {
  */
 export async function reviewBattery(opts: BatteryOptions): Promise<BatteryResult> {
   const start = Date.now();
+  const reviewProvider = selectReviewProvider(opts.reviewProvider);
 
   // Auto-load planText from GitHub issue when not provided (kaizen #902).
   // Use a local variable to avoid mutating the caller's opts object.
@@ -688,6 +771,7 @@ export async function reviewBattery(opts: BatteryOptions): Promise<BatteryResult
       skippedResults.push({
         dimension: dim,
         verdict: 'fail',
+        provider: reviewProvider,
         findings: [{
           requirement: `${DATA_GAP_PREFIX} Plan text available for review`,
           status: 'MISSING',
@@ -709,7 +793,7 @@ export async function reviewBattery(opts: BatteryOptions): Promise<BatteryResult
   const sharedOpts = {
     prUrl: opts.prUrl, issueNum: opts.issueNum, repo: opts.repo,
     issueBody: opts.issueBody, prBody: opts.prBody, prDiffStat: opts.prDiffStat,
-    planText, cwd: opts.cwd, timeoutMs: opts.timeoutMs,
+    planText, cwd: opts.cwd, timeoutMs: opts.timeoutMs, reviewProvider,
   };
 
   const batchResultGroups = await Promise.all(
@@ -721,7 +805,7 @@ export async function reviewBattery(opts: BatteryOptions): Promise<BatteryResult
   );
 
   // Map results back to effective dimension order
-  const resultMap = new Map<string, { review: DimensionReview | null; costUsd: number; durationMs: number }>();
+  const resultMap = new Map<string, { review: DimensionReview | null; costUsd: number; durationMs: number; provider: ReviewProvider; failureClass?: ReviewFailureClass }>();
   for (let i = 0; i < batches.length; i++) {
     for (let j = 0; j < batches[i].length; j++) {
       resultMap.set(batches[i][j], batchResultGroups[i][j]);
@@ -731,10 +815,14 @@ export async function reviewBattery(opts: BatteryOptions): Promise<BatteryResult
 
   // Log per-dim timing and collect failures
   const failedDimensions: string[] = [];
+  const failedDimensionFailures: ReviewDimensionFailure[] = [];
   for (const [i, dim] of effective.entries()) {
     const r = results[i];
     if (r.review === null) {
       failedDimensions.push(dim);
+      if (r.failureClass) {
+        failedDimensionFailures.push({ dimension: dim, provider: r.provider, failureClass: r.failureClass });
+      }
       console.error(`  [review] ${dim}: FAILED in ${Math.round(r.durationMs / 1000)}s`);
     } else {
       console.log(`  [review] ${dim}: ${r.review.verdict.toUpperCase()} in ${Math.round(r.durationMs / 1000)}s ($${r.costUsd.toFixed(3)})`);
@@ -758,12 +846,14 @@ export async function reviewBattery(opts: BatteryOptions): Promise<BatteryResult
 
   return {
     dimensions,
+    reviewProvider,
     verdict: missingCount === 0 && dimensions.length === (effective.length + skippedDimensions.length) ? 'pass' : 'fail',
     missingCount,
     partialCount,
     durationMs,
     costUsd,
     failedDimensions,
+    failedDimensionFailures,
     skippedDimensions,
   };
 }
@@ -786,11 +876,13 @@ export function formatBatteryReport(result: BatteryResult): string {
     `| Partial | ${result.partialCount} |`,
     `| Duration | ${(result.durationMs / 1000).toFixed(1)}s |`,
     `| Cost | $${result.costUsd.toFixed(2)} |`,
+    ...(result.reviewProvider ? [`| Review provider | ${providerLabel(result.reviewProvider)} |`] : []),
     '',
   ];
 
   for (const dim of result.dimensions) {
     lines.push(`#### ${dim.dimension}: ${dim.verdict}`);
+    if (dim.provider) lines.push(`_Provider: ${providerLabel(dim.provider)}_`);
     if (dim.summary) lines.push(`> ${dim.summary}`);
     lines.push('');
 


### PR DESCRIPTION
## Problem

The review battery was a hidden Claude trust boundary. Auto-dent could record provider choice for planning and implementation, but review output still looked provider-neutral even though all review subprocesses ran through Claude.

## Discovery

`src/review-battery.ts` already has clear seams: `spawnReview()`, `spawnBatchReview()`, `reviewBattery()`, and `formatBatteryReport()`. The durable contract is the structured dimension finding, so the safest first #1147 step is to add provider metadata and explicit unsupported Codex classification rather than introducing live Codex review execution before comparison data exists.

## Solution

Adds provider-aware review battery metadata:

- Adds a `ReviewProvider` contract with Claude subscription CLI as the default.
- Records provider metadata on each `DimensionReview` and on `BatteryResult`.
- Allows explicit Claude review selection for hybrid runs, e.g. Codex implementation with Claude review.
- Classifies explicit Codex review as `codex_review_unsupported` without calling Claude or pretending a Claude failure occurred.
- Records provider-aware failure entries for failed dimensions.
- Includes provider identity in formatted battery reports.

Closes #1147
Parent: #1134

## Architecture

```text
reviewBattery({ reviewProvider? })
  │
  ├─ selectReviewProvider()
  │     ├─ claude (default, executes existing runner)
  │     └─ codex (classified unsupported for now)
  │
  ├─ spawnReview()/spawnBatchReview()
  │     └─ DimensionReview.provider
  │
  └─ BatteryResult.reviewProvider + failedDimensionFailures
          │
          └─ formatBatteryReport() shows provider identity
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Default to Claude review | Preserves existing review behavior and tests | Codex review is not live yet |
| Classify Codex as unsupported | Keeps Codex failures distinct from Claude failures without faking support | Later work must add a real Codex runner |
| Store provider in structured results | Auto-dent telemetry and reports can audit review provider choice | Existing callers now receive optional provider fields |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Coverage |
|---|----------|-------------|-------|-----------|----------|
| 1 | Default review provider is Claude and legacy review tests still pass. | code | Unit | `src/review-battery.test.ts` | Tested |
| 2 | Review results record provider per dimension and batch. | artifact | Unit | `src/review-battery.test.ts` | Tested |
| 3 | Hybrid mode can explicitly request Claude review while another phase may use Codex. | provider | Unit | `src/review-battery.test.ts` | Tested |
| 4 | Explicit Codex review is classified separately as unsupported instead of a Claude failure. | provider | Unit | `src/review-battery.test.ts` | Tested |
| 5 | Formatted review reports include provider identity. | operator | Unit | `src/review-battery.test.ts` | Tested |

Deferred: live Codex review subprocess execution is deferred to provider comparison work after the structured trust boundary exists.

## Validation

- [x] `npx vitest run src/review-battery.test.ts`
- [x] `npx vitest run src/review-battery.test.ts scripts/review-fix.test.ts scripts/auto-dent-run.test.ts`
- [x] `npm run typecheck`
- [x] `git diff --check`

## Known Limitations

This PR makes review provider choice explicit and auditable. It does not execute live Codex review; explicit Codex review is classified as unsupported until the parent provider comparison work has evidence that the Codex path preserves the review contract.
