### PR TITLE
[rescue] double-barracuda run 1 verdict binding gates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -78,6 +78,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh",
+            "timeout": 20
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/kaizen-enforce-plan-stored-ts.sh",
             "timeout": 15
           },

--- a/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh
+++ b/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# TS hook shim — enforce-merge-verdict PreToolUse gate (kaizen #1220 / #1227)
+# Blocks `gh pr merge` when the latest stored review round derives FAIL.
+
+source "$(dirname "$0")/lib/scope-guard.sh"
+source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
+KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/enforce-merge-verdict.ts"

--- a/scripts/auto-dent-outcome.test.ts
+++ b/scripts/auto-dent-outcome.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for deriveRunOutcome — the #1224/#1227 verdict→outcome binding.
+ *
+ * Adversarial intent: prove a red run can NEVER stamp `outcome:success`, using
+ * the exact event shape that let PR #1212 land (success + review fail +
+ * process-incomplete + degraded). And prove the binding does NOT over-fire:
+ * a clean run, and a `skipped` review, must stay success.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveRunOutcome, hasRedVerdict } from './auto-dent-outcome.js';
+
+describe('deriveRunOutcome — verdict binding (#1224)', () => {
+  it('downgrades success→failure on the exact #1212 evidence shape', () => {
+    // run-2: outcome:success, review_verdict:fail, process_verdict:process-incomplete, lifecycle:degraded
+    expect(
+      deriveRunOutcome('success', {
+        reviewVerdict: 'fail',
+        processVerdict: 'process-incomplete',
+        lifecycleHealth: 'degraded',
+      }),
+    ).toBe('failure');
+  });
+
+  it('downgrades success→failure when only review verdict is fail', () => {
+    expect(deriveRunOutcome('success', { reviewVerdict: 'fail' })).toBe('failure');
+  });
+
+  it('downgrades success→failure when process verdict is process-incomplete', () => {
+    expect(deriveRunOutcome('success', { processVerdict: 'process-incomplete' })).toBe('failure');
+  });
+
+  it('downgrades success→failure when process verdict is fail-open-warning', () => {
+    expect(deriveRunOutcome('success', { processVerdict: 'fail-open-warning' })).toBe('failure');
+  });
+
+  it('downgrades success→failure when lifecycle health is critical', () => {
+    expect(deriveRunOutcome('success', { lifecycleHealth: 'critical' })).toBe('failure');
+  });
+
+  it('keeps success when all verdicts are clean', () => {
+    expect(
+      deriveRunOutcome('success', {
+        reviewVerdict: 'pass',
+        processVerdict: 'pass',
+        lifecycleHealth: 'clean',
+      }),
+    ).toBe('success');
+  });
+
+  it('does NOT downgrade for a skipped review (no review ran ≠ fail)', () => {
+    expect(
+      deriveRunOutcome('success', {
+        reviewVerdict: 'skipped',
+        processVerdict: 'pass',
+        lifecycleHealth: 'clean',
+      }),
+    ).toBe('success');
+  });
+
+  it('does NOT downgrade for degraded lifecycle alone (soft signal)', () => {
+    // process-incomplete is the hard signal; degraded without a red review/process
+    // is not enough on its own — degraded almost always co-occurs with a red
+    // process verdict (auto-dent-run sets degraded when processVerdict !== pass),
+    // which IS caught. Bare degraded must not over-fire.
+    expect(
+      deriveRunOutcome('success', {
+        reviewVerdict: 'pass',
+        processVerdict: 'pass',
+        lifecycleHealth: 'degraded',
+      }),
+    ).toBe('success');
+  });
+
+  it('keeps success when verdicts are absent (back-compat / explore runs)', () => {
+    expect(deriveRunOutcome('success', {})).toBe('success');
+  });
+
+  it.each(['empty_success', 'failure', 'stop'] as const)(
+    'passes %s through unchanged regardless of verdicts',
+    (base) => {
+      expect(
+        deriveRunOutcome(base, {
+          reviewVerdict: 'fail',
+          processVerdict: 'process-incomplete',
+          lifecycleHealth: 'critical',
+        }),
+      ).toBe(base);
+      expect(deriveRunOutcome(base, {})).toBe(base);
+    },
+  );
+});
+
+describe('hasRedVerdict', () => {
+  it('is true for any single red verdict', () => {
+    expect(hasRedVerdict({ reviewVerdict: 'fail' })).toBe(true);
+    expect(hasRedVerdict({ processVerdict: 'process-incomplete' })).toBe(true);
+    expect(hasRedVerdict({ processVerdict: 'fail-open-warning' })).toBe(true);
+    expect(hasRedVerdict({ lifecycleHealth: 'critical' })).toBe(true);
+  });
+
+  it('is false for clean / skipped / degraded-only / empty', () => {
+    expect(hasRedVerdict({})).toBe(false);
+    expect(hasRedVerdict({ reviewVerdict: 'skipped' })).toBe(false);
+    expect(hasRedVerdict({ reviewVerdict: 'pass', processVerdict: 'pass' })).toBe(false);
+    expect(hasRedVerdict({ lifecycleHealth: 'degraded' })).toBe(false);
+  });
+});

