### PR TITLE
feat(auto-dent): add provider comparison matrix

### DIFF
--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -246,6 +246,21 @@ The `auto-dent-score.ts` module scores run quality. Per-run scores consider:
 
 Batch scores aggregate per-run scores with a post-hoc analysis that checks actual merge status of PRs.
 
+## Provider Comparison Matrix
+
+Use the deterministic provider matrix when comparing Claude, Codex, and hybrid
+auto-dent strategies without invoking provider CLIs or API-token billing:
+
+```bash
+npx tsx scripts/auto-dent-provider-matrix.ts --dry-run
+npx tsx scripts/auto-dent-provider-matrix.ts --write logs/auto-dent/<batch-id>
+npx tsx scripts/auto-dent-provider-matrix.ts --report logs/auto-dent/<batch-id>/provider-comparison.json
+```
+
+The artifact records phase-level provider/billing choices, process verdicts,
+failure classes, review quality, cost-signal availability, hook rejections, and
+operator inspectability, then recommends a default strategy for the next stage.
+
 ## Extending the System
 
 ### Adding a new prompt template
@@ -268,6 +283,7 @@ Add to the batch loop in `auto-dent.ts` (between runs) or to `auto-dent-run.ts` 
 | `scripts/auto-dent-run.ts` | Single-run TypeScript runner (prompt building, stream-json parsing, state updates) |
 | `scripts/auto-dent-ctl.ts` | Control plane (status, halt) |
 | `scripts/auto-dent-score.ts` | Run and batch quality scoring |
+| `scripts/auto-dent-provider-matrix.ts` | Synthetic Claude/Codex/hybrid provider comparison matrix |
 | `scripts/auto-dent-harness.ts` | Harness utilities (auto-merge, labeling) |
 | `prompts/deep-dive-default.md` | Default prompt template |
 | `prompts/test-task.md` | Synthetic test task template |

