### PR TITLE
Populate auto-dent work cycle from hook gate signals

### DIFF
--- a/scripts/auto-dent-progress.ts
+++ b/scripts/auto-dent-progress.ts
@@ -1,0 +1,161 @@
+/**
+ * Shared kaizen work-cycle progress rendering for auto-dent.
+ *
+ * Both in-flight stream comments and post-run progress issue comments use this
+ * module so lifecycle row semantics cannot drift between operator surfaces.
+ */
+
+export interface RunProgressStep {
+  phase: string;
+  state: string;
+  detail: string;
+  url?: string;
+}
+
+export interface ProgressResult {
+  prs: string[];
+  cases: string[];
+  pickedIssue?: string;
+  pickedIssueTitle?: string;
+  progressSteps?: RunProgressStep[];
+  reviewVerdict?: 'pass' | 'fail' | 'skipped';
+  reviewUrls?: string[];
+  stopRequested: boolean;
+  stopReason?: string;
+}
+
+export type ProgressUpsertMode = 'merge' | 'replace';
+
+const PROGRESS_PHASE_ORDER = ['PICK', 'PLAN', 'EVALUATE', 'CASE', 'IMPLEMENT', 'TEST', 'PR', 'REVIEW', 'FIX', 'MERGE', 'REFLECT', 'CLEANUP', 'STOP'];
+const SYNTHETIC_NOT_APPLICABLE_PHASES = new Set(['PLAN', 'EVALUATE', 'CASE', 'TEST', 'REVIEW', 'FIX', 'REFLECT', 'CLEANUP']);
+
+export function formatIssueUrl(issue: string | undefined, repo: string): string {
+  if (!issue) return '';
+  if (/^https?:\/\//.test(issue)) return issue;
+  const match = issue.match(/#?(\d+)/);
+  if (!match || !repo) return issue;
+  return `https://github.com/${repo}/issues/${match[1]}`;
+}
+
+export function formatIssueForDisplay(issue: string | undefined, repo: string, title?: string): string {
+  const url = formatIssueUrl(issue, repo);
+  if (!url) return 'unknown';
+  return title ? `${url} — ${title}` : url;
+}
+
+export function formatReviewForDisplay(result: ProgressResult): string {
+  if (result.pickedIssue === 'not applicable') {
+    const urls = result.prs.length > 0 ? ` (${result.prs.join(', ')})` : '';
+    return `not applicable${urls}`;
+  }
+  const verdict = result.reviewVerdict ?? (result.prs.length > 0 ? 'pending' : 'skipped');
+  const urls = result.reviewUrls && result.reviewUrls.length > 0 ? result.reviewUrls : result.prs;
+  return urls.length > 0 ? `${verdict} (${urls.join(', ')})` : verdict;
+}
+
+export function upsertProgressStep(
+  result: ProgressResult,
+  step: RunProgressStep,
+  mode: ProgressUpsertMode = 'merge',
+): void {
+  result.progressSteps = result.progressSteps || [];
+  const existing = result.progressSteps.find((s) => s.phase === step.phase);
+  if (!existing) {
+    result.progressSteps.push(step);
+    return;
+  }
+  if (mode === 'replace') {
+    existing.state = step.state;
+    existing.detail = step.detail;
+    existing.url = step.url;
+    return;
+  }
+  existing.state = step.state || existing.state;
+  existing.detail = step.detail || existing.detail;
+  existing.url = step.url || existing.url;
+}
+
+function orderedProgressSteps(steps: RunProgressStep[]): RunProgressStep[] {
+  return [...steps].sort((a, b) => {
+    const ai = PROGRESS_PHASE_ORDER.indexOf(a.phase);
+    const bi = PROGRESS_PHASE_ORDER.indexOf(b.phase);
+    const ao = ai === -1 ? PROGRESS_PHASE_ORDER.length : ai;
+    const bo = bi === -1 ? PROGRESS_PHASE_ORDER.length : bi;
+    return ao - bo;
+  });
+}
+
+export function buildKaizenCycleSteps(result: ProgressResult, repo = ''): RunProgressStep[] {
+  const existing = new Map<string, RunProgressStep>();
+  for (const step of result.progressSteps || []) {
+    existing.set(step.phase, step);
+  }
+  const synthetic = result.pickedIssue === 'not applicable';
+  const issueDetail = formatIssueForDisplay(result.pickedIssue, repo, result.pickedIssueTitle);
+  const prDetail = result.prs.join(', ');
+  const caseDetail = result.cases.join(', ');
+
+  const defaults: RunProgressStep[] = [
+    {
+      phase: 'PICK',
+      state: synthetic ? 'not applicable' : result.pickedIssue ? 'selected' : 'not observed',
+      detail: synthetic ? (result.pickedIssueTitle || 'synthetic task') : (result.pickedIssue ? issueDetail : ''),
+      url: synthetic ? undefined : formatIssueUrl(result.pickedIssue, repo),
+    },
+    { phase: 'PLAN', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
+    { phase: 'EVALUATE', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
+    {
+      phase: 'CASE',
+      state: synthetic ? 'not applicable' : result.cases.length > 0 ? 'created' : 'not observed',
+      detail: synthetic ? 'synthetic test task' : caseDetail,
+    },
+    { phase: 'IMPLEMENT', state: synthetic && result.prs.length > 0 ? 'done' : 'not observed', detail: synthetic && result.prs.length > 0 ? 'synthetic file committed' : '' },
+    { phase: 'TEST', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'pipeline probe, not product tests' : '' },
+    {
+      phase: 'PR',
+      state: result.prs.length > 0 ? 'created' : 'not observed',
+      detail: prDetail,
+      url: result.prs[0],
+    },
+    {
+      phase: 'REVIEW',
+      state: synthetic ? 'not applicable' : result.reviewVerdict || (result.prs.length > 0 ? 'pending' : 'not observed'),
+      detail: synthetic ? 'synthetic test task' : formatReviewForDisplay(result),
+      url: result.reviewUrls?.[0] || result.prs[0],
+    },
+    {
+      phase: 'FIX',
+      state: synthetic ? 'not applicable' : result.reviewVerdict === 'pass' || result.reviewVerdict === 'skipped' ? 'not needed' : 'not observed',
+      detail: synthetic ? 'synthetic test task' : '',
+    },
+    { phase: 'MERGE', state: result.prs.length > 0 ? 'not observed' : 'not applicable', detail: prDetail, url: result.prs[0] },
+    { phase: 'REFLECT', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
+    { phase: 'CLEANUP', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
+    { phase: 'STOP', state: result.stopRequested ? 'requested' : 'not requested', detail: result.stopReason || '' },
+  ];
+
+  for (const step of defaults) {
+    const observed = existing.get(step.phase);
+    if (!observed) continue;
+    if (synthetic && SYNTHETIC_NOT_APPLICABLE_PHASES.has(step.phase)) {
+      continue;
+    }
+    step.state = observed.state || step.state;
+    step.detail = observed.detail || step.detail;
+    step.url = observed.url || step.url;
+  }
+  return orderedProgressSteps(defaults);
+}
+
+export function formatProgressStepsMarkdown(result: ProgressResult, repo = ''): string {
+  const lines = [
+    `#### Kaizen Work Cycle`,
+    '',
+    `| Step | State | Detail | Link |`,
+    `|------|-------|--------|------|`,
+  ];
+  for (const step of buildKaizenCycleSteps(result, repo)) {
+    lines.push(`| ${step.phase} | ${step.state} | ${step.detail || '-'} | ${step.url || '-'} |`);
+  }
+  return lines.join('\n');
+}

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -153,6 +153,13 @@ import {
   parseCodexJsonl,
 } from './auto-dent-codex.js';
 import {
+  formatIssueForDisplay,
+  formatProgressStepsMarkdown,
+  formatReviewForDisplay,
+  upsertProgressStep,
+  type RunProgressStep,
+} from './auto-dent-progress.js';
+import {
   compareFinalClaimToEvidence,
   foldFinalClaimWarningsIntoProcess,
   parseFinalRunClaim,
@@ -319,13 +326,6 @@ export interface RunResult {
   finalClaimPath?: string;
   /** Parse/comparison warnings for the final run claim (#1145). */
   finalClaimWarnings?: string[];
-}
-
-export interface RunProgressStep {
-  phase: string;
-  state: string;
-  detail: string;
-  url?: string;
 }
 
 type RunMetricsBaseField =
@@ -1403,7 +1403,7 @@ export function updateBatchProgressIssue(
   if (result.stopRequested) {
     lines.push('', `**STOP requested:** ${result.stopReason}`);
   }
-  const stepsTable = formatProgressStepsMarkdown(result);
+  const stepsTable = formatProgressStepsMarkdown(result, kaizenRepo);
   if (stepsTable) {
     lines.push('', stepsTable);
   }
@@ -1957,127 +1957,6 @@ function printRunSummary(
     `  \u2514${'─'.repeat(54)}`,
   );
   console.log('');
-}
-
-function formatIssueUrl(issue: string | undefined, repo: string): string {
-  if (!issue) return '';
-  if (/^https?:\/\//.test(issue)) return issue;
-  const match = issue.match(/#?(\d+)/);
-  if (!match || !repo) return issue;
-  return `https://github.com/${repo}/issues/${match[1]}`;
-}
-
-function formatIssueForDisplay(issue: string | undefined, repo: string, title?: string): string {
-  const url = formatIssueUrl(issue, repo);
-  if (!url) return 'unknown';
-  return title ? `${url} — ${title}` : url;
-}
-
-function formatReviewForDisplay(result: RunResult): string {
-  if (result.pickedIssue === 'not applicable') {
-    const urls = result.prs.length > 0 ? ` (${result.prs.join(', ')})` : '';
-    return `not applicable${urls}`;
-  }
-  const verdict = result.reviewVerdict ?? (result.prs.length > 0 ? 'pending' : 'skipped');
-  const urls = result.reviewUrls && result.reviewUrls.length > 0 ? result.reviewUrls : result.prs;
-  return urls.length > 0 ? `${verdict} (${urls.join(', ')})` : verdict;
-}
-
-function formatProgressStepsMarkdown(result: RunResult): string {
-  const lines = [
-    `#### Kaizen Work Cycle`,
-    '',
-    `| Step | State | Detail | Link |`,
-    `|------|-------|--------|------|`,
-  ];
-  for (const step of buildKaizenCycleSteps(result)) {
-    lines.push(`| ${step.phase} | ${step.state} | ${step.detail || '-'} | ${step.url || '-'} |`);
-  }
-  return lines.join('\n');
-}
-
-const PROGRESS_PHASE_ORDER = ['PICK', 'PLAN', 'EVALUATE', 'CASE', 'IMPLEMENT', 'TEST', 'PR', 'REVIEW', 'FIX', 'MERGE', 'REFLECT', 'CLEANUP', 'STOP'];
-
-function orderedProgressSteps(steps: RunProgressStep[]): RunProgressStep[] {
-  return [...steps].sort((a, b) => {
-    const ai = PROGRESS_PHASE_ORDER.indexOf(a.phase);
-    const bi = PROGRESS_PHASE_ORDER.indexOf(b.phase);
-    const ao = ai === -1 ? PROGRESS_PHASE_ORDER.length : ai;
-    const bo = bi === -1 ? PROGRESS_PHASE_ORDER.length : bi;
-    return ao - bo;
-  });
-}
-
-function buildKaizenCycleSteps(result: RunResult, repo = ''): RunProgressStep[] {
-  const existing = new Map<string, RunProgressStep>();
-  for (const step of result.progressSteps || []) {
-    existing.set(step.phase, step);
-  }
-  const synthetic = result.pickedIssue === 'not applicable';
-  const issueDetail = formatIssueForDisplay(result.pickedIssue, repo, result.pickedIssueTitle);
-  const prDetail = result.prs.join(', ');
-  const caseDetail = result.cases.join(', ');
-
-  const defaults: RunProgressStep[] = [
-    {
-      phase: 'PICK',
-      state: synthetic ? 'not applicable' : result.pickedIssue ? 'selected' : 'not observed',
-      detail: synthetic ? (result.pickedIssueTitle || 'synthetic task') : (result.pickedIssue ? issueDetail : ''),
-      url: synthetic ? undefined : formatIssueUrl(result.pickedIssue, repo),
-    },
-    { phase: 'PLAN', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'EVALUATE', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    {
-      phase: 'CASE',
-      state: synthetic ? 'not applicable' : result.cases.length > 0 ? 'created' : 'not observed',
-      detail: synthetic ? 'synthetic test task' : caseDetail,
-    },
-    { phase: 'IMPLEMENT', state: synthetic && result.prs.length > 0 ? 'done' : 'not observed', detail: synthetic && result.prs.length > 0 ? 'synthetic file committed' : '' },
-    { phase: 'TEST', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'pipeline probe, not product tests' : '' },
-    {
-      phase: 'PR',
-      state: result.prs.length > 0 ? 'created' : 'not observed',
-      detail: prDetail,
-      url: result.prs[0],
-    },
-    {
-      phase: 'REVIEW',
-      state: synthetic ? 'not applicable' : result.reviewVerdict || (result.prs.length > 0 ? 'pending' : 'not observed'),
-      detail: formatReviewForDisplay(result),
-      url: result.reviewUrls?.[0] || result.prs[0],
-    },
-    {
-      phase: 'FIX',
-      state: synthetic ? 'not applicable' : result.reviewVerdict === 'pass' || result.reviewVerdict === 'skipped' ? 'not needed' : 'not observed',
-      detail: synthetic ? 'synthetic test task' : '',
-    },
-    { phase: 'MERGE', state: result.prs.length > 0 ? 'not observed' : 'not applicable', detail: prDetail, url: result.prs[0] },
-    { phase: 'REFLECT', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'CLEANUP', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'STOP', state: result.stopRequested ? 'requested' : 'not requested', detail: result.stopReason || '' },
-  ];
-
-  for (const step of defaults) {
-    const observed = existing.get(step.phase);
-    if (observed) {
-      step.state = observed.state || step.state;
-      step.detail = observed.detail || step.detail;
-      step.url = observed.url || step.url;
-    }
-  }
-  return orderedProgressSteps(defaults);
-}
-
-function upsertProgressStep(result: RunResult, step: RunProgressStep): void {
-  result.progressSteps = result.progressSteps || [];
-  const existing = result.progressSteps.find((s) => s.phase === step.phase);
-  if (existing) {
-    existing.state = step.state || existing.state;
-    existing.detail = step.detail || existing.detail;
-    existing.url = step.url || existing.url;
-  } else {
-    result.progressSteps.push(step);
-  }
 }
 
 function phaseProvidersForState(state: BatchState): PhaseProviderRecord {

--- a/scripts/auto-dent-stream.test.ts
+++ b/scripts/auto-dent-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+  extractArtifacts,
   postInFlightUpdate,
   buildInFlightComment,
   relativizeWorktreePath,
@@ -184,6 +185,134 @@ describe('buildInFlightComment', () => {
 
     expect(comment).toContain('| **Review state** | not applicable |');
     expect(comment).toContain('| REVIEW | not applicable | synthetic test task | https://github.com/o/r/pull/1 |');
+  });
+
+  it('populates review and reflection rows from canonical gate set signals', () => {
+    const result = makeRunResult({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1242'],
+    });
+
+    extractArtifacts(
+      `---
+hook: pr-review-loop
+type: gate-set
+gate: needs_review
+pr: https://github.com/Garsson-io/kaizen/pull/1242
+round: 2
+reason: Push detected - new review round
+---
+---
+hook: kaizen-reflect
+type: gate-set
+gate: needs_pr_kaizen
+reason: Kaizen reflection required
+---
+`,
+      result,
+    );
+
+    const comment = buildInFlightComment(1, Date.now(), result, {}, 'Garsson-io/kaizen');
+
+    expect(comment).toContain('| REVIEW | pending | round 2: Push detected - new review round | https://github.com/Garsson-io/kaizen/pull/1242 |');
+    expect(comment).toContain('| REFLECT | pending | Kaizen reflection required | - |');
+  });
+
+  it('populates review and reflection rows from canonical gate clear signals', () => {
+    const result = makeRunResult({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1242'],
+    });
+
+    extractArtifacts(
+      `---
+hook: pr-review-loop
+type: gate-clear
+gate: needs_review
+pr: https://github.com/Garsson-io/kaizen/pull/1242
+round: 2
+reason: Review passed
+---
+---
+hook: pr-kaizen-clear
+type: gate-clear
+gate: needs_pr_kaizen
+reason: Impediments filed
+---
+`,
+      result,
+    );
+
+    const comment = buildInFlightComment(1, Date.now(), result, {}, 'Garsson-io/kaizen');
+
+    expect(comment).toContain('| REVIEW | passed | round 2: Review passed | https://github.com/Garsson-io/kaizen/pull/1242 |');
+    expect(comment).toContain('| REFLECT | completed | Impediments filed | - |');
+  });
+
+  it('populates merge rows from canonical post-merge gate signals', () => {
+    const result = makeRunResult({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1242'],
+    });
+
+    extractArtifacts(
+      `---
+hook: post-merge-clear
+type: gate-set
+gate: needs_post_merge
+pr: https://github.com/Garsson-io/kaizen/pull/1242
+reason: Merge confirmed - run /kaizen to reflect
+---
+`,
+      result,
+    );
+
+    let comment = buildInFlightComment(1, Date.now(), result, {}, 'Garsson-io/kaizen');
+    expect(comment).toContain('| MERGE | merged | Merge confirmed - run /kaizen to reflect | https://github.com/Garsson-io/kaizen/pull/1242 |');
+
+    extractArtifacts(
+      `---
+hook: post-merge-clear
+type: gate-clear
+gate: needs_post_merge
+reason: Kaizen reflection completed
+---
+`,
+      result,
+    );
+
+    comment = buildInFlightComment(1, Date.now(), result, {}, 'Garsson-io/kaizen');
+    expect(comment).toContain('| MERGE | completed | Kaizen reflection completed | https://github.com/Garsson-io/kaizen/pull/1242 |');
+  });
+
+  it('keeps synthetic task lifecycle rows not applicable even if gate text is present', () => {
+    const result = makeRunResult({
+      pickedIssue: 'not applicable',
+      pickedIssueTitle: 'synthetic test task',
+      prs: ['https://github.com/o/r/pull/1'],
+      reviewVerdict: 'skipped',
+    });
+
+    extractArtifacts(
+      `---
+hook: pr-review-loop
+type: gate-set
+gate: needs_review
+pr: https://github.com/o/r/pull/1
+round: 1
+reason: PR created
+---
+---
+hook: kaizen-reflect
+type: gate-set
+gate: needs_pr_kaizen
+reason: Kaizen reflection required
+---
+`,
+      result,
+    );
+
+    const comment = buildInFlightComment(1, Date.now(), result, {}, 'Garsson-io/kaizen');
+
+    expect(comment).toContain('| REVIEW | not applicable | synthetic test task | https://github.com/o/r/pull/1 |');
+    expect(comment).toContain('| REFLECT | not applicable | synthetic test task | - |');
   });
 });
 

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -11,6 +11,13 @@
 import type { RunResult } from './auto-dent-run.js';
 import { parseFinalRunClaim } from './auto-dent-final-claim.js';
 import { ghExec } from './auto-dent-github.js';
+import {
+  buildKaizenCycleSteps,
+  formatIssueForDisplay,
+  formatProgressStepsMarkdown,
+  upsertProgressStep,
+  type RunProgressStep,
+} from './auto-dent-progress.js';
 import { parseHookOutputs, type HookOutput } from '../src/hooks/lib/gate-signal.js';
 
 // ANSI color helpers (graceful degradation when NO_COLOR is set or not a TTY)
@@ -284,39 +291,13 @@ function pushPr(result: RunResult, prUrl: string): void {
     state: 'created',
     detail: prUrl,
     url: prUrl,
-  });
-}
-
-type ProgressStep = NonNullable<RunResult['progressSteps']>[number];
-
-function upsertProgressStep(result: RunResult, step: ProgressStep): void {
-  if (!result.progressSteps) result.progressSteps = [];
-  const existing = result.progressSteps.find((s) => s.phase === step.phase);
-  if (existing) {
-    existing.state = step.state;
-    existing.detail = step.detail;
-    existing.url = step.url;
-  } else {
-    result.progressSteps.push(step);
-  }
+  }, 'replace');
 }
 
 function updateProgressFromMarker(marker: PhaseMarker, result: RunResult): void {
   const step = progressStepFromMarker(marker);
   if (!step) return;
-  mergeProgressStep(result, step);
-}
-
-function mergeProgressStep(result: RunResult, step: ProgressStep): void {
-  if (!result.progressSteps) result.progressSteps = [];
-  const existing = result.progressSteps.find((s) => s.phase === step.phase);
-  if (!existing) {
-    result.progressSteps.push(step);
-    return;
-  }
-  existing.state = step.state || existing.state;
-  existing.detail = step.detail || existing.detail;
-  existing.url = step.url || existing.url;
+  upsertProgressStep(result, step);
 }
 
 function updateProgressFromHookOutput(output: HookOutput, result: RunResult): void {
@@ -337,14 +318,14 @@ function updateProgressFromHookOutput(output: HookOutput, result: RunResult): vo
         state: output.type === 'gate-set' ? 'pending' : 'passed',
         detail,
         url,
-      });
+      }, 'replace');
       return;
     case 'needs_pr_kaizen':
       upsertProgressStep(result, {
         phase: 'REFLECT',
         state: output.type === 'gate-set' ? 'pending' : 'completed',
         detail: output.reason,
-      });
+      }, 'replace');
       return;
     case 'needs_post_merge':
       upsertProgressStep(result, {
@@ -352,12 +333,12 @@ function updateProgressFromHookOutput(output: HookOutput, result: RunResult): vo
         state: output.type === 'gate-set' ? 'merged' : 'completed',
         detail: output.reason,
         url,
-      });
+      }, 'replace');
       return;
   }
 }
 
