### PR TITLE
[rescue] disgusted-ant run 1 CI proof redo (#1225)

### DIFF
--- a/.agents/skills/kaizen-review-pr/SKILL.md
+++ b/.agents/skills/kaizen-review-pr/SKILL.md
@@ -229,10 +229,20 @@ npx tsx src/cli-structured-data.ts store-review-summary \
   --pr <PR_NUMBER> --repo <owner/repo> --round <N> --head-sha "$(git rev-parse HEAD)"
 ```
 
-For a derived PASS or PASS-with-partials verdict, `store-review-summary` now verifies the PR's
-current HEAD matches `--head-sha` and that `gh pr checks` is green for that HEAD before it writes
-the summary/sentinel (#1070). Pending, failing, absent, or stale-head CI refuses storage; re-run
-review on the current head after CI passes.
+For a derived PASS or PASS-with-partials verdict, `store-review-summary` proves CI is green at the
+CLI boundary before it writes the summary/sentinel (#1070, redone in #1225). It verifies the PR's
+current HEAD matches `--head-sha` and **waits** for `gh pr checks` to reach a terminal state for
+that HEAD:
+
+- **CI green** → stores the summary.
+- **CI pending** → it *polls* (it does not fail); past `--ci-timeout-sec` (default 600) it exits **2**
+  with a distinct `ci_pending` message — this is NOT a review FAIL. Wait for CI to finish, then
+  re-run; do not treat it as an exhausted fix round (#1221).
+- **CI failing / stale head** → exits **1**; fix CI or re-review the current head.
+- **Non-PR target** (review summary on an issue) → CI proof is skipped, the summary stores (#1222).
+
+Tuning flags: `--ci-timeout-sec <N>`, `--ci-poll-sec <N>`. Escape hatch (logged): `--skip-ci-proof`
+stores a PASS without CI proof — use only when CI genuinely cannot run.
 
 Add `--note "<context>"` only for non-verdict commentary (e.g. "rebased onto main, re-ran tests").
 Read back the derived verdict with `read-review-summary --pr <N> --repo <repo> --round <N>` — the

--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { handlers, parseArgs, resolveContent, resolveRound, type CliArgs } from './cli-structured-data.js';
+import { handlers, parseArgs, resolveContent, resolveRound, ciGateForSummary, type CliArgs } from './cli-structured-data.js';
+import type { CommandRunner } from './review-ci-proof.js';
 import {
   nextReviewRound,
   storePlan,
@@ -44,6 +45,7 @@ vi.mock('./structured-data.js', () => ({
   updatePrSection: vi.fn(),
   storeIterationState: vi.fn().mockReturnValue('https://example.com/iteration'),
   retrieveIterationState: vi.fn().mockReturnValue({ round: 1 }),
+  deriveStoredRoundVerdict: vi.fn().mockReturnValue('PASS'),
 }));
 
 beforeEach(() => vi.clearAllMocks());
@@ -194,7 +196,9 @@ describe('individual command handlers', () => {
 // ── store-review-batch sentinel (category prevention: #966) ─────────────────
 
 describe('store-review-batch — review sentinel', () => {
-  const baseArgs: CliArgs = { command: 'store-review-batch', pr: '903', repo: 'org/repo', round: '1' };
+  // These tests exercise sentinel writing, not the CI gate (#1070), so they opt
+  // out of the CI proof with the explicit escape hatch rather than shelling out.
+  const baseArgs: CliArgs = { command: 'store-review-batch', pr: '903', repo: 'org/repo', round: '1', ['skip-ci-proof']: 'true' };
 
   it('writes review sentinel after storing batch findings', async () => {
     // INVARIANT: store-review-batch must write the review sentinel so the
@@ -251,23 +255,27 @@ describe('store-review-batch — review sentinel', () => {
   });
 });
 
-describe('store-review-summary — CI head proof', () => {
-  it('passes --head-sha through to summary storage before writing the sentinel (#1070)', async () => {
+describe('store-review-summary — storage is side-effect-free, sentinel still written (#1070/#1225)', () => {
+  it('stores the summary with the new 3-arg signature (no CI options baked into storage) then writes the sentinel', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
 
+    // skip-ci-proof keeps this test focused on storage + sentinel; the CI gate
+    // itself is covered by `ciGateForSummary` below with an injected runner.
     await handlers['store-review-summary']({
       command: 'store-review-summary',
       pr: '903',
       repo: 'Garsson-io/kaizen',
       round: '5',
       ['head-sha']: 'abc123',
+      ['skip-ci-proof']: 'true',
     } as CliArgs);
 
+    // New signature: CI proof is NOT threaded into storage as a 4th options arg (#1222).
     expect(vi.mocked(storeReviewSummary)).toHaveBeenCalledWith(
       { kind: 'pr', number: 903, repo: 'Garsson-io/kaizen' },
       5,
       undefined,
-      { expectedHeadSha: 'abc123' },
     );
     const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r5'),
@@ -284,6 +292,77 @@ describe('store-review-summary — CI head proof', () => {
     expect(payload.findingCount).toBeGreaterThanOrEqual(0);
     expect(payload.integrity).toMatch(/^sha256:/);
     log.mockRestore();
+    err.mockRestore();
+  });
+});
+
+describe('ciGateForSummary — CI gate at the CLI boundary (#1070/#1225)', () => {
+  const pr = { kind: 'pr' as const, number: '903', repo: 'Garsson-io/kaizen' };
+  const issueTgt = { kind: 'issue' as const, number: '904', repo: 'Garsson-io/kaizen' };
+  const passChecks = JSON.stringify([{ name: 'tests', bucket: 'pass', state: 'SUCCESS' }]);
+  const pendingChecks = JSON.stringify([{ name: 'tests', bucket: 'pending', state: 'IN_PROGRESS' }]);
+  const failChecks = JSON.stringify([{ name: 'tests', bucket: 'fail', state: 'FAILURE' }]);
+
+  const runner = (prChecks: string, prHead = 'abc'): CommandRunner => (command, argv) => {
+    const joined = `${command} ${argv.join(' ')}`;
+    if (command === 'git') return { status: 0, stdout: 'abc', stderr: '' };
+    if (joined.includes('pr view')) return { status: 0, stdout: prHead, stderr: '' };
+    if (joined.includes('pr checks')) return { status: 0, stdout: prChecks, stderr: '' };
+    return { status: 0, stdout: '', stderr: '' };
+  };
+  const deps = (prChecks: string, prHead = 'abc') => ({
+    runner: runner(prChecks, prHead),
+    sleep: async () => {},
+    now: (() => { let t = 0; return () => (t += 60_000); })(),
+  });
+  const argsWith = (extra: Partial<CliArgs> = {}): CliArgs =>
+    ({ command: 'store-review-summary', pr: '903', repo: 'Garsson-io/kaizen', ['head-sha']: 'abc', ...extra }) as CliArgs;
+
+  it('stores when CI is green', async () => {
+    const d = await ciGateForSummary(pr, 'PASS', argsWith(), deps(passChecks));
+    expect(d.outcome).toBe('store');
+  });
+
+  it('refuses with exit 1 when CI is failing', async () => {
+    const d = await ciGateForSummary(pr, 'PASS', argsWith(), deps(failChecks));
+    expect(d).toMatchObject({ outcome: 'refuse', exitCode: 1 });
+  });
+
+  it('refuses with the distinct ci_pending exit 2 when CI never finishes (#1221)', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const d = await ciGateForSummary(pr, 'PASS', argsWith({ ['ci-timeout-sec']: '1' }), deps(pendingChecks));
+    expect(d).toMatchObject({ outcome: 'refuse', exitCode: 2 });
+    expect(d.message).toMatch(/ci_pending/);
+    err.mockRestore();
+  });
+
+  it('refuses with exit 1 when the reviewed head is stale', async () => {
+    const d = await ciGateForSummary(pr, 'PASS', argsWith(), deps(passChecks, 'different-head'));
+    expect(d).toMatchObject({ outcome: 'refuse', exitCode: 1 });
+  });
+
+  it('stores (skipped) for a non-PR target — never refuses (#1222.1)', async () => {
+    const d = await ciGateForSummary(issueTgt, 'PASS', argsWith(), deps(passChecks));
+    expect(d.outcome).toBe('store');
+  });
+
+  it('stores a FAIL verdict without consulting CI', async () => {
+    let called = false;
+    const spyDeps = { runner: ((c: string, a: string[]) => { called = true; return { status: 0, stdout: '', stderr: '' }; }) as CommandRunner, sleep: async () => {} };
+    const d = await ciGateForSummary(pr, 'FAIL', argsWith(), spyDeps);
+    expect(d.outcome).toBe('store');
+    expect(called).toBe(false);
+  });
+
+  it('stores with --skip-ci-proof and logs the bypass', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let called = false;
+    const spyDeps = { runner: ((c: string, a: string[]) => { called = true; return { status: 0, stdout: '', stderr: '' }; }) as CommandRunner, sleep: async () => {} };
+    const d = await ciGateForSummary(pr, 'PASS', argsWith({ ['skip-ci-proof']: 'true' }), spyDeps);
+    expect(d.outcome).toBe('store');
+    expect(called).toBe(false);
+    expect(err).toHaveBeenCalledWith(expect.stringMatching(/skip-ci-proof/));
+    err.mockRestore();
   });
 });
 

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -58,14 +58,27 @@ import {
   updatePrSection,
   storeIterationState,
   retrieveIterationState,
+  deriveStoredRoundVerdict,
   type ReviewFindingData,
-  type StoreReviewSummaryOptions,
 } from './structured-data.js';
 import {
   buildReviewSentinelRecord,
   serializeReviewSentinel,
 } from './review-sentinel.js';
-import { normalizeReviewFindingData, validateReviewFindingPayload, summarizeFindingStatuses } from './review-finding-contract.js';
+import {
+  normalizeReviewFindingData,
+  validateReviewFindingPayload,
+  summarizeFindingStatuses,
+  summarizeRound,
+  type RoundVerdict,
+} from './review-finding-contract.js';
+import {
+  waitForCiProof,
+  type CiProofOptions,
+  type CommandRunner,
+  type WaitForCiOptions,
+} from './review-ci-proof.js';
+import type { AttachmentTarget } from './section-editor.js';
 
 export type CliArgs = Record<string, string> & { command: string };
 type Handler = (a: CliArgs) => Promise<void>;
@@ -74,7 +87,7 @@ type Handler = (a: CliArgs) => Promise<void>;
  * Flags that are booleans — no value follows, presence means true.
  * Keeps `--stdin` usable without the trap of consuming the next arg.
  */
-const BOOLEAN_FLAGS = new Set(['stdin']);
+const BOOLEAN_FLAGS = new Set(['stdin', 'skip-ci-proof']);
 
 export function parseArgs(argv?: string[]): CliArgs {
   const args = argv ?? process.argv.slice(2);
@@ -177,10 +190,86 @@ function writeReviewSentinel(repo: string, pr: string | undefined, round: number
   }
 }
 
-function reviewSummaryOptions(a: CliArgs): StoreReviewSummaryOptions {
+function ciProofOptions(a: CliArgs): CiProofOptions {
   return {
     expectedHeadSha: a['head-sha'],
   };
+}
+
+/**
+ * The CLI/caller-boundary CI gate for a PASS / PASS-with-partials review summary (#1070, redone
+ * per #1225). Storage stays side-effect-free; this is where the `gh`/`git` proof lives.
+ *
+ * Returns a decision so the wiring is unit-testable (the handler does the actual `process.exit`):
+ *  - FAIL verdict → always `store` (a FAIL summary needs no CI proof).
+ *  - `pass` / `skipped` → `store`.
+ *  - `fail` / `stale` / `no_checks` (terminal) → `refuse` exit 1 (real review-blocking state).
+ *  - `pending` after the wait budget → `refuse` exit 2 with a distinct `ci_pending` message, so a
+ *    caller/loop can tell "CI not done yet" apart from "review FAIL" and wait rather than exhaust
+ *    a fix round (#1221).
+ */
+export interface CiGateDecision {
+  outcome: 'store' | 'refuse';
+  exitCode?: number;
+  message?: string;
+}
+
+export interface CiGateDeps {
+  runner?: CommandRunner;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+export async function ciGateForSummary(
+  target: AttachmentTarget,
+  verdict: RoundVerdict,
+  a: CliArgs,
+  deps: CiGateDeps = {},
+): Promise<CiGateDecision> {
+  // A FAIL summary is always storable — there is nothing to falsely declare passed.
+  if (verdict === 'FAIL') return { outcome: 'store' };
+  // Explicit, logged escape hatch.
+  if (a['skip-ci-proof'] === 'true') {
+    console.error('store-review-summary: ⚠️  --skip-ci-proof set — storing a PASS summary WITHOUT CI proof (#1070 bypass).');
+    return { outcome: 'store' };
+  }
+  const waitOpts: WaitForCiOptions = {
+    ...ciProofOptions(a),
+    ...(deps.runner ? { runner: deps.runner } : {}),
+    ...(deps.sleep ? { sleep: deps.sleep } : {}),
+    ...(deps.now ? { now: deps.now } : {}),
+    ...(a['ci-timeout-sec'] ? { timeoutMs: Number(a['ci-timeout-sec']) * 1000 } : {}),
+    ...(a['ci-poll-sec'] ? { intervalMs: Number(a['ci-poll-sec']) * 1000 } : {}),
+    onPoll: (r, elapsed) => {
+      if (r.status === 'pending' || r.status === 'no_checks') {
+        console.error(`store-review-summary: waiting for CI (${Math.round(elapsed / 1000)}s) — ${r.detail}`);
+      }
+    },
+  };
+  const result = await waitForCiProof(target, waitOpts);
+  switch (result.status) {
+    case 'pass':
+    case 'skipped':
+      return { outcome: 'store' };
+    case 'pending':
+    case 'no_checks':
+      return {
+        outcome: 'refuse',
+        exitCode: 2,
+        message:
+          `store-review-summary: ci_pending — refusing to store a PASS summary because CI has not ` +
+          `finished for the reviewed head. ${result.detail} This is NOT a review FAIL; wait for CI ` +
+          `to go green and re-run, or raise --ci-timeout-sec.`,
+      };
+    case 'fail':
+    case 'stale':
+    default:
+      return {
+        outcome: 'refuse',
+        exitCode: 1,
+        message: `store-review-summary: refusing to store a PASS summary — ${result.detail}`,
+      };
+  }
 }
 
 // Review handlers
@@ -254,7 +343,22 @@ async function handleStoreReviewBatch(a: CliArgs): Promise<void> {
     }
   }
   const findings = parsedBatch as ReviewFindingData[];
-  const result = storeReviewBatch(pr, r, findings, reviewSummaryOptions(a));
+
+  // Same CI-green proof as store-review-summary (#1070/#1225): derive the round verdict from the
+  // batch payload up front and gate a PASS on CI before storing anything.
+  const rows = findings.map(f => {
+    const norm = normalizeReviewFindingData(f);
+    const stats = summarizeFindingStatuses(norm.findings);
+    return { dim: norm.dimension, verdict: norm.verdict, done: stats.done, partial: stats.partial, missing: stats.missing };
+  });
+  const batchVerdict = summarizeRound(rows).verdict;
+  const gate = await ciGateForSummary(pr, batchVerdict, a);
+  if (gate.outcome === 'refuse') {
+    console.error(gate.message ?? 'store-review-batch: CI proof refused.');
+    process.exit(gate.exitCode ?? 1);
+  }
+
+  const result = storeReviewBatch(pr, r, findings);
   // #966: Write review sentinel so pr-review-loop.ts gate guard passes.
   // Mirrors handleStoreReviewSummary — batch includes summary, so sentinel must be written here too.
   writeReviewSentinel(a.repo, a.pr, r);
@@ -275,9 +379,21 @@ async function handleStoreReviewSummary(a: CliArgs): Promise<void> {
   // legacy --text/--file) is non-authoritative commentary appended below the derived block.
   const note = (a.note ?? resolveContent(a)) || undefined;
   const r = resolveRound(a);
+  const target = prTarget(a.pr, a.repo);
+
+  // CI-green proof at the caller boundary (#1070/#1225): derive the verdict from the already-stored
+  // findings, then gate a PASS on CI before writing the summary/sentinel. Storage itself stays
+  // side-effect-free (#1222) and pending CI is a wait, not a false FAIL (#1221).
+  const verdict = deriveStoredRoundVerdict(target, r);
+  const gate = await ciGateForSummary(target, verdict, a);
+  if (gate.outcome === 'refuse') {
+    console.error(gate.message ?? 'store-review-summary: CI proof refused.');
+    process.exit(gate.exitCode ?? 1);
+  }
+
   let url: string;
   try {
-    url = storeReviewSummary(prTarget(a.pr, a.repo), r, note, reviewSummaryOptions(a));
+    url = storeReviewSummary(target, r, note);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);

--- a/src/e2e/review-ci-proof-cli.test.ts
+++ b/src/e2e/review-ci-proof-cli.test.ts
@@ -1,0 +1,116 @@
+/**
+ * review-ci-proof-cli.test.ts — system-level E2E for the redone #1070 CI-proof
+ * gate (#1225, the behavioral test PR #1212 skipped — I23).
+ *
+ * Spawns the REAL `store-review-summary` CLI binary with a fake `gh` on PATH and
+ * asserts the actual process exit codes on the CI-gate decision boundary:
+ *   - failing CI  → exit 1 (refuse, real review-blocking state)
+ *   - pending CI past the wait budget → exit 2 (distinct ci_pending; NOT a FAIL) (#1221)
+ *   - stale head  → exit 1 (refuse)
+ * These paths exit BEFORE any storage, so the fake `gh` only needs to answer
+ * `pr view` / `pr checks`. No network, deterministic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const KAIZEN_REPO_ROOT = path.resolve(__dirname, '../..');
+const CLI_TS = path.join(KAIZEN_REPO_ROOT, 'src/cli-structured-data.ts');
+
+function findTsx(): string | null {
+  const local = path.join(KAIZEN_REPO_ROOT, 'node_modules/.bin/tsx');
+  if (fs.existsSync(local)) return local;
+  let dir = path.dirname(KAIZEN_REPO_ROOT);
+  for (let i = 0; i < 5; i++) {
+    const candidate = path.join(dir, 'node_modules/.bin/tsx');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  try {
+    const common = execSync('git rev-parse --git-common-dir', { cwd: KAIZEN_REPO_ROOT, encoding: 'utf-8' }).trim();
+    const mainTsx = path.join(path.dirname(common), 'node_modules/.bin/tsx');
+    if (fs.existsSync(mainTsx)) return mainTsx;
+  } catch { /* ignore */ }
+  return null;
+}
+
+const TSX_BIN = findTsx();
+const HEAD = 'abc123def456';
+
+let mockBin: string;
+
+/**
+ * Write a fake `gh` that returns the reviewed HEAD for `pr view` and the given
+ * checks JSON for `pr checks`. `currentHead` lets us simulate a stale head.
+ */
+function writeMockGh(checksJson: string, currentHead = HEAD): void {
+  const content = `#!/usr/bin/env bash
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '%s' '${currentHead}'
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+  cat <<'JSON'
+${checksJson}
+JSON
+  exit 0
+fi
+exit 1
+`;
+  const ghPath = path.join(mockBin, 'gh');
+  fs.writeFileSync(ghPath, content);
+  fs.chmodSync(ghPath, 0o755);
+}
+
+function runStoreSummary(extraArgs: string[]): { code: number; stderr: string } {
+  if (!TSX_BIN) throw new Error('tsx not found — cannot run E2E test');
+  const result = spawnSync(
+    TSX_BIN,
+    [CLI_TS, 'store-review-summary', '--pr', '903', '--repo', 'Garsson-io/kaizen', '--round', '5', '--head-sha', HEAD, ...extraArgs],
+    {
+      cwd: KAIZEN_REPO_ROOT,
+      env: { ...process.env, PATH: `${mockBin}:${process.env.PATH ?? ''}` },
+      encoding: 'utf-8',
+    },
+  );
+  return { code: result.status ?? -1, stderr: result.stderr ?? '' };
+}
+
+const failChecks = JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' }]);
+const pendingChecks = JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' }]);
+const passChecks = JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' }]);
+
+const maybe = TSX_BIN ? describe : describe.skip;
+
+maybe('store-review-summary CI gate — real CLI exit codes (#1070/#1225, I23)', () => {
+  beforeEach(() => { mockBin = fs.mkdtempSync(path.join(os.tmpdir(), 'kaizen-ciproof-')); });
+  afterEach(() => { fs.rmSync(mockBin, { recursive: true, force: true }); });
+
+  it('exits 1 (refuse) when CI is failing for the reviewed head', () => {
+    writeMockGh(failChecks);
+    const { code, stderr } = runStoreSummary([]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/refusing to store a PASS summary/i);
+  });
+
+  it('exits 2 with a distinct ci_pending message when CI never finishes (#1221)', () => {
+    writeMockGh(pendingChecks);
+    // timeout 0 → evaluate once, see pending, return immediately (no real wait).
+    const { code, stderr } = runStoreSummary(['--ci-timeout-sec', '0']);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/ci_pending/);
+    expect(stderr).toMatch(/NOT a review FAIL/i);
+  });
+
+  it('exits 1 (refuse) when the PR head has moved past the reviewed head (stale)', () => {
+    writeMockGh(passChecks, 'different-head-sha');
+    const { code, stderr } = runStoreSummary([]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/Reviewed .* but PR .* is currently/i);
+  });
+});

--- a/src/review-ci-proof.test.ts
+++ b/src/review-ci-proof.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  evaluateCiProof,
+  waitForCiProof,
+  type CommandRunner,
+  type CommandResult,
+} from './review-ci-proof.js';
+import { prTarget, issueTarget } from './structured-data.js';
+
+const pr = prTarget('903', 'Garsson-io/kaizen');
+const issue = issueTarget('904', 'Garsson-io/kaizen');
+
+const ok = (stdout: string): CommandResult => ({ status: 0, stdout, stderr: '' });
+
+/**
+ * Build a fake runner driven by simple matchers on the joined arg string.
+ * `gh pr checks` exits non-zero in real life when pending/failing, so callers
+ * must NOT trust status — these fakes return status 0 with the JSON payload to
+ * mirror that the code parses stdout, not the exit code.
+ */
+function runner(map: {
+  revParse?: string;
+  prView?: string;
+  prChecks?: string;
+}): CommandRunner {
+  return (command, args) => {
+    const joined = `${command} ${args.join(' ')}`;
+    if (command === 'git' && args.includes('rev-parse')) return ok(map.revParse ?? 'HEAD_SHA');
+    if (joined.includes('pr view')) return ok(map.prView ?? '');
+    if (joined.includes('pr checks')) return ok(map.prChecks ?? '');
+    return ok('');
+  };
+}
+
+const passChecks = JSON.stringify([
+  { name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' },
+  { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
+]);
+const pendingChecks = JSON.stringify([
+  { name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' },
+]);
+const failChecks = JSON.stringify([
+  { name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' },
+]);
+
+describe('evaluateCiProof', () => {
+  it('returns pass when current head matches and all buckets pass/skipping', () => {
+    const r = evaluateCiProof(pr, { expectedHeadSha: 'abc' }, runner({ prView: 'abc', prChecks: passChecks }));
+    expect(r.status).toBe('pass');
+    expect(r.currentHead).toBe('abc');
+  });
+
+  it('returns pending (not fail) when any bucket is pending', () => {
+    const r = evaluateCiProof(pr, { expectedHeadSha: 'abc' }, runner({ prView: 'abc', prChecks: pendingChecks }));
+    expect(r.status).toBe('pending');
+  });
+
+  it('returns fail when a bucket is failing', () => {
+    const r = evaluateCiProof(pr, { expectedHeadSha: 'abc' }, runner({ prView: 'abc', prChecks: failChecks }));
+    expect(r.status).toBe('fail');
+    expect(r.detail).toMatch(/not green/i);
+  });
+
+  it('returns fail when a bucket is cancelled', () => {
+    const checks = JSON.stringify([{ name: 'x', bucket: 'cancel', state: 'CANCELLED' }]);
+    const r = evaluateCiProof(pr, { expectedHeadSha: 'abc' }, runner({ prView: 'abc', prChecks: checks }));
+    expect(r.status).toBe('fail');
+  });
+
+  it('returns stale when the PR head no longer matches the reviewed head', () => {
+    const r = evaluateCiProof(pr, { expectedHeadSha: 'abc' }, runner({ prView: 'def', prChecks: passChecks }));
+    expect(r.status).toBe('stale');
+    expect(r.reviewedHead).toBe('abc');
+    expect(r.currentHead).toBe('def');
+  });
+
+  it('returns no_checks when the checks array is empty', () => {
+    const r = evaluateCiProof(pr, { expectedHeadSha: 'abc' }, runner({ prView: 'abc', prChecks: '[]' }));
+    expect(r.status).toBe('no_checks');
+  });
+
+  it('returns skipped for a non-PR (issue) target — never throws (#1222.1)', () => {
+    const r = evaluateCiProof(issue, {}, runner({}));
+    expect(r.status).toBe('skipped');
+  });
+
+  it('resolves the reviewed head from git when not passed explicitly', () => {
+    const r = evaluateCiProof(pr, {}, runner({ revParse: 'zzz', prView: 'zzz', prChecks: passChecks }));
+    expect(r.status).toBe('pass');
+    expect(r.reviewedHead).toBe('zzz');
+  });
+
+  it('returns pending (wait, not fail) when the PR head cannot be read', () => {
+    const failing: CommandRunner = (command, args) => {
+      if (command === 'git') return ok('abc');
+      return { status: 1, stdout: '', stderr: 'gh: could not connect' };
+    };
+    const r = evaluateCiProof(pr, { expectedHeadSha: 'abc' }, failing);
+    expect(r.status).toBe('pending');
+  });
+});
+
+describe('waitForCiProof', () => {
+  it('polls pending → pass and returns pass', async () => {
+    const sequence = ['pending', 'pending', 'pass'];
+    let i = 0;
+    const seqRunner: CommandRunner = (command, args) => {
+      const joined = `${command} ${args.join(' ')}`;
+      if (command === 'git') return ok('abc');
+      if (joined.includes('pr view')) return ok('abc');
+      if (joined.includes('pr checks')) {
+        const phase = sequence[Math.min(i, sequence.length - 1)];
+        i++;
+        return ok(phase === 'pass' ? passChecks : pendingChecks);
+      }
+      return ok('');
+    };
+    const sleep = vi.fn(async () => {});
+    const r = await waitForCiProof(pr, {
+      expectedHeadSha: 'abc',
+      runner: seqRunner,
+      sleep,
+      now: (() => { let t = 0; return () => (t += 1000); })(),
+      timeoutMs: 100_000,
+      intervalMs: 1000,
+    });
+    expect(r.status).toBe('pass');
+    expect(sleep).toHaveBeenCalled();
+  });
+
+  it('returns pending (NOT fail) after the timeout elapses (#1221)', async () => {
+    const sleep = vi.fn(async () => {});
+    let t = 0;
+    const r = await waitForCiProof(pr, {
+      expectedHeadSha: 'abc',
+      runner: runner({ prView: 'abc', prChecks: pendingChecks }),
+      sleep,
+      now: () => (t += 60_000), // each call jumps 60s → exceeds timeout fast
+      timeoutMs: 100_000,
+      intervalMs: 1000,
+    });
+    expect(r.status).toBe('pending');
+  });
+
+  it('returns immediately on a terminal fail without sleeping', async () => {
+    const sleep = vi.fn(async () => {});
+    const r = await waitForCiProof(pr, {
+      expectedHeadSha: 'abc',
+      runner: runner({ prView: 'abc', prChecks: failChecks }),
+      sleep,
+      now: (() => { let t = 0; return () => (t += 1000); })(),
+    });
+    expect(r.status).toBe('fail');
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('returns skipped immediately for a non-PR target', async () => {
+    const sleep = vi.fn(async () => {});
+    const r = await waitForCiProof(issue, { runner: runner({}), sleep });
+    expect(r.status).toBe('skipped');
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/src/review-ci-proof.ts
+++ b/src/review-ci-proof.ts
@@ -1,0 +1,256 @@
+/**
+ * CI-proof verifier for review summaries (#1070, redone per #1225/#1221/#1222).
+ *
+ * A PASS / PASS-with-partials review summary may only be stored once CI is green
+ * for the exact commit that was reviewed. This module owns that proof. It lives
+ * OUTSIDE the storage layer (`structured-data.ts`) so storage stays a pure,
+ * side-effect-free primitive (#1222): the gate is applied at the CLI/caller
+ * boundary instead.
+ *
+ * Design:
+ *  - `evaluateCiProof` is a PURE function of an injected `CommandRunner` — it
+ *    never throws for control flow, returning a structured discriminated union
+ *    so callers can branch on `pending` (wait) vs `fail`/`stale` (refuse).
+ *  - `waitForCiProof` polls `evaluateCiProof` while the result is `pending`,
+ *    with an injectable clock + sleep, so "CI not done yet" is a *wait*, not a
+ *    *false review FAIL* (#1221).
+ *  - Non-PR targets are `skipped`, never thrown on (#1222.1).
+ */
+
+import { spawnSync } from 'node:child_process';
+import type { AttachmentTarget } from './section-editor.js';
+
+/** Result of a single command invocation. */
+export interface CommandResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Injectable command runner — real impl shells out; tests pass a fake. */
+export type CommandRunner = (command: string, args: string[]) => CommandResult;
+
+/** The reviewed commit + the PR it belongs to. */
+export interface CiProofOptions {
+  /**
+   * The commit SHA that was reviewed. If omitted, the current local HEAD is
+   * resolved via `git rev-parse HEAD`. Passing it explicitly lets review tooling
+   * prove CI belongs to the same commit it reviewed even if the worktree moved.
+   */
+  expectedHeadSha?: string;
+}
+
+export type CiProofStatus =
+  | 'pass'       // CI green for the reviewed head — safe to store PASS
+  | 'pending'    // CI still running for the reviewed head — wait, do not fail
+  | 'fail'       // a check is failing/cancelled for the reviewed head
+  | 'stale'      // current PR head no longer matches the reviewed head
+  | 'no_checks'  // CI has produced no checks for the reviewed head yet
+  | 'skipped';   // proof not applicable (non-PR target / explicitly skipped)
+
+export interface CiProofResult {
+  status: CiProofStatus;
+  /** Human-readable explanation, suitable for stderr. */
+  detail: string;
+  /** The reviewed head SHA, when it could be resolved. */
+  reviewedHead?: string;
+  /** The PR's current head SHA, when it could be read. */
+  currentHead?: string;
+}
+
+type GhCheck = {
+  name?: string;
+  bucket?: string;
+  state?: string;
+  workflow?: string;
+  link?: string;
+};
+
+/** Default runner — real `gh`/`git` via spawnSync. */
+export const defaultCommandRunner: CommandRunner = (command, args) => {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.error) {
+    return { status: 1, stdout: '', stderr: result.error.message };
+  }
+  return {
+    status: result.status ?? 0,
+    stdout: (result.stdout ?? '').trim(),
+    stderr: (result.stderr ?? '').trim(),
+  };
+};
+
+function formatCheck(check: GhCheck): string {
+  const workflow = check.workflow ? `${check.workflow} / ` : '';
+  const name = check.name ?? '(unnamed check)';
+  const bucket = check.bucket ?? 'unknown';
+  const state = check.state ? ` (${check.state})` : '';
+  return `${workflow}${name}: ${bucket}${state}`;
+}
+
+function resolveReviewedHead(options: CiProofOptions, runner: CommandRunner): { sha?: string; error?: string } {
+  const explicit = options.expectedHeadSha?.trim();
+  if (explicit) return { sha: explicit };
+  const res = runner('git', ['rev-parse', 'HEAD']);
+  if (res.status !== 0 || !res.stdout) {
+    return { error: res.stderr || 'git rev-parse HEAD failed; pass --head-sha explicitly' };
+  }
+  return { sha: res.stdout };
+}
+
+function readPrHead(target: AttachmentTarget, runner: CommandRunner): { sha?: string; error?: string } {
+  const res = runner('gh', ['pr', 'view', target.number, '--repo', target.repo, '--json', 'headRefOid', '--jq', '.headRefOid']);
+  if (res.status !== 0 || !res.stdout) {
+    return { error: res.stderr || `gh pr view #${target.number} failed` };
+  }
+  return { sha: res.stdout };
+}
+
+function readPrChecks(target: AttachmentTarget, runner: CommandRunner): { checks?: GhCheck[]; error?: string } {
+  const res = runner('gh', ['pr', 'checks', target.number, '--repo', target.repo, '--json', 'name,bucket,state,workflow,link']);
+  // `gh pr checks` exits non-zero when checks are pending OR failing; the JSON
+  // payload is still emitted, so prefer parsing stdout over trusting the code.
+  if (!res.stdout) {
+    // No checks have been created yet (gh prints nothing) — treat as no_checks,
+    // not an error, unless stderr signals a real failure.
+    if (res.stderr && !/no checks/i.test(res.stderr)) {
+      return { error: res.stderr };
+    }
+    return { checks: [] };
+  }
+  try {
+    const parsed = JSON.parse(res.stdout);
+    if (!Array.isArray(parsed)) return { error: 'gh pr checks JSON was not an array' };
+    return { checks: parsed as GhCheck[] };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: `unable to parse PR checks JSON (${msg})` };
+  }
+}
+
+/**
+ * Evaluate CI proof for a review summary. Pure given `runner`; never throws for
+ * control flow. Callers branch on `status`.
+ */
+export function evaluateCiProof(
+  target: AttachmentTarget,
+  options: CiProofOptions = {},
+  runner: CommandRunner = defaultCommandRunner,
+): CiProofResult {
+  if (target.kind !== 'pr') {
+    return { status: 'skipped', detail: `CI proof skipped: target is a ${target.kind}, not a PR.` };
+  }
+
+  const reviewed = resolveReviewedHead(options, runner);
+  if (!reviewed.sha) {
+    // Can't establish what we reviewed → cannot prove staleness; treat as
+    // pending so the caller waits/retries rather than recording a false PASS.
+    return { status: 'pending', detail: `CI proof undetermined: ${reviewed.error}` };
+  }
+
+  const current = readPrHead(target, runner);
+  if (!current.sha) {
+    return { status: 'pending', detail: `CI proof undetermined: ${current.error}`, reviewedHead: reviewed.sha };
+  }
+
+  if (current.sha !== reviewed.sha) {
+    return {
+      status: 'stale',
+      detail:
+        `Reviewed ${reviewed.sha}, but PR #${target.number} is currently ${current.sha}. ` +
+        `Re-review the current head before storing a pass summary.`,
+      reviewedHead: reviewed.sha,
+      currentHead: current.sha,
+    };
+  }
+
+  const checksRes = readPrChecks(target, runner);
+  if (checksRes.error) {
+    return { status: 'pending', detail: `CI proof undetermined: ${checksRes.error}`, reviewedHead: reviewed.sha, currentHead: current.sha };
+  }
+  const checks = checksRes.checks ?? [];
+  if (checks.length === 0) {
+    return {
+      status: 'no_checks',
+      detail: `CI has not produced any checks for ${current.sha} yet.`,
+      reviewedHead: reviewed.sha,
+      currentHead: current.sha,
+    };
+  }
+
+  const failing = checks.filter(c => c.bucket === 'fail' || c.bucket === 'cancel');
+  if (failing.length > 0) {
+    return {
+      status: 'fail',
+      detail: `CI is not green for ${current.sha}: ${failing.map(formatCheck).join('; ')}`,
+      reviewedHead: reviewed.sha,
+      currentHead: current.sha,
+    };
+  }
+
+  const unfinished = checks.filter(c => c.bucket !== 'pass' && c.bucket !== 'skipping');
+  if (unfinished.length > 0) {
+    return {
+      status: 'pending',
+      detail: `CI still running for ${current.sha}: ${unfinished.map(formatCheck).join('; ')}`,
+      reviewedHead: reviewed.sha,
+      currentHead: current.sha,
+    };
+  }
+
+  return { status: 'pass', detail: `CI green for ${current.sha}.`, reviewedHead: reviewed.sha, currentHead: current.sha };
+}
+
+const TERMINAL: ReadonlySet<CiProofStatus> = new Set(['pass', 'fail', 'stale', 'skipped']);
+
+export interface WaitForCiOptions extends CiProofOptions {
+  runner?: CommandRunner;
+  /** Total budget before giving up on a pending CI. Default 600_000ms (10m). */
+  timeoutMs?: number;
+  /** Delay between polls. Default 15_000ms. */
+  intervalMs?: number;
+  /** Injectable sleep (tests pass a no-op or fake). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable clock (tests advance it). Default Date.now via a closure. */
+  now?: () => number;
+  /** Called once per poll with the interim result (for progress logging). */
+  onPoll?: (result: CiProofResult, elapsedMs: number) => void;
+}
+
+const realSleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Poll `evaluateCiProof` while the status is `pending` (or transient `no_checks`)
+ * until it reaches a terminal status or the timeout elapses. A timeout returns
+ * the last `pending`/`no_checks` result unchanged — it is NOT promoted to `fail`,
+ * so callers can distinguish "CI not done" from "CI red" (#1221).
+ */
+export async function waitForCiProof(
+  target: AttachmentTarget,
+  options: WaitForCiOptions = {},
+): Promise<CiProofResult> {
+  const runner = options.runner ?? defaultCommandRunner;
+  const timeoutMs = options.timeoutMs ?? 600_000;
+  const intervalMs = options.intervalMs ?? 15_000;
+  const sleep = options.sleep ?? realSleep;
+  // Default clock: capture a monotonic-ish baseline. Date.now is unavailable in
+  // some sandboxes; fall back to a counter driven by elapsed sleeps.
+  let fallbackClock = 0;
+  const now = options.now ?? (() => {
+    try {
+      return Date.now();
+    } catch {
+      return fallbackClock;
+    }
+  });
+
+  const start = now();
+  let last: CiProofResult = evaluateCiProof(target, options, runner);
+  options.onPoll?.(last, 0);
+  while (!TERMINAL.has(last.status) && now() - start < timeoutMs) {
+    await sleep(intervalMs);
+    fallbackClock += intervalMs;
+    last = evaluateCiProof(target, options, runner);
+    options.onPoll?.(last, now() - start);
+  }
+  return last;
+}

--- a/src/review-finding-contract.test.ts
+++ b/src/review-finding-contract.test.ts
@@ -9,6 +9,10 @@ import {
   deriveRoundVerdict,
   summarizeRound,
   assertsPass,
+  extractMetaComment,
+  parseReviewSummaryMeta,
+  extractReviewSummaryMeta,
+  summaryRoundVerdict,
 } from './review-finding-contract.js';
 
 describe('review-finding-contract', () => {
@@ -193,5 +197,46 @@ describe('normalizeReviewFindingData — no fail-coercion on empty (#1039 H5)', 
       findings: [],
     });
     expect(finding.verdict).toBe('pass');
+  });
+});
+
+describe('summary-meta accessor (I29 — replaces hand-rolled regex, #1222.3)', () => {
+  // A real round-summary meta block as written by composeReviewSummary.
+  const summaryBody = (verdict: string, roundVerdict: string) =>
+    `<!-- meta:{"round":5,"verdict":"${verdict}","round_verdict":"${roundVerdict}","dimensions":3,"pass":2,"fail":0,"partial":1,"total_done":7,"total_missing":0,"total_partial":1} -->\n## Review Round 5 — PASS — 1 PARTIAL`;
+
+  it('extractMetaComment parses the first meta JSON object', () => {
+    expect(extractMetaComment(summaryBody('pass', 'PASS_WITH_PARTIALS'))).toMatchObject({ round: 5, round_verdict: 'PASS_WITH_PARTIALS' });
+  });
+
+  it('extractMetaComment returns null when no meta comment is present', () => {
+    expect(extractMetaComment('## Review Round 5 — PASS')).toBeNull();
+  });
+
+  it('parseReviewSummaryMeta validates round_verdict via schema', () => {
+    expect(parseReviewSummaryMeta({ round: 5, round_verdict: 'FAIL' })).toEqual({ round: 5, round_verdict: 'FAIL', });
+    // missing required `round` → rejected
+    expect(parseReviewSummaryMeta({ round_verdict: 'PASS' })).toBeNull();
+    // bogus round_verdict → rejected (not silently coerced)
+    expect(parseReviewSummaryMeta({ round: 1, round_verdict: 'MAYBE' })).toBeNull();
+  });
+
+  it('summaryRoundVerdict prefers round_verdict, falls back to binary verdict', () => {
+    expect(summaryRoundVerdict(summaryBody('pass', 'PASS_WITH_PARTIALS'))).toBe('PASS_WITH_PARTIALS');
+    expect(summaryRoundVerdict(summaryBody('fail', 'FAIL'))).toBe('FAIL');
+    // legacy summary with only a binary verdict
+    expect(summaryRoundVerdict('<!-- meta:{"round":2,"verdict":"pass"} -->\n## Review Round 2 — PASS')).toBe('PASS');
+    expect(summaryRoundVerdict('<!-- meta:{"round":2,"verdict":"fail"} -->\n## Review Round 2 — FAIL')).toBe('FAIL');
+  });
+
+  it('summaryRoundVerdict returns null on a body with no meta', () => {
+    expect(summaryRoundVerdict('## Review Round 2 — PASS')).toBeNull();
+  });
+
+  it('extractReviewSummaryMeta does not mistake a greedy match across two meta comments', () => {
+    // The old hand-rolled /^<!-- meta:(\{.*\}) -->/ was greedy and anchored; the
+    // shared non-greedy extractor must grab only the FIRST object.
+    const two = '<!-- meta:{"round":5,"round_verdict":"PASS"} -->\n<!-- meta:{"round":6} -->';
+    expect(extractReviewSummaryMeta(two)).toMatchObject({ round: 5, round_verdict: 'PASS' });
   });
 });

