### PR TITLE
test(auto-dent): add false-success lifecycle fixtures

### DIFF
--- a/scripts/auto-dent-final-claim.test.ts
+++ b/scripts/auto-dent-final-claim.test.ts
@@ -122,6 +122,40 @@ describe('writeFinalClaimArtifact (#1145)', () => {
 });
 
 describe('foldFinalClaimWarningsIntoProcess (#1145)', () => {
+  it('fixture #1150: a valid structured success claim is not proof without durable evidence', () => {
+    const claim = validClaim({
+      tests: {
+        status: 'pass',
+        command: 'npm test',
+        count: 42,
+        evidence: ['claimed green'],
+      },
+      review_status: 'pass',
+      reflection_status: 'done',
+    });
+
+    const warnings = compareFinalClaimToEvidence(claim, {
+      prs: [],
+      cases: [],
+      testEvidence: false,
+      reviewEvidence: false,
+      reflectionEvidence: false,
+    });
+    const folded = foldFinalClaimWarningsIntoProcess(
+      'pass',
+      0,
+      'process verdict pass (durable evidence complete)',
+      true,
+      warnings,
+    );
+
+    expect(warnings).toContain('claim says tests passed but durable test evidence is missing');
+    expect(warnings).toContain('claim says review passed but durable review evidence is missing');
+    expect(warnings).toContain('claim says reflection completed but durable reflection evidence is missing');
+    expect(folded.verdict).toBe('process-incomplete');
+    expect(folded.issueCount).toBeGreaterThanOrEqual(3);
+  });
+
   it('turns an otherwise passing process verdict into process-incomplete for valid contradictory claims', () => {
     const folded = foldFinalClaimWarningsIntoProcess(
       'pass',

--- a/scripts/auto-dent-lifecycle.test.ts
+++ b/scripts/auto-dent-lifecycle.test.ts
@@ -472,6 +472,23 @@ describe('validateProcessEvidence — durable kaizen evidence verdict (#1149)', 
     expect(result.checks.filter((check) => check.status === 'fail')).toEqual([]);
   });
 
+  it('treats provider review fail as completed review evidence, not missing evidence', () => {
+    const result = validateProcessEvidence(
+      validationWith(['IMPLEMENT', 'TEST', 'PR']),
+      fullEvidence({
+        providerReviewEvidence: {
+          claude: 'pass',
+          codex: 'fail',
+        },
+      }),
+    );
+    expect(result.verdict).toBe('pass');
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      id: 'review-provider',
+      status: 'pass',
+    }));
+  });
+
   it('summarizes failed checks as steering-ready text', () => {
     const result = validateProcessEvidence(
       validationWith(['IMPLEMENT', 'TEST', 'PR']),
@@ -482,4 +499,130 @@ describe('validateProcessEvidence — durable kaizen evidence verdict (#1149)', 
     expect(summary).toContain('plan');
     expect(summary).toContain('test');
   });
+});
+
+describe('adversarial false-success fixtures (#1150)', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'false-success-'));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeLog = (name: string, lines: string[]) => {
+    const f = join(tmpDir, `${name}.log`);
+    writeFileSync(f, lines.join('\n'));
+    return f;
+  };
+
+  const fullEvidence = (over: Partial<ProcessEvidence> = {}): ProcessEvidence => ({
+    planEvidence: true,
+    implementationEvidence: true,
+    prEvidence: true,
+    testEvidence: true,
+    reviewEvidence: true,
+    reflectionEvidence: true,
+    mergeReadiness: 'ready',
+    ...over,
+  });
+
+  const fixtures: Array<{
+    name: string;
+    logShape: 'claude' | 'codex' | 'provider-neutral';
+    lines: string[];
+    evidence: ProcessEvidence;
+    expectedFailedIds: string[];
+  }> = [
+    {
+      name: 'claude-claims-tests-passed-without-durable-test-evidence',
+      logShape: 'claude',
+      lines: [
+        'Claude run completed',
+        'AUTO_DENT_PHASE: IMPLEMENT | case=case-1',
+        'AUTO_DENT_PHASE: TEST | result=pass | count=12',
+        'AUTO_DENT_PHASE: PR | url=https://github.com/test/repo/pull/1',
+      ],
+      evidence: fullEvidence({ testEvidence: false }),
+      expectedFailedIds: ['test'],
+    },
+    {
+      name: 'claude-claims-review-passed-without-review-attachment',
+      logShape: 'claude',
+      lines: [
+        'AUTO_DENT_PHASE: IMPLEMENT | case=case-2',
+        'AUTO_DENT_PHASE: TEST | result=pass | count=5',
+        'AUTO_DENT_PHASE: PR | url=https://github.com/test/repo/pull/2',
+        'review: pass',
+      ],
+      evidence: fullEvidence({ reviewEvidence: false }),
+      expectedFailedIds: ['review'],
+    },
+    {
+      name: 'codex-claims-reflection-done-without-durable-reflection-output',
+      logShape: 'codex',
+      lines: [
+        '[provider] codex synthetic test-task',
+        '[provider] raw_jsonl=run-3-codex.jsonl',
+        '--- codex final text ---',
+        'AUTO_DENT_PHASE: IMPLEMENT | case=case-3',
+        'AUTO_DENT_PHASE: TEST | result=pass | count=4',
+        'AUTO_DENT_PHASE: PR | url=https://github.com/test/repo/pull/3',
+        'AUTO_DENT_PHASE: REFLECT | issues_filed=1',
+      ],
+      evidence: fullEvidence({ reflectionEvidence: false }),
+      expectedFailedIds: ['reflection'],
+    },
+    {
+      name: 'provider-neutral-pr-created-outside-case-worktree',
+      logShape: 'provider-neutral',
+      lines: [
+        'AUTO_DENT_PHASE: TEST | result=pass | count=3',
+        'AUTO_DENT_PHASE: PR | url=https://github.com/test/repo/pull/4',
+      ],
+      evidence: fullEvidence({ implementationEvidence: false, prEvidence: true }),
+      expectedFailedIds: ['implementation'],
+    },
+    {
+      name: 'provider-neutral-resume-lost-plan-state',
+      logShape: 'provider-neutral',
+      lines: [
+        'resume: restored run after interruption; plan_state=missing',
+        'AUTO_DENT_PHASE: IMPLEMENT | case=case-5',
+        'AUTO_DENT_PHASE: TEST | result=pass | count=2',
+      ],
+      evidence: fullEvidence({ planEvidence: false, prEvidence: false, mergeReadiness: 'not-applicable' }),
+      expectedFailedIds: ['plan'],
+    },
+    {
+      name: 'hybrid-review-never-completes-but-worker-claims-success',
+      logShape: 'provider-neutral',
+      lines: [
+        'AUTO_DENT_PHASE: IMPLEMENT | case=case-6',
+        'AUTO_DENT_PHASE: TEST | result=pass | count=9',
+        'AUTO_DENT_PHASE: PR | url=https://github.com/test/repo/pull/6',
+        'AUTO_DENT_PHASE: REFLECT | issues_filed=1',
+      ],
+      evidence: fullEvidence({
+        reviewEvidence: true,
+        providerReviewEvidence: {
+          claude: 'pass',
+          codex: 'pending',
+        },
+      }),
+      expectedFailedIds: ['review-provider'],
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    it(`${fixture.logShape}: ${fixture.name}`, () => {
+      const validation = validateRunLifecycle(writeLog(fixture.name, fixture.lines));
+      const result = validateProcessEvidence(validation, fixture.evidence);
+
+      expect(result.verdict).toBe('process-incomplete');
+      for (const id of fixture.expectedFailedIds) {
+        expect(result.failedChecks.map((check) => check.id)).toContain(id);
+      }
+    });
+  }
 });