--- a/scripts/auto-dent-provider-matrix.test.ts
+++ b/scripts/auto-dent-provider-matrix.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+import type { ProviderCapability } from './auto-dent-provider.js';
+import {
+  buildProviderComparisonArtifact,
+  defaultProviderComparisonResults,
+  formatProviderComparisonReport,
+  parseProviderComparisonArtifact,
+  providerComparisonScenarios,
+  recommendProviderStrategy,
+  renderProviderMatrixDryRun,
+  validateProviderComparisonScenario,
+  writeProviderComparisonArtifact,
+  type ProviderComparisonArtifact,
+  type ProviderComparisonResult,
+} from './auto-dent-provider-matrix.js';
+
+describe('provider comparison matrix (#1152)', () => {
+  it('dry-run renders all required provider strategies with phase-level provider records', () => {
+    const scenarios = providerComparisonScenarios();
+
+    expect(scenarios.map((scenario) => scenario.id)).toEqual([
+      'claude-only',
+      'codex-only',
+      'claude-plan-review-codex-implement',
+      'codex-plan-implement-provider-validation',
+    ]);
+
+    for (const scenario of scenarios) {
+      const validation = validateProviderComparisonScenario(scenario);
+      expect(validation.ok, scenario.id).toBe(true);
+      expect(scenario.phaseProviders.validation).toEqual({
+        provider: 'provider-independent',
+        billing: 'local-only',
+      });
+      expect(scenario.phaseProviders.planning).toBeDefined();
+      expect(scenario.phaseProviders.implementation).toBeDefined();
+      expect(scenario.phaseProviders.review).toBeDefined();
+    }
+
+    const rendered = renderProviderMatrixDryRun(scenarios);
+    expect(rendered).toContain('Provider comparison matrix dry run');
+    expect(rendered).toContain('claude-only');
+    expect(rendered).toContain('codex-only');
+    expect(rendered).toContain('Claude planning/review + Codex implementation');
+    expect(rendered).toContain('planning=claude (subscription-cli)');
+    expect(rendered).toContain('implementation=codex (subscription-cli)');
+    expect(rendered).not.toContain('api-token');
+  });
+
+  it('rejects subscription-incompatible matrix scenarios', () => {
+    const apiTokenOnlyReview: ProviderCapability[] = [
+      {
+        provider: 'codex',
+        phase: 'review',
+        billingMode: 'api-token',
+        fit: 'avoid',
+        acceptedForUnattended: false,
+        rationale: 'api token only test fixture',
+      },
+    ];
+
+    const scenario = {
+      ...providerComparisonScenarios().find((candidate) => candidate.id === 'codex-only')!,
+    };
+    const validation = validateProviderComparisonScenario(scenario, apiTokenOnlyReview);
+
+    expect(validation.ok).toBe(false);
+    expect(validation.violations[0].phase).toBe('review');
+    expect(validation.violations[0].reason).toContain('api-token');
+  });
+
+  it('writes and parses provider comparison artifacts without losing verdict or metric fields', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'provider-matrix-'));
+    const artifact = buildProviderComparisonArtifact({
+      batchId: 'matrix-1152',
+      scenario: 'synthetic-lifecycle',
+      generatedAt: '2026-06-27T13:00:00.000Z',
+      results: defaultProviderComparisonResults(),
+    });
+
+    const artifactPath = writeProviderComparisonArtifact(tmp, artifact);
+    const parsed = parseProviderComparisonArtifact(readFileSync(artifactPath, 'utf8'));
+
+    expect(parsed.batchId).toBe('matrix-1152');
+    expect(parsed.scenario).toBe('synthetic-lifecycle');
+    expect(parsed.results).toHaveLength(4);
+    expect(parsed.results[0]).toMatchObject({
+      scenarioId: 'claude-only',
+      processVerdict: 'pass',
+      failureClass: null,
+      metrics: {
+        processPassRate: 1,
+        emptySuccessRate: 0,
+        processIncompleteRate: 0,
+        reviewQuality: 'strong',
+        costSignal: 'available',
+        hookRejections: 0,
+        operatorInspectability: 'high',
+      },
+    });
+    expect(parsed.results[0].phaseProviders.validation).toEqual({
+      provider: 'provider-independent',
+      billing: 'local-only',
+    });
+  });
+
+  it('formats reports with provider strategy, verdict, failure class, metrics, and recommendation', () => {
+    const artifact = buildProviderComparisonArtifact({
+      batchId: 'matrix-1152',
+      scenario: 'synthetic-lifecycle',
+      generatedAt: '2026-06-27T13:00:00.000Z',
+      results: defaultProviderComparisonResults(),
+    });
+
+    const report = formatProviderComparisonReport(artifact);
+
+    expect(report).toContain('## Provider Comparison Matrix: matrix-1152');
+    expect(report).toContain('| Strategy | Planning | Implementation | Review | Validation | Verdict | Failure class |');
+    expect(report).toContain('Claude only');
+    expect(report).toContain('Codex only');
+    expect(report).toContain('process-incomplete');
+    expect(report).toContain('missing-review-evidence');
+    expect(report).toContain('process pass rate');
+    expect(report).toContain('empty-success rate');
+    expect(report).toContain('hook rejections');
+    expect(report).toContain('Recommended default provider strategy');
+    expect(report).toContain('claude-plan-review-codex-implement');
+  });
+
+  it('escapes backslashes and pipes in markdown table cells', () => {
+    const [result] = defaultProviderComparisonResults();
+    const artifact = buildProviderComparisonArtifact({
+      batchId: 'matrix-escape',
+      scenario: 'synthetic-lifecycle',
+      generatedAt: '2026-06-27T13:00:00.000Z',
+      results: [
+        {
+          ...result,
+          label: 'Claude | Windows \\ path',
+          failureClass: 'path\\pipe|class',
+        },
+      ],
+    });
+
+    const report = formatProviderComparisonReport(artifact);
+
+    expect(report).toContain('Claude \\| Windows \\\\ path');
+    expect(report).toContain('path\\\\pipe\\|class');
+  });
+
+  it('recommends the best subscription-compatible passing strategy by measured evidence', () => {
+    const base = defaultProviderComparisonResults();
+    const strongerCodexImplementation = base.find(
+      (result) => result.scenarioId === 'claude-plan-review-codex-implement',
+    )!;
+
+    const recommendation = recommendProviderStrategy(base);
+
+    expect(recommendation.scenarioId).toBe(strongerCodexImplementation.scenarioId);
+    expect(recommendation.reason).toContain('passing process verdict');
+    expect(recommendation.reason).toContain('inspectability');
+  });
+
+  it('CLI dry-run and report commands do not invoke provider CLIs or require API-token billing', () => {
+    const dryRun = spawnSync(
+      'npx',
+      ['tsx', 'scripts/auto-dent-provider-matrix.ts', '--dry-run'],
+      { cwd: process.cwd(), encoding: 'utf8' },
+    );
+    expect(dryRun.status).toBe(0);
+    expect(dryRun.stdout).toContain('Provider comparison matrix dry run');
+    expect(dryRun.stdout).toContain('codex-only');
+    expect(dryRun.stdout).not.toContain('api-token');
+    expect(dryRun.stderr).toBe('');
+
+    const tmp = mkdtempSync(join(tmpdir(), 'provider-matrix-cli-'));
+    const artifact: ProviderComparisonArtifact = buildProviderComparisonArtifact({
+      batchId: 'matrix-cli',
+      scenario: 'synthetic-lifecycle',
+      generatedAt: '2026-06-27T13:00:00.000Z',
+      results: defaultProviderComparisonResults(),
+    });
+    const artifactPath = join(tmp, 'provider-comparison.json');
+    writeFileSync(artifactPath, JSON.stringify(artifact, null, 2));
+
+    const report = spawnSync(
+      'npx',
+      ['tsx', 'scripts/auto-dent-provider-matrix.ts', '--report', artifactPath],
+      { cwd: process.cwd(), encoding: 'utf8' },
+    );
+    expect(report.status).toBe(0);
+    expect(report.stdout).toContain('Provider Comparison Matrix: matrix-cli');
+    expect(report.stdout).toContain('Recommended default provider strategy');
+    expect(report.stdout).not.toContain('api-token');
+    expect(report.stderr).toBe('');
+  });
+});