--- a/src/review-finding-contract.ts
+++ b/src/review-finding-contract.ts
@@ -8,6 +8,8 @@
  * - review finding metadata shape
  */
 
+import { z } from 'zod';
+
 export type FindingStatus = 'DONE' | 'PARTIAL' | 'MISSING';
 
 export interface ReviewFinding {
@@ -301,12 +303,64 @@ export function parseReviewFindingMeta(value: unknown): ReviewFindingMeta | null
   };
 }
 
-export function extractReviewFindingMeta(content: string): ReviewFindingMeta | null {
+/**
+ * Extract and JSON-parse the first `<!-- meta:{...} -->` comment from a stored
+ * attachment body. Single source of the meta-comment regex so no caller hand-rolls
+ * its own (I29) — both finding and summary accessors go through here.
+ */
+export function extractMetaComment(content: string): unknown | null {
   const match = content.match(/<!-- meta:(\{.*?\}) -->/);
   if (!match) return null;
   try {
-    return parseReviewFindingMeta(JSON.parse(match[1]));
+    return JSON.parse(match[1]);
   } catch {
     return null;
   }
+}
+
+export function extractReviewFindingMeta(content: string): ReviewFindingMeta | null {
+  return parseReviewFindingMeta(extractMetaComment(content));
+}
+
+/**
+ * Schema for the round-*summary* meta block (distinct from per-dimension finding
+ * meta). `composeReviewSummary` writes it; the store-summary CI gate reads
+ * `round_verdict` from it. Validated via zod so no caller hand-rolls a regex +
+ * `JSON.parse` over structured data (I29; the #1222.3 trap).
+ */
+const ReviewSummaryMetaSchema = z.object({
+  round: z.number(),
+  round_verdict: z.enum(['PASS', 'PASS_WITH_PARTIALS', 'FAIL']).optional(),
+  verdict: z.enum(['pass', 'fail']).optional(),
+}).passthrough();
+
+export type ReviewSummaryMeta = {
+  round: number;
+  round_verdict?: RoundVerdict;
+  verdict?: 'pass' | 'fail';
+};
+
+export function parseReviewSummaryMeta(value: unknown): ReviewSummaryMeta | null {
+  const parsed = ReviewSummaryMetaSchema.safeParse(value);
+  if (!parsed.success) return null;
+  const { round, round_verdict, verdict } = parsed.data;
+  return { round, ...(round_verdict ? { round_verdict } : {}), ...(verdict ? { verdict } : {}) };
+}
+
+export function extractReviewSummaryMeta(content: string): ReviewSummaryMeta | null {
+  return parseReviewSummaryMeta(extractMetaComment(content));
+}
+
+/**
+ * The authoritative round verdict carried by a stored summary's meta block.
+ * Prefers the explicit `round_verdict`; falls back to mapping the binary
+ * `verdict` (legacy summaries) — pass → PASS so the CI gate still engages.
+ */
+export function summaryRoundVerdict(content: string): RoundVerdict | null {
+  const meta = extractReviewSummaryMeta(content);
+  if (!meta) return null;
+  if (meta.round_verdict) return meta.round_verdict;
+  if (meta.verdict === 'fail') return 'FAIL';
+  if (meta.verdict === 'pass') return 'PASS';
+  return null;
 }

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -305,87 +305,65 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     const ok = dimComment(2, 'correctness', 'pass', 3, 0, 0); // all DONE → PASS
     ghReturns(ok); // compose: list
     ghReturns(ok); // compose: read
-    ghReturns('abc123'); // gh pr view: current PR head
-    ghReturns(JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' }])); // gh pr checks
     ghReturns(''); // writeAttachment: readAttachment (no existing)
     ghReturns('https://...#issuecomment-sum');
 
-    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes', { expectedHeadSha: 'abc123' });
+    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes');
     const body = bodyOfLastCreate();
     expect(body).toContain('## Review Round 2 — PASS');
     expect(body).toContain('### Reviewer notes (non-authoritative');
     expect(body).toContain('rebased onto main');
   });
 
