### PR TITLE
test(auto-dent): share batch fixtures

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -26,35 +26,8 @@ import {
   type WatchdogResult,
   type AggregateBatchRecord,
 } from './auto-dent-ctl.js';
-import type { BatchState, RunMetrics } from './auto-dent-run.js';
-
-function makeBatchState(overrides: Partial<BatchState> = {}): BatchState {
-  return {
-    batch_id: 'batch-260322-2100-a1b2',
-    batch_start: 1742680800,
-    guidance: 'improve hooks reliability',
-    max_runs: 5,
-    cooldown: 30,
-    budget: '3.00',
-    max_failures: 3,
-    kaizen_repo: 'Garsson-io/kaizen',
-    host_repo: 'Garsson-io/kaizen',
-    run: 0,
-    prs: [],
-    issues_filed: [],
-    issues_closed: [],
-    cases: [],
-    consecutive_failures: 0,
-    current_cooldown: 30,
-    stop_reason: '',
-    last_issue: '',
-    last_pr: '',
-    last_case: '',
-    last_branch: '',
-    last_worktree: '',
-    ...overrides,
-  };
-}
+import type { RunMetrics } from './auto-dent-run.js';
+import { makeBatchState } from './auto-dent-test-utils.js';
 
 function makeBatchInfo(overrides: Partial<BatchInfo> = {}): BatchInfo {
   return {

--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -28,6 +28,7 @@ import {
   type PlanItem,
 } from './auto-dent-plan.js';
 import type { BatchState } from './auto-dent-run.js';
+import { makeBatchState } from './auto-dent-test-utils.js';
 
 function mkItem(overrides: Partial<PlanItem> & { issue: string; title: string }): PlanItem {
   return {
@@ -70,31 +71,12 @@ function makePlanWithDecompose(): BatchPlan {
 }
 
 function makeState(overrides: Partial<BatchState> = {}): BatchState {
-  return {
+  return makeBatchState({
     batch_id: 'batch-260627-1608-k1146',
     batch_start: 0,
     guidance: 'provider-aware planning',
-    max_runs: 5,
-    cooldown: 30,
-    budget: '3.00',
-    max_failures: 3,
-    kaizen_repo: 'Garsson-io/kaizen',
-    host_repo: 'Garsson-io/kaizen',
-    run: 0,
-    prs: [],
-    issues_filed: [],
-    issues_closed: [],
-    cases: [],
-    consecutive_failures: 0,
-    current_cooldown: 30,
-    stop_reason: '',
-    last_issue: '',
-    last_pr: '',
-    last_case: '',
-    last_branch: '',
-    last_worktree: '',
     ...overrides,
-  };
+  });
 }
 
 describe('provider-aware planning (#1146)', () => {

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -39,7 +39,6 @@ import {
   color,
   type BatchState,
   type CleanupResult,
-  type RunResult,
   type PhaseMarker,
   type RunMetrics,
   type StreamContext,
@@ -54,49 +53,7 @@ import {
   shouldRunCodexProvider,
 } from './auto-dent-run.js';
 import * as github from './auto-dent-github.js';
-
-function makeBatchState(overrides: Partial<BatchState> = {}): BatchState {
-  return {
-    batch_id: 'batch-260322-2100-a1b2',
-    batch_start: 1742680800,
-    guidance: 'improve hooks reliability',
-    max_runs: 5,
-    cooldown: 30,
-    budget: '3.00',
-    max_failures: 3,
-    kaizen_repo: 'Garsson-io/kaizen',
-    host_repo: 'Garsson-io/kaizen',
-    run: 0,
-    prs: [],
-    issues_filed: [],
-    issues_closed: [],
-    cases: [],
-    consecutive_failures: 0,
-    current_cooldown: 30,
-    stop_reason: '',
-    last_issue: '',
-    last_pr: '',
-    last_case: '',
-    last_branch: '',
-    last_worktree: '',
-    ...overrides,
-  };
-}
-
-function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
-  return {
-    prs: [],
-    issuesFiled: [],
-    issuesClosed: [],
-    cases: [],
-    cost: 0,
-    toolCalls: 0,
-    stopRequested: false,
-    linesDeleted: 0,
-    issuesPruned: 0,
-    ...overrides,
-  };
-}
+import { makeBatchState, makeRunResult } from './auto-dent-test-utils.js';
 
 describe('buildPrompt', () => {
   it('includes run tag with batch id and run number', () => {

--- a/scripts/auto-dent-test-utils.test.ts
+++ b/scripts/auto-dent-test-utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { makeBatchState, makeRunResult } from './auto-dent-test-utils.js';
+
+describe('auto-dent test utilities', () => {
+  it('centralizes shared batch fixtures for auto-dent tests (#110)', () => {
+    expect(makeBatchState()).toMatchObject({
+      batch_id: 'batch-260322-2100-a1b2',
+      kaizen_repo: 'Garsson-io/kaizen',
+      prs: [],
+    });
+    expect(makeRunResult({ toolCalls: 3 })).toMatchObject({
+      prs: [],
+      toolCalls: 3,
+      stopRequested: false,
+    });
+  });
+});

--- a/scripts/auto-dent-test-utils.ts
+++ b/scripts/auto-dent-test-utils.ts
@@ -1,0 +1,44 @@
+import type { BatchState, RunResult } from './auto-dent-run.js';
+
+export function makeBatchState(overrides: Partial<BatchState> = {}): BatchState {
+  return {
+    batch_id: 'batch-260322-2100-a1b2',
+    batch_start: 1742680800,
+    guidance: 'improve hooks reliability',
+    max_runs: 5,
+    cooldown: 30,
+    budget: '3.00',
+    max_failures: 3,
+    kaizen_repo: 'Garsson-io/kaizen',
+    host_repo: 'Garsson-io/kaizen',
+    run: 0,
+    prs: [],
+    issues_filed: [],
+    issues_closed: [],
+    cases: [],
+    consecutive_failures: 0,
+    current_cooldown: 30,
+    stop_reason: '',
+    last_issue: '',
+    last_pr: '',
+    last_case: '',
+    last_branch: '',
+    last_worktree: '',
+    ...overrides,
+  };
+}
+
+export function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    prs: [],
+    issuesFiled: [],
+    issuesClosed: [],
+    cases: [],
+    cost: 0,
+    toolCalls: 0,
+    stopRequested: false,
+    linesDeleted: 0,
+    issuesPruned: 0,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Story
Once upon a time, `#110` tracked the top duplication offenders from an older jscpd scan: `ipc-cases*`, `github-api.ts`, and `kaizen-reflect.sh`.

Every day since then, the codebase kept moving. Those exact files are no longer present on current `main`, but a fresh scan still found real duplication: `21 exact clones`, `828 duplicated lines`, and repeated auto-dent batch fixture setup across three active test files.

One day, while re-grounding `#110`, the current evidence showed the issue had drifted from its original path list. Because of that, this PR records the stale paths in the stored plan and fixes the highest-signal current TypeScript fixture duplication instead of pretending the old files still exist.

Because of that, auto-dent tests now share one typed fixture helper for `BatchState` and `RunResult`, while local tests keep their scenario-specific defaults explicit.

Until finally, the focused tests pass, typecheck passes, and jscpd reports fewer exact clones: `21 -> 19` total clones and TypeScript clones `13 -> 11`.

And ever since, future auto-dent tests have one fixture source to extend rather than copying the same batch-state object into each file.

Fixes Garsson-io/kaizen#110

## Architecture
```text
scripts/auto-dent-test-utils.ts
  ├─ makeBatchState(overrides)
  └─ makeRunResult(overrides)

scripts/auto-dent-ctl.test.ts   ┐
scripts/auto-dent-run.test.ts   ├─ import shared fixture baseline
scripts/auto-dent-plan.test.ts  ┘
```

## Design Decisions
| Decision | Why | Tradeoff |
|---|---|---|
| Use a small colocated `scripts/auto-dent-test-utils.ts` helper | The duplication is test fixture setup under `scripts/`, not production behavior | Leaves other test-data clones for later passes |
| Keep plan-specific defaults in `auto-dent-plan.test.ts` as overrides | The provider-planning tests intentionally use different `batch_id`, `batch_start`, and `guidance` | Slight wrapper remains, but intent stays visible |
| Do not add `jscpd` as a package dependency | The plan only needs before/after scan evidence | Duplication scan remains one-off for this PR |

## What's In This PR
| File | Purpose |
|---|---|
| `scripts/auto-dent-test-utils.ts` | New shared typed fixture helpers |
| `scripts/auto-dent-test-utils.test.ts` | Guard that the shared fixture mechanism exists and preserves override behavior |
| `scripts/auto-dent-ctl.test.ts` | Replaces local `makeBatchState` copy with shared helper |
| `scripts/auto-dent-run.test.ts` | Replaces local `makeBatchState` and `makeRunResult` copies with shared helpers |
| `scripts/auto-dent-plan.test.ts` | Uses shared `makeBatchState` with local overrides |

## Test Plan (Behaviors x Levels)
| # | Behavior | Perspective | Level | Coverage |
|---|----------|-------------|-------|----------|
| 1 | Shared auto-dent test helper produces the same fixture semantics as duplicated setup blocks. | code | Unit | Tested by `npx vitest run scripts/auto-dent-test-utils.test.ts ...` |
| 2 | Existing auto-dent CLI/run/plan tests still exercise original behavior after setup extraction. | code | Integration | Tested by targeted auto-dent Vitest run: 4 files, 427 tests passed |
| 3 | Duplication scan reflects a real reduction in current exact clones. | user/operator | System | Tested by one-off `npx --yes jscpd ...`: total clones `21 -> 19`, duplicated lines `828 -> 776`, TypeScript clones `13 -> 11` |
| 4 | TypeScript contracts remain valid after moving helpers. | code | Integration | Tested by `npm run typecheck` |

## Validation
- [x] RED guard before helper: `npx vitest run scripts/auto-dent-test-utils.test.ts` failed because `auto-dent-test-utils.ts` did not exist.
- [x] Focused tests: `npx vitest run scripts/auto-dent-test-utils.test.ts scripts/auto-dent-ctl.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts` -> 4 files, 427 tests passed.
- [x] Typecheck: `npm run typecheck` passed.
- [x] Duplication scan before: `21 exact clones`, `828 duplicated lines`, TypeScript `13 clones / 300 duplicated lines`.
- [x] Duplication scan after: `19 exact clones`, `776 duplicated lines`, TypeScript `11 clones / 248 duplicated lines`.
- [ ] Full `npm test`: local run failed in unrelated hook/session E2E timeouts/expectations. The touched auto-dent tests passed; comparison on the parent checkout also failed `src/e2e/synthetic-workflow.test.ts`, so this is not introduced by the fixture extraction.

## Known Limitations
- Current jscpd still reports 19 clones. This PR removes the broad auto-dent fixture setup duplication; remaining candidates include review-wiring test data, hook-gym push-review fixtures, gate-manager/stop-gate setup, and duplicated planning prose.
- The original `#110` path list is stale on current `main`; this PR closes it by documenting that drift and removing a current top TypeScript fixture cluster.
