### PR TITLE
test(hook-gym): validate captured fixtures

### DIFF
--- a/scripts/hook-gym-replay.test.ts
+++ b/scripts/hook-gym-replay.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   extractToolActions,
@@ -12,6 +12,8 @@ import {
   formatFixture,
   type ToolAction,
 } from './hook-gym-replay.js';
+
+const LIVE_PROBE_FIXTURE = resolve(__dirname, '../fixtures/live/probe-hooks.jsonl');
 
 // ── extractToolActions ────────────────────────────────────────────
 
@@ -237,14 +239,51 @@ describe('extractToolActionsFromFile', () => {
 
   it('returns empty for JSON array (hook-event fixture)', () => {
     const hookEvents = [
-      { type: 'system', subtype: 'hook_started', hook_id: 'h1' },
-      { type: 'system', subtype: 'hook_response', hook_id: 'h1' },
+      {
+        type: 'system',
+        subtype: 'hook_started',
+        hook_id: 'h1',
+        hook_name: 'PreToolUse:Bash',
+        hook_event: 'PreToolUse',
+        uuid: 'u1',
+        session_id: 's',
+      },
+      {
+        type: 'system',
+        subtype: 'hook_response',
+        hook_id: 'h1',
+        hook_name: 'PreToolUse:Bash',
+        hook_event: 'PreToolUse',
+        exit_code: 0,
+        outcome: 'success',
+        uuid: 'u2',
+        session_id: 's',
+      },
     ];
     const path = join(tmpDir, 'hooks.json');
     writeFileSync(path, JSON.stringify(hookEvents));
 
     const actions = extractToolActionsFromFile(path);
     expect(actions).toHaveLength(0);
+  });
+
+  it('extracts actions and tool results from the real captured probe-hooks fixture', () => {
+    const actions = extractToolActionsFromFile(LIVE_PROBE_FIXTURE);
+
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions.some(
+      (action) =>
+        action.tool === 'Bash' &&
+        String(action.input.command ?? '').includes('git checkout -b'),
+    )).toBe(true);
+    expect(actions.some(
+      (action) =>
+        action.tool === 'Write' &&
+        String(action.input.file_path ?? '').endsWith('hook-gym-probe.md'),
+    )).toBe(true);
+    expect(actions.some(
+      (action) => action.result?.stdout.includes('Switched to a new branch'),
+    )).toBe(true);
   });
 });
 

--- a/scripts/hook-gym-replay.ts
+++ b/scripts/hook-gym-replay.ts
@@ -18,6 +18,7 @@ import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import type { HookTimeline, ParsedHookEvent, Scenario } from './hook-gym-schema.js';
+import { parseHookGymFixtureContent } from './hook-gym-schema.js';
 import { validateAgainstScenario, type ValidationReport } from './hook-gym-validate.js';
 import { parseHookDecision } from './hook-gym-stream.js';
 
