### PR TITLE
fix(auto-dent): schema-constrain Codex planning

### DIFF
--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -21,6 +21,7 @@ import {
   extractPlanningText,
   formatPlanningFailure,
   selectPlanningProvider,
+  validatePlanningOutputContract,
   withPlanningProvider,
   themeProgress,
   type BatchPlan,
@@ -199,6 +200,26 @@ describe('provider-aware planning (#1146)', () => {
   });
 
   it('validates schema-constrained Codex JSONL into a Codex-attributed plan (#1215)', () => {
+    const providerPlan = {
+      created_at: '2026-06-27T22:20:00Z',
+      guidance: 'codex planning',
+      items: [
+        {
+          issue: '#1215',
+          title: 'Codex planning pre-pass JSON validation fallback',
+          score: 9.25,
+          approach: 'Harden the Codex planning boundary with schema output.',
+          status: 'pending',
+          item_type: 'leaf',
+          parent_epic: null,
+          theme: null,
+        },
+      ],
+      themes: [],
+      wip_excluded: [],
+      epics_scanned: ['#1134 Enable Codex as an auto-dent agent'],
+      decomposition_candidates: [],
+    };
     const codexJsonl = [
       JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
       JSON.stringify({ type: 'turn.started' }),
@@ -207,35 +228,41 @@ describe('provider-aware planning (#1146)', () => {
         item: {
           id: 'item_0',
           type: 'agent_message',
-          text: JSON.stringify({
-            created_at: '2026-06-27T22:20:00Z',
-            guidance: 'codex planning',
-            items: [
-              {
-                issue: '#1215',
-                title: 'Codex planning pre-pass JSON validation fallback',
-                score: 9.25,
-                approach: 'Harden the Codex planning boundary with schema output.',
-                status: 'pending',
-                item_type: 'leaf',
-              },
-            ],
-            wip_excluded: [],
-            epics_scanned: ['#1134 Enable Codex as an auto-dent agent'],
-            decomposition_candidates: [],
-          }),
+          text: JSON.stringify(providerPlan),
         },
       }),
       JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1 } }),
     ].join('\n');
 
     const parsed = extractPlanJson(extractPlanningText('codex', codexJsonl));
+    expect(validatePlanningOutputContract(parsed)).toBe(true);
+
     const plan = validatePlan(parsed);
 
     expect(withPlanningProvider(plan!, { provider: 'codex', billing: 'subscription-cli' })).toMatchObject({
       planning_provider: { provider: 'codex', billing: 'subscription-cli' },
       items: [{ issue: '#1215', status: 'pending', item_type: 'leaf' }],
     });