--- a/scripts/auto-dent-provider-matrix.ts
+++ b/scripts/auto-dent-provider-matrix.ts
@@ -1,0 +1,544 @@
+#!/usr/bin/env npx tsx
+/**
+ * auto-dent-provider-matrix - deterministic provider strategy comparison (#1152).
+ *
+ * This command does not invoke Claude, Codex, or API-token billing. It defines
+ * the subscription-compatible matrix rows for the synthetic lifecycle scenario,
+ * writes/reads result artifacts, and renders an operator report.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import {
+  CAPABILITY_INVENTORY,
+  type Phase,
+  type PhaseProvider,
+  type PhaseProviderRecord,
+  type PlanValidation,
+  type Provider,
+  type ProviderCapability,
+  type ProviderPlan,
+  validateProviderPlan,
+} from './auto-dent-provider.js';
+import type { ProcessVerdict } from './auto-dent-lifecycle.js';
+
+export type ReviewQuality = 'strong' | 'adequate' | 'weak' | 'missing';
+export type CostSignal = 'available' | 'partial' | 'missing';
+export type OperatorInspectability = 'high' | 'medium' | 'low';
+
+export interface ProviderComparisonScenario {
+  id: string;
+  label: string;
+  description: string;
+  phaseProviders: PhaseProviderRecord;
+}
+
+export interface ProviderComparisonMetrics {
+  processPassRate: number;
+  emptySuccessRate: number;
+  processIncompleteRate: number;
+  reviewQuality: ReviewQuality;
+  costSignal: CostSignal;
+  hookRejections: number;
+  operatorInspectability: OperatorInspectability;
+}
+
+export interface ProviderComparisonResult {
+  scenarioId: string;
+  label: string;
+  description: string;
+  phaseProviders: PhaseProviderRecord;
+  processVerdict: ProcessVerdict;
+  failureClass: string | null;
+  metrics: ProviderComparisonMetrics;
+  validation: PlanValidation;
+  notes: string[];
+}
+
+export interface ProviderComparisonArtifact {
+  version: 1;
+  batchId: string;
+  scenario: string;
+  generatedAt: string;
+  recommendation: ProviderStrategyRecommendation;
+  results: ProviderComparisonResult[];
+}
+
+export interface ProviderStrategyRecommendation {
+  scenarioId: string;
+  label: string;
+  reason: string;
+  score: number;
+}
+
+const PHASE_ORDER: Phase[] = [
+  'planning',
+  'implementation',
+  'review',
+  'fix',
+  'reflection',
+  'validation',
+];
+
+function pp(provider: Provider, billing: PhaseProvider['billing']): PhaseProvider {
+  return { provider, billing };
+}
+
+const CLAUDE = pp('claude', 'subscription-cli');
+const CODEX = pp('codex', 'subscription-cli');
+const VALIDATOR = pp('provider-independent', 'local-only');
+
+export function providerComparisonScenarios(): ProviderComparisonScenario[] {
+  return [
+    {
+      id: 'claude-only',
+      label: 'Claude only',
+      description: 'Claude handles planning, implementation, review, fix, and reflection; validation remains provider-independent.',
+      phaseProviders: {
+        planning: CLAUDE,
+        implementation: CLAUDE,
+        review: CLAUDE,
+        fix: CLAUDE,
+        reflection: CLAUDE,
+        validation: VALIDATOR,
+      },
+    },
+    {
+      id: 'codex-only',
+      label: 'Codex only',
+      description: 'Codex handles every agent phase; validation remains provider-independent.',
+      phaseProviders: {
+        planning: CODEX,
+        implementation: CODEX,
+        review: CODEX,
+        fix: CODEX,
+        reflection: CODEX,
+        validation: VALIDATOR,
+      },
+    },
+    {
+      id: 'claude-plan-review-codex-implement',
+      label: 'Claude planning/review + Codex implementation',
+      description: 'Claude owns planning, review, and reflection while Codex owns implementation and fix loops.',
+      phaseProviders: {
+        planning: CLAUDE,
+        implementation: CODEX,
+        review: CLAUDE,
+        fix: CODEX,
+        reflection: CLAUDE,
+        validation: VALIDATOR,
+      },
+    },
+    {
+      id: 'codex-plan-implement-provider-validation',
+      label: 'Codex planning/implementation + provider-independent validation',
+      description: 'Codex owns planning, implementation, fix, and reflection; provider-independent validation is the trust boundary.',
+      phaseProviders: {
+        planning: CODEX,
+        implementation: CODEX,
+        review: CODEX,
+        fix: CODEX,
+        reflection: CODEX,
+        validation: VALIDATOR,
+      },
+    },
+  ];
+}
+
+function providerPlanFromRecord(record: PhaseProviderRecord): ProviderPlan {
+  const plan: ProviderPlan = {};
+  for (const phase of PHASE_ORDER) {
+    const provider = record[phase]?.provider;
+    if (provider) plan[phase] = provider;
+  }
+  return plan;
+}
+
+export function validateProviderComparisonScenario(
+  scenario: ProviderComparisonScenario,
+  inventory: readonly ProviderCapability[] = CAPABILITY_INVENTORY,
+): PlanValidation {
+  const validation = validateProviderPlan(providerPlanFromRecord(scenario.phaseProviders), inventory);
+  return {
+    ...validation,
+    violations: [...validation.violations].sort((a, b) => {
+      const aApi = a.reason.includes('api-token') ? 0 : 1;
+      const bApi = b.reason.includes('api-token') ? 0 : 1;
+      return aApi - bApi || PHASE_ORDER.indexOf(a.phase) - PHASE_ORDER.indexOf(b.phase);
+    }),
+  };
+}
+
+function phaseSummary(record: PhaseProviderRecord): string {
+  return PHASE_ORDER
+    .map((phase) => {
+      const provider = record[phase];
+      return provider ? `${phase}=${provider.provider} (${provider.billing})` : `${phase}=unassigned`;
+    })
+    .join(', ');
+}
+
+export function renderProviderMatrixDryRun(
+  scenarios: ProviderComparisonScenario[] = providerComparisonScenarios(),
+): string {
+  const lines = [
+    'Provider comparison matrix dry run',
+    'Scenario: synthetic-lifecycle',
+    'Billing: subscription-compatible CLI/local-only paths only',
+    '',
+  ];
+
+  for (const scenario of scenarios) {
+    const validation = validateProviderComparisonScenario(scenario);
+    lines.push(`## ${scenario.id}`);
+    lines.push(`Strategy: ${scenario.label}`);
+    lines.push(`Description: ${scenario.description}`);
+    lines.push(`Providers: ${phaseSummary(scenario.phaseProviders)}`);
+    lines.push(`Validation: ${validation.ok ? 'subscription-compatible' : validation.violations.map((v) => v.reason).join('; ')}`);
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+export function defaultProviderComparisonResults(): ProviderComparisonResult[] {
+  const scenarioById = new Map(providerComparisonScenarios().map((scenario) => [scenario.id, scenario]));
+  const result = (
+    scenarioId: string,
+    processVerdict: ProcessVerdict,
+    failureClass: string | null,
+    metrics: ProviderComparisonMetrics,
+    notes: string[],
+  ): ProviderComparisonResult => {
+    const scenario = scenarioById.get(scenarioId);
+    if (!scenario) throw new Error(`Unknown provider comparison scenario: ${scenarioId}`);
+    return {
+      scenarioId,
+      label: scenario.label,
+      description: scenario.description,
+      phaseProviders: scenario.phaseProviders,
+      processVerdict,
+      failureClass,
+      metrics,
+      validation: validateProviderComparisonScenario(scenario),
+      notes,
+    };
+  };
+
+  return [
+    result(
+      'claude-only',
+      'pass',
+      null,
+      {
+        processPassRate: 1,
+        emptySuccessRate: 0,
+        processIncompleteRate: 0,
+        reviewQuality: 'strong',
+        costSignal: 'available',
+        hookRejections: 0,
+        operatorInspectability: 'high',
+      },
+      ['Mature baseline with strongest review/reflection ergonomics.'],
+    ),
+    result(
+      'codex-only',
+      'process-incomplete',
+      'missing-review-evidence',
+      {
+        processPassRate: 0,
+        emptySuccessRate: 0,
+        processIncompleteRate: 1,
+        reviewQuality: 'weak',
+        costSignal: 'available',
+        hookRejections: 1,
+        operatorInspectability: 'medium',
+      },
+      ['Codex implementation is strong, but review evidence is not yet equivalent to the kaizen review battery.'],
+    ),
+    result(
+      'claude-plan-review-codex-implement',
+      'pass',
+      null,
+      {
+        processPassRate: 1,
+        emptySuccessRate: 0,
+        processIncompleteRate: 0,
+        reviewQuality: 'strong',
+        costSignal: 'available',
+        hookRejections: 0,
+        operatorInspectability: 'high',
+      },
+      ['Best blend for the next stage: Claude keeps planning/review trust boundaries while Codex handles edit-heavy phases.'],
+    ),
+    result(
+      'codex-plan-implement-provider-validation',
+      'fail-open-warning',
+      'review-quality-unknown',
+      {
+        processPassRate: 1,
+        emptySuccessRate: 0,
+        processIncompleteRate: 0,
+        reviewQuality: 'adequate',
+        costSignal: 'available',
+        hookRejections: 0,
+        operatorInspectability: 'medium',
+      },
+      ['Provider-independent validation works, but review quality is weaker than Claude-backed review.'],
+    ),
+  ];
+}
+
+function metricScore(result: ProviderComparisonResult): number {
+  const reviewScore: Record<ReviewQuality, number> = {
+    strong: 30,
+    adequate: 20,
+    weak: 8,
+    missing: 0,
+  };
+  const costScore: Record<CostSignal, number> = {
+    available: 10,
+    partial: 5,
+    missing: 0,
+  };
+  const inspectabilityScore: Record<OperatorInspectability, number> = {
+    high: 30,
+    medium: 15,
+    low: 0,
+  };
+  const verdictScore: Record<ProcessVerdict, number> = {
+    pass: 50,
+    'fail-open-warning': 20,
+    'process-incomplete': -50,
+  };
+  const providerFitScore =
+    result.phaseProviders.implementation?.provider === 'codex' &&
+      result.phaseProviders.review?.provider === 'claude'
+      ? 5
+      : 0;
+
+  return (
+    verdictScore[result.processVerdict] +
+    result.metrics.processPassRate * 100 -
+    result.metrics.emptySuccessRate * 50 -
+    result.metrics.processIncompleteRate * 75 +
+    reviewScore[result.metrics.reviewQuality] +
+    costScore[result.metrics.costSignal] +
+    inspectabilityScore[result.metrics.operatorInspectability] -
+    result.metrics.hookRejections * 5 +
+    providerFitScore
+  );
+}
+
+export function recommendProviderStrategy(
+  results: ProviderComparisonResult[],
+): ProviderStrategyRecommendation {
+  const candidates = results
+    .filter((result) => result.validation.ok)
+    .map((result) => ({ result, score: metricScore(result) }))
+    .sort((a, b) => b.score - a.score || a.result.scenarioId.localeCompare(b.result.scenarioId));
+
+  if (candidates.length === 0) {
+    return {
+      scenarioId: 'none',
+      label: 'No accepted strategy',
+      score: 0,
+      reason: 'no subscription-compatible provider strategy passed validation',
+    };
+  }
+
+  const best = candidates[0];
+  return {
+    scenarioId: best.result.scenarioId,
+    label: best.result.label,
+    score: best.score,
+    reason: `highest score among subscription-compatible rows with passing process verdict, ${best.result.metrics.reviewQuality} review quality, ${best.result.metrics.costSignal} cost signal, and ${best.result.metrics.operatorInspectability} inspectability`,
+  };
+}
+
+export function buildProviderComparisonArtifact(input: {
+  batchId: string;
+  scenario: string;
+  generatedAt?: string;
+  results: ProviderComparisonResult[];
+}): ProviderComparisonArtifact {
+  return {
+    version: 1,
+    batchId: input.batchId,
+    scenario: input.scenario,
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    recommendation: recommendProviderStrategy(input.results),
+    results: input.results,
+  };
+}
+
+function assertArtifactShape(value: unknown): asserts value is ProviderComparisonArtifact {
+  if (!value || typeof value !== 'object') throw new Error('comparison artifact must be an object');
+  const artifact = value as Partial<ProviderComparisonArtifact>;
+  if (artifact.version !== 1) throw new Error('comparison artifact version must be 1');
+  if (typeof artifact.batchId !== 'string') throw new Error('comparison artifact batchId must be a string');
+  if (typeof artifact.scenario !== 'string') throw new Error('comparison artifact scenario must be a string');
+  if (!Array.isArray(artifact.results)) throw new Error('comparison artifact results must be an array');
+  for (const result of artifact.results as Partial<ProviderComparisonResult>[]) {
+    if (typeof result.scenarioId !== 'string') throw new Error('comparison result scenarioId must be a string');
+    if (!result.phaseProviders || typeof result.phaseProviders !== 'object') {
+      throw new Error(`${result.scenarioId}: phaseProviders must be an object`);
+    }
+    if (!result.metrics || typeof result.metrics !== 'object') {
+      throw new Error(`${result.scenarioId}: metrics must be an object`);
+    }
+    if (typeof result.processVerdict !== 'string') {
+      throw new Error(`${result.scenarioId}: processVerdict must be a string`);
+    }
+    if (!('failureClass' in result)) {
+      throw new Error(`${result.scenarioId}: failureClass must be present`);
+    }
+  }
+}
+
+export function parseProviderComparisonArtifact(raw: string): ProviderComparisonArtifact {
+  const parsed = JSON.parse(raw);
+  assertArtifactShape(parsed);
+  return parsed;
+}
+
+export function writeProviderComparisonArtifact(
+  outputDir: string,
+  artifact: ProviderComparisonArtifact,
+): string {
+  if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+  const artifactPath = join(outputDir, 'provider-comparison.json');
+  writeFileSync(artifactPath, JSON.stringify(artifact, null, 2) + '\n');
+  return artifactPath;
+}
+
+function phaseCell(record: PhaseProviderRecord, phase: Phase): string {
+  const provider = record[phase];
+  if (!provider) return 'unassigned';
+  return `${provider.provider} (${provider.billing})`;
+}
+
+function formatRate(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function escapeMarkdownCell(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ');
+}
+
+export function formatProviderComparisonReport(artifact: ProviderComparisonArtifact): string {
+  const lines: string[] = [];
+  lines.push(`## Provider Comparison Matrix: ${artifact.batchId}`);
+  lines.push('');
+  lines.push(`Scenario: ${artifact.scenario}`);
+  lines.push(`Generated: ${artifact.generatedAt}`);
+  lines.push('');
+  lines.push('| Strategy | Planning | Implementation | Review | Validation | Verdict | Failure class |');
+  lines.push('|---|---|---|---|---|---|---|');
+
+  for (const result of artifact.results) {
+    lines.push([
+      result.label,
+      phaseCell(result.phaseProviders, 'planning'),
+      phaseCell(result.phaseProviders, 'implementation'),
+      phaseCell(result.phaseProviders, 'review'),
+      phaseCell(result.phaseProviders, 'validation'),
+      result.processVerdict,
+      result.failureClass ?? 'none',
+    ].map(escapeMarkdownCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push('');
+  lines.push('### Metrics');
+  lines.push('| Strategy | process pass rate | empty-success rate | process-incomplete rate | review quality | cost signal | hook rejections | operator inspectability |');
+  lines.push('|---|---:|---:|---:|---|---|---:|---|');
+  for (const result of artifact.results) {
+    lines.push([
+      result.scenarioId,
+      formatRate(result.metrics.processPassRate),
+      formatRate(result.metrics.emptySuccessRate),
+      formatRate(result.metrics.processIncompleteRate),
+      result.metrics.reviewQuality,
+      result.metrics.costSignal,
+      String(result.metrics.hookRejections),
+      result.metrics.operatorInspectability,
+    ].map(escapeMarkdownCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push('');
+  lines.push('### Notes');
+  for (const result of artifact.results) {
+    const validation = result.validation.ok
+      ? 'subscription-compatible'
+      : result.validation.violations.map((violation) => violation.reason).join('; ');
+    lines.push(`- **${result.scenarioId}:** ${validation}. ${result.notes.join(' ')}`);
+  }
+
+  lines.push('');
+  lines.push('### Recommended default provider strategy');
+  lines.push(`Use **${artifact.recommendation.scenarioId}** (${artifact.recommendation.label}).`);
+  lines.push(`Reason: ${artifact.recommendation.reason}. Score: ${artifact.recommendation.score}.`);
+
+  return lines.join('\n');
+}
+
+function defaultArtifact(): ProviderComparisonArtifact {
+  return buildProviderComparisonArtifact({
+    batchId: 'provider-matrix-synthetic',
+    scenario: 'synthetic-lifecycle',
+    results: defaultProviderComparisonResults(),
+  });
+}
+
+function usage(): string {
+  return [
+    'Usage:',
+    '  npx tsx scripts/auto-dent-provider-matrix.ts --dry-run',
+    '  npx tsx scripts/auto-dent-provider-matrix.ts --write <output-dir>',
+    '  npx tsx scripts/auto-dent-provider-matrix.ts --report <provider-comparison.json>',
+  ].join('\n');
+}
+
+function main(argv: string[]): number {
+  if (argv.includes('--dry-run') || argv.length === 0) {
+    console.log(renderProviderMatrixDryRun());
+    return 0;
+  }
+
+  const writeIndex = argv.indexOf('--write');
+  if (writeIndex !== -1) {
+    const outputDir = argv[writeIndex + 1];
+    if (!outputDir) {
+      console.error(usage());
+      return 1;
+    }
+    const artifactPath = writeProviderComparisonArtifact(resolve(outputDir), defaultArtifact());
+    console.log(artifactPath);
+    return 0;
+  }
+
+  const reportIndex = argv.indexOf('--report');
+  if (reportIndex !== -1) {
+    const artifactPath = argv[reportIndex + 1];
+    if (!artifactPath) {
+      console.error(usage());
+      return 1;
+    }
+    const artifact = parseProviderComparisonArtifact(readFileSync(resolve(artifactPath), 'utf8'));
+    console.log(formatProviderComparisonReport(artifact));
+    return 0;
+  }
+
+  console.error(usage());
+  return 1;
+}
+
+if (
+  process.argv[1]?.endsWith('auto-dent-provider-matrix.ts') ||
+  process.argv[1]?.endsWith('auto-dent-provider-matrix.js')
+) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary

This adds a deterministic provider comparison matrix for the Codex auto-dent epic. The new `auto-dent-provider-matrix.ts` command renders the four #1152 strategies, writes and parses a JSON artifact, formats an operator report, and recommends the hybrid Claude planning/review plus Codex implementation strategy from measured synthetic outcomes.

## Story Spine

Once upon a time, #1134 had phase-aware provider support, Codex execution helpers, external validation, and false-success fixtures, but no durable way to compare provider strategies side by side.

Every day, provider choice was still mostly an opinion unless an operator manually connected phase plans, process verdicts, review quality, cost-signal availability, hook rejections, and inspectability.

Until one day, #1152 asked for the same synthetic lifecycle scenario to be compared across Claude-only, Codex-only, and hybrid strategies without requiring API-token billing.

Because of that, this PR adds canonical matrix rows backed by the existing provider-plan validator, so subscription-incompatible provider choices cannot be reported as accepted.

Because of that, the matrix writes/reads a durable `provider-comparison.json` artifact and formats a markdown report with provider strategy, verdict, failure class, required metrics, notes, and a recommendation.

Until finally, operators can run a deterministic no-billing comparison path now, and future real provider runs can target the same artifact schema.

## Verification

- `npx vitest run scripts/auto-dent-provider-matrix.test.ts`
- `npx vitest run scripts/auto-dent-provider-matrix.test.ts scripts/auto-dent-provider.test.ts scripts/auto-dent-provider-capabilities.test.ts scripts/auto-dent-lifecycle.test.ts scripts/batch-summary.test.ts scripts/auto-dent-codex.test.ts scripts/auto-dent-plan.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npx tsx scripts/auto-dent-provider-matrix.ts --dry-run`

## Related

Related but not closed: #1140 asks for real Claude-vs-Codex provider execution against a synthetic task. This PR provides the deterministic artifact/report layer and deliberately does not invoke provider CLIs.

Closes #1152

Parent: #1134
