### PR TITLE
fix(auto-dent): require provenance for actionable artifacts

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -705,10 +705,10 @@ describe('buildPrompt with templates', () => {
 });
 
 describe('extractArtifacts', () => {
-  it('extracts PR URLs from text', () => {
+  it('extracts PR URLs from structured phase markers', () => {
     const result = makeRunResult();
     extractArtifacts(
-      'Created PR: https://github.com/Garsson-io/kaizen/pull/450',
+      'AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/450',
       result,
     );
     expect(result.prs).toEqual([
@@ -716,10 +716,13 @@ describe('extractArtifacts', () => {
     ]);
   });
 
-  it('extracts multiple PR URLs', () => {
+  it('extracts multiple PR URLs from structured phase markers', () => {
     const result = makeRunResult();
     extractArtifacts(
-      'PRs: https://github.com/Garsson-io/kaizen/pull/450 and https://github.com/Garsson-io/kaizen/pull/451',
+      [
+        'AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/450',
+        'AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/451',
+      ].join('\n'),
       result,
     );
     expect(result.prs).toHaveLength(2);
@@ -728,20 +731,20 @@ describe('extractArtifacts', () => {
   it('deduplicates PR URLs', () => {
     const result = makeRunResult();
     extractArtifacts(
-      'https://github.com/Garsson-io/kaizen/pull/450',
+      'AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/450',
       result,
     );
     extractArtifacts(
-      'https://github.com/Garsson-io/kaizen/pull/450',
+      'AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/450',
       result,
     );
     expect(result.prs).toHaveLength(1);
   });
 
-  it('extracts issue URLs', () => {
+  it('extracts filed issue URLs from structured phase markers', () => {
     const result = makeRunResult();
     extractArtifacts(
-      'Filed: https://github.com/Garsson-io/kaizen/issues/267',
+      'AUTO_DENT_PHASE: REFLECT | issues_filed=https://github.com/Garsson-io/kaizen/issues/267',
       result,
     );
     expect(result.issuesFiled).toEqual([
@@ -749,24 +752,29 @@ describe('extractArtifacts', () => {
     ]);
   });
 
-  it('extracts closes/fixes/resolves references', () => {
+  it('extracts closed issue references from structured phase markers', () => {
     const result = makeRunResult();
-    extractArtifacts('Closes #100, fixes #200, resolves #300', result);
+    extractArtifacts('AUTO_DENT_PHASE: REFLECT | issues_closed=#100,#200,#300', result);
     expect(result.issuesClosed).toContain('#100');
     expect(result.issuesClosed).toContain('#200');
     expect(result.issuesClosed).toContain('#300');
   });
 
-  it('extracts "closed" past tense references', () => {
+  it('does not treat referenced PRs or issues as produced artifacts (#1203)', () => {
     const result = makeRunResult();
-    extractArtifacts('Closed #150', result);
-    expect(result.issuesClosed).toContain('#150');
-  });
-
-  it('extracts kaizen issue references', () => {
-    const result = makeRunResult();
-    extractArtifacts('Addressed kaizen #451', result);
-    expect(result.issuesClosed).toContain('#451');
+    extractArtifacts([
+      'AUTO_DENT_PHASE: PICK | issue=#1003 | title=checking availability',
+      'AUTO_DENT_PHASE: EVALUATE | verdict=skip | reason=issue #1003 is already covered by open PR #1012',
+      'AUTO_DENT_PHASE: STOP | reason=#1003 is effectively claimed by open PR https://github.com/Garsson-io/kaizen/pull/1012',
+      'Evidence:',
+      '- Issue `#1003` is open and unassigned, but active PR `#1012` explicitly includes `Fixes Garsson-io/kaizen#1003`.',
+      '- Related PR: https://github.com/Garsson-io/kaizen/pull/621',
+      '- Related issue: https://github.com/Garsson-io/kaizen/issues/1009',
+      'No PRs created, no issues filed, no issues closed.',
+    ].join('\n'), result);
+    expect(result.prs).toEqual([]);
+    expect(result.issuesFiled).toEqual([]);
+    expect(result.issuesClosed).toEqual([]);
   });
 
   it('extracts case references', () => {
@@ -1317,7 +1325,7 @@ describe('processStreamMessage', () => {
           content: [
             {
               type: 'text',
-              text: 'Created https://github.com/Garsson-io/kaizen/pull/500',
+              text: 'AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/500',
             },
           ],
         },
@@ -1370,7 +1378,10 @@ describe('processStreamMessage', () => {
         subtype: 'success',
         total_cost_usd: 1.0,
         result:
-          'Done. Closes #451. PR: https://github.com/Garsson-io/kaizen/pull/500',
+          [
+            'AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/500',
+            'AUTO_DENT_PHASE: REFLECT | issues_closed=#451',
+          ].join('\n'),
       },
       result,
       Date.now(),
@@ -1689,8 +1700,8 @@ describe('e2e: full workflow through stream pipeline', () => {
       msg.text('Created PR: https://github.com/Garsson-io/kaizen/pull/500'),
       msg.phase('PR', { url: 'https://github.com/Garsson-io/kaizen/pull/500' }),
       msg.phase('MERGE', { url: 'https://github.com/Garsson-io/kaizen/pull/500', status: 'queued' }),
-      msg.phase('REFLECT', { issues_filed: '1', lessons: 'shared helpers reduce boilerplate' }),
-      msg.done(2.5, 'Done. Closes #472.'),
+      msg.phase('REFLECT', { issues_filed: '1', issues_closed: '#472', lessons: 'shared helpers reduce boilerplate' }),
+      msg.done(2.5, 'Done.'),
     ]);
 
     expectPhase(capture, 'PICK', '#472', 'improve hook test DRY');
@@ -1819,10 +1830,10 @@ describe('e2e: full workflow through stream pipeline', () => {
 
   it('tracks artifacts across multiple messages', () => {
     const { result } = runStream([
-      msg.text('Filed https://github.com/Garsson-io/kaizen/issues/700'),
-      msg.text('Created https://github.com/Garsson-io/kaizen/pull/701'),
-      msg.text('Also created https://github.com/Garsson-io/kaizen/pull/702'),
-      msg.done(2.0, 'Closes #450. Fixes #451.'),
+      msg.phase('REFLECT', { issues_filed: 'https://github.com/Garsson-io/kaizen/issues/700' }),
+      msg.phase('PR', { url: 'https://github.com/Garsson-io/kaizen/pull/701' }),
+      msg.phase('PR', { url: 'https://github.com/Garsson-io/kaizen/pull/702' }),
+      msg.done(2.0, 'AUTO_DENT_PHASE: REFLECT | issues_closed=#450,#451'),
     ]);
 
     expect(result.issuesFiled).toContain('https://github.com/Garsson-io/kaizen/issues/700');

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -208,28 +208,44 @@ export function formatPhaseMarker(marker: PhaseMarker): string {
 
 // Artifact extraction from agent output
 
+function pushUnique<T>(items: T[], item: T): void {
+  if (!items.includes(item)) items.push(item);
+}
+
+function extractIssueRefs(value: string): string[] {
+  const refs: string[] = [];
+  for (const m of value.matchAll(/#\d+/g)) {
+    pushUnique(refs, m[0]);
+  }
+  for (const m of value.matchAll(/https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+/g)) {
+    pushUnique(refs, m[0]);
+  }
+  return refs;
+}
+
 export function extractArtifacts(text: string, result: RunResult): void {
-  for (const m of text.matchAll(
-    /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/g,
-  )) {
-    if (!result.prs.includes(m[0])) result.prs.push(m[0]);
-  }
-  for (const m of text.matchAll(
-    /https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+/g,
-  )) {
-    if (!result.issuesFiled.includes(m[0])) result.issuesFiled.push(m[0]);
-  }
-  for (const m of text.matchAll(
-    /(?:closes?|closed|fix(?:es|ed)?|resolves?)\s+(#\d+)/gi,
-  )) {
-    if (!result.issuesClosed.includes(m[1])) result.issuesClosed.push(m[1]);
-  }
-  for (const m of text.matchAll(/kaizen\s+#(\d+)/gi)) {
-    const ref = `#${m[1]}`;
-    if (!result.issuesClosed.includes(ref)) result.issuesClosed.push(ref);
+  for (const marker of parsePhaseMarkers(text)) {
+    if (marker.phase === 'PR' && marker.fields.url) {
+      pushUnique(result.prs, marker.fields.url);
+    }
+    if (marker.phase === 'IMPLEMENT' && marker.fields.case) {
+      pushUnique(result.cases, marker.fields.case);
+    }
+    for (const key of ['issues_filed', 'issues_created']) {
+      if (!marker.fields[key]) continue;
+      for (const ref of extractIssueRefs(marker.fields[key])) {
+        pushUnique(result.issuesFiled, ref);
+      }
+    }
+    for (const key of ['issues_closed', 'closed']) {
+      if (!marker.fields[key]) continue;
+      for (const ref of extractIssueRefs(marker.fields[key])) {
+        pushUnique(result.issuesClosed, ref);
+      }
+    }
   }
   for (const m of text.matchAll(/case[:\s]+(\d{6}-\d{4}-[\w-]+)/g)) {
-    if (!result.cases.includes(m[1])) result.cases.push(m[1]);
+    pushUnique(result.cases, m[1]);
   }
   // Extract issues pruned (closed as not-planned/wontfix/duplicate)
   for (const _m of text.matchAll(


### PR DESCRIPTION
## Summary

This fixes the parallel auto-dent blocker from #1203. `extractArtifacts()` no longer treats every PR/issue URL or `Fixes #N` phrase in arbitrary output as an actionable artifact. PRs, filed issues, and closed issues now require structured `AUTO_DENT_PHASE` provenance before post-run hygiene/review/fix/merge can act on them.

Passive text-derived metrics that do not trigger PR hygiene, such as case references, pruned issue commands, and diff-stat line deletion counts, remain supported.

## Verification

- Red first: `npx vitest run scripts/auto-dent-run.test.ts --testNamePattern "extractArtifacts"`
- Green:
  - `npx vitest run scripts/auto-dent-run.test.ts --testNamePattern "extractArtifacts"`
  - `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-codex.test.ts`
  - `npm run typecheck`
  - `git diff --check`
- Replayed the real supervised Codex artifact at `logs/auto-dent/xerothermic-gopher/run-1-codex.jsonl`; after this fix it preserves STOP phases but extracts no actionable PRs/issues from the cited #1012/#621 evidence.

## Notes

The live Codex run itself behaved correctly: it stopped because #1003 was already covered by #1012. The bug was downstream attribution: auto-dent treated referenced PRs/issues as produced outputs and started review/fix handling against #1012. I interrupted that run and removed the stray review comment before this fix.

Fixes Garsson-io/kaizen#1203
Related: Garsson-io/kaizen#842