### PR TITLE
[rescue] double-barracuda run 2 CI proof redo

### DIFF
--- a/.agents/skills/kaizen-review-pr/SKILL.md
+++ b/.agents/skills/kaizen-review-pr/SKILL.md
@@ -229,10 +229,20 @@ npx tsx src/cli-structured-data.ts store-review-summary \
   --pr <PR_NUMBER> --repo <owner/repo> --round <N> --head-sha "$(git rev-parse HEAD)"
 ```
 
-For a derived PASS or PASS-with-partials verdict, `store-review-summary` now verifies the PR's
-current HEAD matches `--head-sha` and that `gh pr checks` is green for that HEAD before it writes
-the summary/sentinel (#1070). Pending, failing, absent, or stale-head CI refuses storage; re-run
-review on the current head after CI passes.
+For a derived PASS or PASS-with-partials verdict, `store-review-summary` proves CI at the CLI
+boundary before it writes the summary/sentinel (#1070, redone per #1225): it checks the PR's
+current HEAD matches `--head-sha` and **waits for `gh pr checks` to reach a terminal state**
+(polling, so a still-running CI is a wait, not a failure — #1221), then refuses storage if CI
+ends failing or the head is stale. Pending, failing, absent, or stale-head CI refuses storage.
+
+The exit code distinguishes the reason so you don't burn a review round on a slow CI:
+- **exit 3 (`ci_pending`)** — CI had not gone green before the wait budget elapsed. This is **not**
+  a review FAIL: wait for CI to finish, then re-store the same summary. Do not count it as an
+  exhausted fix round.
+- **exit 1** — a real refusal (CI red, stale head, or a fabricated-pass note over failing findings).
+
+Tune the wait with `--ci-timeout-ms` / `--ci-poll-ms`; use `--no-ci-proof` only for local/non-CI
+storage (it makes the call a pure local write with no CI gate).
 
 Add `--note "<context>"` only for non-verdict commentary (e.g. "rebased onto main, re-ran tests").
 Read back the derived verdict with `read-review-summary --pr <N> --repo <repo> --round <N>` — the

--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -7,6 +7,7 @@ import {
   storeMetadata,
   storeReviewFinding,
   storeReviewSummary,
+  ReviewCiProofError,
 } from './structured-data.js';
 
 vi.mock('node:fs', () => ({
@@ -44,6 +45,14 @@ vi.mock('./structured-data.js', () => ({
   updatePrSection: vi.fn(),
   storeIterationState: vi.fn().mockReturnValue('https://example.com/iteration'),
   retrieveIterationState: vi.fn().mockReturnValue({ round: 1 }),
+  // The CLI imports the error class to branch ci_pending vs fail; mock it as a real class.
+  ReviewCiProofError: class ReviewCiProofError extends Error {
+    constructor(public result: { status: string; detail?: string }) {
+      super(`ci ${result.status}`);
+      this.name = 'ReviewCiProofError';
+    }
+    get isPending() { return this.result.status === 'pending' || this.result.status === 'no_checks'; }
+  },
 }));
 
 beforeEach(() => vi.clearAllMocks());
@@ -252,7 +261,7 @@ describe('store-review-batch — review sentinel', () => {
 });
 
 describe('store-review-summary — CI head proof', () => {
-  it('passes --head-sha through to summary storage before writing the sentinel (#1070)', async () => {
+  it('passes --head-sha and attaches the real CI verifier at the boundary (#1070/#1222)', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     await handlers['store-review-summary']({
@@ -263,11 +272,13 @@ describe('store-review-summary — CI head proof', () => {
       ['head-sha']: 'abc123',
     } as CliArgs);
 
+    // The CLI is the enforcement boundary: it injects the gh-backed verifier (a function) so the
+    // pure storage layer can perform the CI proof without baking in network side-effects (#1222).
     expect(vi.mocked(storeReviewSummary)).toHaveBeenCalledWith(
       { kind: 'pr', number: 903, repo: 'Garsson-io/kaizen' },
       5,
       undefined,
-      { expectedHeadSha: 'abc123' },
+      { expectedHeadSha: 'abc123', ciVerifier: expect.any(Function) },
     );
     const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r5'),
@@ -284,6 +295,65 @@ describe('store-review-summary — CI head proof', () => {
     expect(payload.findingCount).toBeGreaterThanOrEqual(0);
     expect(payload.integrity).toMatch(/^sha256:/);
     log.mockRestore();
+  });
+
+  it('--no-ci-proof keeps storage pure (no verifier injected) for non-CI/local use', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await handlers['store-review-summary']({
+      command: 'store-review-summary',
+      pr: '903',
+      repo: 'Garsson-io/kaizen',
+      round: '5',
+      ['no-ci-proof']: 'true',
+    } as CliArgs);
+    expect(vi.mocked(storeReviewSummary)).toHaveBeenCalledWith(
+      { kind: 'pr', number: 903, repo: 'Garsson-io/kaizen' },
+      5,
+      undefined,
+      { expectedHeadSha: undefined },
+    );
+    log.mockRestore();
+  });
+
+  it('ci_pending exits 3 (branchable, NOT a fix-round) and writes no sentinel (#1221)', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exit = vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    vi.mocked(storeReviewSummary).mockImplementationOnce(() => {
+      throw new ReviewCiProofError({ status: 'pending', detail: 'TS tests' });
+    });
+    await expect(handlers['store-review-summary']({
+      command: 'store-review-summary',
+      pr: '903',
+      repo: 'Garsson-io/kaizen',
+      round: '5',
+    } as CliArgs)).rejects.toThrow('process.exit(3)');
+    // Gate stays uncleared: no review sentinel written on a pending block.
+    const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
+      ([path]) => typeof path === 'string' && path.includes('.reviewed-r'),
+    );
+    expect(sentinelCall).toBeUndefined();
+    err.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('a real CI fail exits 1 (distinct from ci_pending)', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exit = vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    vi.mocked(storeReviewSummary).mockImplementationOnce(() => {
+      throw new ReviewCiProofError({ status: 'fail', detail: 'red' });
+    });
+    await expect(handlers['store-review-summary']({
+      command: 'store-review-summary',
+      pr: '903',
+      repo: 'Garsson-io/kaizen',
+      round: '5',
+    } as CliArgs)).rejects.toThrow('process.exit(1)');
+    err.mockRestore();
+    exit.mockRestore();
   });
 });
 

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -58,9 +58,11 @@ import {
   updatePrSection,
   storeIterationState,
   retrieveIterationState,
+  ReviewCiProofError,
   type ReviewFindingData,
   type StoreReviewSummaryOptions,
 } from './structured-data.js';
+import { makeGhCiVerifier } from './review-ci-proof.js';
 import {
   buildReviewSentinelRecord,
   serializeReviewSentinel,
@@ -74,7 +76,7 @@ type Handler = (a: CliArgs) => Promise<void>;
  * Flags that are booleans — no value follows, presence means true.
  * Keeps `--stdin` usable without the trap of consuming the next arg.
  */
-const BOOLEAN_FLAGS = new Set(['stdin']);
+const BOOLEAN_FLAGS = new Set(['stdin', 'no-ci-proof']);
 
 export function parseArgs(argv?: string[]): CliArgs {
   const args = argv ?? process.argv.slice(2);
@@ -177,10 +179,46 @@ function writeReviewSentinel(repo: string, pr: string | undefined, round: number
   }
 }
 
+/**
+ * The CLI is the enforcement boundary for the #1070 CI proof (#1222): the storage layer stays
+ * pure, and the real `gh`/`git`-backed verifier is injected here. `--no-ci-proof` opts out (for
+ * non-CI/local contexts or tests); `--ci-timeout-ms` / `--ci-poll-ms` tune the wait-for-CI loop.
+ */
 function reviewSummaryOptions(a: CliArgs): StoreReviewSummaryOptions {
+  if (a['no-ci-proof']) {
+    return { expectedHeadSha: a['head-sha'] };
+  }
   return {
     expectedHeadSha: a['head-sha'],
+    ciVerifier: makeGhCiVerifier({
+      timeoutMs: a['ci-timeout-ms'] !== undefined ? Number(a['ci-timeout-ms']) : undefined,
+      pollIntervalMs: a['ci-poll-ms'] !== undefined ? Number(a['ci-poll-ms']) : undefined,
+    }),
   };
+}
+
+/**
+ * Translate a storage error into an exit. A `ReviewCiProofError` whose CI is merely not-yet-green
+ * (`ci_pending`) exits with code 3 and an explicit "this is not a review failure, wait for CI"
+ * message, so the review-fix loop can distinguish it from a real FAIL and NOT burn a fix round
+ * (#1221). A red/stale CI exits 1. Either way the review sentinel is never written (the gate stays
+ * uncleared) because this throws before the sentinel write.
+ */
+function exitOnReviewStoreError(err: unknown): never {
+  if (err instanceof ReviewCiProofError) {
+    console.error(err.message);
+    if (err.isPending) {
+      console.error(
+        'store-review: CI is not green yet (ci_pending) — this is NOT a review failure. Wait for ' +
+        'CI to reach a terminal state, then re-store the summary. Do not count this as an ' +
+        'exhausted fix round.',
+      );
+      process.exit(3);
+    }
+    process.exit(1);
+  }
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
 }
 
 // Review handlers
@@ -254,7 +292,12 @@ async function handleStoreReviewBatch(a: CliArgs): Promise<void> {
     }
   }
   const findings = parsedBatch as ReviewFindingData[];
-  const result = storeReviewBatch(pr, r, findings, reviewSummaryOptions(a));
+  let result: { urls: string[]; summaryUrl: string };
+  try {
+    result = storeReviewBatch(pr, r, findings, reviewSummaryOptions(a));
+  } catch (err) {
+    exitOnReviewStoreError(err);
+  }
   // #966: Write review sentinel so pr-review-loop.ts gate guard passes.
   // Mirrors handleStoreReviewSummary — batch includes summary, so sentinel must be written here too.
   writeReviewSentinel(a.repo, a.pr, r);
@@ -279,8 +322,7 @@ async function handleStoreReviewSummary(a: CliArgs): Promise<void> {
   try {
     url = storeReviewSummary(prTarget(a.pr, a.repo), r, note, reviewSummaryOptions(a));
   } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
+    exitOnReviewStoreError(err);
   }
   // #920: Write review sentinel so pr-review-loop.ts can verify outcome
   writeReviewSentinel(a.repo, a.pr, r);

--- a/src/review-ci-proof.test.ts
+++ b/src/review-ci-proof.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeGhCiVerifier, evaluateChecks, type CommandRunner, type CommandResult, type GhCheck } from './review-ci-proof.js';
+import { prTarget, issueTarget } from './structured-data.js';
+
+const pr = prTarget('903', 'Garsson-io/kaizen');
+const HEAD = 'abc123def';
+
+/**
+ * Build a scripted runner. `git rev-parse HEAD` and `gh pr view` return fixed heads; each call to
+ * `gh pr checks` consumes the next entry from `checksScript` (so we can model pending-then-pass).
+ */
+function makeRunner(opts: {
+  reviewedHead?: string;
+  prHead?: string;
+  checksScript: Array<GhCheck[] | string>;
+}): { runner: CommandRunner; checksCalls: () => number } {
+  let checksIdx = 0;
+  const runner: CommandRunner = (command, args) => {
+    const ok = (stdout: string): CommandResult => ({ status: 0, stdout, stderr: '' });
+    if (command === 'git' && args[0] === 'rev-parse') return ok(opts.reviewedHead ?? HEAD);
+    if (command === 'gh' && args[0] === 'pr' && args[1] === 'view') return ok(opts.prHead ?? HEAD);
+    if (command === 'gh' && args[0] === 'pr' && args[1] === 'checks') {
+      const entry = opts.checksScript[Math.min(checksIdx, opts.checksScript.length - 1)];
+      checksIdx++;
+      return ok(typeof entry === 'string' ? entry : JSON.stringify(entry));
+    }
+    return { status: 1, stdout: '', stderr: `unexpected ${command} ${args.join(' ')}` };
+  };
+  return { runner, checksCalls: () => checksIdx };
+}
+
+const PASS: GhCheck[] = [
+  { name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' },
+  { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
+];
+const PENDING: GhCheck[] = [{ name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' }];
+const FAILING: GhCheck[] = [{ name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' }];
+
+describe('evaluateChecks — terminal/waiting classification', () => {
+  it('all pass/skipping → pass', () => {
+    expect(evaluateChecks(PASS).status).toBe('pass');
+  });
+  it('zero checks → no_checks (waited, not failed)', () => {
+    expect(evaluateChecks([]).status).toBe('no_checks');
+  });
+  it('any pending → pending', () => {
+    expect(evaluateChecks(PENDING).status).toBe('pending');
+  });
+  it('any fail → fail', () => {
+    expect(evaluateChecks(FAILING).status).toBe('fail');
+  });
+  it('fail wins over a sibling pending (a failed required check will not recover)', () => {
+    expect(evaluateChecks([...FAILING, ...PENDING]).status).toBe('fail');
+  });
+  it('unknown bucket fails closed', () => {
+    expect(evaluateChecks([{ name: 'mystery', bucket: 'weird' }]).status).toBe('fail');
+  });
+  it('undefined bucket is treated as pending (not yet registered)', () => {
+    expect(evaluateChecks([{ name: 'just-queued' }]).status).toBe('pending');
+  });
+});
+
+describe('makeGhCiVerifier — wait-for-CI + structured reasons (#1221/#1222)', () => {
+  const noSleep = vi.fn();
+
+  it('returns pass when head matches and all checks are green', () => {
+    const { runner } = makeRunner({ checksScript: [PASS] });
+    const verify = makeGhCiVerifier({ runner, sleep: noSleep });
+    expect(verify(pr, HEAD)).toEqual({ status: 'pass' });
+  });
+
+  it('WAIT-FOR-CI: pending-then-pass returns pass after polling (#1221)', () => {
+    const { runner, checksCalls } = makeRunner({ checksScript: [PENDING, PENDING, PASS] });
+    const verify = makeGhCiVerifier({ runner, sleep: noSleep, pollIntervalMs: 10, timeoutMs: 10_000 });
+    expect(verify(pr, HEAD).status).toBe('pass');
+    expect(checksCalls()).toBe(3); // it actually polled, not point-in-time
+    expect(noSleep).toHaveBeenCalled();
+  });
+
+  it('BLOCKS: returns pending (not pass) when CI never finishes before timeout', () => {
+    const { runner } = makeRunner({ checksScript: [PENDING] });
+    const verify = makeGhCiVerifier({ runner, sleep: noSleep, pollIntervalMs: 10, timeoutMs: 30 });
+    const result = verify(pr, HEAD);
+    expect(result.status).toBe('pending'); // distinct from fail — caller waits, not exhausts
+  });
+
+  it('BLOCKS: returns fail on a red check even with pending siblings', () => {
+    const { runner } = makeRunner({ checksScript: [[...FAILING, ...PENDING]] });
+    const verify = makeGhCiVerifier({ runner, sleep: noSleep });
+    expect(verify(pr, HEAD).status).toBe('fail');
+  });
+
+  it('returns no_checks (distinct from fail) when CI never registers checks (#1221)', () => {
+    const { runner } = makeRunner({ checksScript: ['[]'] });
+    const verify = makeGhCiVerifier({ runner, sleep: noSleep, pollIntervalMs: 10, timeoutMs: 30 });
+    expect(verify(pr, HEAD).status).toBe('no_checks');
+  });
+
+  it('returns stale_head when PR head moved past the reviewed commit (no checks read)', () => {
+    const { runner, checksCalls } = makeRunner({ reviewedHead: HEAD, prHead: 'zzz999', checksScript: [PASS] });
+    const verify = makeGhCiVerifier({ runner, sleep: noSleep });
+    expect(verify(pr, HEAD).status).toBe('stale_head');
+    expect(checksCalls()).toBe(0);
+  });
+
+  it('SKIP-NOT-THROW: non-PR target returns skipped without touching the runner (#1222.1)', () => {
+    const runner = vi.fn<CommandRunner>(() => ({ status: 0, stdout: '', stderr: '' }));
+    const verify = makeGhCiVerifier({ runner, sleep: noSleep });
+    expect(verify(issueTarget('904', 'Garsson-io/kaizen'), HEAD)).toEqual({
+      status: 'skipped',
+      detail: 'non-PR target — CI proof does not apply',
+    });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('resolves the reviewed head from git when no expectedHeadSha is given', () => {
+    const { runner } = makeRunner({ reviewedHead: 'gitHEAD', prHead: 'gitHEAD', checksScript: [PASS] });
+    const verify = makeGhCiVerifier({ runner, sleep: noSleep });
+    expect(verify(pr).status).toBe('pass'); // git rev-parse HEAD == gitHEAD == prHead
+  });
+});

--- a/src/review-ci-proof.ts
+++ b/src/review-ci-proof.ts
@@ -1,0 +1,198 @@
+/**
+ * CI/head proof for review summaries (#1070, redone correctly per #1221/#1222/#1225).
+ *
+ * Intent (#1070): a review round must NOT be stored as PASS while CI for the reviewed
+ * commit is pending, red, stale, or absent — otherwise "review passed" is self-reported.
+ *
+ * Why this lives OUTSIDE the storage layer (#1222): `storeReviewSummary` is a deterministic
+ * local-storage primitive. Baking `gh`/`git` `spawnSync` into it made every PASS store shell
+ * out to the live GitHub CLI (slow, flaky, auth-dependent, untestable) and throw on non-PR
+ * targets. The proof belongs at the CLI/caller boundary, behind an INJECTABLE runner, so the
+ * storage layer stays pure and unit-testable. `structured-data.ts` only knows the `CiVerifier`
+ * type; the concrete `gh` implementation is here.
+ *
+ * Why this WAITS for CI (#1221): the original gate was a synchronous point-in-time check with
+ * no waiting, so a genuine PASS while CI was still `pending` THREW and false-exhausted the
+ * review-fix loop. This verifier POLLS `gh pr checks` until terminal (or a timeout) and reports
+ * `pending`/`no_checks` distinctly from a real `fail`, so callers can wait instead of burning a
+ * fix round.
+ */
+
+import { spawnSync } from 'node:child_process';
+import type { AttachmentTarget } from './section-editor.js';
+import type { CiProofResult, CiVerifier } from './structured-data.js';
+
+/** Result of running a subprocess — injectable so tests never shell out. */
+export type CommandResult = { status: number | null; stdout: string; stderr: string };
+export type CommandRunner = (command: string, args: string[]) => CommandResult;
+
+/** The only real subprocess site. Everything else takes a runner. */
+export const defaultRunner: CommandRunner = (command, args) => {
+  const r = spawnSync(command, args, { encoding: 'utf8' });
+  if (r.error) {
+    return { status: 1, stdout: '', stderr: r.error.message };
+  }
+  return { status: r.status ?? 0, stdout: (r.stdout ?? '').toString(), stderr: (r.stderr ?? '').toString() };
+};
+
+/** A single `gh pr checks --json` row. */
+export type GhCheck = {
+  name?: string;
+  bucket?: string;
+  state?: string;
+  workflow?: string;
+  link?: string;
+};
+
+export type GhCiVerifierOptions = {
+  /** Injectable command runner (default: real `spawnSync`). */
+  runner?: CommandRunner;
+  /** Poll interval while CI is pending. Default 10s. */
+  pollIntervalMs?: number;
+  /** Max time to wait for CI to leave the pending state. Default 5min. */
+  timeoutMs?: number;
+  /** Injectable sleep (default: blocking sleep). Tests pass a no-op. */
+  sleep?: (ms: number) => void;
+};
+
+/**
+ * Blocking sleep — keeps the verifier synchronous to match the storage call site. Uses
+ * `Atomics.wait` on a throwaway buffer so it parks the thread cleanly (no busy-wait, no
+ * subprocess) for the poll interval. Tests inject a no-op sleep instead.
+ */
+function blockingSleep(ms: number): void {
+  if (ms <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function readReviewedHead(runner: CommandRunner, expectedHeadSha: string | undefined): string {
+  const explicit = expectedHeadSha?.trim();
+  if (explicit) return explicit;
+  const r = runner('git', ['rev-parse', 'HEAD']);
+  const out = r.stdout.trim();
+  if (!out) {
+    throw new Error(
+      'review-ci-proof: unable to determine reviewed HEAD; pass --head-sha explicitly',
+    );
+  }
+  return out;
+}
+
+function readPrHead(runner: CommandRunner, target: AttachmentTarget): string {
+  const r = runner('gh', [
+    'pr', 'view', String(target.number), '--repo', target.repo,
+    '--json', 'headRefOid', '--jq', '.headRefOid',
+  ]);
+  const out = r.stdout.trim();
+  if (!out) {
+    throw new Error(`review-ci-proof: unable to read current head of PR #${target.number}`);
+  }
+  return out;
+}
+
+function readPrChecks(runner: CommandRunner, target: AttachmentTarget): GhCheck[] {
+  const r = runner('gh', [
+    'pr', 'checks', String(target.number), '--repo', target.repo,
+    '--json', 'name,bucket,state,workflow,link',
+  ]);
+  const out = r.stdout.trim();
+  // `gh pr checks` exits non-zero when checks are failing OR when none exist yet; both are
+  // meaningful states we handle from the JSON, so only treat an empty body as "no checks".
+  if (!out) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(out);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`review-ci-proof: unable to parse PR checks JSON (${msg})`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('review-ci-proof: PR checks JSON was not an array');
+  }
+  return parsed as GhCheck[];
+}
+
+function formatCheck(check: GhCheck): string {
+  const workflow = check.workflow ? `${check.workflow} / ` : '';
+  const name = check.name ?? '(unnamed check)';
+  const bucket = check.bucket ?? 'unknown';
+  const state = check.state ? ` (${check.state})` : '';
+  return `${workflow}${name}: ${bucket}${state}`;
+}
+
+const PASS_BUCKETS = new Set(['pass', 'skipping']);
+const PENDING_BUCKETS = new Set(['pending']);
+
+/**
+ * Classify a snapshot of checks into one terminal-or-waiting verdict.
+ *
+ * Precedence: a hard `fail`/`cancel` (or any unknown bucket — fail-closed) wins even if siblings
+ * are still pending, because a failed required check will not recover. Otherwise any pending (or
+ * an as-yet-unregistered/undefined bucket) keeps us waiting. Zero checks => `no_checks` (also
+ * waited on, since CI often registers a few seconds after a push). All pass/skipping => `pass`.
+ */
+export function evaluateChecks(checks: GhCheck[]): CiProofResult {
+  if (checks.length === 0) {
+    return { status: 'no_checks', detail: 'no CI checks registered yet' };
+  }
+  const failing = checks.filter(c => {
+    const bucket = c.bucket;
+    // pending / undefined buckets are "not done yet", not failures.
+    if (bucket === undefined || PENDING_BUCKETS.has(bucket)) return false;
+    return !PASS_BUCKETS.has(bucket);
+  });
+  if (failing.length > 0) {
+    return { status: 'fail', detail: failing.map(formatCheck).join('; ') };
+  }
+  const pending = checks.filter(c => c.bucket === undefined || PENDING_BUCKETS.has(c.bucket));
+  if (pending.length > 0) {
+    return { status: 'pending', detail: pending.map(formatCheck).join('; ') };
+  }
+  return { status: 'pass' };
+}
+
+/**
+ * Build a CI verifier backed by `gh`/`git` (injectable for tests).
+ *
+ * Returns a synchronous `CiVerifier` that:
+ *  - skips (never throws) on non-PR targets — review summaries on issues are legitimate (#1222.1);
+ *  - reports `stale_head` when the PR head no longer matches the reviewed commit;
+ *  - POLLS checks until terminal or timeout, reporting `pending`/`no_checks` distinctly from
+ *    `fail` so a not-yet-green CI is a wait, not a failure (#1221).
+ */
+export function makeGhCiVerifier(opts: GhCiVerifierOptions = {}): CiVerifier {
+  const runner = opts.runner ?? defaultRunner;
+  const pollIntervalMs = opts.pollIntervalMs ?? 10_000;
+  const timeoutMs = opts.timeoutMs ?? 5 * 60_000;
+  const sleep = opts.sleep ?? blockingSleep;
+
+  return (target, expectedHeadSha) => {
+    if (target.kind !== 'pr') {
+      return { status: 'skipped', detail: 'non-PR target — CI proof does not apply' };
+    }
+
+    const reviewedHead = readReviewedHead(runner, expectedHeadSha);
+    const currentHead = readPrHead(runner, target);
+    if (currentHead !== reviewedHead) {
+      return {
+        status: 'stale_head',
+        detail: `reviewed ${reviewedHead}, PR #${target.number} is now ${currentHead}`,
+      };
+    }
+
+    let waited = 0;
+    // Poll until checks reach a terminal verdict (pass/fail) or we exhaust the wait budget.
+    // `pending` and `no_checks` are retryable states that keep us in the loop.
+    for (;;) {
+      const verdict = evaluateChecks(readPrChecks(runner, target));
+      if (verdict.status === 'pass' || verdict.status === 'fail') {
+        return verdict;
+      }
+      if (waited >= timeoutMs) {
+        return verdict; // 'pending' or 'no_checks' — terminal *for this call*, distinct from fail
+      }
+      sleep(pollIntervalMs);
+      waited += pollIntervalMs;
+    }
+  };
+}

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -25,8 +25,11 @@ import {
   retrieveIterationState,
   updatePrSection,
   normalizeReviewFindingData,
+  ReviewCiProofError,
   type ReviewFindingData,
+  type CiVerifier,
 } from './structured-data.js';
