### PR TITLE
fix(auto-dent): parse codex item events

### DIFF
--- a/scripts/auto-dent-codex.test.ts
+++ b/scripts/auto-dent-codex.test.ts
@@ -47,6 +47,49 @@ describe('parseCodexJsonl (#1144)', () => {
     expect(parsed.malformedLines).toEqual(['{not json']);
   });
 
+  it('extracts current Codex item payloads from supervised provider runs (#1197)', () => {
+    const parsed = parseCodexJsonl([
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_0',
+          type: 'agent_message',
+          text: 'I will create the requested probe PR.',
+        },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_1',
+          type: 'command_execution',
+          command: 'gh pr create',
+          aggregated_output: 'https://github.com/Garsson-io/kaizen/pull/1194\n',
+          exit_code: 0,
+          status: 'completed',
+        },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_2',
+          type: 'agent_message',
+          text: [
+            'Completed all requested steps.',
+            'Created and merged PR:',
+            '- https://github.com/Garsson-io/kaizen/pull/1194',
+          ].join('\n'),
+        },
+      }),
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1 } }),
+    ].join('\n'));
+
+    expect(parsed.events).toHaveLength(4);
+    expect(parsed.text).toContain('I will create the requested probe PR.');
+    expect(parsed.text).toContain('https://github.com/Garsson-io/kaizen/pull/1194');
+    expect(parsed.finalText).toContain('Completed all requested steps.');
+    expect(parsed.finalText).toContain('pull/1194');
+  });
+
   it('recovers AUTO_DENT_PHASE markers from parsed Codex text', () => {
     const parsed = parseCodexJsonl(JSON.stringify({
       type: 'final_message',

--- a/scripts/auto-dent-codex.ts
+++ b/scripts/auto-dent-codex.ts
@@ -39,7 +39,7 @@ function collectText(value: unknown, out: string[]): void {
   }
   if (!value || typeof value !== 'object') return;
   const obj = value as Record<string, unknown>;
-  for (const key of ['text', 'message', 'content', 'output', 'final_message']) {
+  for (const key of ['text', 'message', 'content', 'output', 'final_message', 'item', 'aggregated_output']) {
     if (key in obj) collectText(obj[key], out);
   }
 }
@@ -54,6 +54,7 @@ export function parseCodexJsonl(jsonl: string): ParsedCodexJsonl {
   const events: unknown[] = [];
   const textChunks: string[] = [];
   const finalChunks: string[] = [];
+  const agentMessages: string[] = [];
   const malformedLines: string[] = [];
 
   for (const raw of jsonl.split(/\r?\n/)) {
@@ -66,6 +67,13 @@ export function parseCodexJsonl(jsonl: string): ParsedCodexJsonl {
       collectText(event, chunks);
       textChunks.push(...chunks);
       if (isFinalEvent(event)) finalChunks.push(...chunks);
+      const item = (event as Record<string, unknown>).item;
+      if (item && typeof item === 'object') {
+        const itemObj = item as Record<string, unknown>;
+        if (itemObj.type === 'agent_message' && typeof itemObj.text === 'string') {
+          agentMessages.push(itemObj.text);
+        }
+      }
     } catch {
       malformedLines.push(raw);
     }
@@ -74,7 +82,7 @@ export function parseCodexJsonl(jsonl: string): ParsedCodexJsonl {
   return {
     events,
     text: textChunks.join('\n'),
-    finalText: finalChunks.join('\n'),
+    finalText: finalChunks.length > 0 ? finalChunks.join('\n') : (agentMessages.at(-1) ?? ''),
     malformedLines,
   };
 }

--- a/test-probe-20260627142333.md
+++ b/test-probe-20260627142333.md
@@ -1,3 +1,0 @@
-# Test Probe
-Run tag: bright-wombat/run-1
-Timestamp: 2026-06-27T14:23:33.165Z


### PR DESCRIPTION
## Summary

This fixes the supervised Codex run observability gap from #1197. Current Codex CLI JSONL emits useful output under nested `item.completed` payloads; the parser now follows `item` and `aggregated_output`, uses the last agent message as final text when no explicit final/result event exists, and the regression fixture proves PR URLs and final summaries are visible.

It also removes the synthetic probe file that the supervised Codex batch merged in PR #1194.

## Verification

- Red first: `npx vitest run scripts/auto-dent-codex.test.ts`
- Green:
  - `npx vitest run scripts/auto-dent-codex.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent.test.ts`
  - `npm run typecheck`
  - `git diff --check`
  - Parsed the real supervised artifact at `logs/auto-dent/bright-wombat/run-1-codex.jsonl`; it now reports `textLen=2438`, `finalLen=318`, and `hasPr=true`.

## Notes

The supervised batch proved Codex execution can create and merge a PR, but it also proved the harness was blind to the current JSONL shape before this fix. After this lands, rerun the same constrained synthetic batch to verify auto-dent records the PR instead of `empty_success`.

Closes #1197

Parent: #1134
