### PR TITLE
fix: address review gaps for #997 (findingCount=0 bypass)

### DIFF
--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -37,6 +37,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { processHookInput, writeReviewSentinel } from './pr-review-loop.js';
+import { expectedPrReviewDimensions } from '../review-sentinel.js';
 
 /** Run hook with raw string as stdin (for testing malformed input). */
 function runHookRaw(rawStdin: string, extraEnv: Record<string, string> = {}): string {
@@ -281,7 +282,12 @@ describe('pr-review-loop: gh pr diff', () => {
   /** Write a review sentinel to simulate store-review-summary having been called */
   function writeSentinel(stateKey: string, round: string): void {
     const prNumber = stateKey.split('_').pop();
-    writeReviewSentinel(`https://github.com/Garsson-io/kaizen/pull/${prNumber}`, round, testStateDir);
+    const dims = expectedPrReviewDimensions();
+    writeReviewSentinel(`https://github.com/Garsson-io/kaizen/pull/${prNumber}`, round, testStateDir, {
+      dimensionsReviewed: dims,
+      findingCount: dims.length,
+      totalDone: dims.length,
+    });
   }
 
   function createPendingReviewState(prNumber: string, round: string = '1'): void {
@@ -537,7 +543,12 @@ describe('INVARIANT: gate transitions verify outcome, not just trigger command',
         tool_response: { stdout: 'diff --git a/foo b/foo', stderr: '', exit_code: '0' },
       },
       provideOutcome: () => {
-        writeReviewSentinel(PR_URL, '1', testStateDir);
+        const dims = expectedPrReviewDimensions();
+        writeReviewSentinel(PR_URL, '1', testStateDir, {
+          dimensionsReviewed: dims,
+          findingCount: dims.length,
+          totalDone: dims.length,
+        });
       },
       expectBlockedAction: 'needs_review',
       expectPassedAction: 'review_passed',

--- a/src/review-sentinel.test.ts
+++ b/src/review-sentinel.test.ts
@@ -63,4 +63,24 @@ describe('review sentinel contract', () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toContain('missing_expected_dimensions');
   });
+
+  it('rejects a sentinel with findingCount=0 (no stored findings)', () => {
+    const record = buildReviewSentinelRecord({
+      prUrl: PR_URL,
+      round: 1,
+      dimensionsReviewed: expectedPrReviewDimensions(),
+      findingCount: 0,
+      totalDone: 0,
+      totalPartial: 0,
+      totalMissing: 0,
+    });
+
+    const result = validateReviewSentinel(serializeReviewSentinel(record), {
+      prUrl: PR_URL,
+      round: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_findingCount');
+  });
 });

--- a/src/review-sentinel.ts
+++ b/src/review-sentinel.ts
@@ -182,7 +182,8 @@ export function validateReviewSentinel(
   }
 
   for (const key of ['findingCount', 'totalDone', 'totalPartial', 'totalMissing'] as const) {
-    if (!Number.isInteger(record[key]) || record[key]! < 0) {
+    const min = key === 'findingCount' ? 1 : 0;
+    if (!Number.isInteger(record[key]) || record[key]! < min) {
       return { ok: false, reason: `invalid_${key}` };
     }
   }


### PR DESCRIPTION
Follow-up to https://github.com/Garsson-io/kaizen/pull/1217.

## Gap addressed

**[PARTIAL] Finding count validation** — `validateReviewSentinel()` accepted `findingCount=0`, leaving a bypass path: calling `writeReviewSentinel()` in `pr-review-loop.ts` with no options produces a sentinel with all 12 expected dimension names but `findingCount=0`. This is harder than `touch` (requires executing TS) but was still a non-trivial gap.

## Fix

`validateReviewSentinel` now requires `findingCount >= 1`. A sentinel that records zero findings cannot prove any dimension agents actually ran and stored data.

## Gaps skipped

- **Gaps 1 & 2** (plan text data-gaps for improvement-lifecycle/plan-fidelity): These are review-time data availability issues, not code defects. The plan was not stored on the issue before review ran — there is no code change that retroactively provides it.
- **Gap 3** (L3 structural fix — sentinel as PR attachment): Explicitly acknowledged as out of scope in the PR's accepted criteria. The PR text reads: "Moving the sentinel entirely to PR attachments remains a possible future L3 hardening step."

## Test plan

| Behavior | Level | Status |
|----------|-------|--------|
| `findingCount=0` sentinel rejected with `invalid_findingCount` | Unit | DONE |
| Existing `writeSentinel` test helper updated to pass `findingCount: dims.length` | Unit | DONE |
| All 66 sentinel/review/cli-structured-data tests pass | Unit | DONE |