--- a/scripts/auto-dent-outcome.ts
+++ b/scripts/auto-dent-outcome.ts
@@ -1,0 +1,71 @@
+/**
+ * auto-dent-outcome.ts — derive a run's terminal `outcome` from the quality
+ * verdicts the same run already computed.
+ *
+ * #1224 / #1227: a run's `outcome` is a TERMINAL signal — batch summaries,
+ * cross-batch steering, and humans deciding whether to merge all read it. The
+ * bug it closes: `outcome` was computed from only `stopRequested`/`exitCode`/
+ * `modeSuccess()` and never consulted `review_verdict`, `process_verdict`, or
+ * `lifecycle_health` — verdicts already carried on the SAME `run.complete`
+ * event. So a run with `review_verdict:fail` + `process_verdict:process-
+ * incomplete` still stamped `outcome:success` (auto-dent grading its own
+ * homework as passing while the rubric said fail). That false-green is exactly
+ * how PR #1212 was acted on (see #1220, #1227).
+ *
+ * This module is the BINDING: a base `success` is only honoured when no quality
+ * verdict is red. It is PURE (no I/O) so the rule is exhaustively unit-testable
+ * and cannot drift from the data the event already carries.
+ */
+
+import type { LifecycleHealth, ProcessVerdict } from './auto-dent-lifecycle.js';
+
+/** The terminal outcome enum emitted on `run.complete`. */
+export type RunOutcome = 'success' | 'empty_success' | 'failure' | 'stop';
+
+/** Review battery verdict as recorded on the run. */
+export type RunReviewVerdict = 'pass' | 'fail' | 'skipped';
+
+export interface RunVerdicts {
+  /** Review battery verdict. `skipped` is NOT a failure (no review ran). */
+  reviewVerdict?: RunReviewVerdict;
+  /** Process-completeness verdict. Anything other than `pass` is degraded. */
+  processVerdict?: ProcessVerdict;
+  /** Lifecycle health. Only `critical` forces a downgrade. */
+  lifecycleHealth?: LifecycleHealth;
+}
+
+/**
+ * True when the run's quality verdicts say the work was NOT clean, so a
+ * `success` outcome would be a false green.
+ *
+ * Red signals (any one is enough):
+ *   - `reviewVerdict === 'fail'`          — the review battery FAILed.
+ *   - `processVerdict !== 'pass'`         — process-incomplete / fail-open-warning
+ *                                           (no durable plan/impl/PR/test/review
+ *                                           evidence behind the claims).
+ *   - `lifecycleHealth === 'critical'`    — claimed-to-ship-without-building, or
+ *                                           claimed-green-but-ran-nothing.
+ *
+ * `reviewVerdict === 'skipped'` is deliberately NOT red: a run that legitimately
+ * ran no review (e.g. explore/reflect modes) must not be downgraded. A red
+ * `process_verdict` already catches a run that should have reviewed but didn't.
+ */
+export function hasRedVerdict(verdicts: RunVerdicts): boolean {
+  if (verdicts.reviewVerdict === 'fail') return true;
+  if (verdicts.processVerdict != null && verdicts.processVerdict !== 'pass') return true;
+  if (verdicts.lifecycleHealth === 'critical') return true;
+  return false;
+}
+
+/**
+ * Derive the final `outcome` by binding the base outcome to the quality
+ * verdicts. Only a base `success` can be downgraded — `empty_success`, `stop`,
+ * and `failure` are already non-success / terminal and pass through unchanged.
+ *
+ * A base `success` with ANY red verdict becomes `failure`: a run the rubric
+ * graded as failing must never roll up to success.
+ */
+export function deriveRunOutcome(base: RunOutcome, verdicts: RunVerdicts): RunOutcome {
+  if (base !== 'success') return base;
+  return hasRedVerdict(verdicts) ? 'failure' : 'success';
+}

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -124,6 +124,7 @@ export {
   type ProcessGap,
   type ProcessVerdict,
 } from './auto-dent-lifecycle.js';
