### PR TITLE
feat(auto-dent): allow codex provider batches

### DIFF
--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -79,6 +79,9 @@ Key variables: `{{guidance}}`, `{{run_tag}}`, `{{run_context}}`, `{{issues_close
 # Preview without executing
 ./scripts/auto-dent.sh --dry-run "focus on observability"
 
+# Run with Codex subscription CLI instead of Claude
+./scripts/auto-dent.sh --provider codex "focus on provider-safe fixes"
+
 # Custom timeout (default 45min per run)
 ./scripts/auto-dent.sh --max-run-seconds 1800 "simple fixes only"
 ```
@@ -93,6 +96,7 @@ Key variables: `{{guidance}}`, `{{run_tag}}`, `{{run_context}}`, `{{issues_close
 | `--max-budget N.NN` | none | Total batch budget — halts when cumulative cost exceeds |
 | `--max-failures N` | 3 | Stop after N consecutive failures |
 | `--max-run-seconds N` | 1200 (20min) | Wall-time timeout per run |
+| `--provider claude\|codex` | claude | Agent provider; Codex uses subscription CLI JSONL output |
 | `--dry-run` | off | Show what would run |
 | `--test-task` | off | Use synthetic fast task |
 | `--experiment` | off | Enable extra pipeline diagnostics |

--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -103,13 +103,13 @@ describe('provider-aware planning (#1146)', () => {
     });
   });
 
-  it('selects Codex planning only for explicit synthetic Codex batches', () => {
+  it('selects Codex planning for explicit Codex batches', () => {
     expect(selectPlanningProvider(makeState({ provider: 'codex', test_task: true }))).toEqual({
       provider: 'codex',
       billing: 'subscription-cli',
     });
     expect(selectPlanningProvider(makeState({ provider: 'codex', test_task: false }))).toEqual({
-      provider: 'claude',
+      provider: 'codex',
       billing: 'subscription-cli',
     });
   });

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -115,7 +115,7 @@ Output a JSON plan with ranked work items. Format:
 }
 
 export function selectPlanningProvider(state: BatchState): PhaseProvider {
-  if (state.provider === 'codex' && state.test_task === true) {
+  if (state.provider === 'codex') {
     return { provider: 'codex', billing: 'subscription-cli' };
   }
   return { provider: 'claude', billing: 'subscription-cli' };

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -51,6 +51,7 @@ import {
   ensureBatchProgressIssue,
   extractPlanText,
   populateCrossBatchSteering,
+  shouldRunCodexProvider,
 } from './auto-dent-run.js';
 import * as github from './auto-dent-github.js';
 
@@ -1584,6 +1585,13 @@ describe('BatchState provider field (#1144)', () => {
     expect(codexState.provider).toBe('codex');
     expect(codexState.test_task).toBe(true);
     expect(legacyState.provider).toBeUndefined();
+  });
+
+  it('treats Codex as a real run provider outside synthetic test-task mode (#1139)', () => {
+    expect(shouldRunCodexProvider(makeBatchState({ provider: 'codex', test_task: false }))).toBe(true);
+    expect(shouldRunCodexProvider(makeBatchState({ provider: 'codex', test_task: true }))).toBe(true);
+    expect(shouldRunCodexProvider(makeBatchState({ provider: 'claude', test_task: false }))).toBe(false);
+    expect(shouldRunCodexProvider(makeBatchState({ provider: undefined, test_task: false }))).toBe(false);
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -204,7 +204,7 @@ export interface BatchState {
   progress_issue?: string;
   test_task?: boolean;
   experiment?: boolean;
-  /** Agent provider. Defaults to claude for older state files. Codex is synthetic-only (#1144). */
+  /** Agent provider. Defaults to claude for older state files. Codex uses subscription CLI (#1139). */
   provider?: 'claude' | 'codex';
   last_heartbeat?: number;
   max_run_seconds?: number;
@@ -1406,7 +1406,7 @@ interface ProviderRunResult {
   promptMeta: PromptMetadata;
 }
 
-async function runCodexSynthetic(
+async function runCodex(
   input: {
     state: BatchState;
     runNum: number;
@@ -1432,7 +1432,7 @@ async function runCodexSynthetic(
     // Missing version detail should not hide the primary spawn error below.
   }
 
-  appendFileSync(input.logFile, `[provider] codex synthetic test-task\n`);
+  appendFileSync(input.logFile, `[provider] codex subscription-cli\n`);
   appendFileSync(input.logFile, `[provider] version=${version}\n`);
   appendFileSync(input.logFile, `[provider] raw_jsonl=${rawFile}\n`);
   writeFileSync(rawFile, '');
@@ -1549,19 +1549,8 @@ async function runClaude(
   const promptFile = `${logDir}/run-${runNum}-prompt.md`;
   writeFileSync(promptFile, prompt + '\n');
 
-  if (state.provider === 'codex') {
-    if (!state.test_task) {
-      appendFileSync(logFile, '[provider] codex requested for non-synthetic run; refusing\n');
-      return {
-        exitCode: 1,
-        duration: 0,
-        result,
-        mode: modeSelection.mode,
-        modeReason: modeSelection.reason,
-        promptMeta,
-      };
-    }
-    return runCodexSynthetic({
+  if (shouldRunCodexProvider(state)) {
+    return runCodex({
       state,
       runNum,
       logFile,
@@ -1820,6 +1809,10 @@ function phaseProvidersForState(state: BatchState): PhaseProviderRecord {
     reflection: codex,
     validation: { provider: 'provider-independent', billing: 'local-only' },
   };
+}
+
+export function shouldRunCodexProvider(state: Pick<BatchState, 'provider'>): boolean {
+  return state.provider === 'codex';
 }
 
 // Lifecycle validation — implementation lives in ./auto-dent-lifecycle.ts.

--- a/scripts/auto-dent.test.ts
+++ b/scripts/auto-dent.test.ts
@@ -105,16 +105,17 @@ describe('parseAutoDentArgs', () => {
     expect(parseAutoDentArgs(['focus']).provider).toBe('claude');
   });
 
-  it('accepts codex provider only for test-task mode', () => {
+  it('accepts codex provider for normal batches', () => {
+    const opts = parseAutoDentArgs(['--provider', 'codex', 'real work']);
+    expect(opts.provider).toBe('codex');
+    expect(opts.testTask).toBe(false);
+    expect(opts.guidance).toBe('real work');
+  });
+
+  it('still accepts codex provider for test-task mode', () => {
     const opts = parseAutoDentArgs(['--provider', 'codex', '--test-task']);
     expect(opts.provider).toBe('codex');
     expect(opts.testTask).toBe(true);
-  });
-
-  it('rejects codex provider for non-synthetic batches', () => {
-    expect(() => parseAutoDentArgs(['--provider', 'codex', 'real work'])).toThrow(
-      'Codex provider is restricted to --test-task synthetic runs',
-    );
   });
 
   it('rejects unknown options', () => {
@@ -151,9 +152,8 @@ describe('createInitialState', () => {
   });
 
   it('stores selected provider in initial state for dry-run inspection', () => {
-    const state = createInitialState('batch-1', 'synthetic', 1, {
+    const state = createInitialState('batch-1', 'real work', 1, {
       ...baseOpts,
-      testTask: true,
       provider: 'codex',
     }, {
       kaizenRepo: 'Garsson-io/kaizen',
@@ -161,7 +161,7 @@ describe('createInitialState', () => {
     });
 
     expect(state.provider).toBe('codex');
-    expect(state.test_task).toBe(true);
+    expect(state.test_task).toBe(false);
   });
 });
 

--- a/scripts/auto-dent.ts
+++ b/scripts/auto-dent.ts
@@ -81,7 +81,7 @@ Options:
   --max-failures N     Stop after N consecutive failures (default: 3)
   --max-run-seconds N  Wall-time timeout per run in seconds (default: 1200 = 20min)
   --no-plan            Skip planning pre-pass (use discovery mode)
-  --provider NAME      Agent provider: claude (default) or codex (synthetic --test-task only)
+  --provider NAME      Agent provider: claude (default) or codex
   --dry-run            Show what would run without executing
   --test-task          Use synthetic fast task instead of /kaizen-deep-dive
   --experiment         Enable extra pipeline diagnostics
@@ -177,9 +177,6 @@ export function parseAutoDentArgs(argv: string[]): AutoDentOptions {
 
   opts.guidance = positional.join(' ');
   if (!opts.guidance && opts.testTask) opts.guidance = 'synthetic pipeline test';
-  if (opts.provider === 'codex' && !opts.testTask) {
-    throw new Error('Codex provider is restricted to --test-task synthetic runs');
-  }
   return opts;
 }
 
@@ -584,7 +581,7 @@ async function main(): Promise<void> {
   if (opts.dryRun) {
     console.log('[dry-run] Would execute per run:');
     console.log(`  npx tsx ${join(repoRoot, 'scripts', 'auto-dent-run.ts')} ${stateFile}`);
-    console.log(`[dry-run] Provider: ${opts.provider}${opts.provider === 'codex' ? ' (synthetic test-task only)' : ''}`);
+    console.log(`[dry-run] Provider: ${opts.provider}`);
     console.log('');
     console.log('[dry-run] State file:');
     console.log(readFileSync(stateFile, 'utf8').trimEnd());


### PR DESCRIPTION
## Summary

This removes the remaining synthetic-only Codex guardrail from auto-dent. `--provider codex` now works for normal batch guidance, the planning pre-pass follows the selected Codex provider, and the single-run adapter dispatches Codex state to the existing Codex JSONL normalization path instead of refusing non-test runs.

## Story Spine

Once upon a time, the #1134 ladder had Codex execution capture, provider metadata, external validation, and a comparison matrix, but a final sweep found #1139 still open: normal batches could not actually be launched with Codex.

Every day, `--provider codex` looked available, but `parseAutoDentArgs()` rejected it unless `--test-task` was set, and `auto-dent-run.ts` logged a refusal for non-synthetic Codex state.

Until one day, #1139 made that mismatch explicit: auto-dent needed a Codex provider adapter that normalizes Codex output into the same `RunResult` shape the rest of the harness consumes.

Because of that, this PR accepts Codex for normal guidance, sends Codex batches through the existing `codex exec --json` path, preserves raw JSONL/final text/lifecycle marker/final-claim extraction, and keeps downstream lifecycle validation and review wiring unchanged.

Because of that, planning metadata now matches the selected provider for normal Codex batches instead of claiming Codex phases while planning with Claude.

Until finally, a maintainer can dry-run or launch a normal Codex-backed batch through the same auto-dent state/run pipeline, under subscription CLI operation, with provider-independent process validation still judging the output.

## Verification

- Red first:
  - `npx vitest run scripts/auto-dent.test.ts scripts/auto-dent-run.test.ts --testNamePattern "codex provider|Codex as a real run provider|selected provider"`
- Green:
  - `npx vitest run scripts/auto-dent.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts scripts/auto-dent-codex.test.ts scripts/auto-dent-provider.test.ts scripts/auto-dent-provider-matrix.test.ts scripts/batch-summary.test.ts`
  - `npm run typecheck`
  - `git diff --check`
  - `./scripts/auto-dent.sh --dry-run --provider codex "focus on provider adapter" | rg -n 'Provider|test_task|provider|Would execute'`

## Related

Related but not closed: #1186 covers Codex native hook portability. This PR only removes the batch-provider synthetic-only blocker and reuses the existing external validator/review path.

Closes #1139

Parent: #1134
