### PR TITLE
fix(review): require CI proof before pass summaries

### DIFF
--- a/.agents/skills/kaizen-review-pr/SKILL.md
+++ b/.agents/skills/kaizen-review-pr/SKILL.md
@@ -226,8 +226,13 @@ follow-up issue. If any dimension still has MISSING findings, the round is FAIL 
 Store the round summary (required to advance to next round or close the gate):
 ```bash
 npx tsx src/cli-structured-data.ts store-review-summary \
-  --pr <PR_NUMBER> --repo <owner/repo> --round <N>
+  --pr <PR_NUMBER> --repo <owner/repo> --round <N> --head-sha "$(git rev-parse HEAD)"
 ```
+
+For a derived PASS or PASS-with-partials verdict, `store-review-summary` now verifies the PR's
+current HEAD matches `--head-sha` and that `gh pr checks` is green for that HEAD before it writes
+the summary/sentinel (#1070). Pending, failing, absent, or stale-head CI refuses storage; re-run
+review on the current head after CI passes.
 
 Add `--note "<context>"` only for non-verdict commentary (e.g. "rebased onto main, re-ran tests").
 Read back the derived verdict with `read-review-summary --pr <N> --repo <repo> --round <N>` — the

--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -6,6 +6,7 @@ import {
   storePlan,
   storeMetadata,
   storeReviewFinding,
+  storeReviewSummary,
 } from './structured-data.js';
 
 vi.mock('node:fs', () => ({
@@ -238,6 +239,32 @@ describe('store-review-batch — review sentinel', () => {
     );
     expect(sentinelCall).toBeDefined();
     expect(String(sentinelCall![0])).toContain('456');
+  });
+});
+
+describe('store-review-summary — CI head proof', () => {
+  it('passes --head-sha through to summary storage before writing the sentinel (#1070)', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handlers['store-review-summary']({
+      command: 'store-review-summary',
+      pr: '903',
+      repo: 'Garsson-io/kaizen',
+      round: '5',
+      ['head-sha']: 'abc123',
+    } as CliArgs);
+
+    expect(vi.mocked(storeReviewSummary)).toHaveBeenCalledWith(
+      { kind: 'pr', number: 903, repo: 'Garsson-io/kaizen' },
+      5,
+      undefined,
+      { expectedHeadSha: 'abc123' },
+    );
+    const sentinelCall = vi.mocked(appendFileSync).mock.calls.find(
+      ([path]) => typeof path === 'string' && path.includes('.reviewed-r5'),
+    );
+    expect(sentinelCall).toBeDefined();
+    log.mockRestore();
   });
 });
 

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -59,6 +59,7 @@ import {
   storeIterationState,
   retrieveIterationState,
   type ReviewFindingData,
+  type StoreReviewSummaryOptions,
 } from './structured-data.js';
 import { normalizeReviewFindingData, validateReviewFindingPayload, summarizeFindingStatuses } from './review-finding-contract.js';
 
@@ -135,6 +136,12 @@ function writeReviewSentinel(repo: string, pr: string | undefined, round: number
   }
 }
 
+function reviewSummaryOptions(a: CliArgs): StoreReviewSummaryOptions {
+  return {
+    expectedHeadSha: a['head-sha'],
+  };
+}
+
 // Review handlers
 
 async function handleNextRound(a: CliArgs): Promise<void> {
@@ -206,7 +213,7 @@ async function handleStoreReviewBatch(a: CliArgs): Promise<void> {
     }
   }
   const findings = parsedBatch as ReviewFindingData[];
-  const result = storeReviewBatch(pr, r, findings);
+  const result = storeReviewBatch(pr, r, findings, reviewSummaryOptions(a));
   // #966: Write review sentinel so pr-review-loop.ts gate guard passes.
   // Mirrors handleStoreReviewSummary — batch includes summary, so sentinel must be written here too.
   writeReviewSentinel(a.repo, a.pr, r);