@@ -150,16 +151,17 @@ function parseToolResult(text: string, _tool: string): ToolAction['result'] {
  * Extract tool actions from a fixture file (stream.jsonl or JSON array).
  */
 export function extractToolActionsFromFile(fixturePath: string): ToolAction[] {
-  const raw = readFileSync(fixturePath, 'utf-8').trim();
+  const raw = readFileSync(fixturePath, 'utf-8');
+  const records = parseHookGymFixtureContent(raw);
 
-  if (raw.startsWith('[')) {
+  if (raw.trim().startsWith('[')) {
     // JSON array form — these are hook events, not tool actions
     // Can't extract tool actions from hook-only fixtures
     return [];
   }
 
   // Stream-json form — each line is a message
-  return extractToolActions(raw.split('\n'));
+  return extractToolActions(records.map((record) => JSON.stringify(record)));
 }
 
 // ── Hook registry (matches plugin.json) ───────────────────────────

--- a/scripts/hook-gym-schema.test.ts
+++ b/scripts/hook-gym-schema.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  HookResponseEventSchema,
+  parseHookGymFixtureContent,
+} from './hook-gym-schema.js';
+
+const LIVE_PROBE_FIXTURE = resolve(__dirname, '../fixtures/live/probe-hooks.jsonl');
+
+function readLiveFixtureObjects(): Record<string, unknown>[] {
+  return readFileSync(LIVE_PROBE_FIXTURE, 'utf-8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('hook-gym fixture schema validation', () => {
+  it('accepts a real captured probe-hooks fixture', () => {
+    const events = parseHookGymFixtureContent(readFileSync(LIVE_PROBE_FIXTURE, 'utf-8'));
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.some((event) => event.type === 'system' && event.subtype === 'hook_started')).toBe(true);
+    expect(events.some((event) => event.type === 'system' && event.subtype === 'hook_response')).toBe(true);
+    expect(events.some((event) => event.type === 'assistant')).toBe(true);
+    expect(events.some((event) => event.type === 'user')).toBe(true);
+  });
+
+  it('rejects malformed hook responses copied from the real fixture', () => {
+    const objects = readLiveFixtureObjects();
+    const response = objects.find(
+      (event) => event.type === 'system' && event.subtype === 'hook_response',
+    );
+    expect(response).toBeDefined();
+    response!.exit_code = '0';
+
+    const malformedFixture = objects.map((event) => JSON.stringify(event)).join('\n');
+
+    expect(() => parseHookGymFixtureContent(malformedFixture)).toThrow(/Invalid hook-gym fixture/);
+    expect(HookResponseEventSchema.safeParse(response).success).toBe(false);
+  });
+});

--- a/scripts/hook-gym-schema.ts
+++ b/scripts/hook-gym-schema.ts
@@ -1,9 +1,106 @@
+import { z } from 'zod';
+
 /**
  * hook-gym-schema.ts — TypeScript types for Hook Gym.
  *
  * All types for hook events, scenarios, scoring, and iteration tracking.
- * Uses plain TypeScript (no Zod) — data comes from Claude CLI (controlled format).
+ * Runtime schemas validate captured fixtures before the harness scores or
+ * replays them. The capture source is controlled, but fixture files are durable
+ * test artifacts and must fail closed when their shape drifts.
  */
+
+// ── Runtime fixture schemas ───────────────────────────────────────
+
+const UnknownRecordSchema = z.record(z.string(), z.unknown());
+
+const HookEventBaseSchema = z.object({
+  type: z.literal('system'),
+  hook_id: z.string().min(1),
+  hook_name: z.string().min(1),
+  hook_event: z.string().min(1),
+  uuid: z.string().min(1),
+  session_id: z.string().min(1),
+});
+
+export const HookStartedEventSchema = HookEventBaseSchema.extend({
+  subtype: z.literal('hook_started'),
+});
+
+export const HookResponseEventSchema = HookEventBaseSchema.extend({
+  subtype: z.literal('hook_response'),
+  output: z.string().optional(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  exit_code: z.number().int(),
+  outcome: z.string().min(1),
+});
+
+const OtherSystemEventSchema = z.object({
+  type: z.literal('system'),
+  subtype: z.string().optional(),
+}).passthrough().refine(
+  (event) => event.subtype !== 'hook_started' && event.subtype !== 'hook_response',
+  'hook_started and hook_response events must satisfy their hook event schemas',
+);
+
+const AssistantMessageEventSchema = z.object({
+  type: z.literal('assistant'),
+  message: UnknownRecordSchema,
+}).passthrough();
+
+const UserMessageEventSchema = z.object({
+  type: z.literal('user'),
+  message: UnknownRecordSchema,
+}).passthrough();
+
+const RateLimitEventSchema = z.object({
+  type: z.literal('rate_limit_event'),
+}).passthrough();
+
+export const HookGymFixtureEventSchema = z.union([
+  HookStartedEventSchema,
+  HookResponseEventSchema,
+  OtherSystemEventSchema,
+  AssistantMessageEventSchema,
+  UserMessageEventSchema,
+  RateLimitEventSchema,
+]);
+
+export type HookGymFixtureEvent = z.infer<typeof HookGymFixtureEventSchema>;
+
+function parseFixtureJson(raw: string): unknown[] {
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid hook-gym fixture: JSON fixture must be an array');
+    }
+    return parsed;
+  }
+
+  return trimmed.split('\n').map((line, index) => {
+    try {
+      return JSON.parse(line);
+    } catch (error) {
+      throw new Error(`Invalid hook-gym fixture: line ${index + 1} is not valid JSON`, { cause: error });
+    }
+  });
+}
+
+export function parseHookGymFixtureContent(raw: string): HookGymFixtureEvent[] {
+  const records = parseFixtureJson(raw);
+  const result = z.array(HookGymFixtureEventSchema).safeParse(records);
+  if (!result.success) {
+    const issues = result.error.issues
+      .slice(0, 5)
+      .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+      .join('; ');
+    throw new Error(`Invalid hook-gym fixture: ${issues}`);
+  }
+  return result.data;
+}
 
 // ── Hook Event (from --include-hook-events stream) ─────────────────
 