-  describe('CI proof gate (#1070)', () => {
-    const head = 'abc123';
-    const passChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' },
-      { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
-    ]);
-    const pendingChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' },
-    ]);
-    const failChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' },
-    ]);
+  // #1225/#1222: the CI-green proof moved OUT of storage to the CLI boundary
+  // (review-ci-proof.ts + cli-structured-data.ts). Storage must NOT shell out to
+  // `gh pr view` / `gh pr checks` / `git rev-parse` — it only does its own
+  // attachment I/O. These tests pin that the storage layer is CI-proof-free.
+  describe('storage is CI-proof-free (#1222)', () => {
+    const ciProofCall = (args: unknown): boolean => {
+      if (!Array.isArray(args)) return false;
+      const a = args as string[];
+      return (a[0] === 'git' && a.includes('rev-parse'))
+        || (a.includes('pr') && (a.includes('checks') || a.includes('view')) && a.includes('headRefOid'))
+        || (a.includes('pr') && a.includes('checks'));
+    };
+    // mockGh.mock.calls[i] is [command, args]; flatten command+args for the predicate.
+    const noCiProofShellOut = () => {
+      for (const call of mockGh.mock.calls) {
+        const merged = [call[0], ...(Array.isArray(call[1]) ? call[1] : [])];
+        expect(ciProofCall(merged)).toBe(false);
+      }
+    };
 
-    it('stores a derived PASS only when current-head CI is passing', () => {
+    it('stores a derived PASS without any gh pr view / gh pr checks / git rev-parse call', () => {
       const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
       ghReturns(ok); // compose: list
       ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view: current PR head
-      ghReturns(passChecks); // gh pr checks
       ghReturns(''); // writeAttachment: readAttachment (no existing)
       ghReturns('https://...#issuecomment-sum');
 
-      storeReviewSummary(pr, 4, undefined, { expectedHeadSha: head });
-
-      const body = bodyOfLastCreate();
-      expect(body).toContain('## Review Round 4 — PASS');
+      const url = storeReviewSummary(pr, 4);
+      expect(url).toContain('issuecomment');
+      expect(bodyOfLastCreate()).toContain('## Review Round 4 — PASS');
+      noCiProofShellOut();
     });
 
-    it('refuses to store a derived PASS while CI is pending', () => {
-      const ok = dimComment(6, 'correctness', 'pass', 2, 0, 0);
+    it('stores a derived PASS summary on an ISSUE target without throwing (#1222.1 regression)', () => {
+      const ok = dimComment(3, 'correctness', 'pass', 2, 0, 0);
       ghReturns(ok); // compose: list
       ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(pendingChecks); // gh pr checks
+      ghReturns(''); // writeAttachment: readAttachment (no existing)
+      ghReturns('https://...#issuecomment-issue');
 
-      expect(() => storeReviewSummary(pr, 6, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*pending|pending.*CI|#1070/i);
-    });
-
-    it('refuses to store a derived PASS when CI is failing', () => {
-      const ok = dimComment(7, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(failChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 7, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*fail|fail.*CI|#1070/i);
-    });
-
-    it('refuses to store a derived PASS before CI has produced checks', () => {
-      const ok = dimComment(9, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns('[]'); // gh pr checks: CI has not started
-
-      expect(() => storeReviewSummary(pr, 9, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*not produced checks|#1070/i);
-    });
-
-    it('refuses to store a derived PASS when the reviewed head is stale', () => {
-      const ok = dimComment(8, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns('def456'); // gh pr view: current PR head differs from reviewed head
-
-      expect(() => storeReviewSummary(pr, 8, undefined, { expectedHeadSha: head }))
-        .toThrow(/stale|HEAD|#1070/i);
+      const url = storeReviewSummary(issue, 3);
+      expect(url).toContain('issuecomment');
+      // Issue createComment uses `gh issue comment --body <raw>` (not `body=`), so
+      // scan every call arg for the composed summary instead of bodyOfLastCreate.
+      const stored = mockGh.mock.calls.some(call =>
+        (Array.isArray(call[1]) ? call[1] : []).some(
+          arg => typeof arg === 'string' && arg.includes('## Review Round 3 — PASS')));
+      expect(stored).toBe(true);
+      noCiProofShellOut();
     });
   });
 });

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -14,7 +14,6 @@
  */
 
 import YAML from 'yaml';
-import { spawnSync } from 'node:child_process';
 import {
   listAttachments,
   readAttachment,
@@ -31,6 +30,7 @@ import {
   makeReviewFindingMeta,
   extractReviewFindingMeta,
   summarizeRound,
+  summaryRoundVerdict,
   assertsPass,
   type ReviewFinding,
   type ReviewFindingData,
@@ -64,10 +64,9 @@ export function storeReviewBatch(
   target: AttachmentTarget,
   round: number,
   findings: ReviewFindingData[],
-  options: StoreReviewSummaryOptions = {},
 ): { urls: string[]; summaryUrl: string } {
   const urls = findings.map(f => storeReviewFinding(target, round, f));
-  const summaryUrl = storeReviewSummary(target, round, undefined, options);
+  const summaryUrl = storeReviewSummary(target, round);
   return { urls, summaryUrl };
 }
 
@@ -105,130 +104,6 @@ export function extractPlanText(text: string): string | undefined {
 export type { ReviewFinding, ReviewFindingData } from './review-finding-contract.js';
 
 const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MISSING: '❌' };
-
-export type StoreReviewSummaryOptions = {
-  /**
-   * The commit SHA that was reviewed. If omitted, the current local HEAD is used.
-   * Passing this explicitly lets review tooling prove CI belongs to the same
-   * commit it reviewed even if the local worktree has moved.
-   */
-  expectedHeadSha?: string;
-};
-
-type GhCheck = {
-  name?: string;
-  bucket?: string;
-  state?: string;
-  workflow?: string;
-  link?: string;
-};
-
-function spawnText(command: string, args: string[], failureContext: string): string {
-  const result = spawnSync(command, args, { encoding: 'utf8' });
-  if (result.error) {
-    throw new Error(`${failureContext}: ${result.error.message}`);
-  }
-  const stdout = (result.stdout ?? '').trim();
-  if ((result.status ?? 0) !== 0 && !stdout) {
-    const stderr = (result.stderr ?? '').trim();
-    throw new Error(`${failureContext}: ${stderr || `${command} exited ${result.status}`}`);
-  }
-  return stdout;
-}
-
-function resolveReviewedHeadSha(expectedHeadSha: string | undefined): string {
-  const explicit = expectedHeadSha?.trim();
-  if (explicit) return explicit;
-  return spawnText(
-    'git',
-    ['rev-parse', 'HEAD'],
-    'store-review-summary: #1070 unable to determine reviewed HEAD; pass --head-sha explicitly',
-  );
-}
-
-function readPrHeadSha(target: AttachmentTarget): string {
-  return spawnText(
-    'gh',
-    ['pr', 'view', String(target.number), '--repo', target.repo, '--json', 'headRefOid', '--jq', '.headRefOid'],
-    'store-review-summary: #1070 unable to read current PR head',
-  );
-}
-
-function readPrChecks(target: AttachmentTarget): GhCheck[] {
-  const stdout = spawnText(
-    'gh',
-    ['pr', 'checks', String(target.number), '--repo', target.repo, '--json', 'name,bucket,state,workflow,link'],
-    'store-review-summary: #1070 unable to read PR checks',
-  );
-  try {
-    const parsed = JSON.parse(stdout);
-    if (!Array.isArray(parsed)) {
-      throw new Error('JSON was not an array');
-    }
-    return parsed as GhCheck[];
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`store-review-summary: #1070 unable to parse PR checks JSON (${msg})`);
-  }
-}
-
-function formatCheck(check: GhCheck): string {
-  const workflow = check.workflow ? `${check.workflow} / ` : '';
-  const name = check.name ?? '(unnamed check)';
-  const bucket = check.bucket ?? 'unknown';
-  const state = check.state ? ` (${check.state})` : '';
-  return `${workflow}${name}: ${bucket}${state}`;
-}
-
-function assertReviewSummaryCiPassed(target: AttachmentTarget, options: StoreReviewSummaryOptions): void {
-  if (target.kind !== 'pr') {
-    throw new Error('store-review-summary: #1070 CI proof requires a PR target');
-  }
-
-  const reviewedHead = resolveReviewedHeadSha(options.expectedHeadSha);
-  const currentHead = readPrHeadSha(target);
-  if (currentHead !== reviewedHead) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary for stale HEAD. ` +
-      `Reviewed ${reviewedHead}, but PR #${target.number} is currently ${currentHead}. ` +
-      `Re-review the current head before storing a pass summary.`,
-    );
-  }
-
-  const checks = readPrChecks(target);
-  if (checks.length === 0) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI has not produced checks for ${currentHead}.`,
-    );
-  }
-
-  const blocking = checks.filter(check => {
-    const bucket = check.bucket;
-    return bucket !== 'pass' && bucket !== 'skipping';
-  });
-  if (blocking.length > 0) {
-    const details = blocking.map(formatCheck).join('; ');
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI is not green for ${currentHead}: ${details}`,
-    );
-  }
-}
-
-function extractSummaryRoundVerdict(summary: string): RoundVerdict | null {
-  const match = summary.match(/^<!-- meta:(\{.*\}) -->/);
-  if (!match) return null;
-  try {
-    const meta = JSON.parse(match[1]) as { round_verdict?: RoundVerdict; verdict?: string };
-    if (meta.round_verdict === 'PASS' || meta.round_verdict === 'PASS_WITH_PARTIALS' || meta.round_verdict === 'FAIL') {
-      return meta.round_verdict;
-    }
-    if (meta.verdict === 'fail') return 'FAIL';
-    if (meta.verdict === 'pass') return 'PASS';
-    return null;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Defensive coercion for CLI/API payloads. Supports legacy shapes (status-only,
@@ -391,19 +266,20 @@ export function deriveStoredRoundVerdict(target: AttachmentTarget, round: number
  * FAIL, throw — the agent must fix the findings or escalate, not narrate a passing verdict on
  * top of failing data (the exact #1019 bypass). The derived block stays authoritative either way.
  *
+ * This function is SIDE-EFFECT-FREE storage (#1222): it does NOT shell out to `gh`/`git`. The
+ * CI-green proof for a PASS summary (#1070) is enforced at the CLI/caller boundary via
+ * `review-ci-proof.ts` (`waitForCiProof`), so a pending CI is a *wait*, not a false review FAIL
+ * (#1221), and a non-PR review summary is stored without a CI gate.
+ *
  * Attachment name: review/r{round}/summary
  */
 export function storeReviewSummary(
   target: AttachmentTarget,
   round: number,
   note?: string,
-  options: StoreReviewSummaryOptions = {},
 ): string {
   const derived = composeReviewSummary(target, round);
-  const roundVerdict = extractSummaryRoundVerdict(derived) ?? deriveStoredRoundVerdict(target, round);
-  if (roundVerdict !== 'FAIL') {
-    assertReviewSummaryCiPassed(target, options);
-  }
+  const roundVerdict = summaryRoundVerdict(derived) ?? deriveStoredRoundVerdict(target, round);
 
   let content = derived;
 


### PR DESCRIPTION
## Rescue Context

This is a draft rescue PR for orphaned work from auto-dent batch `disgusted-ant`, run 1.

- Run: `disgusted-ant/run-1`
- Ticket worked on: #1225 — redo the #1070 CI-proof gate correctly after PR #1212 merged a broken implementation.
- Worktree: `/home/aviad/projects/kaizen/.claude/worktrees/2606271929-8f0b`
- Branch: `case/2606272230-k1225-ci-proof-redo`
- Rescue commit: `173df3b` `rescue(auto-dent): preserve stranded CI proof redo work`

## Why It Stopped

The run hit the auto-dent watchdog wall-time limit after 1205 seconds and was terminated with `exit 143` / SIGTERM before it created a PR. The last log activity was full-suite triage; the in-flight `npm test` task was stopped with `Exit code 137` when the watchdog killed the session.

Auto-dent recorded:

- `failure_class`: timeout
- `process_verdict`: process-incomplete
- `process_summary`: plan/work was claimed or produced without durable plan evidence
- PR created by the run: none

## Preserved Work

This branch preserves the in-flight forward-fix for #1225: moving CI proof out of storage and into the CLI/caller boundary, adding `review-ci-proof` logic/tests, structured summary meta parsing, and review skill updates.

## Rescue Notes

Quality gates were intentionally skipped for this rescue operation, per request. Treat this PR as preserved interrupted work, not validated work.

Refs #1225
Refs #1221
Refs #1222
Refs #1227
Refs #1255