+  });
+
+  it('rejects Codex provider payloads that omit required nullable schema fields (#1215)', () => {
+    expect(validatePlanningOutputContract({
+      created_at: '2026-06-27T22:20:00Z',
+      guidance: 'codex planning',
+      items: [
+        {
+          issue: '#1215',
+          title: 'Codex planning pre-pass JSON validation fallback',
+          score: 9.25,
+          approach: 'Harden the Codex planning boundary with schema output.',
+          status: 'pending',
+          item_type: 'leaf',
+        },
+      ],
+      wip_excluded: [],
+      epics_scanned: ['#1134 Enable Codex as an auto-dent agent'],
+      decomposition_candidates: [],
+    })).toBe(false);
   });
 
   it('attaches planning provider metadata to created plans', () => {

--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -14,6 +14,7 @@ import {
   formatPlanSummary,
   buildPlanPrompt,
   buildPlanningCommand,
+  buildPlanningSchemaFile,
   titleTokens,
   deriveThemes,
   ensureThemes,
@@ -138,11 +139,13 @@ describe('provider-aware planning (#1146)', () => {
   });
 
   it('builds a Codex exec planning command with prompt on stdin', () => {
+    const schemaFile = '/tmp/auto-dent-plan-schema.json';
     const command = buildPlanningCommand(
       { provider: 'codex', billing: 'subscription-cli' },
       'plan prompt',
       makeState(),
       '/repo',
+      schemaFile,
     );
 
     expect(command.command).toBe('codex');
@@ -156,9 +159,28 @@ describe('provider-aware planning (#1146)', () => {
       '--dangerously-bypass-approvals-and-sandbox',
       '--color',
       'never',
+      '--output-schema',
+      schemaFile,
       '-',
     ]);
     expect(command.stdin).toBe('plan prompt');
+  });
+
+  it('writes a Codex planning schema file derived from the plan contract', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'plan-schema-test-'));
+    try {
+      const schemaFile = buildPlanningSchemaFile(tmpDir);
+      const schema = JSON.parse(readFileSync(schemaFile, 'utf8'));
+
+      expect(schema.type).toBe('object');
+      expect(schema.required).toContain('items');
+      expect(schema.properties.items.type).toBe('array');
+      expect(schema.properties.items.items.required).toEqual(
+        expect.arrayContaining(['issue', 'title']),
+      );
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('extracts provider output text from Claude stream-json and Codex JSONL', () => {
@@ -174,6 +196,46 @@ describe('provider-aware planning (#1146)', () => {
 
     expect(validatePlan(extractPlanJson(claudeText))).not.toBeNull();
     expect(validatePlan(extractPlanJson(codexText))).not.toBeNull();
+  });
+
+  it('validates schema-constrained Codex JSONL into a Codex-attributed plan (#1215)', () => {
+    const codexJsonl = [
+      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
+      JSON.stringify({ type: 'turn.started' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_0',
+          type: 'agent_message',
+          text: JSON.stringify({
+            created_at: '2026-06-27T22:20:00Z',
+            guidance: 'codex planning',
+            items: [
+              {
+                issue: '#1215',
+                title: 'Codex planning pre-pass JSON validation fallback',
+                score: 9.25,
+                approach: 'Harden the Codex planning boundary with schema output.',
+                status: 'pending',
+                item_type: 'leaf',
+              },
+            ],
+            wip_excluded: [],
+            epics_scanned: ['#1134 Enable Codex as an auto-dent agent'],
+            decomposition_candidates: [],
+          }),
+        },
+      }),
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1 } }),
+    ].join('\n');
+
+    const parsed = extractPlanJson(extractPlanningText('codex', codexJsonl));
+    const plan = validatePlan(parsed);
+
+    expect(withPlanningProvider(plan!, { provider: 'codex', billing: 'subscription-cli' })).toMatchObject({
+      planning_provider: { provider: 'codex', billing: 'subscription-cli' },
+      items: [{ issue: '#1215', status: 'pending', item_type: 'leaf' }],
+    });
   });
 
   it('attaches planning provider metadata to created plans', () => {

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -132,6 +132,10 @@ const RawPlanThemeInputSchema = z.object({
   issues: z.array(z.unknown()).min(1),
 }).passthrough();
 
+export function validatePlanningOutputContract(raw: unknown): boolean {
+  return PlanningOutputSchema.safeParse(raw).success;
+}
+
 function readState(stateFile: string): BatchState {
   return JSON.parse(readFileSync(stateFile, 'utf8'));
 }

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -20,6 +20,7 @@ import { spawn } from 'child_process';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
+import { z } from 'zod';
 import {
   type BatchState,
   buildTemplateVars,
@@ -74,6 +75,62 @@ export interface PlanningCommand {
   /** Prompt stdin for providers that read the prompt from stdin. */
   stdin?: string;
 }
+
+const PlanningOutputItemSchema = z.object({
+  issue: z.string().min(1),
+  title: z.string().min(1),
+  score: z.number(),
+  approach: z.string(),
+  status: z.enum(['pending', 'assigned', 'done', 'skipped']),
+  item_type: z.enum(['leaf', 'decompose']),
+  parent_epic: z.string().nullable(),
+  theme: z.string().nullable(),
+}).strict();
+
+const PlanningOutputThemeSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  rationale: z.string(),
+  issues: z.array(z.string()).min(1),
+}).strict();
+
+const PlanningOutputSchema = z.object({
+  created_at: z.string(),
+  guidance: z.string(),
+  items: z.array(PlanningOutputItemSchema).min(1),
+  themes: z.array(PlanningOutputThemeSchema),
+  wip_excluded: z.array(z.string()),
+  epics_scanned: z.array(z.string()),
+  decomposition_candidates: z.array(z.string()),
+}).strict();
+
+const RawPlanningInputSchema = z.object({
+  created_at: z.unknown().optional(),
+  guidance: z.unknown().optional(),
+  planning_provider: z.unknown().optional(),
+  items: z.array(z.unknown()),
+  themes: z.unknown().optional(),
+  wip_excluded: z.unknown().optional(),
+  epics_scanned: z.unknown().optional(),
+  decomposition_candidates: z.unknown().optional(),
+}).passthrough();
+
+const RawPlanItemInputSchema = z.object({
+  issue: z.unknown(),
+  title: z.unknown(),
+  score: z.unknown().optional(),
+  approach: z.unknown().optional(),
+  item_type: z.unknown().optional(),
+  parent_epic: z.unknown().optional(),
+  theme: z.unknown().optional(),
+}).passthrough();
+
+const RawPlanThemeInputSchema = z.object({
+  id: z.unknown(),
+  title: z.unknown(),
+  rationale: z.unknown().optional(),
+  issues: z.array(z.unknown()).min(1),
+}).passthrough();
 
 function readState(stateFile: string): BatchState {
   return JSON.parse(readFileSync(stateFile, 'utf8'));
@@ -130,11 +187,17 @@ export function buildPlanningCommand(
   prompt: string,
   state: BatchState,
   repoRoot: string,
+  schemaFile?: string,
 ): PlanningCommand {
   if (planningProviderName(provider) === 'codex') {
+    const args = buildCodexExecArgs(repoRoot);
+    if (schemaFile) {
+      const promptArgIndex = args.lastIndexOf('-');
+      args.splice(promptArgIndex >= 0 ? promptArgIndex : args.length, 0, '--output-schema', schemaFile);
+    }
     return {
       command: 'codex',
-      args: buildCodexExecArgs(repoRoot),
+      args,
       stdin: prompt,
     };
   }
@@ -155,6 +218,12 @@ export function buildPlanningCommand(
   }
 
   return { command: 'claude', args };
+}
+
+export function buildPlanningSchemaFile(logDir: string): string {
+  const schemaFile = resolve(logDir, 'plan-output.schema.json');
+  writeFileSync(schemaFile, JSON.stringify(z.toJSONSchema(PlanningOutputSchema), null, 2) + '\n');
+  return schemaFile;
 }
 
 export function extractPlanningText(provider: PlanningProviderName, raw: string): string {
@@ -228,11 +297,15 @@ export function extractPlanJson(text: string): BatchPlan | null {
  * Validate and normalize a parsed plan.
  */
 export function validatePlan(raw: any): BatchPlan | null {
-  if (!raw || !Array.isArray(raw.items)) return null;
+  const parsed = RawPlanningInputSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  const rawPlan = parsed.data;
 
-  const items: PlanItem[] = raw.items
-    .filter((item: any) => item.issue && item.title)
-    .map((item: any) => ({
+  const items: PlanItem[] = rawPlan.items
+    .map((item: any) => RawPlanItemInputSchema.safeParse(item))
+    .filter((result: z.ZodSafeParseResult<z.infer<typeof RawPlanItemInputSchema>>) => result.success && Boolean(result.data.issue) && Boolean(result.data.title))
+    .map((result: z.ZodSafeParseSuccess<z.infer<typeof RawPlanItemInputSchema>>) => result.data)
+    .map((item) => ({
       issue: String(item.issue),
       title: String(item.title),
       score: Number(item.score) || 0,
@@ -244,16 +317,16 @@ export function validatePlan(raw: any): BatchPlan | null {
 
   if (items.length === 0) return null;
 
-  const themes = validateThemes(raw.themes);
+  const themes = validateThemes(rawPlan.themes);
 
   return {
-    created_at: raw.created_at || new Date().toISOString(),
-    guidance: raw.guidance || '',
-    ...(raw.planning_provider ? { planning_provider: raw.planning_provider } : {}),
+    created_at: rawPlan.created_at || new Date().toISOString(),
+    guidance: rawPlan.guidance || '',
+    ...(rawPlan.planning_provider ? { planning_provider: rawPlan.planning_provider as PhaseProvider } : {}),
     items,
-    wip_excluded: Array.isArray(raw.wip_excluded) ? raw.wip_excluded : [],
-    epics_scanned: Array.isArray(raw.epics_scanned) ? raw.epics_scanned : [],
-    decomposition_candidates: Array.isArray(raw.decomposition_candidates) ? raw.decomposition_candidates : [],
+    wip_excluded: Array.isArray(rawPlan.wip_excluded) ? rawPlan.wip_excluded : [],
+    epics_scanned: Array.isArray(rawPlan.epics_scanned) ? rawPlan.epics_scanned : [],
+    decomposition_candidates: Array.isArray(rawPlan.decomposition_candidates) ? rawPlan.decomposition_candidates : [],
     ...(themes.length > 0 ? { themes } : {}),
   };
 }
@@ -269,16 +342,17 @@ export function validateThemes(raw: any): PlanTheme[] {
   const claimed = new Set<string>();
   const out: PlanTheme[] = [];
   for (const t of raw) {
-    if (!t || !t.id || !t.title || !Array.isArray(t.issues)) continue;
-    const issues = t.issues
+    const parsed = RawPlanThemeInputSchema.safeParse(t);
+    if (!parsed.success || !parsed.data.id || !parsed.data.title) continue;
+    const issues = parsed.data.issues
       .map((i: any) => String(i))
       .filter((i: string) => !claimed.has(i));
     if (issues.length === 0) continue;
     for (const i of issues) claimed.add(i);
     out.push({
-      id: String(t.id),
-      title: String(t.title),
-      rationale: String(t.rationale || ''),
+      id: String(parsed.data.id),
+      title: String(parsed.data.title),
+      rationale: String(parsed.data.rationale || ''),
       issues,
     });
   }
@@ -442,11 +516,13 @@ export function themeProgress(plan: BatchPlan): ThemeProgress[] {
 async function runPlanning(
   state: BatchState,
   repoRoot: string,
+  logDir: string,
 ): Promise<BatchPlan | null> {
   const prompt = buildPlanPrompt(state);
   const provider = selectPlanningProvider(state);
   const providerName = planningProviderName(provider);
-  const command = buildPlanningCommand(provider, prompt, state, repoRoot);
+  const schemaFile = providerName === 'codex' ? buildPlanningSchemaFile(logDir) : undefined;
+  const command = buildPlanningCommand(provider, prompt, state, repoRoot, schemaFile);
   let rawOutput = '';
 
   return new Promise((resolve) => {
@@ -659,7 +735,7 @@ async function main(): Promise<void> {
   const provider = selectPlanningProvider(state);
   console.log(`    Provider: ${planningProviderName(provider)} (${provider.billing})`);
 
-  const plan = await runPlanning(state, repoRoot);
+  const plan = await runPlanning(state, repoRoot, logDir);
 
   if (!plan) {
     console.log('>>> Planning failed — batch will use discovery mode (no plan).');


### PR DESCRIPTION
Fixes Garsson-io/kaizen#1215
Related: Garsson-io/kaizen#1176

## Story Spine

Once upon a time, auto-dent had a planning pre-pass that could steer batches with a ranked issue list, WIP exclusions, scanned epics, and decomposition candidates.

Every day, that worked by asking the selected planning provider to emit JSON and then parsing it into `plan.json` before the run loop started.

One day, supervised Codex runs on June 27, 2026 showed a provider parity gap: the Codex planning pre-pass printed `[plan:codex] plan JSON failed validation` and fell back to discovery mode in both the `xerothermic-gopher` and `fine-ant` runs. The batch could continue, but without the intended plan steering.

Because of that, this PR gives Codex planning a real structured-output contract. `scripts/auto-dent-plan.ts` now derives a JSON schema from zod, writes it into the batch log directory, and passes it to `codex exec --output-schema` for Codex planning only. Claude planning keeps its existing command shape.

Because of that, the parsed plan path now also uses zod `safeParse()` boundaries for raw plans, items, and themes while preserving the existing normalization behavior that drops malformed entries instead of fabricating plan evidence.

Until finally, a real temporary Codex planning pre-pass now writes both `plan-output.schema.json` and `plan.json` with `planning_provider.provider === "codex"` and one item for `#1215`, instead of falling back to discovery.

And ever since, Codex planning has an L3 provider boundary: the CLI enforces the response shape, the code validates the accepted object, and auto-dent keeps plan-driven steering for structurally valid Codex output.

## Architecture

```text
Batch state
  |
  v
buildPlanPrompt()
  |
  v
selectPlanningProvider()
  |
  +-- Claude -> existing claude -p stream-json path
  |
  +-- Codex  -> buildPlanningSchemaFile(logDir)
               codex exec --json --output-schema plan-output.schema.json -
               extractPlanningText('codex', raw JSONL)
               extractPlanJson()
               validatePlan() via zod raw-boundary schemas
               withPlanningProvider(...)
               plan.json
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use Codex `--output-schema` instead of prompt-only JSON instructions | Removes the failure class where Codex emits a structurally different final answer and validation falls back to discovery | Codex schema mode requires all declared properties to be required, so non-applicable item fields are nullable in the provider schema |
| Derive the schema from zod | Keeps the response contract code-owned and avoids a hand-written parallel JSON schema | The provider-facing schema is stricter than the backward-compatible normalizer |
| Keep Claude command shape unchanged | #1215 is a Codex parity issue, not a Claude planning migration | Two provider paths remain in `buildPlanningCommand()` |
| Preserve permissive normalization for existing callers | Existing tests and plan files rely on defaults and dropping malformed items | Bad objects still return `null` if no valid items remain |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-plan.ts` | Adds zod plan schemas, writes Codex output schema files, passes `--output-schema` to Codex planning, and validates raw plan/item/theme boundaries with zod |
| `scripts/auto-dent-plan.test.ts` | Adds coverage for Codex schema command wiring, schema generation, and Codex JSONL schema-shaped plan validation |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|---|---|---|---|---|
| 1 | Codex planning command carries a real `--output-schema` file while Claude command shape remains unchanged | code | Unit | Tested | `npx vitest run scripts/auto-dent-plan.test.ts scripts/auto-dent-codex.test.ts scripts/auto-dent-run.test.ts` |
| 2 | A Codex JSONL `agent_message.text` payload containing schema-shaped plan JSON extracts and validates into a non-null plan | code | Unit | Tested | Fixture now includes all provider-schema required fields and asserts `validatePlanningOutputContract(parsed) === true` |
| 3 | Invalid or empty plan objects are rejected with null rather than normalized into fake plan evidence | code | Unit | Tested | Existing `validatePlan()` tests plus provider-contract-invalid negative test for missing nullable fields |
| 4 | A real temporary Codex planning pre-pass writes `plan.json` for constrained issue #1215 | user/operator | System | Tested | Manual dogfood command below; updated stored issue test plan names `/tmp/kaizen-1215-codex-plan-dogfood/output.log` as the local audit artifact pattern |

## Validation

- [x] RED confirmed before implementation: `npx vitest run scripts/auto-dent-plan.test.ts` failed because Codex argv lacked `--output-schema` and `buildPlanningSchemaFile` did not exist.
- [x] Review fix: Codex JSONL fixture now satisfies the generated provider schema via `validatePlanningOutputContract(parsed) === true`.
- [x] Review fix: provider-contract-invalid payload missing required nullable fields is rejected.
- [x] `npx vitest run scripts/auto-dent-plan.test.ts scripts/auto-dent-codex.test.ts scripts/auto-dent-run.test.ts` -> 3 files passed, 368 tests passed.
- [x] `npx tsc --noEmit` passed.
- [x] `git diff --check` passed.
- [x] Manual dogfood after final parser change: temporary state with `provider: "codex"` ran `npx tsx scripts/auto-dent-plan.ts <state.json>` and produced `SCHEMA=present`, `PLAN=present`, `codex 1 #1215`.
- [x] Stored issue test plan now specifies a durable local dogfood pattern using `/tmp/kaizen-1215-codex-plan-dogfood/output.log`, `plan-output.schema.json`, and `plan.json` for future fallback triage.

## Known Limitations

- `npm test` in this nested worktree failed in unrelated session-simulator E2E tests: `src/e2e/synthetic-workflow.test.ts` timeout/warning-count assertions plus initial related timeouts. The same `src/e2e/synthetic-workflow.test.ts` passed from the clean main checkout, so I am treating this as worktree-local E2E behavior rather than a regression in the auto-dent planning diff.
- This PR does not close the broader planning visibility loop in #1176; it only restores Codex planning pre-pass structural reliability for #1215.