--- a/scripts/hook-gym-validate.test.ts
+++ b/scripts/hook-gym-validate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { writeFileSync, mkdtempSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import {
   validateAgainstScenario,
   loadFixture,
@@ -9,7 +9,10 @@ import {
   formatValidationReport,
 } from './hook-gym-validate.js';
 import { parseLogFile } from './hook-gym-stream.js';
+import { getScenario } from './hook-gym-scenarios.js';
 import type { Scenario, HookTimeline } from './hook-gym-schema.js';
+
+const LIVE_PROBE_FIXTURE = resolve(__dirname, '../fixtures/live/probe-hooks.jsonl');
 
 // ── Small helpers to build synthetic timelines ─────────────────────
 
@@ -483,6 +486,40 @@ describe('validateFixtureFile — invariant I1 (PR has Closes #N)', () => {
     expect(report.passed).toBe(false);
     expect(report.criticalMisses).toBe(1);
     expect(report.confusionPairs[0].expected).toBe('deny');
+  });
+});
+
+describe('validateFixtureFile — real captured fixtures', () => {
+  it('scores the live probe-hooks fixture from observed hook verdicts', () => {
+    const probeHooks = getScenario('probe-hooks');
+    expect(probeHooks).toBeDefined();
+
+    const report = validateFixtureFile(LIVE_PROBE_FIXTURE, probeHooks!);
+
+    expect(report.passed).toBe(true);
+    expect(report.criticalMisses).toBe(0);
+    expect(report.hookResults.some(
+      (result) =>
+        result.expected.expectedDecision === 'set-gate' &&
+        result.actualDecision === 'set-gate',
+    )).toBe(true);
+  });
+
+  it('rejects a malformed copy of the live probe-hooks fixture before scoring', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'hg-live-bad-'));
+    const fixturePath = join(tmp, 'probe-hooks-bad.jsonl');
+    const lines = readFileSync(LIVE_PROBE_FIXTURE, 'utf-8').trim().split('\n');
+    const events = lines.map((line) => JSON.parse(line) as Record<string, unknown>);
+    const response = events.find(
+      (event) => event.type === 'system' && event.subtype === 'hook_response',
+    );
+    expect(response).toBeDefined();
+    response!.exit_code = '0';
+    writeFileSync(fixturePath, events.map((event) => JSON.stringify(event)).join('\n'));
+
+    const probeHooks = getScenario('probe-hooks');
+    expect(probeHooks).toBeDefined();
+    expect(() => validateFixtureFile(fixturePath, probeHooks!)).toThrow(/Invalid hook-gym fixture/);
   });
 });
 

--- a/scripts/hook-gym-validate.ts
+++ b/scripts/hook-gym-validate.ts
@@ -21,6 +21,7 @@ import type {
   HookDecision,
 } from './hook-gym-schema.js';
 import { SEVERITY_WEIGHT } from './hook-gym-schema.js';
