### PR TITLE
[rescue] double-barracuda run 3 verdict binding work

### DIFF
--- a/.agents/skills/kaizen-review-pr/SKILL.md
+++ b/.agents/skills/kaizen-review-pr/SKILL.md
@@ -229,10 +229,19 @@ npx tsx src/cli-structured-data.ts store-review-summary \
   --pr <PR_NUMBER> --repo <owner/repo> --round <N> --head-sha "$(git rev-parse HEAD)"
 ```
 
-For a derived PASS or PASS-with-partials verdict, `store-review-summary` now verifies the PR's
-current HEAD matches `--head-sha` and that `gh pr checks` is green for that HEAD before it writes
-the summary/sentinel (#1070). Pending, failing, absent, or stale-head CI refuses storage; re-run
-review on the current head after CI passes.
+For a derived PASS or PASS-with-partials verdict, the CLI verifies CI at the command boundary
+before it writes the summary/sentinel (#1070, redone correctly per #1225): it checks the PR's
+current HEAD matches `--head-sha` and **waits** (polls `gh pr checks`) until CI is terminal for
+that HEAD. The storage layer itself stays side-effect-free (#1222).
+
+Distinguish the two non-pass outcomes — they are NOT the same (#1221):
+- **CI still pending after the wait timeout → exit code 75** (`ci_pending`). This is **NOT a
+  review FAIL** and must **not** burn a fix round. Wait for CI to finish, then re-run
+  `store-review-summary`. (`KAIZEN_SKIP_CI_PROOF=1` bypasses the wait if you must.)
+- **Stale head or red CI → exit code 1.** A real failure: re-review on the current head after CI
+  passes / fix the red checks.
+
+A FAIL verdict stores without a CI proof (you are recording the failure, not asserting a pass).
 
 Add `--note "<context>"` only for non-verdict commentary (e.g. "rebased onto main, re-ran tests").
 Read back the derived verdict with `read-review-summary --pr <N> --repo <repo> --round <N>` — the

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -78,6 +78,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh",
+            "timeout": 20
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/kaizen-enforce-plan-stored-ts.sh",
             "timeout": 15
           },

--- a/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh
+++ b/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# TS hook shim — enforce-merge-verdict PreToolUse gate (#1220 / #1227)
+# Blocks `gh pr merge` when the PR's latest review round derived a FAIL verdict.
+
+source "$(dirname "$0")/lib/scope-guard.sh"
+source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
+KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/enforce-merge-verdict.ts"

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -183,6 +183,7 @@ class TestEdgeCases:
         "kaizen-enforce-pr-review-ts.sh",
         "kaizen-enforce-case-worktree.sh",
         "kaizen-check-dirty-files-ts.sh",
+        "kaizen-enforce-merge-verdict-ts.sh",
         "kaizen-pr-quality-checks-ts.sh",
     ])
     def test_empty_command(self, review_harness, hook):
@@ -193,6 +194,7 @@ class TestEdgeCases:
         "kaizen-enforce-pr-review-ts.sh",
         "kaizen-enforce-case-worktree.sh",
         "kaizen-check-dirty-files-ts.sh",
+        "kaizen-enforce-merge-verdict-ts.sh",
         "kaizen-pr-quality-checks-ts.sh",
     ])
     def test_missing_tool_input(self, review_harness, hook):
@@ -205,6 +207,7 @@ class TestEdgeCases:
         "kaizen-enforce-pr-review-ts.sh",
         "kaizen-enforce-case-worktree.sh",
         "kaizen-check-dirty-files-ts.sh",
+        "kaizen-enforce-merge-verdict-ts.sh",
         "kaizen-pr-quality-checks-ts.sh",
     ])
     def test_malformed_json(self, review_harness, hook):

--- a/docs/verdict-binding-inventory.md
+++ b/docs/verdict-binding-inventory.md
@@ -1,0 +1,48 @@
+# Verdict → Terminal-Action Binding Inventory (#1227)
+
+**The category.** Kaizen *computes* quality verdicts well. The recurring failure
+is that **no mechanism is required to honour a verdict at the irreversible
+action.** At a point-of-no-return the system asks *"does an artifact exist?"*
+instead of *"did the relevant verdict pass?"* — so a correct FAIL is computed,
+logged, and then silently overruled by the absence of any consumer.
+
+This is distinct from #943 (the gate *measures* the wrong thing — a
+**measurement** error). Here the verdict is measured *correctly* and then
+*nothing consumes it* at the action that matters — a **binding** error.
+
+**The rule.** Every irreversible / finalizing action MUST mechanically consume
+the relevant computed verdict and **fail closed**. A computed verdict with no
+enforcing consumer at a terminal action is itself a defect.
+
+The pinned, machine-checked version of this table is
+[`src/verdict-binding-invariant.test.ts`](../src/verdict-binding-invariant.test.ts):
+if a binding is removed, that test goes red.
+
+## Inventory
+
+| Terminal action | Verdict it must consume | Enforcing consumer | Fail-closed behaviour | Ticket |
+|---|---|---|---|---|
+| `gh pr merge` | latest stored review round verdict | `src/hooks/enforce-merge-verdict.ts` (PreToolUse Bash hook) | DENY merge when latest round derives FAIL (covers fix-loop-exhausted). Override: `KAIZEN_ALLOW_MERGE_FAIL=1` (explicit + logged). | #1220 |
+| auto-dent run-success stamp | `review_verdict` / `process_verdict` / `lifecycle_health` | `deriveRunOutcome()` in `scripts/auto-dent-run.ts` | `review_verdict==fail` ∨ `process_verdict==process-incomplete` ∨ `lifecycle_health==critical` ⇒ `outcome=failure`, never `success`. | #1224 |
+| store a PASS review summary | CI status for the reviewed head | `enforceCiProofForPass()` in `src/cli-structured-data.ts`, backed by `src/review-ci-proof.ts` | Wait for CI (poll). `pending` after timeout ⇒ exit 75 (`ci_pending`, NOT a review FAIL). Stale head / red CI ⇒ exit 1. PASS only when CI is green. | #1221, #1222, #1225 |
+| store a review summary (storage layer) | (none — must stay side-effect-free) | `storeReviewSummary()` in `src/structured-data.ts` | No `gh`/`git` shell-outs in the storage primitive; the proof lives at the CLI boundary. | #1222 |
+
+## Residual / tracked-elsewhere bindings
+
+These are *known* terminal actions whose verdict binding is weaker than the
+above and is tracked separately — listed here so they are not mistaken for
+"covered":
+
+| Terminal action | Verdict | Status |
+|---|---|---|
+| `gh pr merge` of a PR with **no** stored review | (review existence) | WARN only — categorically blocking unreviewed merges would over-block in host-project mode. Tracked by #843 (hook enforcement unverified in headless mode) / #1166 (Claude-only gates). |
+| issue close (`Closes #N`) | I2 scope-match | L1 only (agent must remember). #1227 flags it as a binding gap. |
+| post-merge completion / deployment verify | merged-state verdict | #86 / #1165. |
+
+## Why a categorical test, not just three fixes
+
+Fixing #1220 + #1224 + #1225 individually leaves the *next* terminal action
+ungated. The invariant test turns the inventory into a forcing function: adding
+a new finalizing action, or removing a binding, must keep this table — and the
+test — honest. That is the compound interest (see the [Zen of Kaizen](../.agents/kaizen/zen.md):
+*"an enforcement point is worth a thousand instructions"*).

