### PR TITLE
fix(auto-dent): bind run outcome to recorded verdicts (#1224)

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_BANDIT_C,
   banditExplorationC,
   modeSuccess,
+  deriveRunOutcome,
   weightedModeSelect,
   computeModeDistribution,
   formatBatchFooter,
@@ -2498,6 +2499,95 @@ describe('modeSuccess', () => {
 
   it('unknown modes fall back to PRs', () => {
     expect(modeSuccess('unknown', makeRunMetrics({ prs: ['pr1'] }))).toBe(1);
+  });
+});
+
+describe('deriveRunOutcome — verdict binding (#1224, meta #1227)', () => {
+  // Baseline: a clean win. Each adversarial test perturbs one verdict.
+  const cleanWin = {
+    stopRequested: false,
+    exitCode: 0,
+    artifactCount: 1,
+    reviewVerdict: 'pass' as const,
+    processVerdict: 'pass' as const,
+    lifecycleHealth: 'clean' as const,
+  };
+
+  it('the #1212 shape: artifact produced but review:fail + process-incomplete ⇒ failure (NOT success)', () => {
+    // The exact run.complete shape from eastern-ant/run-2 that produced PR #1212.
+    expect(
+      deriveRunOutcome({
+        stopRequested: false,
+        exitCode: 0,
+        artifactCount: 1, // a PR was created
+        reviewVerdict: 'fail',
+        processVerdict: 'process-incomplete',
+        lifecycleHealth: 'degraded',
+      }),
+    ).toBe('failure');
+  });
+
+  it('review:fail alone blocks success', () => {
+    expect(deriveRunOutcome({ ...cleanWin, reviewVerdict: 'fail' })).toBe('failure');
+  });
+
+  it('process-incomplete alone blocks success', () => {
+    expect(deriveRunOutcome({ ...cleanWin, processVerdict: 'process-incomplete' })).toBe('failure');
+  });
+
+  it('lifecycle critical alone blocks success', () => {
+    expect(deriveRunOutcome({ ...cleanWin, lifecycleHealth: 'critical' })).toBe('failure');
+  });
+
+  it('a quality-failed run with no artifacts is failure, not empty_success', () => {
+    expect(
+      deriveRunOutcome({ ...cleanWin, artifactCount: 0, processVerdict: 'process-incomplete' }),
+    ).toBe('failure');
+  });
+
+  it('clean win with artifacts ⇒ success (happy path preserved)', () => {
+    expect(deriveRunOutcome(cleanWin)).toBe('success');
+  });
+
+  it('clean run with no artifacts ⇒ empty_success (preserved)', () => {
+    expect(deriveRunOutcome({ ...cleanWin, artifactCount: 0 })).toBe('empty_success');
+  });
+
+  it('fail-open-warning does NOT flip a win (fail-open by design)', () => {
+    expect(deriveRunOutcome({ ...cleanWin, processVerdict: 'fail-open-warning' })).toBe('success');
+  });
+
+  it('lifecycle degraded alone does NOT block (too broad to gate on)', () => {
+    expect(deriveRunOutcome({ ...cleanWin, lifecycleHealth: 'degraded' })).toBe('success');
+  });
+
+  it('skipped review is legitimate ⇒ success', () => {
+    expect(deriveRunOutcome({ ...cleanWin, reviewVerdict: 'skipped' })).toBe('success');
+  });
+
+  it('undefined verdicts are treated as non-failing (no over-broad gate)', () => {
+    expect(
+      deriveRunOutcome({
+        stopRequested: false,
+        exitCode: 0,
+        artifactCount: 1,
+        reviewVerdict: undefined,
+        processVerdict: undefined,
+        lifecycleHealth: undefined,
+      }),
+    ).toBe('success');
+  });
+
+  it('stopRequested ⇒ stop, even with artifacts and verdicts', () => {
+    expect(deriveRunOutcome({ ...cleanWin, stopRequested: true })).toBe('stop');
+  });
+
+  it('nonzero exit code ⇒ failure', () => {
+    expect(deriveRunOutcome({ ...cleanWin, exitCode: 1 })).toBe('failure');
+  });
+
+  it('stop precedence: stopRequested wins over a nonzero exit code', () => {
+    expect(deriveRunOutcome({ ...cleanWin, stopRequested: true, exitCode: 1 })).toBe('stop');
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -687,6 +687,58 @@ export function modeSuccess(mode: string, metrics: RunMetrics): number {
   }
 }
 
+/** Telemetry outcome for a completed run (the `run.complete.outcome` field). */
+export type RunOutcome = 'success' | 'empty_success' | 'failure' | 'stop';
+
+/** Signals consumed to bind a run's outcome to its recorded verdicts. */
+export interface RunOutcomeSignals {
+  stopRequested: boolean;
+  exitCode: number;
+  /** Mode-aware artifact count — the output of {@link modeSuccess}. */
+  artifactCount: number;
+  reviewVerdict?: 'pass' | 'fail' | 'skipped';
+  processVerdict?: ProcessVerdict;
+  lifecycleHealth?: LifecycleHealth;
+}
+
+/**
+ * Derive a run's telemetry `outcome` from BOTH its artifact count and the
+ * quality verdicts the same `run.complete` event already records (#1224,
+ * meta #1227).
+ *
+ * The run-success stamp is a terminal action; binding it to the verdicts means
+ * a run that recorded a quality FAILURE can never roll up to
+ * `success`/`empty_success`. Otherwise a red run reads as green in the batch
+ * summary — which is how PR #1212 (review battery FAIL) got merged (#1220).
+ *
+ * Quality-fail signals (any one ⇒ `failure`, failing closed):
+ *   - `reviewVerdict === 'fail'`         — review battery + fix loop failed/exhausted
+ *   - `processVerdict === 'process-incomplete'` — lifecycle evidence missing
+ *   - `lifecycleHealth === 'critical'`   — structural lifecycle gap
+ *
+ * Intentionally NOT gated (documented, to avoid over-broad false-failures):
+ *   - `processVerdict 'fail-open-warning'` — fail-open by design (validator
+ *     did not run / soft warning); must not flip a real win to a loss.
+ *   - `lifecycleHealth 'degraded'` — set whenever `processVerdict !== 'pass'`
+ *     (see the emit path), so it is a superset of `process-incomplete` and too
+ *     broad to gate on directly; the precise signal already covers the failure.
+ *   - `reviewVerdict 'skipped'` / undefined verdicts — legitimate for modes
+ *     with no PR to review; treated as non-failing.
+ *
+ * Precedence (preserved from the original inline computation): a requested STOP
+ * wins, then a hard nonzero exit, then the verdict gate, then artifact count.
+ */
+export function deriveRunOutcome(signals: RunOutcomeSignals): RunOutcome {
+  if (signals.stopRequested) return 'stop';
+  if (signals.exitCode !== 0) return 'failure';
+  const qualityFailed =
+    signals.reviewVerdict === 'fail' ||
+    signals.processVerdict === 'process-incomplete' ||
+    signals.lifecycleHealth === 'critical';
+  if (qualityFailed) return 'failure';
+  return signals.artifactCount > 0 ? 'success' : 'empty_success';
+}
+
 /** Schedulable cognitive modes (contemplate is an overlay, not bandit-scheduled). */
 export const SCHEDULABLE_MODES = ['exploit', 'explore', 'reflect', 'subtract'] as const;
 
@@ -2307,10 +2359,18 @@ async function main(): Promise<void> {
       lines_deleted: result.linesDeleted,
       issues_pruned: result.issuesPruned,
     };
-    const outcome = result.stopRequested ? 'stop' as const
-      : (exitCode === 0 && modeSuccess(runMode, runMetricsForOutcome) > 0) ? 'success' as const
-      : (exitCode === 0) ? 'empty_success' as const
-      : 'failure' as const;
+    // Bind the run-success stamp to the verdicts this run already recorded
+    // (#1224, meta #1227): a review FAIL / process-incomplete / critical
+    // lifecycle gap must never roll up to `success` — red runs cannot read as
+    // green in the batch summary.
+    const outcome = deriveRunOutcome({
+      stopRequested: result.stopRequested,
+      exitCode,
+      artifactCount: modeSuccess(runMode, runMetricsForOutcome),
+      reviewVerdict,
+      processVerdict,
+      lifecycleHealth,
+    });
     events.emit({
       type: 'run.complete',
       run_id: runId,


### PR DESCRIPTION
## The problem — a red run that read as green

Auto-dent batch `eastern-ant/run-2` produced PR #1212 and emitted this
`run.complete` event:

```json
{ "outcome": "success", "review_verdict": "fail",
  "process_verdict": "process-incomplete", "lifecycle_health": "degraded",
  "prs_created": 1, "issues_closed": 1 }
```

The review battery **FAILED**, the fix loop returned `success:false`, the process
verdict was `process-incomplete` — and the run was still stamped
`outcome:"success"`. In the batch summary it looked like a win. A human saw
"run-2: success, PR #1212 created" and merged it — straight past its own FAIL
battery (#1220). Auto-dent was grading its own homework as passing while the
rubric said fail.

## The discovery — the verdict was measured, then nobody consumed it

At `scripts/auto-dent-run.ts`, `outcome` was computed from artifact count alone:

```ts
const outcome = result.stopRequested ? 'stop'
  : (exitCode === 0 && modeSuccess(runMode, metrics) > 0) ? 'success'
  : (exitCode === 0) ? 'empty_success'
  : 'failure';
```

`modeSuccess > 0` answers *"did this run produce an artifact?"* — never *"did it
produce a clean win?"*. Yet `review_verdict`, `process_verdict`, and
`lifecycle_health` are all computed earlier **in the same scope** and emitted on
the very same event. The verdict was measured correctly and then no terminal
action consumed it. This is the verdict-**binding** category (#1227), distinct
from the measurement gap of #943: the run-success stamp is a terminal action
that must bind to the verdict, failing closed.

## The fix — bind the stamp to the verdicts

Extract a pure, exported `deriveRunOutcome(signals)` and call it at the emit
block. Any recorded quality-fail signal downgrades the run to `failure`, so it
can never roll up to `success`/`empty_success`:

- `reviewVerdict === 'fail'` — review battery + fix loop failed/exhausted
- `processVerdict === 'process-incomplete'` — lifecycle evidence missing
- `lifecycleHealth === 'critical'` — structural lifecycle gap

Intentionally **not** gated, to avoid over-broad false-failures (the batch
already runs a ~50% review-fail rate; turning legitimate wins into losses would
be its own defect):

- `processVerdict 'fail-open-warning'` — fail-open by design (validator didn't run).
- `lifecycleHealth 'degraded'` — set whenever `processVerdict !== 'pass'`
  (`auto-dent-run.ts:2221`), so it is a superset of `process-incomplete` and too
  broad to gate on directly.
- `reviewVerdict 'skipped'` / undefined — legitimate for modes with no PR to review.

Precedence is preserved exactly: STOP wins, then a hard nonzero exit, then the
verdict gate, then artifact count. **Blast radius is the emitted
`run.complete.outcome` and the `batch-summary-report.md` rollup only** — the
`outcome` const is local to the telemetry-emit block and does not drive batch
control flow (max-failures/cooldown key off `exitCode`/`result`). So this changes
exactly the signal #1224 names as wrong, nothing else.

## Evidence

The headline test reconstructs the exact #1212 shape and asserts it now yields
`failure`:

```ts
deriveRunOutcome({ exitCode: 0, artifactCount: 1, reviewVerdict: 'fail',
  processVerdict: 'process-incomplete', lifecycleHealth: 'degraded' }) // => 'failure'
```

TDD: 14 tests written first (all red — `deriveRunOutcome is not a function`),
then green after the implementation. The 4 affected test files pass (409 tests).

### Behaviors × levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| #1212 shape (artifact + review:fail + process-incomplete) ⇒ failure | ✅ | — | — | — | — |
| Each quality-fail signal alone blocks success (review/process/critical) | ✅ | — | — | — | — |
| Quality-fail + zero artifacts ⇒ failure (not empty_success) | ✅ | — | — | — | — |
| Clean win / clean no-op preserved (success / empty_success) | ✅ | — | — | — | — |
| No false-failure: fail-open-warning, degraded, skipped, undefined ⇒ unchanged | ✅ | — | — | — | — |
| STOP and nonzero-exit precedence preserved | ✅ | — | — | — | — |

`deriveRunOutcome` is a pure function; the binding logic is fully exercised by
unit tests at the exact incident shape. The call-site swap is trivial wiring
proven by typecheck. There is no live hook/skill path here for an I23 E2E to add
coverage — the adversarial "the gate blocks" tests are the proof.

## Impact

Red runs can no longer read as green in batch summaries. The next time a run
records a FAIL review or incomplete process, its outcome is `failure` — the
human (or the next batch) sees the truth instead of a false "success, PR
created" that invites a bad merge. One terminal action (#1227's inventory) moved
from "does an artifact exist?" to "did the verdict pass?".

Closes #1224
Refs: #1227 (verdict-binding meta), #1220 (unguarded merge — where false-green is acted on), #1212 (the incident)

Run-tag: disgusted-ant/run-2
