### PR TITLE
fix: validate review sentinel provenance

### DIFF
--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFileSync, appendFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { handlers, parseArgs, resolveContent, resolveRound, type CliArgs } from './cli-structured-data.js';
 import {
   nextReviewRound,
@@ -12,7 +12,8 @@ import {
 vi.mock('node:fs', () => ({
   readFileSync: vi.fn().mockReturnValue('file-content'),
   mkdirSync: vi.fn(),
-  appendFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readdirSync: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
@@ -211,14 +212,22 @@ describe('store-review-batch — review sentinel', () => {
     });
     log.mockRestore();
 
-    // appendFileSync must have been called with a path containing '.reviewed-r1'
-    const calls = vi.mocked(appendFileSync).mock.calls;
+    // writeFileSync must have been called with a path containing '.reviewed-r1'
+    const calls = vi.mocked(writeFileSync).mock.calls;
     const sentinelCall = calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r1'),
     );
     expect(sentinelCall).toBeDefined();
     expect(String(sentinelCall![0])).toMatch(/\.reviewed-r1$/);
-    expect(String(sentinelCall![1])).toMatch(/reviewed_at=/);
+    const payload = JSON.parse(String(sentinelCall![1]));
+    expect(payload).toMatchObject({
+      schemaVersion: 1,
+      prUrl: 'https://github.com/org/repo/pull/903',
+      round: 1,
+      dimensionsReviewed: ['correctness', 'security'],
+      dimensionCount: 2,
+    });
+    expect(payload.integrity).toMatch(/^sha256:/);
   });
 
   it('sentinel path encodes PR number and repo', async () => {
@@ -233,7 +242,7 @@ describe('store-review-batch — review sentinel', () => {
     });
     log.mockRestore();
 
-    const calls = vi.mocked(appendFileSync).mock.calls;
+    const calls = vi.mocked(writeFileSync).mock.calls;
     const sentinelCall = calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r'),
     );
@@ -260,10 +269,20 @@ describe('store-review-summary — CI head proof', () => {
       undefined,
       { expectedHeadSha: 'abc123' },
     );
-    const sentinelCall = vi.mocked(appendFileSync).mock.calls.find(
+    const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r5'),
     );
     expect(sentinelCall).toBeDefined();
+    const payload = JSON.parse(String(sentinelCall![1]));
+    expect(payload).toMatchObject({
+      schemaVersion: 1,
+      prUrl: 'https://github.com/Garsson-io/kaizen/pull/903',
+      round: 5,
+      dimensionsReviewed: ['correctness', 'security'],
+      dimensionCount: 2,
+    });
+    expect(payload.findingCount).toBeGreaterThanOrEqual(0);
+    expect(payload.integrity).toMatch(/^sha256:/);
     log.mockRestore();
   });
 });
@@ -364,7 +383,7 @@ describe('store-review-finding — strict payload validation (#1039)', () => {
       text: JSON.stringify([{ dimension: 'correctness', verdict: 'fail', summary: 'bad', findings: [] }]),
     } as CliArgs)).rejects.toThrow('process.exit(1)');
     // Sentinel must NOT be written when batch is rejected
-    const sentinelCall = vi.mocked(appendFileSync).mock.calls.find(
+    const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r'),
     );
     expect(sentinelCall).toBeUndefined();

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -33,7 +33,7 @@
  *   npx tsx src/cli-structured-data.ts retrieve-iteration --pr 903 --repo R
  */
 