-function progressStepFromMarker(marker: PhaseMarker): NonNullable<RunResult['progressSteps']>[number] | null {
+function progressStepFromMarker(marker: PhaseMarker): RunProgressStep | null {
   const f = marker.fields;
   switch (marker.phase) {
     case 'PICK':
@@ -508,7 +489,7 @@ export function buildInFlightComment(
     `| **Tool calls** | ${result.toolCalls} |`,
     `| **Cost so far** | $${result.cost.toFixed(2)} |`,
     `| **Status** | ${status} |`,
-    `| **Issue worked** | ${formatIssueForComment(result.pickedIssue, result.pickedIssueTitle, repo)} |`,
+    `| **Issue worked** | ${formatIssueForDisplay(result.pickedIssue, repo, result.pickedIssueTitle)} |`,
     `| **PR generated** | ${result.prs.length > 0 ? result.prs.join(', ') : 'none yet'} |`,
     `| **Review state** | ${synthetic ? 'not applicable' : result.reviewVerdict ?? (result.prs.length > 0 ? 'pending' : 'not started')} |`,
   ];
@@ -524,86 +505,10 @@ export function buildInFlightComment(
   }
   lines.push(
     '',
-    `#### Kaizen Work Cycle`,
-    '',
-    `| Step | State | Detail | Link |`,
-    `|------|-------|--------|------|`,
+    formatProgressStepsMarkdown(result, repo),
   );
-  for (const step of buildKaizenCycleSteps(result, repo)) {
-    lines.push(`| ${step.phase} | ${step.state} | ${step.detail || '-'} | ${step.url || '-'} |`);
-  }
 
   return lines.join('\n');
-}
-
-function formatIssueForComment(issue: string | undefined, title: string | undefined, repo: string): string {
-  if (!issue) return 'unknown';
-  const url = issue.startsWith('http') ? issue : issue.replace(/^#?(\d+)$/, repo ? `https://github.com/${repo}/issues/$1` : issue);
-  return title ? `${url} — ${title}` : url;
-}
-
-const PROGRESS_PHASE_ORDER = ['PICK', 'PLAN', 'EVALUATE', 'CASE', 'IMPLEMENT', 'TEST', 'PR', 'REVIEW', 'FIX', 'MERGE', 'REFLECT', 'CLEANUP', 'STOP'];
-
-function orderedProgressSteps(steps: NonNullable<RunResult['progressSteps']>): NonNullable<RunResult['progressSteps']> {
-  return [...steps].sort((a, b) => {
-    const ai = PROGRESS_PHASE_ORDER.indexOf(a.phase);
-    const bi = PROGRESS_PHASE_ORDER.indexOf(b.phase);
-    const ao = ai === -1 ? PROGRESS_PHASE_ORDER.length : ai;
-    const bo = bi === -1 ? PROGRESS_PHASE_ORDER.length : bi;
-    return ao - bo;
-  });
-}
-
-function buildKaizenCycleSteps(result: RunResult, repo: string): NonNullable<RunResult['progressSteps']> {
-  const existing = new Map<string, NonNullable<RunResult['progressSteps']>[number]>();
-  for (const step of result.progressSteps || []) existing.set(step.phase, step);
-  const synthetic = result.pickedIssue === 'not applicable';
-  const issueDetail = formatIssueForComment(result.pickedIssue, result.pickedIssueTitle, repo);
-  const prDetail = result.prs.join(', ');
-  const defaults: NonNullable<RunResult['progressSteps']> = [
-    {
-      phase: 'PICK',
-      state: synthetic ? 'not applicable' : result.pickedIssue ? 'selected' : 'not observed',
-      detail: synthetic ? (result.pickedIssueTitle || 'synthetic task') : (result.pickedIssue ? issueDetail : ''),
-      url: synthetic || !result.pickedIssue ? undefined : formatIssueForComment(result.pickedIssue, undefined, repo),
-    },
-    { phase: 'PLAN', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'EVALUATE', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    {
-      phase: 'CASE',
-      state: synthetic ? 'not applicable' : result.cases.length > 0 ? 'created' : 'not observed',
-      detail: synthetic ? 'synthetic test task' : result.cases.join(', '),
-    },
-    { phase: 'IMPLEMENT', state: synthetic && result.prs.length > 0 ? 'done' : 'not observed', detail: synthetic && result.prs.length > 0 ? 'synthetic file committed' : '' },
-    { phase: 'TEST', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'pipeline probe, not product tests' : '' },
-    { phase: 'PR', state: result.prs.length > 0 ? 'created' : 'not observed', detail: prDetail, url: result.prs[0] },
-    {
-      phase: 'REVIEW',
-      state: synthetic ? 'not applicable' : result.reviewVerdict || (result.prs.length > 0 ? 'pending' : 'not observed'),
-      detail: synthetic ? 'synthetic test task' : result.reviewVerdict || result.prs.length > 0 ? [result.reviewVerdict, result.prs[0]].filter(Boolean).join(' ') : '',
-      url: result.reviewUrls?.[0] || result.prs[0],
-    },
-    {
-      phase: 'FIX',
-      state: synthetic ? 'not applicable' : result.reviewVerdict === 'pass' || result.reviewVerdict === 'skipped' ? 'not needed' : 'not observed',
-      detail: synthetic ? 'synthetic test task' : '',
-    },
-    { phase: 'MERGE', state: result.prs.length > 0 ? 'not observed' : 'not applicable', detail: prDetail, url: result.prs[0] },
-    { phase: 'REFLECT', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'CLEANUP', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'STOP', state: result.stopRequested ? 'requested' : 'not requested', detail: result.stopReason || '' },
-  ];
-  for (const step of defaults) {
-    const observed = existing.get(step.phase);
-    if (!observed) continue;
-    if (synthetic && ['PLAN', 'EVALUATE', 'CASE', 'TEST', 'REVIEW', 'FIX', 'REFLECT', 'CLEANUP'].includes(step.phase)) {
-      continue;
-    }
-    step.state = observed.state || step.state;
-    step.detail = observed.detail || step.detail;
-    step.url = observed.url || step.url;
-  }
-  return orderedProgressSteps(defaults);
 }
 
 /**

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -11,7 +11,7 @@
 import type { RunResult } from './auto-dent-run.js';
 import { parseFinalRunClaim } from './auto-dent-final-claim.js';
 import { ghExec } from './auto-dent-github.js';
-import { parseHookOutput, type HookOutput } from '../src/hooks/lib/gate-signal.js';
+import { parseHookOutputs, type HookOutput } from '../src/hooks/lib/gate-signal.js';
 
 // ANSI color helpers (graceful degradation when NO_COLOR is set or not a TTY)
 
@@ -317,15 +317,6 @@ function mergeProgressStep(result: RunResult, step: ProgressStep): void {
   existing.state = step.state || existing.state;
   existing.detail = step.detail || existing.detail;
   existing.url = step.url || existing.url;
-}
-
-function parseHookOutputs(text: string): HookOutput[] {
-  const outputs: HookOutput[] = [];
-  for (const match of text.matchAll(/^---\n[\s\S]*?\n---/gm)) {
-    const parsed = parseHookOutput(match[0]);
-    if (parsed) outputs.push(parsed);
-  }
-  return outputs;
 }
 
 function updateProgressFromHookOutput(output: HookOutput, result: RunResult): void {

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -11,6 +11,7 @@
 import type { RunResult } from './auto-dent-run.js';
 import { parseFinalRunClaim } from './auto-dent-final-claim.js';
 import { ghExec } from './auto-dent-github.js';
+import { parseHookOutput, type HookOutput } from '../src/hooks/lib/gate-signal.js';
 
 // ANSI color helpers (graceful degradation when NO_COLOR is set or not a TTY)
 
@@ -224,6 +225,9 @@ function extractIssueRefs(value: string): string[] {
 }
 
 export function extractArtifacts(text: string, result: RunResult): void {
+  for (const output of parseHookOutputs(text)) {
+    updateProgressFromHookOutput(output, result);
+  }
   for (const marker of parsePhaseMarkers(text)) {
     updateProgressFromMarker(marker, result);
     if (marker.phase === 'PICK' && marker.fields.issue) {
@@ -275,14 +279,19 @@ export function extractArtifacts(text: string, result: RunResult): void {
 
 function pushPr(result: RunResult, prUrl: string): void {
   pushUnique(result.prs, prUrl);
-  if (!result.progressSteps) result.progressSteps = [];
-  const existing = result.progressSteps.find((s) => s.phase === 'PR');
-  const step = {
+  upsertProgressStep(result, {
     phase: 'PR',
     state: 'created',
     detail: prUrl,
     url: prUrl,
-  };
+  });
+}
+
+type ProgressStep = NonNullable<RunResult['progressSteps']>[number];
+
+function upsertProgressStep(result: RunResult, step: ProgressStep): void {
+  if (!result.progressSteps) result.progressSteps = [];
+  const existing = result.progressSteps.find((s) => s.phase === step.phase);
   if (existing) {
     existing.state = step.state;
     existing.detail = step.detail;
@@ -295,14 +304,65 @@ function pushPr(result: RunResult, prUrl: string): void {
 function updateProgressFromMarker(marker: PhaseMarker, result: RunResult): void {
   const step = progressStepFromMarker(marker);
   if (!step) return;
+  mergeProgressStep(result, step);
+}
+
+function mergeProgressStep(result: RunResult, step: ProgressStep): void {
   if (!result.progressSteps) result.progressSteps = [];
   const existing = result.progressSteps.find((s) => s.phase === step.phase);
-  if (existing) {
-    existing.state = step.state || existing.state;
-    existing.detail = step.detail || existing.detail;
-    existing.url = step.url || existing.url;
-  } else {
+  if (!existing) {
     result.progressSteps.push(step);
+    return;
+  }
+  existing.state = step.state || existing.state;
+  existing.detail = step.detail || existing.detail;
+  existing.url = step.url || existing.url;
+}
+
+function parseHookOutputs(text: string): HookOutput[] {
+  const outputs: HookOutput[] = [];
+  for (const match of text.matchAll(/^---\n[\s\S]*?\n---/gm)) {
+    const parsed = parseHookOutput(match[0]);
+    if (parsed) outputs.push(parsed);
+  }
+  return outputs;
+}
+
+function updateProgressFromHookOutput(output: HookOutput, result: RunResult): void {
+  if (output.type !== 'gate-set' && output.type !== 'gate-clear') return;
+  if (!output.gate) return;
+
+  if (output.pr) pushPr(result, output.pr);
+
+  const detail = [output.round ? `round ${output.round}:` : '', output.reason]
+    .filter(Boolean)
+    .join(' ');
+  const url = output.pr || result.prs[0];
+
+  switch (output.gate) {
+    case 'needs_review':
+      upsertProgressStep(result, {
+        phase: 'REVIEW',
+        state: output.type === 'gate-set' ? 'pending' : 'passed',
+        detail,
+        url,
+      });
+      return;
+    case 'needs_pr_kaizen':
+      upsertProgressStep(result, {
+        phase: 'REFLECT',
+        state: output.type === 'gate-set' ? 'pending' : 'completed',
+        detail: output.reason,
+      });
+      return;
+    case 'needs_post_merge':
+      upsertProgressStep(result, {
+        phase: 'MERGE',
+        state: output.type === 'gate-set' ? 'merged' : 'completed',
+        detail: output.reason,
+        url,
+      });
+      return;
   }
 }
 
@@ -545,6 +605,9 @@ function buildKaizenCycleSteps(result: RunResult, repo: string): NonNullable<Run
   for (const step of defaults) {
     const observed = existing.get(step.phase);
     if (!observed) continue;
+    if (synthetic && ['PLAN', 'EVALUATE', 'CASE', 'TEST', 'REVIEW', 'FIX', 'REFLECT', 'CLEANUP'].includes(step.phase)) {
+      continue;
+    }
     step.state = observed.state || step.state;
     step.detail = observed.detail || step.detail;
     step.url = observed.url || step.url;

--- a/scripts/hook-signals.ts
+++ b/scripts/hook-signals.ts
@@ -37,7 +37,7 @@
  */
 
 import { z } from 'zod';
-import { parseHookOutput } from '../src/hooks/lib/gate-signal.js';
+import { parseHookOutputs } from '../src/hooks/lib/gate-signal.js';
 
 export type HookSignalSource = 'permission-decision' | 'stop-decision' | 'canonical-yaml';
 
@@ -106,12 +106,7 @@ function jsonSignalFromText(text: string): HookSignal | null {
  */
 function yamlSignals(log: string): HookSignal[] {
   const signals: HookSignal[] = [];
-  // Match each `---\n...\n---` fenced block; parseHookOutput validates content.
-  const fenceRe = /^---\n[\s\S]*?\n---/gm;
-  const blocks = log.match(fenceRe);
-  if (!blocks) return signals;
-  for (const block of blocks) {
-    const output = parseHookOutput(block);
+  for (const output of parseHookOutputs(log)) {
     if (output && (output.type === 'deny' || output.type === 'block')) {
       signals.push({
         kind: output.type,

--- a/src/hooks/lib/gate-signal.test.ts
+++ b/src/hooks/lib/gate-signal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatHookOutput, parseHookOutput, formatGateSignal, parseGateSignal, type HookOutput } from './gate-signal.js';
+import { formatHookOutput, parseHookOutput, parseHookOutputs, formatGateSignal, parseGateSignal, type HookOutput } from './gate-signal.js';
 
 describe('formatHookOutput', () => {
   it('produces a YAML block delimited by ---', () => {
@@ -103,6 +103,28 @@ describe('parseHookOutput', () => {
 
   it('rejects unknown gate names', () => {
     expect(parseHookOutput('---\nhook: x\ntype: gate-set\ngate: unknown_gate\nreason: test\n---\n')).toBeNull();
+  });
+});
+
+describe('parseHookOutputs', () => {
+  it('extracts every valid YAML hook output block from mixed text', () => {
+    const text = [
+      'prefix',
+      formatHookOutput({ hook: 'pr-review-loop', type: 'gate-set', gate: 'needs_review', reason: 'PR created' }),
+      'middle',
+      '---\nhook: invalid\n---',
+      formatHookOutput({ hook: 'pr-kaizen-clear', type: 'gate-clear', gate: 'needs_pr_kaizen', reason: 'cleared' }),
+      'suffix',
+    ].join('\n');
+
+    expect(parseHookOutputs(text)).toEqual([
+      { hook: 'pr-review-loop', type: 'gate-set', gate: 'needs_review', reason: 'PR created' },
+      { hook: 'pr-kaizen-clear', type: 'gate-clear', gate: 'needs_pr_kaizen', reason: 'cleared' },
+    ]);
+  });
+
+  it('returns an empty array when no valid hook output blocks exist', () => {
+    expect(parseHookOutputs('plain\n---\nhook: invalid\n---')).toEqual([]);
   });
 });
 

--- a/src/hooks/lib/gate-signal.ts
+++ b/src/hooks/lib/gate-signal.ts
@@ -83,5 +83,17 @@ export function parseHookOutput(text: string): HookOutput | null {
   }
 }
 
+/**
+ * Extract every valid HookOutput YAML block from mixed hook output text.
+ */
+export function parseHookOutputs(text: string): HookOutput[] {
+  const outputs: HookOutput[] = [];
+  for (const match of text.matchAll(/^---\n[\s\S]*?\n---/gm)) {
+    const parsed = parseHookOutput(match[0]);
+    if (parsed) outputs.push(parsed);
+  }
+  return outputs;
+}
+
 // Convenience alias
 export const parseGateSignal = parseHookOutput;


### PR DESCRIPTION
## Story

Once upon a time, auto-dent progress comments had a shared kaizen work-cycle renderer, but several lifecycle rows still depended on narration-style `AUTO_DENT_PHASE` markers or defaults.

One day, validation showed a more durable source was already available: the hooks emit canonical YAML gate signals for review, reflection, and post-merge work.

Because of that, this PR teaches `extractArtifacts()` to consume those hook-output blocks through the shared parser in `src/hooks/lib/gate-signal.ts`. Gate events now map directly into work-cycle rows:

- `needs_review` set/clear -> REVIEW `pending` / `passed`
- `needs_pr_kaizen` set/clear -> REFLECT `pending` / `completed`
- `needs_post_merge` set/clear -> MERGE `merged` / `completed`

Because of that, progress comments can show observed gate states without inventing evidence. Synthetic test tasks still keep kaizen-only rows as `not applicable`, so operator output distinguishes `not observed`, `not applicable`, and observed gate states.

Until finally, this branch is rebased onto the already-merged shared progress renderer from PR #1261 and only carries the remaining gate-signal ingestion behavior needed for #1242.

Fixes Garsson-io/kaizen#1242

## Architecture

```text
stream text / tool_result content
        |
        v
extractArtifacts()
        |
        +-- parsePhaseMarkers()        -> existing AUTO_DENT_PHASE rows
        +-- parseHookOutputs() blocks  -> REVIEW / MERGE / REFLECT rows
        +-- PR/case/prose extractors   -> existing artifacts
        |
        v
formatProgressStepsMarkdown() -> shared Kaizen Work Cycle table
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Reuse the hook YAML parser | Hook output is already structured and Zod-validated. | `auto-dent-stream.ts` imports one hook-library parser. |
| Share multi-block parsing | `scripts/hook-signals.ts` and stream extraction both need to scan mixed text for canonical hook blocks. | Adds `parseHookOutputs()` beside the existing single-block parser. |
| Use replace-mode progress upserts for gates | Gate-clear events must be able to replace earlier gate-set states. | Existing phase marker updates keep merge semantics. |
| Preserve synthetic `not applicable` rows | Synthetic test tasks are pipeline probes, not real kaizen lifecycle work. | Gate text embedded in synthetic output will not override those rows. |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/lib/gate-signal.ts` | Adds `parseHookOutputs()` for mixed text with multiple hook YAML blocks. |
| `scripts/hook-signals.ts` | Reuses the shared multi-block parser instead of duplicating YAML fence scanning. |
| `scripts/auto-dent-stream.ts` | Parses canonical hook YAML blocks and maps gate transitions into work-cycle progress rows. |
| `scripts/auto-dent-progress.ts` | Adds replace-mode upserts and keeps synthetic lifecycle rows `not applicable`. |
| `scripts/auto-dent-run.ts` | Passes the repo into the shared progress formatter for issue links. |
| Tests | Cover parser reuse, gate rows, post-merge rows, and synthetic-task behavior. |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Coverage |
|---|----------|-------------|-------|----------|
| 1 | Canonical hook YAML in stream/tool-result text updates lifecycle rows without `AUTO_DENT_PHASE` narration. | code | Unit | `scripts/auto-dent-stream.test.ts`. |
| 2 | REVIEW row distinguishes gate set from gate clear and preserves PR links when present. | user/operator | Unit | `scripts/auto-dent-stream.test.ts`. |
| 3 | REFLECT row distinguishes reflection gate set from clear. | user/operator | Unit | `scripts/auto-dent-stream.test.ts`. |
| 4 | MERGE row reflects post-merge gate set and clear signals. | user/operator | Unit | `scripts/auto-dent-stream.test.ts`. |
| 5 | Shared hook-output scanning extracts valid YAML blocks from mixed text and ignores invalid blocks. | code | Unit | `src/hooks/lib/gate-signal.test.ts`, `scripts/hook-signals.test.ts`. |
| 6 | Synthetic test-task output remains `not applicable` where no kaizen lifecycle step is required. | user/operator | Unit | `scripts/auto-dent-stream.test.ts`. |
| 7 | Existing run/review progress behavior remains intact after rebasing onto PR #1261. | integration | Existing related suites | `scripts/auto-dent-run.test.ts`, `scripts/auto-dent-review-wiring.test.ts`. |
| 8 | Type contracts remain valid after importing hook parser across `src/` and `scripts/`. | system | TypeScript compile | `npx tsc --noEmit`. |

## Validation

- [x] Confirmed `origin/main` already contains the shared progress renderer from PR #1261 / commit `d4dcdd2`.
- [x] Confirmed `origin/main` does not contain this PR's hook-gate ingestion (`parseHookOutputs()` stream wiring and gate row updates).
- [x] Rebased/merged the branch onto current `origin/main`.
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/hooks/lib/gate-signal.test.ts scripts/hook-signals.test.ts scripts/auto-dent-stream.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-review-wiring.test.ts` -> 5 files, 383 tests passed.
- [x] `git diff --check`

## Known Limitations

This PR does not claim PLAN, CASE, TEST, FIX, or CLEANUP from hook signals because those rows do not yet have equivalent canonical gate events. They continue to use the existing phase markers, artifacts, and defaults until durable source-specific evidence exists.
