### PR TITLE
refactor(auto-dent): share run metrics builder

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -32,6 +32,7 @@ import {
   banditExplorationC,
   modeSuccess,
   deriveRunOutcome,
+  buildRunMetrics,
   weightedModeSelect,
   computeModeDistribution,
   formatBatchFooter,
@@ -2612,6 +2613,89 @@ describe('deriveRunOutcome — verdict binding (#1224, meta #1227)', () => {
 
   it('stop precedence: stopRequested wins over a nonzero exit code', () => {
     expect(deriveRunOutcome({ ...cleanWin, stopRequested: true, exitCode: 1 })).toBe('stop');
+  });
+});
+
+describe('buildRunMetrics', () => {
+  it('maps shared RunResult fields into RunMetrics once', () => {
+    const result = makeRunResult({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1'],
+      issuesFiled: ['#10'],
+      issuesClosed: ['#11'],
+      cases: ['case-1'],
+      cost: 1.25,
+      toolCalls: 7,
+      stopRequested: true,
+      linesDeleted: 42,
+      issuesPruned: 2,
+    });
+
+    const metrics = buildRunMetrics({
+      runNum: 3,
+      runStartEpoch: 1742680800,
+      duration: 91,
+      exitCode: 0,
+      runMode: 'subtract',
+      result,
+    });
+
+    expect(metrics).toMatchObject({
+      run: 3,
+      start_epoch: 1742680800,
+      duration_seconds: 91,
+      exit_code: 0,
+      cost_usd: 1.25,
+      tool_calls: 7,
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1'],
+      issues_filed: ['#10'],
+      issues_closed: ['#11'],
+      cases: ['case-1'],
+      stop_requested: true,
+      mode: 'subtract',
+      lines_deleted: 42,
+      issues_pruned: 2,
+    });
+  });
+
+  it('adds persisted metadata without duplicating the base mapping', () => {
+    const metrics = buildRunMetrics({
+      runNum: 4,
+      runStartEpoch: 1742680900,
+      duration: 30,
+      exitCode: 0,
+      runMode: 'exploit',
+      result: makeRunResult({
+        finalClaimStatus: 'valid',
+        finalClaimPath: '/tmp/final-claim.json',
+        finalClaimWarnings: ['warning'],
+      }),
+      metadata: {
+        prompt_template: 'make-a-dent.md',
+        prompt_hash: 'abc123',
+        lifecycle_violations: 1,
+        lifecycle_health: 'degraded',
+        process_verdict: 'pass',
+        process_issue_count: 0,
+        process_summary: 'ok',
+        review_verdict: 'pass',
+        review_cost_usd: 0.12,
+      },
+    });
+
+    expect(metrics).toMatchObject({
+      prompt_template: 'make-a-dent.md',
+      prompt_hash: 'abc123',
+      lifecycle_violations: 1,
+      lifecycle_health: 'degraded',
+      process_verdict: 'pass',
+      process_issue_count: 0,
+      process_summary: 'ok',
+      review_verdict: 'pass',
+      review_cost_usd: 0.12,
+      final_claim_status: 'valid',
+      final_claim_path: '/tmp/final-claim.json',
+      final_claim_warnings: ['warning'],
+    });
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -328,6 +328,63 @@ export interface RunProgressStep {
   url?: string;
 }
 
+type RunMetricsBaseField =
+  | 'run'
+  | 'start_epoch'
+  | 'duration_seconds'
+  | 'exit_code'
+  | 'cost_usd'
+  | 'tool_calls'
+  | 'prs'
+  | 'issues_filed'
+  | 'issues_closed'
+  | 'cases'
+  | 'stop_requested'
+  | 'mode'
+  | 'lines_deleted'
+  | 'issues_pruned'
+  | 'final_claim_status'
+  | 'final_claim'
+  | 'final_claim_path'
+  | 'final_claim_warnings';
+
+export type RunMetricsMetadata = Partial<Omit<RunMetrics, RunMetricsBaseField>>;
+
+export interface BuildRunMetricsInput {
+  runNum: number;
+  runStartEpoch: number;
+  duration: number;
+  exitCode: number;
+  runMode: string;
+  result: RunResult;
+  metadata?: RunMetricsMetadata;
+}
+
+export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
+  const { runNum, runStartEpoch, duration, exitCode, runMode, result, metadata = {} } = input;
+  return {
+    run: runNum,
+    start_epoch: runStartEpoch,
+    duration_seconds: duration,
+    exit_code: exitCode,
+    cost_usd: result.cost,
+    tool_calls: result.toolCalls,
+    prs: result.prs,
+    issues_filed: result.issuesFiled,
+    issues_closed: result.issuesClosed,
+    cases: result.cases,
+    stop_requested: result.stopRequested,
+    mode: runMode,
+    lines_deleted: result.linesDeleted,
+    issues_pruned: result.issuesPruned,
+    final_claim_status: result.finalClaimStatus,
+    final_claim: result.finalClaim,
+    final_claim_path: result.finalClaimPath,
+    final_claim_warnings: result.finalClaimWarnings,
+    ...metadata,
+  };
+}
+
 import { extractPlanText } from '../src/structured-data.js';
 export { extractPlanText };
 
@@ -2548,22 +2605,14 @@ async function main(): Promise<void> {
   // Uses mode-aware success: explore/reflect runs that file issues count as success,
   // not just runs that produce PRs.
   {
-    const runMetricsForOutcome: RunMetrics = {
-      run: runNum,
-      start_epoch: runStartEpoch,
-      duration_seconds: duration,
-      exit_code: exitCode,
-      cost_usd: result.cost,
-      tool_calls: result.toolCalls,
-      prs: result.prs,
-      issues_filed: result.issuesFiled,
-      issues_closed: result.issuesClosed,
-      cases: result.cases,
-      stop_requested: result.stopRequested,
-      mode: runMode,
-      lines_deleted: result.linesDeleted,
-      issues_pruned: result.issuesPruned,
-    };
+    const runMetricsForOutcome = buildRunMetrics({
+      runNum,
+      runStartEpoch,
+      duration,
+      exitCode,
+      runMode,
+      result,
+    });
     // Bind the run-success stamp to the verdicts this run already recorded
     // (#1224, meta #1227): a review FAIL / process-incomplete / critical
     // lifecycle gap must never roll up to `success` — red runs cannot read as
@@ -2748,36 +2797,26 @@ async function main(): Promise<void> {
   freshState.run = runNum;
 
   // Append per-run metrics for batch observability
-  const runMetrics: RunMetrics = {
-    run: runNum,
-    start_epoch: runStartEpoch,
-    duration_seconds: duration,
-    exit_code: exitCode,
-    cost_usd: result.cost,
-    tool_calls: result.toolCalls,
-    prs: result.prs,
-    issues_filed: result.issuesFiled,
-    issues_closed: result.issuesClosed,
-    cases: result.cases,
-    stop_requested: result.stopRequested,
-    mode: runMode,
-    lines_deleted: result.linesDeleted,
-    issues_pruned: result.issuesPruned,
-    prompt_template: promptMeta.template,
-    prompt_hash: promptMeta.hash,
-    lifecycle_violations: lifecycleViolationCount,
-    lifecycle_health: lifecycleHealth,
-    process_verdict: processVerdict,
-    process_issue_count: processIssueCount,
-    process_summary: processSummary,
-    review_verdict: reviewVerdict,
-    review_cost_usd: reviewCostUsd,
-    phase_providers: phaseProvidersForState(state),
-    final_claim_status: result.finalClaimStatus,
-    final_claim: result.finalClaim,
-    final_claim_path: result.finalClaimPath,
-    final_claim_warnings: result.finalClaimWarnings,
-  };
+  const runMetrics = buildRunMetrics({
+    runNum,
+    runStartEpoch,
+    duration,
+    exitCode,
+    runMode,
+    result,
+    metadata: {
+      prompt_template: promptMeta.template,
+      prompt_hash: promptMeta.hash,
+      lifecycle_violations: lifecycleViolationCount,
+      lifecycle_health: lifecycleHealth,
+      process_verdict: processVerdict,
+      process_issue_count: processIssueCount,
+      process_summary: processSummary,
+      review_verdict: reviewVerdict,
+      review_cost_usd: reviewCostUsd,
+      phase_providers: phaseProvidersForState(state),
+    },
+  });
   // Classify failure: wall-clock timeout is authoritative (#686), then heuristics.
   // Feed the run log so the log-based branch (hook_rejection, infrastructure,
   // etc.) actually runs — without this argument it was dead code (#1102).


### PR DESCRIPTION
Fixes Garsson-io/kaizen#1249

## Story

`auto-dent-run.ts` had two places that knew how to turn the completed run result into `RunMetrics`: one for `run.complete` outcome derivation, and another for persisted `run_history` state.

They were not exact clones. The first mapping was a base metrics object for `modeSuccess`; the second was a larger persisted metrics object with prompt, lifecycle, process, review, provider, and final-claim fields. The duplication was semantic: every new metrics field had to be classified manually as "needed for telemetry", "needed for state", or "both" at two callsites.

This PR makes that mapping explicit with `buildRunMetrics()`. Telemetry now asks for the shared base metrics. State persistence asks for the same base metrics plus persistence metadata. The outcome, scoring, failure classification, and persisted fields stay unchanged, but the knowledge of how `RunResult` becomes `RunMetrics` now has one owner.

## Architecture

```text
RunResult + run context
        |
        v
buildRunMetrics()
   |                 |
   v                 v
modeSuccess()     run_history persistence
(outcome)         (+ lifecycle/review/process metadata)
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Keep the builder in `auto-dent-run.ts` | It owns `RunResult`, `RunMetrics`, and the post-run workflow | The file remains large, but this avoids a premature module split |
| Separate base fields from metadata | Base mapping is shared; persistence-only fields stay explicit at the callsite | Metadata still needs a callsite object, but no longer repeats result-to-metrics fields |
| Export the builder | Direct unit tests can lock the mapping down | Adds one more exported helper from an already broad module |

## What's In This PR

| File | Purpose |
| --- | --- |
| `scripts/auto-dent-run.ts` | Adds `buildRunMetrics()` and replaces both inline `RunMetrics` constructions |
| `scripts/auto-dent-run.test.ts` | Adds focused coverage for base mapping and persistence metadata mapping |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Status | Evidence |
| --- | --- | --- | --- |
| Shared builder maps `RunResult` base fields used by telemetry and scoring | Unit | tested | `npx vitest run scripts/auto-dent-run.test.ts -t "buildRunMetrics"` passed: 2 tests |
| Existing run outcome/scoring tests still pass after replacing inline metrics | Unit | tested | `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-score.test.ts` passed: 419 tests |
| Type-level coverage catches missed `RunMetrics` field shape changes | Unit | tested | `npm run typecheck` passed |

## Validation

- RED: `npx vitest run scripts/auto-dent-run.test.ts -t "buildRunMetrics"` failed with `TypeError: buildRunMetrics is not a function`
- GREEN: `npx vitest run scripts/auto-dent-run.test.ts -t "buildRunMetrics"`
- `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-score.test.ts`
- `npm run typecheck`

## Known Limitations

This PR only consolidates the run-result-to-metrics mapping. It does not address other semantic duplication in auto-dent control/reporting code.