-import { readFileSync, mkdirSync, appendFileSync } from 'node:fs';
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import YAML from 'yaml';
 import {
   prTarget,
@@ -61,6 +61,10 @@ import {
   type ReviewFindingData,
   type StoreReviewSummaryOptions,
 } from './structured-data.js';
+import {
+  buildReviewSentinelRecord,
+  serializeReviewSentinel,
+} from './review-sentinel.js';
 import { normalizeReviewFindingData, validateReviewFindingPayload, summarizeFindingStatuses } from './review-finding-contract.js';
 
 export type CliArgs = Record<string, string> & { command: string };
@@ -125,12 +129,49 @@ export function resolveRound(a: CliArgs): number {
   return 1;
 }
 
+function parseFindingMeta(content: string): { done: number; partial: number; missing: number } | null {
+  const match = content.match(/^<!-- meta:(\{.*\}) -->/);
+  if (!match) return null;
+  try {
+    const meta = JSON.parse(match[1]) as { done?: number; partial?: number; missing?: number };
+    return {
+      done: Number.isInteger(meta.done) ? meta.done! : 0,
+      partial: Number.isInteger(meta.partial) ? meta.partial! : 0,
+      missing: Number.isInteger(meta.missing) ? meta.missing! : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function writeReviewSentinel(repo: string, pr: string | undefined, round: number): void {
+  if (!pr) return;
   try {
     const stateDir = process.env.STATE_DIR ?? '/tmp/.pr-review-state';
-    const stateKey = `${repo.replace('/', '_')}_${pr ?? ''}`;
+    const stateKey = `${repo.replace('/', '_')}_${pr}`;
+    const target = prTarget(pr, repo);
+    const dimensionsReviewed = listReviewDimensions(target, round);
+    const totals = dimensionsReviewed.reduce(
+      (acc, dim) => {
+        const content = readReviewFinding(target, round, dim);
+        const meta = content ? parseFindingMeta(content) : null;
+        if (!meta) return acc;
+        acc.totalDone += meta.done;
+        acc.totalPartial += meta.partial;
+        acc.totalMissing += meta.missing;
+        acc.findingCount += meta.done + meta.partial + meta.missing;
+        return acc;
+      },
+      { findingCount: 0, totalDone: 0, totalPartial: 0, totalMissing: 0 },
+    );
+    const record = buildReviewSentinelRecord({
+      prUrl: `https://github.com/${repo}/pull/${pr}`,
+      round,
+      dimensionsReviewed,
+      ...totals,
+    });
     mkdirSync(stateDir, { recursive: true });
-    appendFileSync(`${stateDir}/${stateKey}.reviewed-r${round}`, `reviewed_at=${new Date().toISOString()}\n`);
+    writeFileSync(`${stateDir}/${stateKey}.reviewed-r${round}`, serializeReviewSentinel(record));
   } catch {
     // best effort — sentinel is advisory
   }

--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -280,7 +280,20 @@ describe('pr-review-loop: cross-worktree isolation', () => {
 describe('pr-review-loop: gh pr diff', () => {
   /** Write a review sentinel to simulate store-review-summary having been called */
   function writeSentinel(stateKey: string, round: string): void {
-    fs.writeFileSync(path.join(testStateDir, `${stateKey}.reviewed-r${round}`), `reviewed_at=${new Date().toISOString()}\n`);
+    const prNumber = stateKey.split('_').pop();
+    writeReviewSentinel(`https://github.com/Garsson-io/kaizen/pull/${prNumber}`, round, testStateDir);
+  }
+
+  function createPendingReviewState(prNumber: string, round: string = '1'): void {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf-8',
+    }).trim();
+    createState(`Garsson-io_kaizen_${prNumber}`, {
+      PR_URL: `https://github.com/Garsson-io/kaizen/pull/${prNumber}`,
+      ROUND: round,
+      STATUS: 'needs_review',
+      BRANCH: branch,
+    });
   }
 
   it('outputs checklist and transitions to passed (with sentinel)', () => {
@@ -323,6 +336,51 @@ describe('pr-review-loop: gh pr diff', () => {
 
     const state = readState('Garsson-io_kaizen_201');
     expect(state.LAST_REVIEWED_SHA).toBeTruthy();
+  });
+
+  it('rejects a manually touched empty sentinel', () => {
+    createPendingReviewState('997', '1');
+    fs.closeSync(fs.openSync(path.join(testStateDir, 'Garsson-io_kaizen_997.reviewed-r1'), 'w'));
+
+    const output = runHook(
+      prDiffInput('https://github.com/Garsson-io/kaizen/pull/997'),
+    );
+
+    expect(output).toContain('no valid review sentinel stored for round 1');
+    expect(output).toContain('/kaizen-review-pr');
+    const state = readState('Garsson-io_kaizen_997');
+    expect(state.STATUS).toBe('needs_review');
+  });
+
+  it('rejects the legacy timestamp-only sentinel format', () => {
+    createPendingReviewState('998', '1');
+    fs.writeFileSync(path.join(testStateDir, 'Garsson-io_kaizen_998.reviewed-r1'), `reviewed_at=${new Date().toISOString()}\n`);
+
+    const output = runHook(
+      prDiffInput('https://github.com/Garsson-io/kaizen/pull/998'),
+    );
+
+    expect(output).toContain('invalid review sentinel');
+    const state = readState('Garsson-io_kaizen_998');
+    expect(state.STATUS).toBe('needs_review');
+  });
+
+  it('records rejected forged sentinels in hook trace', () => {
+    const traceFile = path.join(testStateDir, 'trace.jsonl');
+    createPendingReviewState('999', '1');
+    fs.closeSync(fs.openSync(path.join(testStateDir, 'Garsson-io_kaizen_999.reviewed-r1'), 'w'));
+
+    runHookRaw(
+      JSON.stringify(prDiffInput('https://github.com/Garsson-io/kaizen/pull/999')),
+      { KAIZEN_HOOK_TRACE: traceFile },
+    );
+
+    const entries = fs.readFileSync(traceFile, 'utf8')
+      .trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+    const reviewEntry = entries.find((e: Record<string, string>) => e.hook === 'pr-review-loop');
+    expect(reviewEntry).toBeDefined();
+    expect(reviewEntry.action).toBe('needs_review');
+    expect(reviewEntry.reason).toBe('invalid_review_sentinel');
   });
 
   it('exits silently when already passed', () => {

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -21,8 +21,15 @@
  */
 
 import { execSync } from 'node:child_process';
-import { appendFileSync, readFileSync, statSync, unlinkSync } from 'node:fs';
+import { appendFileSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import {
+  buildReviewSentinelRecord,
+  serializeReviewSentinel,
+  validateReviewSentinel,
+  type ReviewSentinelInput,
+  type ReviewSentinelValidation,
+} from '../review-sentinel.js';
 import { type HookInput, readHookInput, writeHookOutput } from './hook-io.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import {
@@ -117,17 +124,17 @@ function isValidPrUrl(url: string): boolean {
 }
 
 /**
- * Check if a review sentinel exists for the given PR and round.
+ * Check if a review sentinel proves the given PR and round were reviewed.
  * The sentinel is written by store-review-summary in cli-structured-data.ts.
  * Format: <stateDir>/<stateKey>.reviewed-r<round>
  */
-function defaultCheckReviewSentinel(prUrl: string, round: string, stateDir: string): boolean {
+function defaultCheckReviewSentinel(prUrl: string, round: string, stateDir: string): ReviewSentinelValidation {
   const sentinel = join(stateDir, `${prUrlToStateKey(prUrl)}.reviewed-r${round}`);
   try {
     statSync(sentinel);
-    return true;
+    return validateReviewSentinel(readFileSync(sentinel, 'utf-8'), { prUrl, round });
   } catch {
-    return false;
+    return { ok: false, reason: 'missing_sentinel' };
   }
 }
 
@@ -135,10 +142,16 @@ function defaultCheckReviewSentinel(prUrl: string, round: string, stateDir: stri
  * Write a review sentinel for the given PR and round.
  * Called by store-review-summary after findings are stored.
  */
-export function writeReviewSentinel(prUrl: string, round: string | number, stateDir: string = DEFAULT_STATE_DIR): void {
+export function writeReviewSentinel(
+  prUrl: string,
+  round: string | number,
+  stateDir: string = DEFAULT_STATE_DIR,
+  options: Partial<ReviewSentinelInput> = {},
+): void {
   ensureStateDir(stateDir);
   const sentinel = join(stateDir, `${prUrlToStateKey(prUrl)}.reviewed-r${round}`);
-  appendFileSync(sentinel, `reviewed_at=${new Date().toISOString()}\n`);
+  const record = buildReviewSentinelRecord({ ...options, prUrl, round });
+  writeFileSync(sentinel, serializeReviewSentinel(record));
 }
 
 function printChecklist(
@@ -447,10 +460,16 @@ export function processHookInput(
     // #920: Verify review outcome exists before clearing gate.
     // The sentinel is written by store-review-summary (cli-structured-data.ts).
     // Without it, gh pr diff alone doesn't prove dimension agents were spawned.
-    const checkSentinel = options.checkReviewSentinel ?? defaultCheckReviewSentinel;
-    if (!checkSentinel(found.prUrl, found.round, stateDir)) {
-      const msg = `\n\ud83d\udccb REVIEW ROUND ${found.round}/${MAX_ROUNDS}\n${printChecklist(found.prUrl, found.round, MAX_ROUNDS)}\n\u26a0\ufe0f No review findings stored for round ${found.round}. Run \`/kaizen-review-pr ${found.prUrl}\` to spawn dimension agents.\n`;
-      return decide('needs_review', 'no_review_sentinel', msg, { prUrl: found.prUrl, round: found.round });
+    const sentinelResult = options.checkReviewSentinel
+      ? {
+          ok: options.checkReviewSentinel(found.prUrl, found.round, stateDir),
+          reason: 'custom_check_failed',
+        }
+      : defaultCheckReviewSentinel(found.prUrl, found.round, stateDir);
+    if (!sentinelResult.ok) {
+      const reason = sentinelResult.reason === 'missing_sentinel' ? 'no_review_sentinel' : 'invalid_review_sentinel';
+      const msg = `\n\ud83d\udccb REVIEW ROUND ${found.round}/${MAX_ROUNDS}\n${printChecklist(found.prUrl, found.round, MAX_ROUNDS)}\n\u26a0\ufe0f invalid review sentinel: no valid review sentinel stored for round ${found.round} (${sentinelResult.reason}). Run \`/kaizen-review-pr ${found.prUrl}\` to spawn dimension agents.\n`;
+      return decide('needs_review', reason, msg, { prUrl: found.prUrl, round: found.round, sentinelReason: sentinelResult.reason });
     }
 
     const fp = writeStateFile(stateDir, prUrlToStateKey(found.prUrl), {

--- a/src/review-sentinel.test.ts
+++ b/src/review-sentinel.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildReviewSentinelRecord,
+  expectedPrReviewDimensions,
+  serializeReviewSentinel,
+  validateReviewSentinel,
+} from './review-sentinel.js';
+
+const PR_URL = 'https://github.com/Garsson-io/kaizen/pull/997';
+
+describe('review sentinel contract', () => {
+  it('validates a complete structured sentinel', () => {
+    const record = buildReviewSentinelRecord({
+      prUrl: PR_URL,
+      round: 1,
+      dimensionsReviewed: expectedPrReviewDimensions(),
+      findingCount: 12,
+      totalDone: 12,
+    });
+
+    const result = validateReviewSentinel(serializeReviewSentinel(record), {
+      prUrl: PR_URL,
+      round: 1,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.record?.dimensionsReviewed).toEqual(expectedPrReviewDimensions());
+  });
+
+  it('rejects tampered sentinel content', () => {
+    const record = buildReviewSentinelRecord({
+      prUrl: PR_URL,
+      round: 1,
+      dimensionsReviewed: expectedPrReviewDimensions(),
+      findingCount: 12,
+      totalDone: 12,
+    });
+    const tampered = { ...record, totalMissing: 1 };
+
+    const result = validateReviewSentinel(JSON.stringify(tampered), {
+      prUrl: PR_URL,
+      round: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('integrity_mismatch');
+  });
+
+  it('rejects sentinels missing expected review dimensions', () => {
+    const record = buildReviewSentinelRecord({
+      prUrl: PR_URL,
+      round: 1,
+      dimensionsReviewed: ['correctness'],
+      findingCount: 1,
+      totalDone: 1,
+    });
+
+    const result = validateReviewSentinel(serializeReviewSentinel(record), {
+      prUrl: PR_URL,
+      round: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('missing_expected_dimensions');
+  });
+});

--- a/src/review-sentinel.ts
+++ b/src/review-sentinel.ts
@@ -1,0 +1,196 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import { resolve } from 'node:path';
+import YAML from 'yaml';
+import { resolveProjectRoot } from './lib/resolve-project-root.js';
+
+export const REVIEW_SENTINEL_SCHEMA_VERSION = 1;
+
+export const DEFAULT_PR_REVIEW_DIMENSIONS = [
+  'correctness',
+  'dry',
+  'improvement-lifecycle',
+  'plan-fidelity',
+  'pr-description',
+  'requirements',
+  'scope-fidelity',
+  'security',
+  'skill-changes',
+  'test-plan',
+  'test-quality',
+  'tooling-fitness',
+] as const;
+
+export interface ReviewSentinelRecord {
+  schemaVersion: 1;
+  prUrl: string;
+  repo: string;
+  prNumber: number;
+  round: number;
+  reviewedAt: string;
+  dimensionsReviewed: string[];
+  dimensionCount: number;
+  findingCount: number;
+  totalDone: number;
+  totalPartial: number;
+  totalMissing: number;
+  integrity: string;
+}
+
+export interface ReviewSentinelInput {
+  prUrl: string;
+  round: string | number;
+  reviewedAt?: string;
+  dimensionsReviewed?: string[];
+  findingCount?: number;
+  totalDone?: number;
+  totalPartial?: number;
+  totalMissing?: number;
+}
+
+export interface ReviewSentinelValidation {
+  ok: boolean;
+  reason: string;
+  record?: ReviewSentinelRecord;
+}
+
+type ReviewSentinelUnsigned = Omit<ReviewSentinelRecord, 'integrity'>;
+
+function parsePrUrl(prUrl: string): { repo: string; prNumber: number } | null {
+  const match = prUrl.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)$/);
+  if (!match) return null;
+  return { repo: match[1], prNumber: Number(match[2]) };
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(unsigned: ReviewSentinelUnsigned): string {
+  return `sha256:${createHash('sha256').update(stableStringify(unsigned)).digest('hex')}`;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map(v => v.trim()).filter(Boolean))].sort();
+}
+
+export function expectedPrReviewDimensions(): string[] {
+  try {
+    const promptsDir = resolve(resolveProjectRoot(process.cwd()), 'prompts');
+    const files = fs.readdirSync(promptsDir).filter(f => /^review-.*\.md$/.test(f));
+    const dimensions = files.flatMap(file => {
+      const content = fs.readFileSync(resolve(promptsDir, file), 'utf8');
+      const match = content.match(/^---\n([\s\S]*?)\n---/);
+      if (!match) return [];
+      const frontmatter = YAML.parse(match[1]) as { name?: string; applies_to?: string } | null;
+      if (!frontmatter?.name) return [];
+      if (frontmatter.applies_to !== 'pr' && frontmatter.applies_to !== 'both') return [];
+      return [frontmatter.name];
+    });
+    const parsed = uniqueSorted(dimensions);
+    return parsed.length > 0 ? parsed : [...DEFAULT_PR_REVIEW_DIMENSIONS];
+  } catch {
+    return [...DEFAULT_PR_REVIEW_DIMENSIONS];
+  }
+}
+
+export function buildReviewSentinelRecord(input: ReviewSentinelInput): ReviewSentinelRecord {
+  const parsed = parsePrUrl(input.prUrl);
+  if (!parsed) {
+    throw new Error(`invalid PR URL for review sentinel: ${input.prUrl}`);
+  }
+
+  const dimensionsReviewed = uniqueSorted(input.dimensionsReviewed ?? expectedPrReviewDimensions());
+  const unsigned: ReviewSentinelUnsigned = {
+    schemaVersion: REVIEW_SENTINEL_SCHEMA_VERSION,
+    prUrl: input.prUrl,
+    repo: parsed.repo,
+    prNumber: parsed.prNumber,
+    round: Number(input.round),
+    reviewedAt: input.reviewedAt ?? new Date().toISOString(),
+    dimensionsReviewed,
+    dimensionCount: dimensionsReviewed.length,
+    findingCount: input.findingCount ?? 0,
+    totalDone: input.totalDone ?? 0,
+    totalPartial: input.totalPartial ?? 0,
+    totalMissing: input.totalMissing ?? 0,
+  };
+
+  return { ...unsigned, integrity: digest(unsigned) };
+}
+
+export function serializeReviewSentinel(record: ReviewSentinelRecord): string {
+  return `${JSON.stringify(record, null, 2)}\n`;
+}
+
+export function validateReviewSentinel(
+  content: string,
+  expected: { prUrl: string; round: string | number },
+): ReviewSentinelValidation {
+  if (!content.trim()) {
+    return { ok: false, reason: 'empty_sentinel' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return { ok: false, reason: 'malformed_json' };
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return { ok: false, reason: 'not_object' };
+  }
+
+  const record = parsed as Partial<ReviewSentinelRecord>;
+  if (record.schemaVersion !== REVIEW_SENTINEL_SCHEMA_VERSION) {
+    return { ok: false, reason: 'unsupported_schema' };
+  }
+  if (record.prUrl !== expected.prUrl) {
+    return { ok: false, reason: 'pr_url_mismatch' };
+  }
+  if (record.round !== Number(expected.round)) {
+    return { ok: false, reason: 'round_mismatch' };
+  }
+  if (!record.reviewedAt || Number.isNaN(Date.parse(record.reviewedAt))) {
+    return { ok: false, reason: 'invalid_reviewed_at' };
+  }
+  if (!Array.isArray(record.dimensionsReviewed)) {
+    return { ok: false, reason: 'missing_dimensions' };
+  }
+  if (record.dimensionCount !== record.dimensionsReviewed.length) {
+    return { ok: false, reason: 'dimension_count_mismatch' };
+  }
+  if (new Set(record.dimensionsReviewed).size !== record.dimensionsReviewed.length) {
+    return { ok: false, reason: 'duplicate_dimensions' };
+  }
+
+  const expectedDimensions = expectedPrReviewDimensions();
+  const reviewed = new Set(record.dimensionsReviewed);
+  const missing = expectedDimensions.filter(dim => !reviewed.has(dim));
+  if (missing.length > 0) {
+    return { ok: false, reason: `missing_expected_dimensions:${missing.join(',')}` };
+  }
+
+  for (const key of ['findingCount', 'totalDone', 'totalPartial', 'totalMissing'] as const) {
+    if (!Number.isInteger(record[key]) || record[key]! < 0) {
+      return { ok: false, reason: `invalid_${key}` };
+    }
+  }
+
+  const { integrity, ...unsigned } = record as ReviewSentinelRecord;
+  if (integrity !== digest(unsigned)) {
+    return { ok: false, reason: 'integrity_mismatch' };
+  }
+
+  return { ok: true, reason: 'valid', record: record as ReviewSentinelRecord };
+}


### PR DESCRIPTION
## Once upon a time

The PR review loop used a local sentinel file as the proof that a review round had completed. The hook correctly blocked `gh pr diff` until that sentinel existed.

## Every day

`store-review-summary` and `store-review-batch` wrote the sentinel, but the sentinel was only a timestamp. The hook checked file existence, so a manually created file had the same authority as a real review summary.

## One day

Issue #997 documented four bypasses where `touch /tmp/.pr-review-state/...reviewed-rN` cleared the gate for PR #978 and PR #995. Those PRs merged with partial review coverage while the hook trace reported `review_passed`.

## Because of that

This PR replaces existence-only checks with a structured review sentinel:

- `schemaVersion`, PR URL, repo, PR number, round, and review timestamp
- `dimensionsReviewed` and `dimensionCount`
- finding totals from stored review finding metadata
- deterministic `sha256:` integrity digest over the sentinel payload

The hook now parses and validates the sentinel before clearing the review gate. Empty files, timestamp-only legacy files, malformed JSON, PR/round mismatches, missing expected dimensions, duplicate dimensions, invalid totals, and digest tampering all fail closed.

## Because of that

The normal review storage path writes the new sentinel format after structured review storage succeeds. The hook trace now distinguishes missing sentinels from forged or malformed ones:

- `no_review_sentinel` for absent sentinel files
- `invalid_review_sentinel` for files that exist but fail provenance validation

## Until finally

The bypass path now stays blocked. A touched sentinel keeps the state at `needs_review`, prints an invalid-sentinel warning, and records the rejected attempt in hook trace. A valid sentinel written by the production helper still clears the gate.

## And ever since

The review gate now requires proof of review provenance and dimension coverage, not just filesystem presence.

Run tag: worrying-squid/run-1

Fixes Garsson-io/kaizen#997
Related: Garsson-io/kaizen#1038

## Architecture

```text
store-review-finding(s)
        |
        v
store-review-summary / store-review-batch
        |
        v
review-sentinel.ts builds JSON + digest
        |
        v
$STATE_DIR/<repo>_<pr>.reviewed-rN
        |
        v
pr-review-loop validates PR, round, dimensions, totals, digest
        |
        v
gate clears only when sentinel is valid
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep the sentinel local but make it structured | Fixes the immediate local hook bypass without adding network reads to every hook run | A future L3 remote-only sentinel could still harden this further |
| Validate expected PR review dimensions | Count-only validation could be forged with arbitrary names | Dimension set is read from prompts with a 12-dimension fallback |
| Add a digest over sentinel fields | Detects casual manual edits and malformed recreation attempts | This is integrity checking, not a secret signature |
| Write the sentinel with `writeFileSync` | Re-storing a summary should replace the proof, not append corrupt JSON | Existing tests needed to move from append assertions to JSON assertions |

## What's In This PR

| File | Purpose |
|---|---|
| `src/review-sentinel.ts` | New sentinel schema, serialization, expected-dimension discovery, and validation |
| `src/hooks/pr-review-loop.ts` | Validates sentinel content before clearing `gh pr diff` review gate |
| `src/cli-structured-data.ts` | Writes provenance-rich sentinels from stored review findings |
| `src/review-sentinel.test.ts` | Unit coverage for valid, tampered, and missing-dimension sentinels |
| `src/hooks/pr-review-loop.test.ts` | Hook-level regressions for touched and timestamp-only sentinel bypasses |
| `src/cli-structured-data.test.ts` | CLI writer coverage for JSON sentinel payloads |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Coverage |
|---|----------|-------------|-------|----------|
| 1 | Sentinel validation rejects empty, legacy timestamp-only, malformed, mismatched PR/round, insufficient dimension count, and bad digest records. | code | Unit | Tested in `src/review-sentinel.test.ts` and `src/hooks/pr-review-loop.test.ts` |
| 2 | A valid sentinel written through the production helper clears the PR diff gate. | code | Integration | Tested in `src/hooks/pr-review-loop.test.ts` |
| 3 | `store-review-summary` and `store-review-batch` write structured sentinels with reviewed dimensions and finding totals only after structured review storage succeeds. | code | Unit | Tested in `src/cli-structured-data.test.ts` |
| 4 | Running the real hook subprocess with a manually created sentinel does not clear the gate and records a rejected/malformed sentinel reason in hook trace. | user/operator | System | Tested in `src/hooks/pr-review-loop.test.ts` |
| 5 | Running the real hook subprocess with a valid structured sentinel clears the gate. | user/operator | System | Tested in `src/hooks/pr-review-loop.test.ts` |

No deferred behaviors.

## Validation

- [x] `npx vitest run src/hooks/pr-review-loop.test.ts --reporter=default` - 32 tests passed
- [x] `npx vitest run src/cli-structured-data.test.ts --reporter=default` - 30 tests passed
- [x] `npx vitest run src/review-sentinel.test.ts --reporter=default` - 3 tests passed
- [x] `npx vitest run src/hooks/pr-review-loop.test.ts src/cli-structured-data.test.ts src/review-sentinel.test.ts src/structured-data.test.ts --reporter=default` - 100 tests passed
- [x] `npm run typecheck` - passed
- [ ] `npm test` - unrelated existing failures in `src/e2e/setup-e2e.test.ts`, `src/e2e/synthetic-workflow.test.ts`, and `src/hooks/kaizen-reflect.test.ts` due session timeout assertions

## Known Limitations

This is an L2 hardening of the local sentinel. It rejects manual `touch` and malformed sentinels, verifies dimension names and counts, and detects tampering, but it is not a secret-backed signature. Moving the sentinel entirely to PR attachments remains a possible future L3 hardening step.

Dual failure mode check:

| If absent | If over-corrected |
|---|---|
| Manual filesystem writes can clear review gates without a full review battery. | Legitimate summaries could be blocked if the validator requires stale or wrong dimensions. This PR reads the active prompt dimensions and falls back to the current 12 PR dimensions to keep valid full reviews working. |