+import { makeGhCiVerifier, type CommandRunner } from './review-ci-proof.js';
 
 vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(),
@@ -180,8 +183,12 @@ describe('storeReviewBatch — multiple findings + auto-summary', () => {
     // listAttachments fetches comments
     const stored1 = JSON.stringify({ url: 'https://...#issuecomment-10', body: `<!-- kaizen:review/r5/correctness -->\n<!-- meta:{"round":5,"dimension":"correctness","verdict":"pass","done":2,"partial":0,"missing":0} -->` });
     const stored2 = JSON.stringify({ url: 'https://...#issuecomment-11', body: `<!-- kaizen:review/r5/test-quality -->\n<!-- meta:{"round":5,"dimension":"test-quality","verdict":"pass","done":1,"partial":0,"missing":1} -->` });
-    ghReturns(`${stored1}\n${stored2}`); // listAttachments for review/r5/
-    // readReviewFinding for each dim
+    ghReturns(`${stored1}\n${stored2}`); // composeReviewSummary: listAttachments for review/r5/
+    // composeReviewSummary: readReviewFinding for each dim
+    ghReturns(stored1);
+    ghReturns(stored2);
+    // deriveStoredRoundVerdict re-reads the same findings (I29: structural derivation, no regex)
+    ghReturns(`${stored1}\n${stored2}`); // derive: listAttachments
     ghReturns(stored1);
     ghReturns(stored2);
     // writeAttachment for summary: readAttachment (no existing) + createComment
@@ -292,6 +299,8 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     const sec = dimComment(5, 'security', 'fail', 1, 0, 2);
     ghReturns(sec); // compose: list
     ghReturns(sec); // compose: read
+    ghReturns(sec); // derive: list
+    ghReturns(sec); // derive: read
     ghReturns(''); // writeAttachment: readAttachment (no existing summary) → create
     ghReturns('https://...#issuecomment-sum');
 
@@ -305,87 +314,130 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     const ok = dimComment(2, 'correctness', 'pass', 3, 0, 0); // all DONE → PASS
     ghReturns(ok); // compose: list
     ghReturns(ok); // compose: read
-    ghReturns('abc123'); // gh pr view: current PR head
-    ghReturns(JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' }])); // gh pr checks
+    ghReturns(ok); // derive: list
+    ghReturns(ok); // derive: read
     ghReturns(''); // writeAttachment: readAttachment (no existing)
     ghReturns('https://...#issuecomment-sum');
 
-    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes', { expectedHeadSha: 'abc123' });
+    // No verifier supplied → pure storage, no CI work (the #1222 fix).
+    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes');
     const body = bodyOfLastCreate();
     expect(body).toContain('## Review Round 2 — PASS');
     expect(body).toContain('### Reviewer notes (non-authoritative');
     expect(body).toContain('rebased onto main');
   });
 
-  describe('CI proof gate (#1070)', () => {
-    const head = 'abc123';
-    const passChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' },
-      { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
-    ]);
-    const pendingChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' },
-    ]);
-    const failChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' },
-    ]);
+  // #1070 redone per #1221/#1222/#1225: the gate is now an INJECTABLE verifier. Storage is pure
+  // by default (no verifier => no network); the CLI boundary supplies the real one. These tests
+  // prove storage HONORS a non-pass verdict (gate BLOCKS) and is otherwise side-effect-free.
+  describe('CI proof binding (#1070, injectable per #1222)', () => {
+    // Each non-throwing store needs: compose(list,read) + derive(list,read) + write(read,create).
+    const composeAndDerive = (c: string) => { ghReturns(c); ghReturns(c); ghReturns(c); ghReturns(c); };
+    const writeStubs = () => { ghReturns(''); ghReturns('https://...#issuecomment-sum'); };
 
-    it('stores a derived PASS only when current-head CI is passing', () => {
-      const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view: current PR head
-      ghReturns(passChecks); // gh pr checks
-      ghReturns(''); // writeAttachment: readAttachment (no existing)
-      ghReturns('https://...#issuecomment-sum');
-
-      storeReviewSummary(pr, 4, undefined, { expectedHeadSha: head });
-
-      const body = bodyOfLastCreate();
-      expect(body).toContain('## Review Round 4 — PASS');
+    it('stores a derived PASS when the injected verifier returns pass', () => {
+      composeAndDerive(dimComment(4, 'correctness', 'pass', 2, 0, 0));
+      writeStubs();
+      const verifier: CiVerifier = () => ({ status: 'pass' });
+      storeReviewSummary(pr, 4, undefined, { expectedHeadSha: 'abc123', ciVerifier: verifier });
+      expect(bodyOfLastCreate()).toContain('## Review Round 4 — PASS');
     });
 
-    it('refuses to store a derived PASS while CI is pending', () => {
-      const ok = dimComment(6, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(pendingChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 6, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*pending|pending.*CI|#1070/i);
+    it('BLOCKS: refuses a derived PASS while CI is pending, and the error is branchable (isPending)', () => {
+      composeAndDerive(dimComment(6, 'correctness', 'pass', 2, 0, 0));
+      let caught: unknown;
+      try {
+        storeReviewSummary(pr, 6, undefined, { ciVerifier: () => ({ status: 'pending', detail: 'TS tests' }) });
+      } catch (e) { caught = e; }
+      expect(caught).toBeInstanceOf(ReviewCiProofError);
+      expect((caught as ReviewCiProofError).result.status).toBe('pending');
+      expect((caught as ReviewCiProofError).isPending).toBe(true);
     });
 
-    it('refuses to store a derived PASS when CI is failing', () => {
-      const ok = dimComment(7, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(failChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 7, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*fail|fail.*CI|#1070/i);
+    it('BLOCKS: refuses a derived PASS when CI is failing', () => {
+      composeAndDerive(dimComment(7, 'correctness', 'pass', 2, 0, 0));
+      expect(() => storeReviewSummary(pr, 7, undefined, { ciVerifier: () => ({ status: 'fail', detail: 'x' }) }))
+        .toThrow(ReviewCiProofError);
     });
 
-    it('refuses to store a derived PASS before CI has produced checks', () => {
-      const ok = dimComment(9, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns('[]'); // gh pr checks: CI has not started
-
-      expect(() => storeReviewSummary(pr, 9, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*not produced checks|#1070/i);
+    it('BLOCKS: refuses a derived PASS when the reviewed head is stale', () => {
+      composeAndDerive(dimComment(8, 'correctness', 'pass', 2, 0, 0));
+      expect(() => storeReviewSummary(pr, 8, undefined, { ciVerifier: () => ({ status: 'stale_head' }) }))
+        .toThrow(ReviewCiProofError);
     });
 
-    it('refuses to store a derived PASS when the reviewed head is stale', () => {
-      const ok = dimComment(8, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns('def456'); // gh pr view: current PR head differs from reviewed head
+    it('BLOCKS: refuses a derived PASS before CI has produced checks (no_checks)', () => {
+      composeAndDerive(dimComment(9, 'correctness', 'pass', 2, 0, 0));
+      let caught: unknown;
+      try {
+        storeReviewSummary(pr, 9, undefined, { ciVerifier: () => ({ status: 'no_checks' }) });
+      } catch (e) { caught = e; }
+      expect(caught).toBeInstanceOf(ReviewCiProofError);
+      expect((caught as ReviewCiProofError).isPending).toBe(true); // wait, don't burn a fix round
+    });
 
-      expect(() => storeReviewSummary(pr, 8, undefined, { expectedHeadSha: head }))
-        .toThrow(/stale|HEAD|#1070/i);
+    it('is PURE without a verifier — stores a derived PASS doing zero CI work (#1222)', () => {
+      composeAndDerive(dimComment(10, 'correctness', 'pass', 2, 0, 0));
+      writeStubs();
+      storeReviewSummary(pr, 10); // no ciVerifier
+      expect(bodyOfLastCreate()).toContain('## Review Round 10 — PASS');
+    });
+
+    it('SKIP-NOT-THROW: a verifier returning skipped allows the store', () => {
+      composeAndDerive(dimComment(12, 'correctness', 'pass', 2, 0, 0));
+      writeStubs();
+      storeReviewSummary(pr, 12, undefined, { ciVerifier: () => ({ status: 'skipped' }) });
+      expect(bodyOfLastCreate()).toContain('## Review Round 12 — PASS');
+    });
+
+    it('FAIL verdict never invokes the verifier — failed evidence stays recordable', () => {
+      composeAndDerive(dimComment(11, 'security', 'fail', 1, 0, 2));
+      writeStubs();
+      const verifier = vi.fn((): { status: 'pending' } => ({ status: 'pending' }));
+      storeReviewSummary(pr, 11, undefined, { ciVerifier: verifier });
+      expect(verifier).not.toHaveBeenCalled();
+      expect(bodyOfLastCreate()).toContain('## Review Round 11 — FAIL');
+    });
+
+    it('non-PR target: verifier is NOT invoked and the summary stores on an issue (#1222.1)', () => {
+      composeAndDerive(dimComment(3, 'correctness', 'pass', 2, 0, 0));
+      writeStubs();
+      const verifier = vi.fn((): { status: 'pass' } => ({ status: 'pass' }));
+      storeReviewSummary(issue, 3, undefined, { ciVerifier: verifier });
+      expect(verifier).not.toHaveBeenCalled();
+    });
+
+    // INTEGRATION: storage + the REAL makeGhCiVerifier wired together over an injected gh runner.
+    // Proves the end-to-end gate (#1212 shipped no such test) without any network.
+    describe('wired with the real gh verifier (injected runner)', () => {
+      const greenRunner = (): CommandRunner => (command, args) => {
+        const ok = (stdout: string) => ({ status: 0, stdout, stderr: '' });
+        if (command === 'git') return ok('wiredHEAD');
+        if (args[1] === 'view') return ok('wiredHEAD');
+        return ok(JSON.stringify([{ name: 'tests', bucket: 'pass' }]));
+      };
+      const pendingRunner = (): CommandRunner => (command, args) => {
+        const ok = (stdout: string) => ({ status: 0, stdout, stderr: '' });
+        if (command === 'git') return ok('wiredHEAD');
+        if (args[1] === 'view') return ok('wiredHEAD');
+        return ok(JSON.stringify([{ name: 'tests', bucket: 'pending' }]));
+      };
+
+      it('green CI through the real verifier stores the PASS summary', () => {
+        composeAndDerive(dimComment(14, 'correctness', 'pass', 2, 0, 0));
+        writeStubs();
+        const verifier = makeGhCiVerifier({ runner: greenRunner(), sleep: () => {} });
+        storeReviewSummary(pr, 14, undefined, { expectedHeadSha: 'wiredHEAD', ciVerifier: verifier });
+        expect(bodyOfLastCreate()).toContain('## Review Round 14 — PASS');
+      });
+
+      it('BLOCKS: pending CI through the real verifier refuses the PASS summary', () => {
+        composeAndDerive(dimComment(15, 'correctness', 'pass', 2, 0, 0));
+        const verifier = makeGhCiVerifier({ runner: pendingRunner(), sleep: () => {}, pollIntervalMs: 1, timeoutMs: 3 });
+        expect(() =>
+          storeReviewSummary(pr, 15, undefined, { expectedHeadSha: 'wiredHEAD', ciVerifier: verifier }),
+        ).toThrow(ReviewCiProofError);
+      });
     });
   });
 });

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -14,7 +14,6 @@
  */
 
 import YAML from 'yaml';
-import { spawnSync } from 'node:child_process';
 import {
   listAttachments,
   readAttachment,
@@ -106,129 +105,62 @@ export type { ReviewFinding, ReviewFindingData } from './review-finding-contract
 
 const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MISSING: '❌' };
 
+/**
+ * CI-proof contract (#1070, redone per #1221/#1222/#1225).
+ *
+ * The verdict-binding intent of #1070 — a review round cannot be stored PASS while CI for the
+ * reviewed commit is pending/red/stale/absent — is preserved, but the proof MECHANISM is now an
+ * injectable dependency that lives OUTSIDE this storage layer (see `review-ci-proof.ts`). That
+ * keeps `storeReviewSummary` side-effect-free and unit-testable (#1222): with no `ciVerifier`
+ * supplied, storage performs NO network/process work, exactly as before #1070. The CLI boundary
+ * (`cli-structured-data.ts`) supplies the real verifier so the proof is still enforced where it
+ * belongs.
+ */
+export type CiProofStatus = 'pass' | 'pending' | 'fail' | 'no_checks' | 'stale_head' | 'skipped';
+export type CiProofResult = { status: CiProofStatus; detail?: string };
+
+/**
+ * Synchronous CI verifier. Returns a structured result rather than throwing so callers can branch
+ * on `pending`/`no_checks`/`stale_head` (a wait, not a review FAIL) vs `fail` (#1221). Non-PR
+ * targets must return `skipped` — review summaries on issues are legitimate (#1222).
+ */
+export type CiVerifier = (target: AttachmentTarget, expectedHeadSha?: string) => CiProofResult;
+
+/**
+ * Thrown by `storeReviewSummary` when a non-FAIL summary is refused because CI proof did not pass.
+ * Carries the structured `result` so the review-fix loop can distinguish a not-yet-green CI
+ * (`ci_pending` family — retry/wait) from a real failure (#1221), instead of treating every throw
+ * as an exhausted fix round.
+ */
+export class ReviewCiProofError extends Error {
+  constructor(public readonly result: CiProofResult) {
+    super(
+      `store-review-summary: #1070 refusing to store a passing review summary — CI ${result.status}` +
+      (result.detail ? `: ${result.detail}` : ''),
+    );
+    this.name = 'ReviewCiProofError';
+  }
+
+  /** True when the block is "CI not ready yet" (caller should wait/retry, not burn a fix round). */
+  get isPending(): boolean {
+    return this.result.status === 'pending' || this.result.status === 'no_checks';
+  }
+}
+
 export type StoreReviewSummaryOptions = {
   /**
-   * The commit SHA that was reviewed. If omitted, the current local HEAD is used.
-   * Passing this explicitly lets review tooling prove CI belongs to the same
-   * commit it reviewed even if the local worktree has moved.
+   * The commit SHA that was reviewed. If omitted, the verifier resolves the local HEAD.
+   * Passing this explicitly lets review tooling prove CI belongs to the same commit it reviewed
+   * even if the local worktree has moved.
    */
   expectedHeadSha?: string;
+  /**
+   * Injectable CI proof. When provided AND the derived verdict is non-FAIL AND the target is a PR,
+   * the verifier must return `pass`/`skipped` or storage throws `ReviewCiProofError`. When omitted,
+   * storage performs NO CI proof — it stays a pure, deterministic local-storage primitive (#1222).
+   */
+  ciVerifier?: CiVerifier;
 };
-
-type GhCheck = {
-  name?: string;
-  bucket?: string;
-  state?: string;
-  workflow?: string;
-  link?: string;
-};
-
-function spawnText(command: string, args: string[], failureContext: string): string {
-  const result = spawnSync(command, args, { encoding: 'utf8' });
-  if (result.error) {
-    throw new Error(`${failureContext}: ${result.error.message}`);
-  }
-  const stdout = (result.stdout ?? '').trim();
-  if ((result.status ?? 0) !== 0 && !stdout) {
-    const stderr = (result.stderr ?? '').trim();
-    throw new Error(`${failureContext}: ${stderr || `${command} exited ${result.status}`}`);
-  }
-  return stdout;
-}
-
-function resolveReviewedHeadSha(expectedHeadSha: string | undefined): string {
-  const explicit = expectedHeadSha?.trim();
-  if (explicit) return explicit;
-  return spawnText(
-    'git',
-    ['rev-parse', 'HEAD'],
-    'store-review-summary: #1070 unable to determine reviewed HEAD; pass --head-sha explicitly',
-  );
-}
-
-function readPrHeadSha(target: AttachmentTarget): string {
-  return spawnText(
-    'gh',
-    ['pr', 'view', String(target.number), '--repo', target.repo, '--json', 'headRefOid', '--jq', '.headRefOid'],
-    'store-review-summary: #1070 unable to read current PR head',
-  );
-}
-
-function readPrChecks(target: AttachmentTarget): GhCheck[] {
-  const stdout = spawnText(
-    'gh',
-    ['pr', 'checks', String(target.number), '--repo', target.repo, '--json', 'name,bucket,state,workflow,link'],
-    'store-review-summary: #1070 unable to read PR checks',
-  );
-  try {
-    const parsed = JSON.parse(stdout);
-    if (!Array.isArray(parsed)) {
-      throw new Error('JSON was not an array');
-    }
-    return parsed as GhCheck[];
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`store-review-summary: #1070 unable to parse PR checks JSON (${msg})`);
-  }
-}
-
-function formatCheck(check: GhCheck): string {
-  const workflow = check.workflow ? `${check.workflow} / ` : '';
-  const name = check.name ?? '(unnamed check)';
-  const bucket = check.bucket ?? 'unknown';
-  const state = check.state ? ` (${check.state})` : '';
-  return `${workflow}${name}: ${bucket}${state}`;
-}
-
-function assertReviewSummaryCiPassed(target: AttachmentTarget, options: StoreReviewSummaryOptions): void {
-  if (target.kind !== 'pr') {
-    throw new Error('store-review-summary: #1070 CI proof requires a PR target');
-  }
-
-  const reviewedHead = resolveReviewedHeadSha(options.expectedHeadSha);
-  const currentHead = readPrHeadSha(target);
-  if (currentHead !== reviewedHead) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary for stale HEAD. ` +
-      `Reviewed ${reviewedHead}, but PR #${target.number} is currently ${currentHead}. ` +
-      `Re-review the current head before storing a pass summary.`,
-    );
-  }
-
-  const checks = readPrChecks(target);
-  if (checks.length === 0) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI has not produced checks for ${currentHead}.`,
-    );
-  }
-
-  const blocking = checks.filter(check => {
-    const bucket = check.bucket;
-    return bucket !== 'pass' && bucket !== 'skipping';
-  });
-  if (blocking.length > 0) {
-    const details = blocking.map(formatCheck).join('; ');
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI is not green for ${currentHead}: ${details}`,
-    );
-  }
-}
-
-function extractSummaryRoundVerdict(summary: string): RoundVerdict | null {
-  const match = summary.match(/^<!-- meta:(\{.*\}) -->/);
-  if (!match) return null;
-  try {
-    const meta = JSON.parse(match[1]) as { round_verdict?: RoundVerdict; verdict?: string };
-    if (meta.round_verdict === 'PASS' || meta.round_verdict === 'PASS_WITH_PARTIALS' || meta.round_verdict === 'FAIL') {
-      return meta.round_verdict;
-    }
-    if (meta.verdict === 'fail') return 'FAIL';
-    if (meta.verdict === 'pass') return 'PASS';
-    return null;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Defensive coercion for CLI/API payloads. Supports legacy shapes (status-only,
@@ -400,9 +332,18 @@ export function storeReviewSummary(
   options: StoreReviewSummaryOptions = {},
 ): string {
   const derived = composeReviewSummary(target, round);
-  const roundVerdict = extractSummaryRoundVerdict(derived) ?? deriveStoredRoundVerdict(target, round);
-  if (roundVerdict !== 'FAIL') {
-    assertReviewSummaryCiPassed(target, options);
+  // I29: derive the round verdict structurally from the stored findings — never by re-parsing the
+  // composed summary's meta comment with a regex (the #1222.3 trap). `deriveStoredRoundVerdict`
+  // reads each finding's meta via the structured accessor and is the single authoritative source.
+  const roundVerdict = deriveStoredRoundVerdict(target, round);
+  // CI proof binds a non-FAIL verdict to observed CI. It only runs when a verifier is injected
+  // (the CLI boundary supplies the real one) and only for PR targets — non-PR summaries skip it
+  // (#1222.1). A non-pass/non-skipped result throws a typed error so the loop can branch (#1221).
+  if (roundVerdict !== 'FAIL' && options.ciVerifier && target.kind === 'pr') {
+    const proof = options.ciVerifier(target, options.expectedHeadSha);
+    if (proof.status !== 'pass' && proof.status !== 'skipped') {
+      throw new ReviewCiProofError(proof);
+    }
   }
 
   let content = derived;

--- a/src/worktree-isolation.test.ts
+++ b/src/worktree-isolation.test.ts
@@ -71,6 +71,14 @@ describe('kaizen-review-pr SKILL.md — review findings storage contract (#966)'
     expect(skill).toMatch(/--head-sha "\$\(git rev-parse HEAD\)"/);
     expect(skill).toMatch(/Pending, failing, absent, or stale-head CI refuses storage/);
   });
+
+  it('documents wait-for-CI and the ci_pending exit code (#1221/#1225)', () => {
+    // INVARIANT: the skill must teach that a still-running CI is a WAIT, not a fix-round burn,
+    // so the loop does not false-exhaust on pending CI (the #1221 regression).
+    const skill = readFileSync(REVIEW_PR_SKILL, 'utf8');
+    expect(skill).toMatch(/ci_pending/);
+    expect(skill).toMatch(/wait/i);
+  });
 });
 
 describe('kaizen-implement SKILL.md — review battery storage reference (#966)', () => {


### PR DESCRIPTION
## Rescue Context

This is a draft rescue PR for auto-dent batch `double-barracuda/run-2`.

The run was terminated by the watchdog after 1204 seconds (`exit 143`, SIGTERM) before auto-dent created a PR. This PR preserves the branch for later review; it is not being presented as ready-to-merge work.

## Preserved Work

- Worktree: `/home/aviad/projects/kaizen/.claude/worktrees/2606271956-9d5b`
- Branch: `case/260627-k1225-ci-proof-redo`
- Commit preserved:
  - `5328e69` `fix(review): redo #1070 CI-proof gate correctly — injectable, pure storage, wait-for-CI`

## Rescue Notes

Quality gates were intentionally skipped for the rescue operation. The interrupted run had performed targeted checks and was still dealing with broader suite/e2e flakiness when it timed out. This draft PR needs a fresh rescue pass before merge consideration.

Refs #1070
Refs #1221
Refs #1222
Refs #1225
Refs #1227
Refs #1228