--- a/scripts/auto-dent-lifecycle.ts
+++ b/scripts/auto-dent-lifecycle.ts
@@ -168,6 +168,7 @@ export interface EvidenceVerification {
 export type ProcessVerdict = 'pass' | 'process-incomplete' | 'fail-open-warning';
 export type ProcessCheckStatus = 'pass' | 'fail' | 'warning' | 'not-applicable';
 export type MergeReadinessEvidence = 'ready' | 'not-ready' | 'unknown' | 'not-applicable';
+export type ProviderReviewEvidenceStatus = 'pass' | 'fail' | 'skipped' | 'missing' | 'pending';
 
 export interface ProcessEvidence {
   /** Durable plan or claimed-plan assignment evidence exists. */
@@ -180,6 +181,12 @@ export interface ProcessEvidence {
   testEvidence?: boolean;
   /** Review-battery verdict exists (pass/fail both count as evidence). */
   reviewEvidence?: boolean;
+  /**
+   * Optional per-provider review evidence for hybrid/provider-comparison runs.
+   * `pass` and `fail` both prove a provider review completed; skipped/missing/pending
+   * mean the worker cannot claim review completion for that provider.
+   */
+  providerReviewEvidence?: Record<string, ProviderReviewEvidenceStatus>;
   /** Durable reflection output exists. */
   reflectionEvidence?: boolean;
   /** Merge readiness signal for PR-producing runs. */
@@ -187,10 +194,24 @@ export interface ProcessEvidence {
 }
 
 export interface ProcessCheck {
-  id: 'plan' | 'implementation' | 'pr' | 'test' | 'review' | 'reflection' | 'merge-readiness';
+  id: 'plan' | 'implementation' | 'pr' | 'test' | 'review' | 'review-provider' | 'reflection' | 'merge-readiness';
   status: ProcessCheckStatus;
   reason: string;
   remediation?: string;
+}
+
+function completedReviewProviderStatuses(providerEvidence: Record<string, ProviderReviewEvidenceStatus>): {
+  complete: boolean;
+  incompleteProviders: string[];
+} {
+  const entries = Object.entries(providerEvidence);
+  if (entries.length === 0) {
+    return { complete: false, incompleteProviders: ['(none recorded)'] };
+  }
+  const incompleteProviders = entries
+    .filter(([, status]) => status !== 'pass' && status !== 'fail')
+    .map(([provider, status]) => `${provider}:${status}`);
+  return { complete: incompleteProviders.length === 0, incompleteProviders };
 }
 
 export interface ProcessValidation {
@@ -294,6 +315,23 @@ export function validateProcessEvidence(
     'review evidence exists',
     'run the review battery and store a pass/fail verdict',
   );
+
+  if (needsReview && evidence.providerReviewEvidence !== undefined) {
+    const providerReview = completedReviewProviderStatuses(evidence.providerReviewEvidence);
+    checks.push(providerReview.complete
+      ? {
+        id: 'review-provider',
+        status: 'pass',
+        reason: 'all provider review attempts have durable pass/fail evidence',
+      }
+      : {
+        id: 'review-provider',
+        status: 'fail',
+        reason: `provider review evidence incomplete: ${providerReview.incompleteProviders.join(', ')}`,
+        remediation: 'wait for every selected provider review to finish and store its pass/fail evidence before claiming review success',
+      });
+  }
+
   addCheck(
     checks,
     'reflection',


### PR DESCRIPTION
Closes #1150

Parent: #1134

## Story

The external process validator from #1149 gave auto-dent a durable evidence layer: markers and final claims are worker self-report, while plans, cases, PRs, tests, reviews, reflections, and merge readiness are judge evidence.

Every day, that validator had individual unit tests for missing plan/test/review/reflection/implementation evidence. But the exact adversarial false-success scenarios from #1150 were not grouped as fixtures, and hybrid runs still had one subtle blind spot: `reviewEvidence: true` could mean one provider review completed while another selected provider review never finished.

One day, #1150 asked for fixtures that model the failure mode directly: agents claiming process completion without durable evidence, across Claude-shaped logs, Codex-shaped logs, provider-neutral artifacts, and structured final claims.

Because of that, this PR adds a named adversarial fixture suite to `scripts/auto-dent-lifecycle.test.ts`. It covers missing test evidence, missing review attachment, missing reflection output, PR outside a case worktree, resume losing plan state, and hybrid provider review incompletion.

Because of that, this PR also adds optional provider-level review evidence to `ProcessEvidence`. Existing provider-neutral runs keep using `reviewEvidence`; hybrid/provider-comparison runs can now provide statuses like `{ claude: "pass", codex: "pending" }`, and the validator fails the process until every listed provider has durable pass/fail review evidence.

Until finally, `scripts/auto-dent-final-claim.test.ts` now has a #1150 fixture proving a valid structured success claim is still not proof when durable PR/case/test/review/reflection evidence is missing.

And ever since, the validator has executable false-success examples for the exact ways an auto-dent worker can look complete while skipping required process evidence.

## Architecture

```text
AUTO_DENT_PHASE log markers
        |
        v
validateRunLifecycle()
        |
        v
validateProcessEvidence(validation, durableEvidence)
        |
        +-- plan/test/review/reflection/case/PR/merge readiness checks
        |
        +-- optional providerReviewEvidence
              pass/fail  -> completed provider review evidence
              skipped/missing/pending -> process-incomplete

FinalRunClaim JSON remains separate:
compareFinalClaimToEvidence() -> warnings
foldFinalClaimWarningsIntoProcess() -> process-incomplete when durable evidence contradicts a valid claim
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Make provider review evidence optional | Preserves existing provider-neutral validator behavior | Hybrid callers must opt in by supplying per-provider statuses |
| Treat review `pass` and `fail` as completed evidence | A failed review is still durable review evidence; pending/missing/skipped is not | The process verdict remains about evidence completeness, not review quality |
| Keep final-claim proof in final-claim tests | Structured claims are a separate self-report contract from lifecycle marker parsing | #1150 evidence is split across lifecycle and final-claim test files |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-lifecycle.ts` | Adds optional provider review evidence status and a provider-review process check |
| `scripts/auto-dent-lifecycle.test.ts` | Adds six adversarial false-success fixtures for Claude, Codex, provider-neutral, and hybrid run shapes |
| `scripts/auto-dent-final-claim.test.ts` | Adds a structured final-claim fixture proving valid claims are not durable proof |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Coverage |
|---|----------|-------------|-------|----------|
| 1 | Missing durable test evidence fails even when the run log claims `TEST result=pass` | code | Unit | Tested in `scripts/auto-dent-lifecycle.test.ts` |
| 2 | Missing durable review evidence fails even when the worker claims PR/review success | code | Unit | Tested in `scripts/auto-dent-lifecycle.test.ts` |
| 3 | Missing durable reflection evidence fails for a Codex-shaped reflection claim | code | Unit | Tested in `scripts/auto-dent-lifecycle.test.ts` |
| 4 | A PR outside a case worktree fails implementation evidence | code | Unit | Tested in `scripts/auto-dent-lifecycle.test.ts` |
| 5 | Resume/interruption with lost plan state fails plan evidence | code | Unit | Tested in `scripts/auto-dent-lifecycle.test.ts` |
| 6 | Hybrid provider review missing/pending fails even when aggregate review evidence exists | code | Unit | Tested in `scripts/auto-dent-lifecycle.test.ts` |
| 7 | Structured final claims are not proof without durable evidence | code | Unit | Tested in `scripts/auto-dent-final-claim.test.ts` |

## Validation

- [x] Red run: `npx vitest run scripts/auto-dent-lifecycle.test.ts scripts/auto-dent-final-claim.test.ts` failed on `hybrid-review-never-completes-but-worker-claims-success`
- [x] Green focused run: `npx vitest run scripts/auto-dent-lifecycle.test.ts scripts/auto-dent-final-claim.test.ts` -> 54 tests passed
- [x] Related run: `npx vitest run scripts/auto-dent-lifecycle.test.ts scripts/auto-dent-final-claim.test.ts scripts/auto-dent-review-wiring.test.ts scripts/auto-dent-provider.test.ts scripts/batch-summary.test.ts` -> 112 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`

## Known Limitations

This PR adds the provider-review evidence field and validator behavior. Wiring real hybrid batch telemetry into `providerReviewEvidence` belongs with the provider comparison matrix work in #1152.