@@ -229,7 +236,7 @@ async function handleStoreReviewSummary(a: CliArgs): Promise<void> {
   const r = resolveRound(a);
   let url: string;
   try {
-    url = storeReviewSummary(prTarget(a.pr, a.repo), r, note);
+    url = storeReviewSummary(prTarget(a.pr, a.repo), r, note, reviewSummaryOptions(a));
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -39,7 +39,7 @@ function ghReturns(stdout: string) {
 }
 
 
-beforeEach(() => { vi.clearAllMocks(); clearCommentCache(); });
+beforeEach(() => { vi.clearAllMocks(); mockGh.mockReset(); clearCommentCache(); });
 
 const pr = prTarget('903', 'Garsson-io/kaizen');
 const issue = issueTarget('904', 'Garsson-io/kaizen');
@@ -305,16 +305,88 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     const ok = dimComment(2, 'correctness', 'pass', 3, 0, 0); // all DONE → PASS
     ghReturns(ok); // compose: list
     ghReturns(ok); // compose: read
-    ghReturns(ok); // deriveStoredRoundVerdict: list
-    ghReturns(ok); // deriveStoredRoundVerdict: read
+    ghReturns('abc123'); // gh pr view: current PR head
+    ghReturns(JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' }])); // gh pr checks
     ghReturns(''); // writeAttachment: readAttachment (no existing)
     ghReturns('https://...#issuecomment-sum');
 
-    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes');
+    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes', { expectedHeadSha: 'abc123' });
     const body = bodyOfLastCreate();
     expect(body).toContain('## Review Round 2 — PASS');
     expect(body).toContain('### Reviewer notes (non-authoritative');
     expect(body).toContain('rebased onto main');
+  });
+
+  describe('CI proof gate (#1070)', () => {
+    const head = 'abc123';
+    const passChecks = JSON.stringify([
+      { name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' },
+      { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
+    ]);
+    const pendingChecks = JSON.stringify([
+      { name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' },
+    ]);
+    const failChecks = JSON.stringify([
+      { name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' },
+    ]);
+
+    it('stores a derived PASS only when current-head CI is passing', () => {
+      const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
+      ghReturns(ok); // compose: list
+      ghReturns(ok); // compose: read
+      ghReturns(head); // gh pr view: current PR head
+      ghReturns(passChecks); // gh pr checks
+      ghReturns(''); // writeAttachment: readAttachment (no existing)
+      ghReturns('https://...#issuecomment-sum');
+
+      storeReviewSummary(pr, 4, undefined, { expectedHeadSha: head });
+
+      const body = bodyOfLastCreate();
+      expect(body).toContain('## Review Round 4 — PASS');
+    });
+
+    it('refuses to store a derived PASS while CI is pending', () => {
+      const ok = dimComment(6, 'correctness', 'pass', 2, 0, 0);
+      ghReturns(ok); // compose: list
+      ghReturns(ok); // compose: read
+      ghReturns(head); // gh pr view
+      ghReturns(pendingChecks); // gh pr checks
+
+      expect(() => storeReviewSummary(pr, 6, undefined, { expectedHeadSha: head }))
+        .toThrow(/CI.*pending|pending.*CI|#1070/i);
+    });
+
+    it('refuses to store a derived PASS when CI is failing', () => {
+      const ok = dimComment(7, 'correctness', 'pass', 2, 0, 0);
+      ghReturns(ok); // compose: list
+      ghReturns(ok); // compose: read
+      ghReturns(head); // gh pr view
+      ghReturns(failChecks); // gh pr checks
+
+      expect(() => storeReviewSummary(pr, 7, undefined, { expectedHeadSha: head }))
+        .toThrow(/CI.*fail|fail.*CI|#1070/i);
+    });
+
+    it('refuses to store a derived PASS before CI has produced checks', () => {
+      const ok = dimComment(9, 'correctness', 'pass', 2, 0, 0);
+      ghReturns(ok); // compose: list
+      ghReturns(ok); // compose: read
+      ghReturns(head); // gh pr view
+      ghReturns('[]'); // gh pr checks: CI has not started
+
+      expect(() => storeReviewSummary(pr, 9, undefined, { expectedHeadSha: head }))
+        .toThrow(/CI.*not produced checks|#1070/i);
+    });
+
+    it('refuses to store a derived PASS when the reviewed head is stale', () => {
+      const ok = dimComment(8, 'correctness', 'pass', 2, 0, 0);
+      ghReturns(ok); // compose: list
+      ghReturns(ok); // compose: read
+      ghReturns('def456'); // gh pr view: current PR head differs from reviewed head
+
+      expect(() => storeReviewSummary(pr, 8, undefined, { expectedHeadSha: head }))
+        .toThrow(/stale|HEAD|#1070/i);
+    });
   });
 });
 

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -14,6 +14,7 @@
  */
 
 import YAML from 'yaml';
+import { spawnSync } from 'node:child_process';
 import {
   listAttachments,
   readAttachment,
@@ -63,9 +64,10 @@ export function storeReviewBatch(
   target: AttachmentTarget,
   round: number,
   findings: ReviewFindingData[],
+  options: StoreReviewSummaryOptions = {},
 ): { urls: string[]; summaryUrl: string } {
   const urls = findings.map(f => storeReviewFinding(target, round, f));
-  const summaryUrl = storeReviewSummary(target, round);
+  const summaryUrl = storeReviewSummary(target, round, undefined, options);
   return { urls, summaryUrl };
 }
 
@@ -103,6 +105,130 @@ export function extractPlanText(text: string): string | undefined {
 export type { ReviewFinding, ReviewFindingData } from './review-finding-contract.js';
 
 const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MISSING: '❌' };
+
+export type StoreReviewSummaryOptions = {
+  /**
+   * The commit SHA that was reviewed. If omitted, the current local HEAD is used.
+   * Passing this explicitly lets review tooling prove CI belongs to the same
+   * commit it reviewed even if the local worktree has moved.
+   */
+  expectedHeadSha?: string;
+};
+
+type GhCheck = {
+  name?: string;
+  bucket?: string;
+  state?: string;
+  workflow?: string;
+  link?: string;
+};
+
+function spawnText(command: string, args: string[], failureContext: string): string {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.error) {
+    throw new Error(`${failureContext}: ${result.error.message}`);
+  }
+  const stdout = (result.stdout ?? '').trim();
+  if ((result.status ?? 0) !== 0 && !stdout) {
+    const stderr = (result.stderr ?? '').trim();
+    throw new Error(`${failureContext}: ${stderr || `${command} exited ${result.status}`}`);
+  }
+  return stdout;
+}
+
+function resolveReviewedHeadSha(expectedHeadSha: string | undefined): string {
+  const explicit = expectedHeadSha?.trim();
+  if (explicit) return explicit;
+  return spawnText(
+    'git',
+    ['rev-parse', 'HEAD'],
+    'store-review-summary: #1070 unable to determine reviewed HEAD; pass --head-sha explicitly',
+  );
+}
+
+function readPrHeadSha(target: AttachmentTarget): string {
+  return spawnText(
+    'gh',
+    ['pr', 'view', String(target.number), '--repo', target.repo, '--json', 'headRefOid', '--jq', '.headRefOid'],
+    'store-review-summary: #1070 unable to read current PR head',
+  );
+}
+
+function readPrChecks(target: AttachmentTarget): GhCheck[] {
+  const stdout = spawnText(
+    'gh',
+    ['pr', 'checks', String(target.number), '--repo', target.repo, '--json', 'name,bucket,state,workflow,link'],
+    'store-review-summary: #1070 unable to read PR checks',
+  );
+  try {
+    const parsed = JSON.parse(stdout);
+    if (!Array.isArray(parsed)) {
+      throw new Error('JSON was not an array');
+    }
+    return parsed as GhCheck[];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`store-review-summary: #1070 unable to parse PR checks JSON (${msg})`);
+  }
+}
+
+function formatCheck(check: GhCheck): string {
+  const workflow = check.workflow ? `${check.workflow} / ` : '';
+  const name = check.name ?? '(unnamed check)';
+  const bucket = check.bucket ?? 'unknown';
+  const state = check.state ? ` (${check.state})` : '';
+  return `${workflow}${name}: ${bucket}${state}`;
+}
+
+function assertReviewSummaryCiPassed(target: AttachmentTarget, options: StoreReviewSummaryOptions): void {
+  if (target.kind !== 'pr') {
+    throw new Error('store-review-summary: #1070 CI proof requires a PR target');
+  }
+
+  const reviewedHead = resolveReviewedHeadSha(options.expectedHeadSha);
+  const currentHead = readPrHeadSha(target);
+  if (currentHead !== reviewedHead) {
+    throw new Error(
+      `store-review-summary: #1070 refusing to store a passing review summary for stale HEAD. ` +
+      `Reviewed ${reviewedHead}, but PR #${target.number} is currently ${currentHead}. ` +
+      `Re-review the current head before storing a pass summary.`,
+    );
+  }
+
+  const checks = readPrChecks(target);
+  if (checks.length === 0) {
+    throw new Error(
+      `store-review-summary: #1070 refusing to store a passing review summary because CI has not produced checks for ${currentHead}.`,
+    );
+  }
+
+  const blocking = checks.filter(check => {
+    const bucket = check.bucket;
+    return bucket !== 'pass' && bucket !== 'skipping';
+  });
+  if (blocking.length > 0) {
+    const details = blocking.map(formatCheck).join('; ');
+    throw new Error(
+      `store-review-summary: #1070 refusing to store a passing review summary because CI is not green for ${currentHead}: ${details}`,
+    );
+  }
+}
+
+function extractSummaryRoundVerdict(summary: string): RoundVerdict | null {
+  const match = summary.match(/^<!-- meta:(\{.*\}) -->/);
+  if (!match) return null;
+  try {
+    const meta = JSON.parse(match[1]) as { round_verdict?: RoundVerdict; verdict?: string };
+    if (meta.round_verdict === 'PASS' || meta.round_verdict === 'PASS_WITH_PARTIALS' || meta.round_verdict === 'FAIL') {
+      return meta.round_verdict;
+    }
+    if (meta.verdict === 'fail') return 'FAIL';
+    if (meta.verdict === 'pass') return 'PASS';
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Defensive coercion for CLI/API payloads. Supports legacy shapes (status-only,
@@ -271,13 +397,18 @@ export function storeReviewSummary(
   target: AttachmentTarget,
   round: number,
   note?: string,
+  options: StoreReviewSummaryOptions = {},
 ): string {
   const derived = composeReviewSummary(target, round);
+  const roundVerdict = extractSummaryRoundVerdict(derived) ?? deriveStoredRoundVerdict(target, round);
+  if (roundVerdict !== 'FAIL') {
+    assertReviewSummaryCiPassed(target, options);
+  }
+
   let content = derived;
 
   const trimmed = note?.trim();
   if (trimmed) {
-    const roundVerdict = deriveStoredRoundVerdict(target, round);
     if (roundVerdict === 'FAIL' && assertsPass(trimmed)) {
       throw new Error(
         `store-review-summary: refusing to store a note that asserts the round PASSED while the ` +

--- a/src/worktree-isolation.test.ts
+++ b/src/worktree-isolation.test.ts
@@ -62,6 +62,15 @@ describe('kaizen-review-pr SKILL.md — review findings storage contract (#966)'
     const skill = readFileSync(REVIEW_PR_SKILL, 'utf8');
     expect(skill).toMatch(/store-review-summary/);
   });
+
+  it('requires current-head CI proof when storing a pass summary (#1070)', () => {
+    // INVARIANT: the skill must not regress to instruction-only CI checking.
+    // The storage command carries the reviewed head so the CLI can reject
+    // pending, failing, absent, or stale-head CI before writing the sentinel.
+    const skill = readFileSync(REVIEW_PR_SKILL, 'utf8');
+    expect(skill).toMatch(/--head-sha "\$\(git rev-parse HEAD\)"/);
+    expect(skill).toMatch(/Pending, failing, absent, or stale-head CI refuses storage/);
+  });
 });
 
 describe('kaizen-implement SKILL.md — review battery storage reference (#966)', () => {


### PR DESCRIPTION
Fixes Garsson-io/kaizen#1070

Run tag: eastern-ant/run-2

## Story

Once upon a time, `/kaizen-review-pr` could derive a review round as PASS from stored dimension findings and write the `store-review-summary` sentinel that clears the review gate.

Every day, that protected against fabricated review findings, but it still trusted local review evidence more than the CI system that actually runs the broader matrix.

One day, issue #1070 captured the concrete failure: a review was declared PASSED while CI was still running or already red on the branch. The missing check was not another instruction; it was a missing enforcement point at the summary writer.

Because of that, this PR makes `storeReviewSummary()` require current-head CI proof before it can persist any derived PASS or PASS-with-partials summary. It reads the PR `headRefOid`, compares it with the reviewed head, reads `gh pr checks` buckets, and refuses storage for pending, failing, canceled, absent, or stale-head checks. Derived FAIL summaries still store normally so failed review evidence is not blocked.

Because of that, both `store-review-summary` and `store-review-batch` share the same gate, and the review skill now passes `--head-sha "$(git rev-parse HEAD)"` so the checked CI belongs to the reviewed commit.

Until finally, the tests prove the false-pass paths directly: pass stores, pending fails, red CI fails, no checks fails, stale HEAD fails, and the CLI forwards the reviewed head before writing the review sentinel.

And ever since, a passing review summary is no longer self-reported. The storage layer observes the current PR outcome before it clears the review gate.

## Architecture

```
review findings -> composeReviewSummary()
                    |
                    v
             derived round verdict
                    |
          FAIL -----+----> write summary evidence
                    |
                 PASS / PASS_WITH_PARTIALS
                    |
                    v
        gh pr view headRefOid == reviewed head
                    |
                    v
        gh pr checks buckets all pass/skipping
                    |
                    v
              write summary + sentinel
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Gate in `storeReviewSummary()` | It is the durable choke point that writes the pass summary/sentinel. | Adds a GitHub CLI dependency to pass-summary storage. |
| Allow FAIL summaries without CI proof | Failed review evidence should remain recordable even when CI is red. | The CI gate applies only to non-failing derived verdicts. |
| Use observed `gh pr checks` buckets, not `--ci-status pass` | Self-reported CI status recreates the original false-pass failure. | Review storage can wait on CI rather than clearing immediately. |
| Compare PR head to reviewed head | Green checks for an older commit do not prove the reviewed diff. | Callers should pass `--head-sha`; otherwise local HEAD is used. |
| Treat `skipping` as non-blocking | GitHub reports skipped optional checks such as automation jobs. | Unknown buckets fail closed. |

## What's In This PR

| File | Purpose |
|---|---|
| `src/structured-data.ts` | Adds the CI/head proof check and applies it before storing passing review summaries. |
| `src/cli-structured-data.ts` | Adds `--head-sha` plumbing for summary and batch storage. |
| `src/structured-data.test.ts` | Covers pass, pending, fail, no-checks, stale-head, and existing derived-verdict behavior. |
| `src/cli-structured-data.test.ts` | Verifies the CLI passes `--head-sha` before sentinel writing. |
| `src/worktree-isolation.test.ts` | Pins the review skill contract so the command keeps carrying current-head proof. |
| `.agents/skills/kaizen-review-pr/SKILL.md` | Updates Phase 5 instructions to use the enforced current-head CI proof path. |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status | Test File |
|---|----------|-------|--------|-----------|
| 1 | A derived PASS review summary is stored when the PR head equals the reviewed HEAD and check buckets are pass/skipping only. | Unit | Tested | `src/structured-data.test.ts` |
| 2 | A derived PASS review summary is refused when any check bucket is pending. | Unit | Tested | `src/structured-data.test.ts` |
| 3 | A derived PASS review summary is refused when any check bucket is fail/cancel. | Unit | Tested | `src/structured-data.test.ts` |
| 4 | A derived PASS review summary is refused when the PR head differs from the reviewed/local HEAD. | Unit | Tested | `src/structured-data.test.ts` |
| 5 | `store-review-summary` CLI accepts `--head-sha` and passes it to the CI gate before writing the review sentinel. | Unit | Tested | `src/cli-structured-data.test.ts` |

No deferred behaviors.

## Validation

- [x] `npx vitest run src/structured-data.test.ts src/cli-structured-data.test.ts` — 65 tests passed.
- [x] `npx vitest run src/structured-data.test.ts src/cli-structured-data.test.ts src/worktree-isolation.test.ts` — 71 tests passed.
- [x] `npm run typecheck` — passed.
- [x] `git diff --check` — passed.
- [ ] `npm test` — 3036 passed, 11 skipped, 4 failed in pre-existing E2E/hook timeout paths: `src/e2e/setup-e2e.test.ts`, `src/e2e/synthetic-workflow.test.ts`, `src/hooks/kaizen-reflect.test.ts`.
- [ ] `npm run test:hooks` — 404 passed, 2 failed; both failures are `kaizen-reflect-ts.sh` timeouts in `.claude/hooks/tests/test_hooks.py`, unrelated to review summary storage.

## Known Limitations

This PR does not add a live GitHub E2E test because the failure mode is fully at the deterministic storage/CLI boundary: parse PR head, parse check buckets, and refuse storage. The PR's own CI will provide the real GitHub check run for this branch.