+import { parseHookGymFixtureContent } from './hook-gym-schema.js';
 import { parseLogFile } from './hook-gym-stream.js';
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -285,17 +286,9 @@ export function validateAgainstScenario(
  *     hand-written invariant fixtures)
  */
 export function loadFixture(fixturePath: string): HookTimeline {
-  const raw = readFileSync(fixturePath, 'utf-8').trim();
-
-  if (raw.startsWith('[')) {
-    // JSON array form — wrap each event as a stream-json line
-    const events = JSON.parse(raw) as Record<string, any>[];
-    const nld = events.map((e) => JSON.stringify(e)).join('\n');
-    return parseLogFile(nld);
-  }
-
-  // Stream-json (newline-delimited) form
-  return parseLogFile(raw);
+  const raw = readFileSync(fixturePath, 'utf-8');
+  const events = parseHookGymFixtureContent(raw);
+  return parseLogFile(events.map((e) => JSON.stringify(e)).join('\n'));
 }
 
 /**


### PR DESCRIPTION
Closes #1199

Run tag: eastern-ant/run-1

## Story

Hook-gym is the harness we use to prove hook behavior, so its own fixture boundary needs to fail closed. The current code already had several hook-gym tests, but the schema file was still type-only and the replay path could consume fixture files without runtime shape validation.

This PR adds a Zod-backed runtime schema for captured hook-gym fixture events and routes both score-only validation and replay extraction through it. The tests use the real captured `fixtures/live/probe-hooks.jsonl` fixture, mutate that captured shape to prove malformed hook responses are rejected, and assert the fixture scoring observes real `set-gate` hook verdicts.

## Architecture

`fixture file -> parseHookGymFixtureContent -> loadFixture / extractToolActionsFromFile -> validateAgainstScenario / replay`

The schema sits before both scoring and replay extraction, so bad fixture data is rejected before the harness can report a misleading pass.

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use Zod in `hook-gym-schema.ts` | Existing dependency and stronger structured validation than hand-rolled checks | Adds runtime schema alongside TypeScript types |
| Validate real captured JSONL fixture in tests | Proves the production capture shape, not a miniature synthetic shape | Test fixture is larger than handcrafted snippets |
| Keep replay test at extraction/score-only replay layer | Avoids invoking every real hook in a unit suite while still proving captured tool/result extraction | Full hook execution remains covered by existing replay APIs |

## What's Changed

| File | Purpose |
|---|---|
| `scripts/hook-gym-schema.ts` | Adds runtime schemas and `parseHookGymFixtureContent` |
| `scripts/hook-gym-validate.ts` | Validates fixtures before scoring |
| `scripts/hook-gym-replay.ts` | Validates fixtures before extracting replay actions |
| `scripts/hook-gym-schema.test.ts` | Covers real captured fixture acceptance and malformed rejection |
| `scripts/hook-gym-validate.test.ts` | Scores the real fixture and rejects a malformed captured copy |
| `scripts/hook-gym-replay.test.ts` | Extracts actions/results from the real captured fixture |

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration | System/E2E | Evidence |
|---|---|---|---|---|
| Real captured hook-gym fixtures validate against the schema | `hook-gym-schema.test.ts` loads `fixtures/live/probe-hooks.jsonl` | `hook-gym-validate.test.ts` scores the same fixture | CLI `--validate-fixture` against `probe-hooks` | Tested |
| Malformed fixtures are rejected before replay/scoring | Mutates a real `hook_response.exit_code` to a string and expects rejection | `validateFixtureFile` rejects the malformed captured copy | Not required | Tested |
| Replay observes captured tool/results and hook verdicts | `hook-gym-replay.test.ts` extracts actions/results from real JSONL | `hook-gym-validate.test.ts` asserts observed `set-gate` verdicts | CLI `--replay` against `probe-hooks` | Tested |

## Validation

- [x] `npx vitest run scripts/hook-gym*.test.ts` — 147 tests passed
- [x] `npx tsc --noEmit --pretty false`
- [x] `npx tsx scripts/hook-gym.ts --validate-fixture fixtures/live/probe-hooks.jsonl --scenario probe-hooks`
- [x] `npx tsx scripts/hook-gym.ts --replay fixtures/live/probe-hooks.jsonl --scenario probe-hooks`
- [ ] `npm test` — current clean branch still has unrelated existing failures in `src/e2e/setup-e2e.test.ts`, `src/e2e/synthetic-workflow.test.ts`, and `src/hooks/kaizen-reflect.test.ts` timeout/warning assertions.

## Known Limitations

This PR does not change hook verdict semantics. It hardens the harness boundary and proves the current captured fixture path observes real outcomes.