--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { handlers, parseArgs, resolveContent, resolveRound, type CliArgs } from './cli-structured-data.js';
+import { handlers, parseArgs, resolveContent, resolveRound, enforceCiProofForPass, type CliArgs } from './cli-structured-data.js';
+import type { CiProofRunner } from './review-ci-proof.js';
 import {
   nextReviewRound,
   storePlan,
@@ -44,9 +45,19 @@ vi.mock('./structured-data.js', () => ({
   updatePrSection: vi.fn(),
   storeIterationState: vi.fn().mockReturnValue('https://example.com/iteration'),
   retrieveIterationState: vi.fn().mockReturnValue({ round: 1 }),
+  deriveStoredRoundVerdict: vi.fn().mockReturnValue('PASS'),
 }));
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Handler tests assert storage wiring, not the CI proof — skip the network
+  // gate (its behaviour is covered by review-ci-proof.test.ts and the
+  // enforceCiProofForPass tests below). Without this, handlers would shell out.
+  process.env.KAIZEN_SKIP_CI_PROOF = '1';
+});
+afterEach(() => {
+  delete process.env.KAIZEN_SKIP_CI_PROOF;
+});
 
 describe('parseArgs', () => {
   it('extracts command and flags', () => {
@@ -251,8 +262,8 @@ describe('store-review-batch — review sentinel', () => {
   });
 });
 
-describe('store-review-summary — CI head proof', () => {
-  it('passes --head-sha through to summary storage before writing the sentinel (#1070)', async () => {
+describe('store-review-summary — storage wiring (#1222: side-effect-free storage)', () => {
+  it('calls storeReviewSummary with target+round only — no options/CI args baked into storage', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     await handlers['store-review-summary']({
@@ -263,11 +274,12 @@ describe('store-review-summary — CI head proof', () => {
       ['head-sha']: 'abc123',
     } as CliArgs);
 
+    // The CI/head proof no longer travels into the storage primitive (#1225);
+    // storeReviewSummary takes exactly (target, round, note).
     expect(vi.mocked(storeReviewSummary)).toHaveBeenCalledWith(
       { kind: 'pr', number: 903, repo: 'Garsson-io/kaizen' },
       5,
       undefined,
-      { expectedHeadSha: 'abc123' },
     );
     const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r5'),
@@ -284,6 +296,78 @@ describe('store-review-summary — CI head proof', () => {
     expect(payload.findingCount).toBeGreaterThanOrEqual(0);
     expect(payload.integrity).toMatch(/^sha256:/);
     log.mockRestore();
+  });
+});
+
+// ── enforceCiProofForPass — verdict→CI binding at the CLI boundary (#1227) ──
+
+describe('enforceCiProofForPass — binds PASS verdict to CI', () => {
+  const target = { kind: 'pr', number: '903', repo: 'org/repo' } as const;
+  const noEnv: NodeJS.ProcessEnv = {};
+  const greenRunner: CiProofRunner = {
+    localHead: () => 'abc',
+    prHeadSha: () => 'abc',
+    prChecks: () => [{ bucket: 'pass', state: 'SUCCESS' }],
+    sleep: async () => {},
+    now: () => 0,
+  };
+
+  it('FAIL verdict short-circuits — no proof needed to store a FAIL', async () => {
+    let proofRan = false;
+    const r = await enforceCiProofForPass(target, 1, { command: 'x' } as CliArgs, {
+      env: noEnv,
+      deriveVerdict: () => 'FAIL',
+      runner: { ...greenRunner, prChecks: () => { proofRan = true; return []; } },
+      exit: (() => { throw new Error('should not exit'); }) as never,
+    });
+    expect(r).toEqual({ status: 'skipped' });
+    expect(proofRan).toBe(false);
+  });
+
+  it('PASS verdict + green CI → proceeds (no exit)', async () => {
+    const r = await enforceCiProofForPass(target, 1, { command: 'x' } as CliArgs, {
+      env: noEnv,
+      deriveVerdict: () => 'PASS',
+      runner: greenRunner,
+      exit: (() => { throw new Error('should not exit'); }) as never,
+    });
+    expect(r).toMatchObject({ status: 'pass' });
+  });
+
+  it('PASS verdict + CI RED → exits 1 (real fail BLOCKS the PASS)', async () => {
+    const exits: number[] = [];
+    await enforceCiProofForPass(target, 1, { command: 'x' } as CliArgs, {
+      env: noEnv,
+      deriveVerdict: () => 'PASS',
+      runner: { ...greenRunner, prChecks: () => [{ bucket: 'fail', state: 'FAILURE' }] },
+      exit: ((code: number) => { exits.push(code); return undefined as never; }),
+      log: () => {},
+    });
+    expect(exits).toEqual([1]);
+  });
+
+  it('PASS verdict + CI pending past timeout → exits 75 (NOT a fail) — #1221', async () => {
+    const exits: number[] = [];
+    await enforceCiProofForPass(target, 1, { command: 'x', ['ci-timeout-sec']: '0', ['ci-poll-sec']: '0' } as CliArgs, {
+      env: noEnv,
+      deriveVerdict: () => 'PASS',
+      runner: { ...greenRunner, prChecks: () => [{ bucket: 'pending', state: 'IN_PROGRESS' }] },
+      exit: ((code: number) => { exits.push(code); return undefined as never; }),
+      log: () => {},
+    });
+    expect(exits).toEqual([75]);
+  });
+
+  it('--skip-ci-proof bypasses the gate (logged override)', async () => {
+    let proofRan = false;
+    const r = await enforceCiProofForPass(target, 1, { command: 'x', ['skip-ci-proof']: 'true' } as CliArgs, {
+      env: noEnv,
+      deriveVerdict: () => { proofRan = true; return 'PASS'; },
+      runner: greenRunner,
+      exit: (() => { throw new Error('should not exit'); }) as never,
+    });
+    expect(r).toEqual({ status: 'skipped' });
+    expect(proofRan).toBe(false);
   });
 });
 

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -40,7 +40,6 @@ import {
   issueTarget,
   storeReviewFinding,
   storeReviewSummary,
-  storeReviewBatch,
   storeQuickPass,
   nextReviewRound,
   listReviewRounds,
@@ -58,14 +57,24 @@ import {
   updatePrSection,
   storeIterationState,
   retrieveIterationState,
+  deriveStoredRoundVerdict,
   type ReviewFindingData,
-  type StoreReviewSummaryOptions,
 } from './structured-data.js';
 import {
   buildReviewSentinelRecord,
   serializeReviewSentinel,
 } from './review-sentinel.js';
 import { normalizeReviewFindingData, validateReviewFindingPayload, summarizeFindingStatuses } from './review-finding-contract.js';
+import {
+  waitForCiProof,
+  ciProofExitCode,
+  formatCiProofFailure,
+  createDefaultCiProofRunner,
+  type CiProofRunner,
+  type CiProofResult,
+} from './review-ci-proof.js';
+import type { AttachmentTarget } from './section-editor.js';
+import type { RoundVerdict } from './review-finding-contract.js';
 
 export type CliArgs = Record<string, string> & { command: string };
 type Handler = (a: CliArgs) => Promise<void>;
@@ -74,7 +83,7 @@ type Handler = (a: CliArgs) => Promise<void>;
  * Flags that are booleans — no value follows, presence means true.
  * Keeps `--stdin` usable without the trap of consuming the next arg.
  */
-const BOOLEAN_FLAGS = new Set(['stdin']);
+const BOOLEAN_FLAGS = new Set(['stdin', 'skip-ci-proof']);
 
 export function parseArgs(argv?: string[]): CliArgs {
   const args = argv ?? process.argv.slice(2);
@@ -177,10 +186,73 @@ function writeReviewSentinel(repo: string, pr: string | undefined, round: number
   }
 }
 
-function reviewSummaryOptions(a: CliArgs): StoreReviewSummaryOptions {
-  return {
-    expectedHeadSha: a['head-sha'],
-  };
+const DEFAULT_CI_PROOF_TIMEOUT_SEC = 900; // 15 min — covers a typical CI run.
+const DEFAULT_CI_PROOF_POLL_SEC = 15;
+
+function intFromEnvOrArg(value: string | undefined, fallback: number): number {
+  const n = value != null ? parseInt(value, 10) : NaN;
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+/**
+ * Dependencies for the CI-proof gate. Injectable so the wiring (verdict →
+ * proof → exit) is unit-testable without shelling out or killing the process.
+ */
+export interface CiProofGateDeps {
+  runner?: CiProofRunner;
+  deriveVerdict?: (target: AttachmentTarget, round: number) => RoundVerdict;
+  exit?: (code: number) => never;
+  env?: NodeJS.ProcessEnv;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Verdict→terminal-action binding (#1227): a PASS review summary must not be
+ * recorded unless CI is green for the reviewed head. The proof lives HERE, at
+ * the CLI boundary — not in the side-effect-free storage layer (#1222/#1225).
+ *
+ * Behaviour:
+ *   - derived verdict FAIL  → no proof needed (storing a FAIL is always allowed)
+ *   - non-PR target / skip  → proof skipped
+ *   - waits for CI (poll), so `pending` is a WAIT, not a FAIL (#1221)
+ *   - pending after timeout → exit 75 (EX_TEMPFAIL): NOT a review FAIL
+ *   - stale head / CI red   → exit 1: real FAIL, re-review/re-fix required
+ */
+export async function enforceCiProofForPass(
+  target: AttachmentTarget,
+  round: number,
+  a: CliArgs,
+  deps: CiProofGateDeps = {},
+): Promise<CiProofResult | { status: 'skipped' }> {
+  const env = deps.env ?? process.env;
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
+  const log = deps.log ?? ((msg: string) => process.stderr.write(`${msg}\n`));
+
+  if ('skip-ci-proof' in a || env.KAIZEN_SKIP_CI_PROOF === '1') {
+    log('[ci-proof] OVERRIDE: skipping CI proof (--skip-ci-proof / KAIZEN_SKIP_CI_PROOF=1).');
+    return { status: 'skipped' };
+  }
+
+  const derive = deps.deriveVerdict ?? deriveStoredRoundVerdict;
+  const verdict = derive(target, round);
+  if (verdict === 'FAIL') return { status: 'skipped' };
+
+  const runner = deps.runner ?? createDefaultCiProofRunner();
+  const timeoutMs = intFromEnvOrArg(a['ci-timeout-sec'] ?? env.KAIZEN_CI_PROOF_TIMEOUT_SEC, DEFAULT_CI_PROOF_TIMEOUT_SEC) * 1000;
+  const intervalMs = intFromEnvOrArg(a['ci-poll-sec'] ?? env.KAIZEN_CI_PROOF_POLL_SEC, DEFAULT_CI_PROOF_POLL_SEC) * 1000;
+
+  const result = await waitForCiProof(
+    { kind: target.kind, number: target.number, repo: target.repo },
+    { expectedHeadSha: a['head-sha'] },
+    runner,
+    { timeoutMs, intervalMs },
+  );
+
+  if (result.status === 'pass' || result.status === 'skipped_non_pr') return result;
+
+  log(formatCiProofFailure(result));
+  exit(ciProofExitCode(result));
+  return result; // unreachable when exit really exits; kept for injected exits.
 }
 
 // Review handlers
@@ -254,12 +326,18 @@ async function handleStoreReviewBatch(a: CliArgs): Promise<void> {
     }
   }
   const findings = parsedBatch as ReviewFindingData[];
-  const result = storeReviewBatch(pr, r, findings, reviewSummaryOptions(a));
+  // Store findings (raw evidence) first, then enforce the CI proof on the
+  // derived verdict BEFORE recording the PASS summary + sentinel. A non-green
+  // CI exits here (75 pending / 1 red) without stamping a PASS the review gate
+  // would later consume (#1227 binding).
+  const urls = findings.map(f => storeReviewFinding(pr, r, f));
+  await enforceCiProofForPass(pr, r, a);
+  const summaryUrl = storeReviewSummary(pr, r);
   // #966: Write review sentinel so pr-review-loop.ts gate guard passes.
   // Mirrors handleStoreReviewSummary — batch includes summary, so sentinel must be written here too.
   writeReviewSentinel(a.repo, a.pr, r);
-  console.log(`Batch stored: ${result.urls.length} findings + summary (round ${r})`);
-  console.log(`Summary: ${result.summaryUrl}`);
+  console.log(`Batch stored: ${urls.length} findings + summary (round ${r})`);
+  console.log(`Summary: ${summaryUrl}`);
 }
 
 async function handleQuickPass(a: CliArgs): Promise<void> {
@@ -275,9 +353,13 @@ async function handleStoreReviewSummary(a: CliArgs): Promise<void> {
   // legacy --text/--file) is non-authoritative commentary appended below the derived block.
   const note = (a.note ?? resolveContent(a)) || undefined;
   const r = resolveRound(a);
+  const target = prTarget(a.pr, a.repo);
+  // Bind the PASS verdict to CI before recording it (#1227). FAIL summaries and
+  // non-PR / skipped contexts pass through without a proof.
+  await enforceCiProofForPass(target, r, a);
   let url: string;
   try {
-    url = storeReviewSummary(prTarget(a.pr, a.repo), r, note, reviewSummaryOptions(a));
+    url = storeReviewSummary(target, r, note);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);

--- a/src/hooks/enforce-merge-verdict.test.ts
+++ b/src/hooks/enforce-merge-verdict.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkMergeVerdict,
+  parseMergeTarget,
+  MERGE_BYPASS_ENV,
+  type MergeVerdictReader,
+} from './enforce-merge-verdict.js';
+
+const REPO = 'Garsson-io/kaizen';
+const readerFor = (verdict: 'PASS' | 'PASS_WITH_PARTIALS' | 'FAIL' | null, round: number | null = 4): MergeVerdictReader =>
+  () => ({ round: verdict === null ? null : round, verdict });
+
+describe('parseMergeTarget', () => {
+  it('parses a full PR URL', () => {
+    expect(parseMergeTarget('gh pr merge https://github.com/Garsson-io/kaizen/pull/903 --squash'))
+      .toEqual({ repo: 'Garsson-io/kaizen', prNumber: '903' });
+  });
+  it('parses bare number + --repo', () => {
+    expect(parseMergeTarget('gh pr merge 903 --repo Garsson-io/kaizen --squash --auto'))
+      .toEqual({ repo: 'Garsson-io/kaizen', prNumber: '903' });
+  });
+  it('parses bare number using repoFromGit fallback', () => {
+    expect(parseMergeTarget('gh pr merge 903 --squash', 'org/repo'))
+      .toEqual({ repo: 'org/repo', prNumber: '903' });
+  });
+  it('returns null when no PR can be determined', () => {
+    expect(parseMergeTarget('gh pr merge --squash')).toBeNull();
+  });
+});
+
+describe('checkMergeVerdict — the gate BLOCKS a FAIL merge (#1220)', () => {
+  it('DENIES merge when the latest review round derived FAIL', () => {
+    const r = checkMergeVerdict(`gh pr merge 903 --repo ${REPO} --squash --auto`, {
+      reader: readerFor('FAIL'),
+      env: {},
+    });
+    expect(r.action).toBe('deny');
+    expect(r.message).toMatch(/MERGE BLOCKED/);
+    expect(r.message).toMatch(/#903/);
+    expect(r.message).toMatch(/FAIL/);
+  });
+
+  it('DENIES a FAIL merge given as a URL', () => {
+    const r = checkMergeVerdict(`gh pr merge https://github.com/${REPO}/pull/903 --squash`, {
+      reader: readerFor('FAIL'),
+      env: {},
+    });
+    expect(r.action).toBe('deny');
+  });
+
+  it('ALLOWS merge when the latest round is PASS', () => {
+    const r = checkMergeVerdict(`gh pr merge 903 --repo ${REPO} --squash`, {
+      reader: readerFor('PASS'),
+      env: {},
+    });
+    expect(r.action).toBe('allow');
+  });
+
+  it('ALLOWS merge when the latest round is PASS_WITH_PARTIALS', () => {
+    const r = checkMergeVerdict(`gh pr merge 903 --repo ${REPO} --squash`, {
+      reader: readerFor('PASS_WITH_PARTIALS'),
+      env: {},
+    });
+    expect(r.action).toBe('allow');
+  });
+
+  it('WARNS (does not block) when the PR has no stored review', () => {
+    const r = checkMergeVerdict(`gh pr merge 903 --repo ${REPO} --squash`, {
+      reader: readerFor(null),
+      env: {},
+    });
+    expect(r.action).toBe('warn');
+    expect(r.message).toMatch(/no stored review/);
+  });
+
+  it('OVERRIDE: KAIZEN_ALLOW_MERGE_FAIL=1 allows a FAIL merge but logs it', () => {
+    const r = checkMergeVerdict(`gh pr merge 903 --repo ${REPO} --squash`, {
+      reader: readerFor('FAIL'),
+      env: { [MERGE_BYPASS_ENV]: '1' },
+    });
+    expect(r.action).toBe('allow');
+    expect(r.bypassed).toBe(true);
+    expect(r.message).toMatch(/OVERRIDE/);
+  });
+
+  it('the override does NOT fire for any other value', () => {
+    const r = checkMergeVerdict(`gh pr merge 903 --repo ${REPO} --squash`, {
+      reader: readerFor('FAIL'),
+      env: { [MERGE_BYPASS_ENV]: 'true' },
+    });
+    expect(r.action).toBe('deny');
+  });
+
+  it('ALLOWS non-merge commands without touching the reader', () => {
+    let called = false;
+    const r = checkMergeVerdict(`gh pr create --title x`, {
+      reader: () => { called = true; return { round: 1, verdict: 'FAIL' }; },
+      env: {},
+    });
+    expect(r.action).toBe('allow');
+    expect(called).toBe(false);
+  });
+
+  it('does not match `gh pr merge` appearing inside a quoted string argument', () => {
+    const r = checkMergeVerdict(`echo "remember to gh pr merge later"`, {
+      reader: readerFor('FAIL'),
+      env: {},
+    });
+    expect(r.action).toBe('allow');
+  });
+
+  it('WARNS when the reader throws (e.g. network error) rather than blocking blindly', () => {
+    const r = checkMergeVerdict(`gh pr merge 903 --repo ${REPO} --squash`, {
+      reader: () => { throw new Error('gh offline'); },
+      env: {},
+    });
+    expect(r.action).toBe('warn');
+    expect(r.message).toMatch(/gh offline/);
+  });
+
+  it('WARNS when the PR cannot be identified from the command', () => {
+    const r = checkMergeVerdict(`gh pr merge --squash`, {
+      reader: readerFor('FAIL'),
+      env: {},
+    });
+    expect(r.action).toBe('warn');
+  });
+});

--- a/src/hooks/enforce-merge-verdict.ts
+++ b/src/hooks/enforce-merge-verdict.ts
@@ -1,0 +1,166 @@
+/**
+ * enforce-merge-verdict.ts — PreToolUse gate: bind `gh pr merge` to the review verdict.
+ *
+ * @enforces I15/I18 at the irreversible step — the merge.
+ *
+ * The category (#1227): kaizen computes review verdicts correctly but no
+ * mechanism honoured them at the point of no return. PR #1212 was merged to
+ * main while its own review battery returned FAIL and the fix loop was
+ * exhausted, because the only merge-aware hook (`check-dirty-files`) checks
+ * dirty files, never the verdict. #1220 is that hole.
+ *
+ * This gate reads the latest stored review round for the PR being merged and
+ * DENIES the merge when the derived verdict is FAIL (which also covers a
+ * fix-loop that exhausted leaving the last round red). PASS /
+ * PASS_WITH_PARTIALS allow. A PR with no stored review WARNs (surfaced, not
+ * blocked — categorically blocking unreviewed merges is a different gap, #843,
+ * and would over-block in host-project mode). Override is explicit and logged:
+ * KAIZEN_ALLOW_MERGE_FAIL=1.
+ */
+
+import { readHookInput, traceNullInput } from './hook-io.js';
+import { isGhPrCommand, reconstructPrUrl, stripHeredocBody } from './parse-command.js';
+import { prTarget, latestReviewRound, deriveStoredRoundVerdict } from '../structured-data.js';
+import type { RoundVerdict } from '../review-finding-contract.js';
+
+export const MERGE_BYPASS_ENV = 'KAIZEN_ALLOW_MERGE_FAIL';
+
+export interface MergeVerdict {
+  /** Latest review round with data, or null when no review exists for the PR. */
+  round: number | null;
+  verdict: RoundVerdict | null;
+}
+
+export type MergeVerdictReader = (repo: string, prNumber: string) => MergeVerdict;
+
+export interface CheckMergeVerdictDeps {
+  reader: MergeVerdictReader;
+  env?: NodeJS.ProcessEnv;
+  /** Repo (owner/name) detected from the git remote, for bare `gh pr merge N`. */
+  repoFromGit?: string;
+}
+
+export type MergeGateAction = 'allow' | 'warn' | 'deny';
+
+export interface MergeGateResult {
+  action: MergeGateAction;
+  message?: string;
+  bypassed?: boolean;
+}
+
+/** Parse the repo + PR number a `gh pr merge` invocation targets. */
+export function parseMergeTarget(
+  cmdLine: string,
+  repoFromGit?: string,
+): { repo: string; prNumber: string } | null {
+  const url = reconstructPrUrl(cmdLine, '', '', 'merge', repoFromGit);
+  if (!url) return null;
+  const match = url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+  if (!match) return null;
+  return { repo: match[1], prNumber: match[2] };
+}
+
+export function checkMergeVerdict(
+  command: string,
+  deps: CheckMergeVerdictDeps,
+): MergeGateResult {
+  const cmdLine = stripHeredocBody(command);
+  if (!isGhPrCommand(cmdLine, 'merge')) return { action: 'allow' };
+
+  const env = deps.env ?? process.env;
+
+  const target = parseMergeTarget(cmdLine, deps.repoFromGit);
+  if (!target) {
+    return {
+      action: 'warn',
+      message:
+        `[merge-verdict] Could not determine the PR being merged from the command, so the ` +
+        `review verdict was not checked. Ensure the merge targets the intended PR.`,
+    };
+  }
+
+  if (env[MERGE_BYPASS_ENV] === '1') {
+    return {
+      action: 'allow',
+      bypassed: true,
+      message:
+        `[merge-verdict] OVERRIDE: ${MERGE_BYPASS_ENV}=1 — merging PR #${target.prNumber} ` +
+        `WITHOUT honouring the review verdict. This override is logged.`,
+    };
+  }
+
+  let result: MergeVerdict;
+  try {
+    result = deps.reader(target.repo, target.prNumber);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      action: 'warn',
+      message: `[merge-verdict] Could not read the review verdict for PR #${target.prNumber} (${msg}). Proceeding without the verdict check.`,
+    };
+  }
+
+  if (result.verdict === 'FAIL') {
+    return {
+      action: 'deny',
+      message:
+        `MERGE BLOCKED — PR #${target.prNumber}'s latest review round (round ${result.round}) ` +
+        `derived a FAIL verdict.\n\n` +
+        `A FAIL means MISSING requirements remain (or the fix loop exhausted and the last round ` +
+        `is still red). Merging now lands unreviewed-as-failing code on main — exactly the #1212 ` +
+        `incident this gate (#1220) exists to prevent.\n\n` +
+        `Do ONE of:\n` +
+        `  • Fix the findings and re-run the review battery until the round derives PASS, then merge.\n` +
+        `  • If a human has reviewed and accepts the risk, set ${MERGE_BYPASS_ENV}=1 to override ` +
+        `(explicit + logged).\n\n` +
+        `Inspect: npx tsx src/cli-structured-data.ts read-review-summary --pr ${target.prNumber} --repo ${target.repo} --round ${result.round}`,
+    };
+  }
+
+  if (result.round == null) {
+    return {
+      action: 'warn',
+      message:
+        `[merge-verdict] PR #${target.prNumber} has no stored review round, so the verdict could ` +
+        `not be honoured at merge. (Unreviewed-merge enforcement is tracked separately — #843.)`,
+    };
+  }
+
+  return { action: 'allow' };
+}
+
+/** Production reader — reads the latest stored review verdict from the PR. */
+export function defaultMergeVerdictReader(repo: string, prNumber: string): MergeVerdict {
+  const target = prTarget(prNumber, repo);
+  const round = latestReviewRound(target);
+  if (!round || round < 1) return { round: null, verdict: null };
+  return { round, verdict: deriveStoredRoundVerdict(target, round) };
+}
+
+async function main(): Promise<void> {
+  const input = await readHookInput();
+  if (!input) { traceNullInput('enforce-merge-verdict'); process.exit(0); }
+
+  const command = input.tool_input?.command ?? '';
+  const result = checkMergeVerdict(command, { reader: defaultMergeVerdictReader });
+
+  if (result.action === 'deny') {
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: result.message,
+      },
+    }));
+  } else if ((result.action === 'warn' || result.bypassed) && result.message) {
+    process.stderr.write(`\n${result.message}\n`);
+  }
+  process.exit(0);
+}
+
+if (
+  process.argv[1]?.endsWith('enforce-merge-verdict.ts') ||
+  process.argv[1]?.endsWith('enforce-merge-verdict.js')
+) {
+  main().catch(() => process.exit(0));
+}

--- a/src/review-ci-proof.test.ts
+++ b/src/review-ci-proof.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyCiProof,
+  waitForCiProof,
+  ciProofExitCode,
+  formatCiProofFailure,
+  EXIT_CI_PENDING,
+  EXIT_CI_FAILED,
+  type CiProofRunner,
+  type GhCheck,
+  type CiProofTarget,
+} from './review-ci-proof.js';
+
+const PR: CiProofTarget = { kind: 'pr', number: '903', repo: 'org/repo' };
+
+/**
+ * Scriptable fake runner. `checksSequence` lets a test feed a different checks
+ * snapshot on each poll so the wait-for-CI behaviour can be exercised without
+ * real time or network.
+ */
+function fakeRunner(opts: {
+  localHead?: string;
+  prHead?: string;
+  checks?: GhCheck[];
+  checksSequence?: GhCheck[][];
+}): CiProofRunner & { sleeps: number[]; clock: { t: number } } {
+  const clock = { t: 0 };
+  const sleeps: number[] = [];
+  let idx = 0;
+  return {
+    sleeps,
+    clock,
+    localHead: () => opts.localHead ?? 'HEAD',
+    prHeadSha: () => opts.prHead ?? opts.localHead ?? 'HEAD',
+    prChecks: () => {
+      if (opts.checksSequence) {
+        const c = opts.checksSequence[Math.min(idx, opts.checksSequence.length - 1)];
+        idx++;
+        return c;
+      }
+      return opts.checks ?? [];
+    },
+    async sleep(ms: number) {
+      sleeps.push(ms);
+      clock.t += ms;
+    },
+    now: () => clock.t,
+  };
+}
+
+describe('classifyCiProof — point-in-time classification', () => {
+  it('skips non-PR targets (terminal, no throw — #1222.1)', () => {
+    const r = classifyCiProof({ kind: 'issue', number: '5', repo: 'org/repo' }, {}, fakeRunner({}));
+    expect(r.status).toBe('skipped_non_pr');
+    expect(r.terminal).toBe(true);
+  });
+
+  it('PASS when every check is pass/skipping', () => {
+    const checks: GhCheck[] = [
+      { name: 'tests', bucket: 'pass', state: 'SUCCESS' },
+      { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
+    ];
+    const r = classifyCiProof(PR, { expectedHeadSha: 'abc' }, fakeRunner({ prHead: 'abc', checks }));
+    expect(r.status).toBe('pass');
+    expect(r.terminal).toBe(true);
+  });
+
+  it('stale_head when the PR head moved since review (terminal)', () => {
+    const r = classifyCiProof(PR, { expectedHeadSha: 'abc' }, fakeRunner({ prHead: 'def', checks: [] }));
+    expect(r.status).toBe('stale_head');
+    expect(r.terminal).toBe(true);
+    expect(r.detail).toMatch(/abc/);
+    expect(r.detail).toMatch(/def/);
+  });
+
+  it('no_checks (non-terminal) when CI has not produced checks yet', () => {
+    const r = classifyCiProof(PR, { expectedHeadSha: 'abc' }, fakeRunner({ prHead: 'abc', checks: [] }));
+    expect(r.status).toBe('no_checks');
+    expect(r.terminal).toBe(false);
+  });
+
+  it('ci_pending (non-terminal) while a check is still running — #1221', () => {
+    const checks: GhCheck[] = [
+      { name: 'tests', bucket: 'pending', state: 'IN_PROGRESS' },
+    ];
+    const r = classifyCiProof(PR, { expectedHeadSha: 'abc' }, fakeRunner({ prHead: 'abc', checks }));
+    expect(r.status).toBe('ci_pending');
+    expect(r.terminal).toBe(false);
+  });
+
+  it('ci_failed (terminal) when any check failed', () => {
+    const checks: GhCheck[] = [
+      { name: 'tests', bucket: 'fail', state: 'FAILURE' },
+      { name: 'lint', bucket: 'pass', state: 'SUCCESS' },
+    ];
+    const r = classifyCiProof(PR, { expectedHeadSha: 'abc' }, fakeRunner({ prHead: 'abc', checks }));
+    expect(r.status).toBe('ci_failed');
+    expect(r.terminal).toBe(true);
+  });
+
+  it('a real fail wins over a pending sibling (terminal fail, not wait)', () => {
+    const checks: GhCheck[] = [
+      { name: 'tests', bucket: 'pending', state: 'IN_PROGRESS' },
+      { name: 'lint', bucket: 'fail', state: 'FAILURE' },
+    ];
+    const r = classifyCiProof(PR, { expectedHeadSha: 'abc' }, fakeRunner({ prHead: 'abc', checks }));
+    expect(r.status).toBe('ci_failed');
+  });
+
+  it('uses local HEAD when no expectedHeadSha is supplied', () => {
+    const r = classifyCiProof(PR, {}, fakeRunner({ localHead: 'zzz', prHead: 'zzz', checks: [{ bucket: 'pass' }] }));
+    expect(r.status).toBe('pass');
+  });
+});
+
+describe('waitForCiProof — pending is a WAIT, not a FAIL (#1221)', () => {
+  it('polls while pending, then returns PASS once CI goes green', async () => {
+    const runner = fakeRunner({
+      prHead: 'abc',
+      localHead: 'abc',
+      checksSequence: [
+        [{ name: 'tests', bucket: 'pending', state: 'IN_PROGRESS' }],
+        [{ name: 'tests', bucket: 'pending', state: 'IN_PROGRESS' }],
+        [{ name: 'tests', bucket: 'pass', state: 'SUCCESS' }],
+      ],
+    });
+    const r = await waitForCiProof(PR, { expectedHeadSha: 'abc' }, runner, { timeoutMs: 100000, intervalMs: 10 });
+    expect(r.status).toBe('pass');
+    expect(runner.sleeps.length).toBe(2); // waited twice before green
+  });
+
+  it('returns ci_pending (non-terminal) on timeout — never fabricates pass or fail', async () => {
+    const runner = fakeRunner({
+      prHead: 'abc',
+      localHead: 'abc',
+      checks: [{ name: 'tests', bucket: 'pending', state: 'IN_PROGRESS' }],
+    });
+    const r = await waitForCiProof(PR, { expectedHeadSha: 'abc' }, runner, { timeoutMs: 30, intervalMs: 10 });
+    expect(r.status).toBe('ci_pending');
+    expect(r.terminal).toBe(false);
+  });
+
+  it('returns immediately on a terminal fail without waiting', async () => {
+    const runner = fakeRunner({
+      prHead: 'abc',
+      localHead: 'abc',
+      checks: [{ name: 'tests', bucket: 'fail', state: 'FAILURE' }],
+    });
+    const r = await waitForCiProof(PR, { expectedHeadSha: 'abc' }, runner, { timeoutMs: 100000, intervalMs: 10 });
+    expect(r.status).toBe('ci_failed');
+    expect(runner.sleeps.length).toBe(0);
+  });
+});
+
+describe('ciProofExitCode — ci_pending is distinct from a real FAIL', () => {
+  it('pass / skipped → 0', () => {
+    expect(ciProofExitCode({ status: 'pass', terminal: true })).toBe(0);
+    expect(ciProofExitCode({ status: 'skipped_non_pr', terminal: true })).toBe(0);
+  });
+  it('ci_pending / no_checks → EX_TEMPFAIL (75), NOT a fail', () => {
+    expect(ciProofExitCode({ status: 'ci_pending', terminal: false })).toBe(EXIT_CI_PENDING);
+    expect(ciProofExitCode({ status: 'no_checks', terminal: false })).toBe(EXIT_CI_PENDING);
+  });
+  it('stale_head / ci_failed → 1 (real fail)', () => {
+    expect(ciProofExitCode({ status: 'stale_head', terminal: true })).toBe(EXIT_CI_FAILED);
+    expect(ciProofExitCode({ status: 'ci_failed', terminal: true })).toBe(EXIT_CI_FAILED);
+  });
+  it('pending failure message announces it is NOT a review FAIL', () => {
+    const msg = formatCiProofFailure({ status: 'ci_pending', terminal: false, detail: 'tests: pending' });
+    expect(msg).toMatch(/NOT a review FAIL/i);
+    expect(msg).toMatch(/75/);
+  });
+});

--- a/src/review-ci-proof.ts
+++ b/src/review-ci-proof.ts
@@ -1,0 +1,289 @@
+/**
+ * review-ci-proof.ts — CI/head proof for review PASS verdicts.
+ *
+ * Intent (originally #1070): a review round must NOT be recorded PASS while the
+ * PR's CI for the *reviewed* HEAD is pending, failing, stale, or absent. A
+ * "PASS" that was never confirmed by CI is exactly the decorative verdict
+ * #1227 warns about.
+ *
+ * Why this module exists separately (redo per #1221/#1222/#1225):
+ *   PR #1212 baked the proof into `storeReviewSummary()` in structured-data.ts.
+ *   That was wrong on three axes:
+ *     - it gave a pure local-storage primitive network/process side-effects
+ *       (every PASS store shelled out to `gh`/`git`) — #1222.2;
+ *     - it threw on non-PR targets — #1222.1;
+ *     - it was a synchronous point-in-time check with no wait, so a genuine
+ *       PASS recorded while CI was still `pending` threw and burned a fix
+ *       round / false-exhausted the loop — #1221.
+ *
+ * The fix: isolate the proof behind an INJECTABLE runner (storage stays
+ * side-effect-free and unit-testable), classify CI into a STRUCTURED result so
+ * callers can tell `ci_pending` apart from a real fail, and provide a
+ * wait-for-CI poll that treats pending as "wait", not "fail". The proof is
+ * invoked at the CLI/caller boundary, not inside the storage layer.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { setTimeout as sleepMs } from 'node:timers/promises';
+
+export type GhCheck = {
+  name?: string;
+  bucket?: string;
+  state?: string;
+  workflow?: string;
+  link?: string;
+};
+
+export type CiProofTarget = { kind: string; number: string; repo: string };
+
+export interface CiProofOptions {
+  /**
+   * The commit SHA that was reviewed. When omitted the runner's local HEAD is
+   * used. Passing it explicitly lets tooling prove CI belongs to the same
+   * commit it reviewed even if the local worktree has moved.
+   */
+  expectedHeadSha?: string;
+}
+
+/**
+ * The only seam that touches the network / process. Inject a fake in tests so
+ * neither the storage layer nor unit tests ever shell out to `gh`/`git`.
+ */
+export interface CiProofRunner {
+  /** Local HEAD sha (`git rev-parse HEAD`). */
+  localHead(): string;
+  /** Current PR head sha (`gh pr view --json headRefOid`). */
+  prHeadSha(repo: string, prNumber: string): string;
+  /** PR checks (`gh pr checks --json ...`). */
+  prChecks(repo: string, prNumber: string): GhCheck[];
+  /** Sleep `ms` milliseconds (injectable so tests don't actually wait). */
+  sleep(ms: number): Promise<void>;
+  /** Monotonic-ish clock in milliseconds. */
+  now(): number;
+}
+
+export type CiProofStatus =
+  | 'pass'           // CI green for the reviewed head — safe to record PASS
+  | 'skipped_non_pr' // target is not a PR — proof does not apply
+  | 'stale_head'     // PR head moved since review — re-review required
+  | 'no_checks'      // CI has not produced checks yet — keep waiting
+  | 'ci_pending'     // checks exist but some are still running — keep waiting
+  | 'ci_failed';     // at least one check failed/cancelled — real fail
+
+export interface CiProofResult {
+  status: CiProofStatus;
+  /** True when no amount of further waiting can change the outcome. */
+  terminal: boolean;
+  detail?: string;
+  reviewedHead?: string;
+  currentHead?: string;
+}
+
+/** Suggested process exit code for a non-pass proof result at a CLI boundary. */
+export const EXIT_CI_PENDING = 75; // EX_TEMPFAIL — "try again later", not a review FAIL.
+export const EXIT_CI_FAILED = 1;
+
+const PENDING_BUCKETS = new Set(['pending']);
+const PASS_BUCKETS = new Set(['pass', 'skipping']);
+const FAIL_BUCKETS = new Set(['fail', 'cancel']);
+const PENDING_STATES = new Set([
+  'IN_PROGRESS', 'QUEUED', 'PENDING', 'WAITING', 'REQUESTED', 'EXPECTED',
+]);
+const FAIL_STATES = new Set([
+  'FAILURE', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE',
+]);
+
+function bucketOf(check: GhCheck): 'pass' | 'fail' | 'pending' {
+  const bucket = (check.bucket ?? '').toLowerCase();
+  const state = (check.state ?? '').toUpperCase();
+  if (FAIL_BUCKETS.has(bucket) || FAIL_STATES.has(state)) return 'fail';
+  if (PENDING_BUCKETS.has(bucket) || PENDING_STATES.has(state)) return 'pending';
+  if (PASS_BUCKETS.has(bucket)) return 'pass';
+  // Unknown bucket with no recognised pass marker: treat conservatively as
+  // pending so we wait rather than declare a premature PASS.
+  return state ? 'pending' : 'pass';
+}
+
+function formatCheck(check: GhCheck): string {
+  const workflow = check.workflow ? `${check.workflow} / ` : '';
+  const name = check.name ?? '(unnamed check)';
+  const bucket = check.bucket ?? 'unknown';
+  const state = check.state ? ` (${check.state})` : '';
+  return `${workflow}${name}: ${bucket}${state}`;
+}
+
+/**
+ * Point-in-time classification of the PR's CI for the reviewed head.
+ * Pure given the runner — no waiting, no retries.
+ */
+export function classifyCiProof(
+  target: CiProofTarget,
+  options: CiProofOptions,
+  runner: CiProofRunner,
+): CiProofResult {
+  if (target.kind !== 'pr') {
+    return { status: 'skipped_non_pr', terminal: true };
+  }
+
+  const reviewedHead = (options.expectedHeadSha ?? '').trim() || runner.localHead();
+  const currentHead = runner.prHeadSha(target.repo, target.number);
+  if (currentHead && reviewedHead && currentHead !== reviewedHead) {
+    return {
+      status: 'stale_head',
+      terminal: true,
+      reviewedHead,
+      currentHead,
+      detail:
+        `PR #${target.number} head is ${currentHead} but the review covered ${reviewedHead}. ` +
+        `Re-review the current head before recording a pass.`,
+    };
+  }
+
+  const checks = runner.prChecks(target.repo, target.number);
+  if (checks.length === 0) {
+    return {
+      status: 'no_checks',
+      terminal: false,
+      currentHead,
+      detail: `CI has not produced any checks for ${currentHead || 'the reviewed head'} yet.`,
+    };
+  }
+
+  const failing = checks.filter(c => bucketOf(c) === 'fail');
+  if (failing.length > 0) {
+    return {
+      status: 'ci_failed',
+      terminal: true,
+      currentHead,
+      detail: `CI is red for ${currentHead}: ${failing.map(formatCheck).join('; ')}`,
+    };
+  }
+
+  const pending = checks.filter(c => bucketOf(c) === 'pending');
+  if (pending.length > 0) {
+    return {
+      status: 'ci_pending',
+      terminal: false,
+      currentHead,
+      detail: `CI is still running for ${currentHead}: ${pending.map(formatCheck).join('; ')}`,
+    };
+  }
+
+  return { status: 'pass', terminal: true, currentHead };
+}
+
+export interface WaitOptions {
+  timeoutMs: number;
+  intervalMs: number;
+}
+
+/**
+ * Poll `classifyCiProof` until it returns a terminal result or the timeout
+ * elapses. On timeout the last (non-terminal) result is returned — so callers
+ * see `ci_pending` / `no_checks`, never a fabricated pass or fail.
+ */
+export async function waitForCiProof(
+  target: CiProofTarget,
+  options: CiProofOptions,
+  runner: CiProofRunner,
+  wait: WaitOptions,
+): Promise<CiProofResult> {
+  const deadline = runner.now() + Math.max(0, wait.timeoutMs);
+  let result = classifyCiProof(target, options, runner);
+  while (!result.terminal && runner.now() < deadline) {
+    await runner.sleep(Math.max(1, wait.intervalMs));
+    result = classifyCiProof(target, options, runner);
+  }
+  return result;
+}
+
+/** Map a proof result to a CLI exit code. pass / skipped → 0. */
+export function ciProofExitCode(result: CiProofResult): number {
+  switch (result.status) {
+    case 'pass':
+    case 'skipped_non_pr':
+      return 0;
+    case 'ci_pending':
+    case 'no_checks':
+      return EXIT_CI_PENDING;
+    case 'stale_head':
+    case 'ci_failed':
+    default:
+      return EXIT_CI_FAILED;
+  }
+}
+
+/** Human-readable explanation for a non-pass proof result. */
+export function formatCiProofFailure(result: CiProofResult): string {
+  const detail = result.detail ? ` ${result.detail}` : '';
+  switch (result.status) {
+    case 'ci_pending':
+    case 'no_checks':
+      return (
+        `store-review-summary: not recording a PASS yet — CI is not terminal.${detail} ` +
+        `This is NOT a review FAIL (exit ${EXIT_CI_PENDING}); wait for CI to finish, then re-run, ` +
+        `or set KAIZEN_SKIP_CI_PROOF=1 to bypass (logged).`
+      );
+    case 'stale_head':
+      return `store-review-summary: refusing to record a PASS for a stale head.${detail}`;
+    case 'ci_failed':
+      return `store-review-summary: refusing to record a PASS while CI is red.${detail}`;
+    default:
+      return `store-review-summary: CI proof failed (${result.status}).${detail}`;
+  }
+}
+
+// ── Default runner (the only place that shells out) ──────────────────
+
+function spawnText(command: string, args: string[], failureContext: string): string {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.error) {
+    throw new Error(`${failureContext}: ${result.error.message}`);
+  }
+  const stdout = (result.stdout ?? '').trim();
+  if ((result.status ?? 0) !== 0 && !stdout) {
+    const stderr = (result.stderr ?? '').trim();
+    throw new Error(`${failureContext}: ${stderr || `${command} exited ${result.status}`}`);
+  }
+  return stdout;
+}
+
+export function createDefaultCiProofRunner(): CiProofRunner {
+  return {
+    localHead() {
+      return spawnText('git', ['rev-parse', 'HEAD'], 'ci-proof: unable to determine local HEAD');
+    },
+    prHeadSha(repo, prNumber) {
+      return spawnText(
+        'gh',
+        ['pr', 'view', String(prNumber), '--repo', repo, '--json', 'headRefOid', '--jq', '.headRefOid'],
+        'ci-proof: unable to read current PR head',
+      );
+    },
+    prChecks(repo, prNumber) {
+      const stdout = spawnText(
+        'gh',
+        ['pr', 'checks', String(prNumber), '--repo', repo, '--json', 'name,bucket,state,workflow,link'],
+        'ci-proof: unable to read PR checks',
+      );
+      if (!stdout) return [];
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`ci-proof: unable to parse PR checks JSON (${msg})`);
+      }
+      if (!Array.isArray(parsed)) {
+        throw new Error('ci-proof: PR checks JSON was not an array');
+      }
+      return parsed as GhCheck[];
+    },
+    sleep(ms) {
+      return sleepMs(ms);
+    },
+    now() {
+      return Date.now();
+    },
+  };
+}

--- a/src/review-finding-contract.ts
+++ b/src/review-finding-contract.ts
@@ -301,12 +301,25 @@ export function parseReviewFindingMeta(value: unknown): ReviewFindingMeta | null
   };
 }
 
-export function extractReviewFindingMeta(content: string): ReviewFindingMeta | null {
+/**
+ * Extract the raw JSON object from the first `<!-- meta:{...} -->` comment in a
+ * stored attachment. Single structured accessor for the meta block so callers
+ * never hand-roll a regex + JSON.parse (I29). The meta JSON is always flat
+ * (no nested braces), so the non-greedy `\{.*?\}` is correct.
+ */
+export function extractMetaComment(content: string): Record<string, unknown> | null {
   const match = content.match(/<!-- meta:(\{.*?\}) -->/);
   if (!match) return null;
   try {
-    return parseReviewFindingMeta(JSON.parse(match[1]));
+    const parsed = JSON.parse(match[1]);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
   } catch {
     return null;
   }
+}
+
+export function extractReviewFindingMeta(content: string): ReviewFindingMeta | null {
+  return parseReviewFindingMeta(extractMetaComment(content));
 }

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -305,88 +305,36 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     const ok = dimComment(2, 'correctness', 'pass', 3, 0, 0); // all DONE → PASS
     ghReturns(ok); // compose: list
     ghReturns(ok); // compose: read
-    ghReturns('abc123'); // gh pr view: current PR head
-    ghReturns(JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' }])); // gh pr checks
     ghReturns(''); // writeAttachment: readAttachment (no existing)
     ghReturns('https://...#issuecomment-sum');
 
-    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes', { expectedHeadSha: 'abc123' });
+    // No CI proof here: storeReviewSummary is a side-effect-free storage
+    // primitive (#1222/#1225). The PASS→CI binding moved to the CLI boundary
+    // (see review-ci-proof.test.ts / cli-structured-data.test.ts).
+    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes');
     const body = bodyOfLastCreate();
     expect(body).toContain('## Review Round 2 — PASS');
     expect(body).toContain('### Reviewer notes (non-authoritative');
     expect(body).toContain('rebased onto main');
   });
 
-  describe('CI proof gate (#1070)', () => {
-    const head = 'abc123';
-    const passChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' },
-      { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
-    ]);
-    const pendingChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' },
-    ]);
-    const failChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' },
-    ]);
+  it('storeReviewSummary stores a derived PASS without shelling out (no gh pr view / checks)', () => {
+    const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
+    ghReturns(ok); // compose: list
+    ghReturns(ok); // compose: read
+    ghReturns(''); // writeAttachment: readAttachment (no existing)
+    ghReturns('https://...#issuecomment-sum');
 
-    it('stores a derived PASS only when current-head CI is passing', () => {
-      const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view: current PR head
-      ghReturns(passChecks); // gh pr checks
-      ghReturns(''); // writeAttachment: readAttachment (no existing)
-      ghReturns('https://...#issuecomment-sum');
+    storeReviewSummary(pr, 4);
 
-      storeReviewSummary(pr, 4, undefined, { expectedHeadSha: head });
-
-      const body = bodyOfLastCreate();
-      expect(body).toContain('## Review Round 4 — PASS');
+    // Regression guard for #1222: the storage layer must NOT invoke
+    // `gh pr view` / `gh pr checks` — only attachment read/write calls.
+    const sawCiCall = mockGh.mock.calls.some(call => {
+      const args = (call[1] as string[]) ?? [];
+      return args.includes('checks') || args.includes('headRefOid');
     });
-
-    it('refuses to store a derived PASS while CI is pending', () => {
-      const ok = dimComment(6, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(pendingChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 6, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*pending|pending.*CI|#1070/i);
-    });
-
-    it('refuses to store a derived PASS when CI is failing', () => {
-      const ok = dimComment(7, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(failChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 7, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*fail|fail.*CI|#1070/i);
-    });
-
-    it('refuses to store a derived PASS before CI has produced checks', () => {
-      const ok = dimComment(9, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns('[]'); // gh pr checks: CI has not started
-
-      expect(() => storeReviewSummary(pr, 9, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*not produced checks|#1070/i);
-    });
-
-    it('refuses to store a derived PASS when the reviewed head is stale', () => {
-      const ok = dimComment(8, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns('def456'); // gh pr view: current PR head differs from reviewed head
-
-      expect(() => storeReviewSummary(pr, 8, undefined, { expectedHeadSha: head }))
-        .toThrow(/stale|HEAD|#1070/i);
-    });
+    expect(sawCiCall).toBe(false);
+    expect(bodyOfLastCreate()).toContain('## Review Round 4 — PASS');
   });
 });
 

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -14,7 +14,6 @@
  */
 
 import YAML from 'yaml';
-import { spawnSync } from 'node:child_process';
 import {
   listAttachments,
   readAttachment,
@@ -30,6 +29,7 @@ import {
   normalizeReviewFindingData as normalizeReviewFindingDataContract,
   makeReviewFindingMeta,
   extractReviewFindingMeta,
+  extractMetaComment,
   summarizeRound,
   assertsPass,
   type ReviewFinding,
@@ -64,10 +64,9 @@ export function storeReviewBatch(
   target: AttachmentTarget,
   round: number,
   findings: ReviewFindingData[],
-  options: StoreReviewSummaryOptions = {},
 ): { urls: string[]; summaryUrl: string } {
   const urls = findings.map(f => storeReviewFinding(target, round, f));
-  const summaryUrl = storeReviewSummary(target, round, undefined, options);
+  const summaryUrl = storeReviewSummary(target, round);
   return { urls, summaryUrl };
 }
 
@@ -106,128 +105,24 @@ export type { ReviewFinding, ReviewFindingData } from './review-finding-contract
 
 const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MISSING: '❌' };
 
-export type StoreReviewSummaryOptions = {
-  /**
-   * The commit SHA that was reviewed. If omitted, the current local HEAD is used.
-   * Passing this explicitly lets review tooling prove CI belongs to the same
-   * commit it reviewed even if the local worktree has moved.
-   */
-  expectedHeadSha?: string;
-};
-
-type GhCheck = {
-  name?: string;
-  bucket?: string;
-  state?: string;
-  workflow?: string;
-  link?: string;
-};
-
-function spawnText(command: string, args: string[], failureContext: string): string {
-  const result = spawnSync(command, args, { encoding: 'utf8' });
-  if (result.error) {
-    throw new Error(`${failureContext}: ${result.error.message}`);
-  }
-  const stdout = (result.stdout ?? '').trim();
-  if ((result.status ?? 0) !== 0 && !stdout) {
-    const stderr = (result.stderr ?? '').trim();
-    throw new Error(`${failureContext}: ${stderr || `${command} exited ${result.status}`}`);
-  }
-  return stdout;
-}
-
-function resolveReviewedHeadSha(expectedHeadSha: string | undefined): string {
-  const explicit = expectedHeadSha?.trim();
-  if (explicit) return explicit;
-  return spawnText(
-    'git',
-    ['rev-parse', 'HEAD'],
-    'store-review-summary: #1070 unable to determine reviewed HEAD; pass --head-sha explicitly',
-  );
-}
-
-function readPrHeadSha(target: AttachmentTarget): string {
-  return spawnText(
-    'gh',
-    ['pr', 'view', String(target.number), '--repo', target.repo, '--json', 'headRefOid', '--jq', '.headRefOid'],
-    'store-review-summary: #1070 unable to read current PR head',
-  );
-}
-
-function readPrChecks(target: AttachmentTarget): GhCheck[] {
-  const stdout = spawnText(
-    'gh',
-    ['pr', 'checks', String(target.number), '--repo', target.repo, '--json', 'name,bucket,state,workflow,link'],
-    'store-review-summary: #1070 unable to read PR checks',
-  );
-  try {
-    const parsed = JSON.parse(stdout);
-    if (!Array.isArray(parsed)) {
-      throw new Error('JSON was not an array');
-    }
-    return parsed as GhCheck[];
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`store-review-summary: #1070 unable to parse PR checks JSON (${msg})`);
-  }
-}
-
-function formatCheck(check: GhCheck): string {
-  const workflow = check.workflow ? `${check.workflow} / ` : '';
-  const name = check.name ?? '(unnamed check)';
-  const bucket = check.bucket ?? 'unknown';
-  const state = check.state ? ` (${check.state})` : '';
-  return `${workflow}${name}: ${bucket}${state}`;
-}
-
-function assertReviewSummaryCiPassed(target: AttachmentTarget, options: StoreReviewSummaryOptions): void {
-  if (target.kind !== 'pr') {
-    throw new Error('store-review-summary: #1070 CI proof requires a PR target');
-  }
-
-  const reviewedHead = resolveReviewedHeadSha(options.expectedHeadSha);
-  const currentHead = readPrHeadSha(target);
-  if (currentHead !== reviewedHead) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary for stale HEAD. ` +
-      `Reviewed ${reviewedHead}, but PR #${target.number} is currently ${currentHead}. ` +
-      `Re-review the current head before storing a pass summary.`,
-    );
-  }
-
-  const checks = readPrChecks(target);
-  if (checks.length === 0) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI has not produced checks for ${currentHead}.`,
-    );
-  }
-
-  const blocking = checks.filter(check => {
-    const bucket = check.bucket;
-    return bucket !== 'pass' && bucket !== 'skipping';
-  });
-  if (blocking.length > 0) {
-    const details = blocking.map(formatCheck).join('; ');
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI is not green for ${currentHead}: ${details}`,
-    );
-  }
-}
-
+/**
+ * Read the authoritative round verdict from a composed summary's meta block.
+ *
+ * Uses the shared `extractMetaComment` accessor rather than a hand-rolled regex
+ * + JSON.parse (I29). The CI/head proof that PR #1212 baked in here has moved
+ * to the CLI boundary (`review-ci-proof.ts`) so this storage layer stays
+ * side-effect-free and unit-testable (#1222 / #1225).
+ */
 function extractSummaryRoundVerdict(summary: string): RoundVerdict | null {
-  const match = summary.match(/^<!-- meta:(\{.*\}) -->/);
-  if (!match) return null;
-  try {
-    const meta = JSON.parse(match[1]) as { round_verdict?: RoundVerdict; verdict?: string };
-    if (meta.round_verdict === 'PASS' || meta.round_verdict === 'PASS_WITH_PARTIALS' || meta.round_verdict === 'FAIL') {
-      return meta.round_verdict;
-    }
-    if (meta.verdict === 'fail') return 'FAIL';
-    if (meta.verdict === 'pass') return 'PASS';
-    return null;
-  } catch {
-    return null;
+  const meta = extractMetaComment(summary);
+  if (!meta) return null;
+  const roundVerdict = meta.round_verdict;
+  if (roundVerdict === 'PASS' || roundVerdict === 'PASS_WITH_PARTIALS' || roundVerdict === 'FAIL') {
+    return roundVerdict;
   }
+  if (meta.verdict === 'fail') return 'FAIL';
+  if (meta.verdict === 'pass') return 'PASS';
+  return null;
 }
 
 /**
@@ -391,19 +286,19 @@ export function deriveStoredRoundVerdict(target: AttachmentTarget, round: number
  * FAIL, throw — the agent must fix the findings or escalate, not narrate a passing verdict on
  * top of failing data (the exact #1019 bypass). The derived block stays authoritative either way.
  *
+ * Side-effect-free: this is a local-storage primitive. The CI/head proof that
+ * gates a PASS verdict lives at the CLI boundary (`review-ci-proof.ts`), not
+ * here — so storage never shells out to `gh`/`git` (#1222 / #1225).
+ *
  * Attachment name: review/r{round}/summary
  */
 export function storeReviewSummary(
   target: AttachmentTarget,
   round: number,
   note?: string,
-  options: StoreReviewSummaryOptions = {},
 ): string {
   const derived = composeReviewSummary(target, round);
   const roundVerdict = extractSummaryRoundVerdict(derived) ?? deriveStoredRoundVerdict(target, round);
-  if (roundVerdict !== 'FAIL') {
-    assertReviewSummaryCiPassed(target, options);
-  }
 
   let content = derived;
 

--- a/src/verdict-binding-invariant.test.ts
+++ b/src/verdict-binding-invariant.test.ts
@@ -1,0 +1,102 @@
+/**
+ * verdict-binding-invariant.test.ts — categorical guard for #1227.
+ *
+ * The #1227 category: kaizen computes quality verdicts correctly, but a verdict
+ * is decorative unless a MECHANISM is required to honour it at the irreversible
+ * action. At every point-of-no-return the system must ask "did the verdict
+ * pass?", not "does an artifact exist?", and fail closed.
+ *
+ * This is the compound-interest piece of the deep-dive: rather than only fixing
+ * the three known holes, this test pins an INVENTORY of (terminal action →
+ * verdict it consumes → enforcing consumer) and asserts each binding is wired.
+ * A computed verdict with no enforcing consumer at a terminal action is itself
+ * a defect — if a future change removes a binding (e.g. reverts the merge gate,
+ * re-bakes CI side-effects into storage, or decouples run-outcome from the
+ * verdicts), this test goes red.
+ *
+ * The canonical human-readable inventory lives in
+ * docs/verdict-binding-inventory.md.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { checkMergeVerdict } from './hooks/enforce-merge-verdict.js';
+import { deriveRunOutcome } from '../scripts/auto-dent-run.js';
+
+const ROOT = join(__dirname, '..');
+const read = (rel: string) => readFileSync(join(ROOT, rel), 'utf8');
+
+describe('#1227 — terminal actions are BOUND to verdicts (binding inventory)', () => {
+  // ── 1. Merge → latest review verdict (#1220) ──────────────────────
+  describe('merge → review verdict (#1220)', () => {
+    it('the merge-verdict gate is registered as a PreToolUse Bash hook', () => {
+      const plugin = read('.claude-plugin/plugin.json');
+      expect(plugin).toContain('kaizen-enforce-merge-verdict-ts.sh');
+    });
+
+    it('the gate BLOCKS a merge whose latest review round derived FAIL', () => {
+      const r = checkMergeVerdict('gh pr merge 903 --repo org/repo --squash --auto', {
+        reader: () => ({ round: 4, verdict: 'FAIL' }),
+        env: {},
+      });
+      expect(r.action).toBe('deny');
+    });
+
+    it('the gate ALLOWS a merge whose latest review round derived PASS', () => {
+      const r = checkMergeVerdict('gh pr merge 903 --repo org/repo --squash', {
+        reader: () => ({ round: 4, verdict: 'PASS' }),
+        env: {},
+      });
+      expect(r.action).toBe('allow');
+    });
+  });
+
+  // ── 2. Run-success stamp → run verdicts (#1224) ───────────────────
+  describe('auto-dent run-success → recorded verdicts (#1224)', () => {
+    it('a review FAIL can never roll up to success', () => {
+      expect(deriveRunOutcome({ stopRequested: false, exitCode: 0, artifactCount: 1, reviewVerdict: 'fail' }))
+        .toBe('failure');
+    });
+
+    it('process-incomplete can never roll up to success', () => {
+      expect(deriveRunOutcome({ stopRequested: false, exitCode: 0, artifactCount: 1, processVerdict: 'process-incomplete' }))
+        .toBe('failure');
+    });
+
+    it('a clean run with artifacts still rolls up to success (no over-blocking)', () => {
+      expect(deriveRunOutcome({ stopRequested: false, exitCode: 0, artifactCount: 1, reviewVerdict: 'pass' }))
+        .toBe('success');
+    });
+  });
+
+  // ── 3. PASS review summary → CI proof (#1221 / #1222 / #1225) ──────
+  describe('PASS review summary → CI proof, with side-effect-free storage (#1222/#1225)', () => {
+    it('storage layer (structured-data.ts) does NOT shell out — no spawnSync / gh CI calls', () => {
+      const src = read('src/structured-data.ts');
+      expect(src).not.toMatch(/spawnSync/);
+      expect(src).not.toMatch(/headRefOid/);
+      expect(src).not.toMatch(/pr['"\s,]+checks/);
+    });
+
+    it('the CI proof is enforced at the CLI boundary on BOTH PASS-storing handlers', () => {
+      const cli = read('src/cli-structured-data.ts');
+      // both store-review-summary and store-review-batch must call the gate
+      const calls = cli.match(/enforceCiProofForPass\(/g) ?? [];
+      expect(calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('the CI proof distinguishes ci_pending (wait, exit 75) from a real FAIL (exit 1) — #1221', () => {
+      const src = read('src/review-ci-proof.ts');
+      expect(src).toContain('EXIT_CI_PENDING');
+      expect(src).toContain('waitForCiProof');
+    });
+  });
+
+  // ── 4. I29 — structured meta read through the shared accessor ──────
+  it('summary verdict is read via the shared meta accessor, not a hand-rolled regex (I29)', () => {
+    const src = read('src/structured-data.ts');
+    expect(src).toContain('extractMetaComment');
+    // the old greedy anchored regex must be gone
+    expect(src).not.toMatch(/summary\.match\(\/\^<!-- meta/);
+  });
+});


### PR DESCRIPTION
## Rescue Context

This is a draft rescue PR for auto-dent batch `double-barracuda/run-3`.

The run was terminated by the watchdog after 1205 seconds (`exit 143`, SIGTERM) before auto-dent created a PR. Its worktree still contained uncommitted changes, so this rescue PR includes an explicit as-is rescue commit.

## Preserved Work

- Worktree: `/home/aviad/projects/kaizen/.claude/worktrees/2606272016-e9be`
- Branch: `case/2606272016-k1227-verdict-binding`
- Rescue commit:
  - `0afd865` `rescue(auto-dent): preserve double-barracuda run 3 work`

The work includes the merge-verdict hook, review CI proof extraction, verdict-binding inventory docs/tests, CLI structured-data changes, and review skill updates that were in-flight when the watchdog stopped the run.

## Rescue Notes

Quality gates were intentionally skipped for the rescue operation. The run had a background `npm test` still in progress and had just stored plan/test-plan comments on #1227 when it timed out. Treat this as preserved interrupted work, not validated work.

Refs #1220
Refs #1221
Refs #1222
Refs #1225
Refs #1227
Refs #1228