+import { deriveRunOutcome } from './auto-dent-outcome.js';
 
 // Import for internal use
 import {
@@ -2307,10 +2308,19 @@ async function main(): Promise<void> {
       lines_deleted: result.linesDeleted,
       issues_pruned: result.issuesPruned,
     };
-    const outcome = result.stopRequested ? 'stop' as const
+    const baseOutcome = result.stopRequested ? 'stop' as const
       : (exitCode === 0 && modeSuccess(runMode, runMetricsForOutcome) > 0) ? 'success' as const
       : (exitCode === 0) ? 'empty_success' as const
       : 'failure' as const;
+    // #1224/#1227: bind the terminal outcome to the quality verdicts this run
+    // already computed. A base `success` with a red review/process/lifecycle
+    // verdict is a false green — downgrade it to `failure` so batch summaries
+    // and downstream merge decisions can't act on a run the rubric failed.
+    const outcome = deriveRunOutcome(baseOutcome, {
+      reviewVerdict,
+      processVerdict,
+      lifecycleHealth,
+    });
     events.emit({
       type: 'run.complete',
       run_id: runId,

--- a/scripts/verdict-binding-inventory.test.ts
+++ b/scripts/verdict-binding-inventory.test.ts
@@ -1,0 +1,83 @@
+/**
+ * verdict-binding-inventory.test.ts — the #1227 binding lint.
+ *
+ * #1227's category: kaizen computes quality verdicts correctly, then no
+ * mechanism is required to HONOR them at the irreversible action. The fix is a
+ * standing INVENTORY: every terminal/finalizing action must mechanically
+ * consume the relevant computed verdict, failing closed. A computed verdict with
+ * no enforcing consumer at a terminal action is itself a defect.
+ *
+ * This test is that inventory as code. Each entry pins a terminal action to the
+ * source evidence that it consumes its verdict. If a future edit decouples a
+ * terminal action from its verdict (the #1212 regression class), the matching
+ * assertion fails — turning an L1 "remember to bind it" into an L2 CI gate.
+ *
+ * When you add a NEW terminal/finalizing action (issue-close scope-match,
+ * batch-finalize, gate-clear, post-merge verify — #1165), ADD it here with the
+ * evidence it consumes its verdict. Leaving it out is the bug this guards.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..');
+const read = (rel: string) => readFileSync(join(REPO_ROOT, rel), 'utf-8');
+
+/**
+ * Each terminal action and the evidence it is bound to its verdict.
+ * `evidence` are substrings that MUST all be present in `file`.
+ */
+interface BindingEntry {
+  action: string;
+  verdict: string;
+  file: string;
+  evidence: string[];
+}
+
+const INVENTORY: BindingEntry[] = [
+  {
+    action: 'auto-dent run.complete outcome stamp',
+    verdict: 'review_verdict / process_verdict / lifecycle_health',
+    file: 'scripts/auto-dent-run.ts',
+    // The outcome emitted on run.complete must route through deriveRunOutcome,
+    // not a raw success ternary (#1224).
+    evidence: ['deriveRunOutcome(', 'outcome,'],
+  },
+  {
+    action: 'gh pr merge',
+    verdict: 'latest review round verdict',
+    file: 'src/hooks/enforce-merge-verdict.ts',
+    // The merge gate must read a derived verdict and be able to DENY (#1220).
+    evidence: ['deriveStoredRoundVerdict', "action: 'deny'", 'isGhPrCommand'],
+  },
+];
+
+describe('verdict→terminal-action binding inventory (#1227)', () => {
+  it.each(INVENTORY)('$action is bound to its verdict ($verdict)', ({ file, evidence }) => {
+    const src = read(file);
+    for (const needle of evidence) {
+      expect(src, `${file} must contain "${needle}" to keep its verdict binding`).toContain(needle);
+    }
+  });
+
+  it('deriveRunOutcome consumes all three run verdicts (no silent decoupling)', () => {
+    const src = read('scripts/auto-dent-outcome.ts');
+    expect(src).toContain('reviewVerdict');
+    expect(src).toContain('processVerdict');
+    expect(src).toContain('lifecycleHealth');
+    // A base success must be able to become failure — fail-closed.
+    expect(src).toMatch(/return\s+hasRedVerdict\(verdicts\)\s*\?\s*'failure'\s*:\s*'success'/);
+  });
+
+  it('the merge-verdict gate is registered in plugin.json (binding is actually wired)', () => {
+    const plugin = read('.claude-plugin/plugin.json');
+    expect(plugin).toContain('kaizen-enforce-merge-verdict-ts.sh');
+  });
+
+  it('the merge-verdict gate has its executable wrapper present', () => {
+    // A registration with no wrapper is a dead binding (kaizen-doctor territory).
+    const wrapper = read('.claude/hooks/kaizen-enforce-merge-verdict-ts.sh');
+    expect(wrapper).toContain('enforce-merge-verdict.ts');
+  });
+});

--- a/src/hooks/enforce-merge-verdict.integration.test.ts
+++ b/src/hooks/enforce-merge-verdict.integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Integration test for enforce-merge-verdict's DEFAULT verdict reader.
+ *
+ * The pure-logic tests inject a fake reader. This test drives the REAL default
+ * path (latestReviewRound → deriveStoredRoundVerdict → stored findings) with the
+ * GitHub CLI mocked, proving the gate BLOCKS a merge when the PR's actual stored
+ * findings derive FAIL — not just when a stub reader says so (#1220 / #1227).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { clearCommentCache } from '../section-editor.js';
+import { checkMergeVerdict } from './enforce-merge-verdict.js';
+
+vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }));
+const mockGh = vi.mocked(spawnSync);
+
+/** Make every `gh` comment fetch return the same comment list. */
+function commentsReturn(comments: Array<{ url: string; body: string }>): void {
+  const stdout = comments.map((c) => JSON.stringify(c)).join('\n');
+  mockGh.mockReturnValue({
+    status: 0, stdout, stderr: '', signal: null, pid: 0, output: [null, stdout, ''],
+  } as any);
+}
+
+beforeEach(() => { vi.clearAllMocks(); mockGh.mockReset(); clearCommentCache(); });
+
+const MERGE_CMD = 'gh pr merge 1212 --repo Garsson-io/kaizen --squash';
+
+describe('enforce-merge-verdict — default reader over the real storage stack', () => {
+  it('BLOCKS the merge when the latest stored round derives FAIL (2 MISSING)', () => {
+    // Mirrors the #1212 battery: a dimension with MISSING findings → derives FAIL.
+    commentsReturn([
+      {
+        url: 'https://github.com/Garsson-io/kaizen/issues/1212#issuecomment-1',
+        body: '<!-- kaizen:review/r1/improvement-lifecycle -->\n<!-- meta:{"round":1,"dimension":"improvement-lifecycle","verdict":"fail","done":0,"partial":0,"missing":2} -->',
+      },
+      {
+        url: 'https://github.com/Garsson-io/kaizen/issues/1212#issuecomment-2',
+        body: '<!-- kaizen:review/r1/summary -->\n<!-- meta:{"round":1,"verdict":"fail","round_verdict":"FAIL"} -->',
+      },
+    ]);
+
+    const r = checkMergeVerdict(MERGE_CMD, { env: {} });
+    expect(r.action).toBe('deny');
+    expect(r.message).toContain('MERGE BLOCKED');
+  });
+
+  it('allows the merge when the latest stored round is all DONE (PASS)', () => {
+    commentsReturn([
+      {
+        url: 'https://github.com/Garsson-io/kaizen/issues/1212#issuecomment-3',
+        body: '<!-- kaizen:review/r1/correctness -->\n<!-- meta:{"round":1,"dimension":"correctness","verdict":"pass","done":3,"partial":0,"missing":0} -->',
+      },
+    ]);
+
+    const r = checkMergeVerdict(MERGE_CMD, { env: {} });
+    expect(r.action).toBe('allow');
+  });
+
+  it('warns (advisory) when the PR has no stored review rounds at all', () => {
+    commentsReturn([
+      {
+        url: 'https://github.com/Garsson-io/kaizen/issues/1212#issuecomment-4',
+        body: '<!-- kaizen:plan -->\nsome plan text, no review',
+      },
+    ]);
+
+    const r = checkMergeVerdict(MERGE_CMD, { env: {} });
+    expect(r.action).toBe('warn');
+  });
+});

--- a/src/hooks/enforce-merge-verdict.test.ts
+++ b/src/hooks/enforce-merge-verdict.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for enforce-merge-verdict — the #1220/#1227 merge→verdict binding.
+ *
+ * Adversarial intent: prove the gate actually BLOCKS a merge when the latest
+ * review round derives FAIL (the exact #1212 hole), via the injected-reader
+ * end-to-end path; and prove it does NOT over-fire (PASS allows, no-data warns,
+ * explicit override allows + logs).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  decideMergeGate,
+  parseMergeTarget,
+  checkMergeVerdict,
+  MERGE_OVERRIDE_ENV,
+  type VerdictReader,
+} from './enforce-merge-verdict.js';
+
+describe('parseMergeTarget', () => {
+  it('parses bare PR number + --repo', () => {
+    expect(parseMergeTarget('gh pr merge 123 --repo Garsson-io/kaizen --squash')).toEqual({
+      pr: '123',
+      repo: 'Garsson-io/kaizen',
+    });
+  });
+
+  it('parses the URL form auto-dent emits', () => {
+    expect(
+      parseMergeTarget(
+        'gh pr merge https://github.com/Garsson-io/kaizen/pull/456 --repo Garsson-io/kaizen --squash --delete-branch --auto',
+      ),
+    ).toEqual({ pr: '456', repo: 'Garsson-io/kaizen' });
+  });
+
+  it('returns null when no repo and no URL', () => {
+    expect(parseMergeTarget('gh pr merge 123 --squash')).toBeNull();
+  });
+});
+
+describe('decideMergeGate — pure decision (#1220)', () => {
+  const target = { pr: '1212', repo: 'Garsson-io/kaizen' };
+
+  it('DENIES a merge when the verdict is FAIL (the #1212 hole)', () => {
+    const r = decideMergeGate('FAIL', { override: false, target });
+    expect(r.action).toBe('deny');
+    expect(r.message).toContain('MERGE BLOCKED');
+    expect(r.message).toContain('PR #1212');
+  });
+
+  it('allows PASS', () => {
+    expect(decideMergeGate('PASS', { override: false, target }).action).toBe('allow');
+  });
+
+  it('allows PASS_WITH_PARTIALS', () => {
+    expect(decideMergeGate('PASS_WITH_PARTIALS', { override: false, target }).action).toBe('allow');
+  });
+
+  it('warns (does not block) when there is no review data', () => {
+    expect(decideMergeGate(null, { override: false, target }).action).toBe('warn');
+  });
+
+  it('allows FAIL under explicit override but flags + logs it', () => {
+    const r = decideMergeGate('FAIL', { override: true, target });
+    expect(r.action).toBe('allow');
+    expect(r.bypassed).toBe(true);
+    expect(r.message).toContain('OVERRIDE');
+    expect(r.message).toContain(MERGE_OVERRIDE_ENV);
+  });
+});
+
+describe('checkMergeVerdict — end to end with injected reader', () => {
+  const failReader: VerdictReader = () => 'FAIL';
+  const passReader: VerdictReader = () => 'PASS';
+  const noDataReader: VerdictReader = () => null;
+  const throwReader: VerdictReader = () => {
+    throw new Error('gh offline');
+  };
+
+  it('BLOCKS a real merge command when the latest round is FAIL', () => {
+    const r = checkMergeVerdict(
+      'gh pr merge https://github.com/Garsson-io/kaizen/pull/1212 --repo Garsson-io/kaizen --squash --auto',
+      { readVerdict: failReader, env: {} },
+    );
+    expect(r.action).toBe('deny');
+    expect(r.message).toContain('MERGE BLOCKED');
+  });
+
+  it('allows a merge when the latest round is PASS', () => {
+    const r = checkMergeVerdict('gh pr merge 1212 --repo Garsson-io/kaizen --squash', {
+      readVerdict: passReader,
+      env: {},
+    });
+    expect(r.action).toBe('allow');
+  });
+
+  it('warns (not block) when the PR has no review rounds', () => {
+    const r = checkMergeVerdict('gh pr merge 999 --repo Garsson-io/kaizen', {
+      readVerdict: noDataReader,
+      env: {},
+    });
+    expect(r.action).toBe('warn');
+  });
+
+  it('honours the explicit override env on a FAIL', () => {
+    const r = checkMergeVerdict('gh pr merge 1212 --repo Garsson-io/kaizen', {
+      readVerdict: failReader,
+      env: { [MERGE_OVERRIDE_ENV]: '1' },
+    });
+    expect(r.action).toBe('allow');
+    expect(r.bypassed).toBe(true);
+  });
+
+  it('fails OPEN (warn) if the verdict read throws — a hiccup must not wedge every merge', () => {
+    const r = checkMergeVerdict('gh pr merge 1212 --repo Garsson-io/kaizen', {
+      readVerdict: throwReader,
+      env: {},
+    });
+    expect(r.action).toBe('warn');
+  });
+
+  it('ignores non-merge commands', () => {
+    expect(checkMergeVerdict('gh pr create --title x', { readVerdict: failReader }).action).toBe('allow');
+    expect(checkMergeVerdict('git push origin HEAD', { readVerdict: failReader }).action).toBe('allow');
+    expect(checkMergeVerdict('echo gh pr merge 1', { readVerdict: failReader }).action).toBe('allow');
+  });
+
+  it('is advisory when the merge target cannot be resolved', () => {
+    const r = checkMergeVerdict('gh pr merge --squash', { readVerdict: failReader });
+    expect(r.action).toBe('warn');
+  });
+});

--- a/src/hooks/enforce-merge-verdict.ts
+++ b/src/hooks/enforce-merge-verdict.ts
@@ -1,0 +1,228 @@
+/**
+ * enforce-merge-verdict.ts — PreToolUse gate: bind `gh pr merge` to the stored
+ * review verdict.
+ *
+ * @enforces I15/I18 at the irreversible step — a merge cannot land while the
+ *           latest review round derives FAIL. Canonical: docs/kaizen-invariants.md.
+ *
+ * #1220 / #1227: merge was the unguarded choke point. The only merge-aware hook
+ * (check-dirty-files) blocks `pr_merge` on DIRTY FILES only — nothing read the
+ * review verdict. So a PR whose review battery returned FAIL / whose fix loop
+ * exhausted could be merged straight to main (exactly how PR #1212 landed). The
+ * verdict was computed correctly and then NO mechanism consumed it at the
+ * point of no return — a BINDING gap, not a measurement gap.
+ *
+ * This hook closes the binding: on `gh pr merge <N|url>`, read the latest stored
+ * review round's DERIVED verdict (authoritative — from stored per-dimension
+ * findings, never caller text; an exhausted fix loop leaves the latest round
+ * still deriving FAIL) and DENY the merge when it is FAIL.
+ *
+ * Fail-CLOSED on FAIL, but false-positive-free elsewhere:
+ *   - FAIL                       → DENY (explicit, logged override only).
+ *   - PASS / PASS_WITH_PARTIALS  → allow.
+ *   - no review data (null)      → WARN only — never block a legitimate
+ *                                  non-kaizen merge that simply has no battery.
+ *
+ * Override: KAIZEN_ALLOW_MERGE_ON_FAIL=1 allows the merge but emits a loud,
+ * logged override line — the human override is explicit and recorded, never the
+ * silent default.
+ *
+ * The verdict read is injectable (readVerdict) so the decision logic is
+ * unit-testable without shelling out to `gh` — the same injectable-runner
+ * discipline #1222 asks for in the storage layer.
+ */
+
+import { readHookInput, traceNullInput } from './hook-io.js';
+import {
+  isGhPrCommand,
+  extractPrNumber,
+  extractRepoFlag,
+  extractPrUrl,
+  stripHeredocBody,
+} from './parse-command.js';
+import {
+  prTarget,
+  latestReviewRound,
+  deriveStoredRoundVerdict,
+} from '../structured-data.js';
+import type { RoundVerdict } from '../review-finding-contract.js';
+
+/** Env flag that allows a merge past a FAIL verdict (explicit + logged). */
+export const MERGE_OVERRIDE_ENV = 'KAIZEN_ALLOW_MERGE_ON_FAIL';
+
+export interface MergeTarget {
+  pr: string;
+  repo: string;
+}
+
+/**
+ * Parse the PR number + repo a `gh pr merge` command targets. Handles both the
+ * bare-number form (`gh pr merge 123 --repo R`) and the URL form
+ * (`gh pr merge https://github.com/owner/repo/pull/123` — what auto-dent emits).
+ * Returns null when neither a PR ref nor a repo can be resolved.
+ */
+export function parseMergeTarget(cmdLine: string): MergeTarget | null {
+  const url = extractPrUrl(cmdLine);
+  if (url) {
+    const m = url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+    if (m) return { repo: m[1], pr: m[2] };
+  }
+  const pr = extractPrNumber(cmdLine, 'merge');
+  const repo = extractRepoFlag(cmdLine);
+  if (pr && repo) return { pr, repo };
+  return null;
+}
+
+/** Verdict a reader returns: the derived round verdict, or null (no review data). */
+export type MergeVerdict = RoundVerdict | null;
+
+/** Reads the latest stored review verdict for a PR. Injectable for tests. */
+export type VerdictReader = (target: MergeTarget) => MergeVerdict;
+
+/**
+ * Default reader: derive the latest round verdict from stored findings on the
+ * PR (authoritative). Returns null when the PR has no review rounds at all.
+ */
+export const defaultVerdictReader: VerdictReader = (target) => {
+  const t = prTarget(target.pr, target.repo);
+  const round = latestReviewRound(t);
+  if (round === 0) return null;
+  return deriveStoredRoundVerdict(t, round);
+};
+
+export interface MergeGateResult {
+  action: 'allow' | 'warn' | 'deny';
+  message?: string;
+  bypassed?: boolean;
+}
+
+/**
+ * Pure decision: given the verdict and whether an override is set, decide
+ * whether to allow, warn, or deny the merge. No I/O — the testable core.
+ */
+export function decideMergeGate(
+  verdict: MergeVerdict,
+  opts: { override: boolean; target?: MergeTarget } = { override: false },
+): MergeGateResult {
+  const prRef = opts.target ? `PR #${opts.target.pr}` : 'this PR';
+
+  if (verdict === 'FAIL') {
+    if (opts.override) {
+      return {
+        action: 'allow',
+        bypassed: true,
+        message:
+          `[enforce-merge-verdict] OVERRIDE: ${MERGE_OVERRIDE_ENV} is set — ` +
+          `merging ${prRef} despite a FAIL review verdict. This override is logged.`,
+      };
+    }
+    return {
+      action: 'deny',
+      message: `MERGE BLOCKED — ${prRef}'s latest review round derives FAIL.
+
+A PR whose review battery FAILED (or whose fix loop exhausted, leaving MISSING
+findings) must NOT be merged to main. The verdict was computed by the review
+battery; merge is the irreversible step that must honour it (#1220 / #1227).
+
+To proceed you MUST do ONE of:
+  1. Fix the findings and re-run the review until the latest round derives PASS
+     (re-run /kaizen-review-pr — a fresh round supersedes the FAIL), OR
+  2. Explicitly override with a logged human decision:
+       ${MERGE_OVERRIDE_ENV}=1 gh pr merge ...
+     (override is recorded — do not make it the silent default).
+
+This is the exact failure class that let PR #1212 merge past a red battery.`,
+    };
+  }
+
+  if (verdict === null) {
+    return {
+      action: 'warn',
+      message:
+        `[enforce-merge-verdict] No stored review rounds found for ${prRef}; ` +
+        `merge-verdict gate is advisory here (cannot confirm a passing review).`,
+    };
+  }
+
+  // PASS / PASS_WITH_PARTIALS
+  return { action: 'allow' };
+}
+
+export interface CheckMergeVerdictOptions {
+  readVerdict?: VerdictReader;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Top-level check: detect a `gh pr merge`, resolve the target, read the verdict,
+ * and decide. Verdict read failures fail OPEN with a warning (a network/auth
+ * hiccup must not wedge every merge) — the FAIL block only fires on a verdict
+ * the reader actually returned as FAIL.
+ */
+export function checkMergeVerdict(
+  command: string,
+  options: CheckMergeVerdictOptions = {},
+): MergeGateResult {
+  const cmdLine = stripHeredocBody(command);
+  if (!isGhPrCommand(cmdLine, 'merge')) return { action: 'allow' };
+
+  const target = parseMergeTarget(cmdLine);
+  if (!target) {
+    return {
+      action: 'warn',
+      message:
+        `[enforce-merge-verdict] could not resolve PR number/repo from the merge ` +
+        `command — gate is advisory for this invocation.`,
+    };
+  }
+
+  const env = options.env ?? process.env;
+  const override = env[MERGE_OVERRIDE_ENV] === '1';
+  const read = options.readVerdict ?? defaultVerdictReader;
+
+  let verdict: MergeVerdict;
+  try {
+    verdict = read(target);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      action: 'warn',
+      message:
+        `[enforce-merge-verdict] could not read review verdict for PR #${target.pr} ` +
+        `(${msg}) — gate is advisory for this invocation.`,
+    };
+  }
+
+  return decideMergeGate(verdict, { override, target });
+}
+
+async function main(): Promise<void> {
+  const input = await readHookInput();
+  if (!input) { traceNullInput('enforce-merge-verdict'); process.exit(0); }
+
+  const command = input.tool_input?.command ?? '';
+  const result = checkMergeVerdict(command);
+
+  if (result.action === 'deny') {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: result.message,
+        },
+      }),
+    );
+  } else if (result.message) {
+    // warn / logged override — surface on stderr, do not block.
+    process.stderr.write(`\n${result.message}\n`);
+  }
+  process.exit(0);
+}
+
+if (
+  process.argv[1]?.endsWith('enforce-merge-verdict.ts') ||
+  process.argv[1]?.endsWith('enforce-merge-verdict.js')
+) {
+  main().catch(() => process.exit(0));
+}


### PR DESCRIPTION
## Rescue Context

This is a draft rescue PR for auto-dent batch `double-barracuda/run-1`.

The run was terminated by the watchdog after 1205 seconds (`exit 143`, SIGTERM) before auto-dent created a PR. This PR preserves the branch for later review; it is not being presented as ready-to-merge work.

## Preserved Work

- Worktree: `/home/aviad/projects/kaizen/.claude/worktrees/2606271935-05e3`
- Branch: `case/260627-k1220-verdict-binding-gates`
- Commits preserved:
  - `922aee5` `fix(auto-dent): derive run outcome from quality verdicts (#1224)`
  - `45987f6` `feat(hooks): gate gh pr merge on the stored review verdict (#1220)`
  - `2299524` `test(verdict-binding): inventory lint for terminal-action bindings (#1227)`

## Rescue Notes

Quality gates were intentionally skipped for the rescue operation. The original run log showed targeted test evidence before timeout, but this draft PR needs a fresh human/agent pass before it is considered mergeable.

Refs #1220
Refs #1224
Refs #1227
Refs #1228
