### PR TITLE
[rescue] disgusted-ant run 3 review CI proof work (#1225)

### DIFF
--- a/.agents/skills/kaizen-review-pr/SKILL.md
+++ b/.agents/skills/kaizen-review-pr/SKILL.md
@@ -229,10 +229,16 @@ npx tsx src/cli-structured-data.ts store-review-summary \
   --pr <PR_NUMBER> --repo <owner/repo> --round <N> --head-sha "$(git rev-parse HEAD)"
 ```
 
-For a derived PASS or PASS-with-partials verdict, `store-review-summary` now verifies the PR's
-current HEAD matches `--head-sha` and that `gh pr checks` is green for that HEAD before it writes
-the summary/sentinel (#1070). Pending, failing, absent, or stale-head CI refuses storage; re-run
-review on the current head after CI passes.
+For a derived PASS or PASS-with-partials verdict, the CLI verifies — at the storage *action*
+boundary — that the PR's current HEAD matches `--head-sha` and that `gh pr checks` is green for
+that HEAD before it writes the summary/sentinel (#1070; redone side-effect-free in #1221/#1222).
+Behavior by CI state:
+- **Failing or stale-head CI** → storage is refused (exit 1). Fix CI or re-review the current head.
+- **Pending CI** → the CLI *waits* for CI to finish (default up to 300s; tune with `--wait-ci-secs`).
+  If still unfinished after the wait, it exits with a distinct `ci_pending` marker (exit 2) — this
+  is **retriable, NOT a review FAIL**: re-run `store-review-summary` once CI completes; do not treat
+  it as a failed round or burn a fix iteration on it.
+- **Green CI** → the summary/sentinel is written.
 
 Add `--note "<context>"` only for non-verdict commentary (e.g. "rebased onto main, re-ran tests").
 Read back the derived verdict with `read-review-summary --pr <N> --repo <repo> --round <N>` — the

--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { handlers, parseArgs, resolveContent, resolveRound, type CliArgs } from './cli-structured-data.js';
 import {
@@ -7,6 +7,9 @@ import {
   storeMetadata,
   storeReviewFinding,
   storeReviewSummary,
+  storeReviewBatch,
+  waitForCiProof,
+  deriveStoredRoundVerdict,
 } from './structured-data.js';
 
 vi.mock('node:fs', () => ({
@@ -44,6 +47,8 @@ vi.mock('./structured-data.js', () => ({
   updatePrSection: vi.fn(),
   storeIterationState: vi.fn().mockReturnValue('https://example.com/iteration'),
   retrieveIterationState: vi.fn().mockReturnValue({ round: 1 }),
+  deriveStoredRoundVerdict: vi.fn().mockReturnValue('PASS'),
+  waitForCiProof: vi.fn().mockResolvedValue({ status: 'pass', reason: 'ci green (mock)' }),
 }));
 
 beforeEach(() => vi.clearAllMocks());
@@ -251,39 +256,132 @@ describe('store-review-batch — review sentinel', () => {
   });
 });
 
-describe('store-review-summary — CI head proof', () => {
-  it('passes --head-sha through to summary storage before writing the sentinel (#1070)', async () => {
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+// ── store-review CI proof at the action boundary (#1070 redone, #1221/#1222) ─
+// The proof now runs in the CLI handler — NOT inside the side-effect-free storage
+// layer. These tests prove the gate BLOCKS at the irreversible "record PASS" action
+// (the #1227 verdict-binding shape) and distinguishes retriable pending from a FAIL.
 
-    await handlers['store-review-summary']({
-      command: 'store-review-summary',
-      pr: '903',
-      repo: 'Garsson-io/kaizen',
-      round: '5',
-      ['head-sha']: 'abc123',
-    } as CliArgs);
+describe('store-review-summary — CI proof gate (#1070/#1221/#1222)', () => {
+  const baseArgs = {
+    command: 'store-review-summary',
+    pr: '903',
+    repo: 'Garsson-io/kaizen',
+    round: '5',
+    ['head-sha']: 'abc123',
+    ['wait-ci-secs']: '0',
+  } as CliArgs;
 
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    vi.mocked(deriveStoredRoundVerdict).mockReturnValue('PASS');
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('threads the reviewed --head-sha into the CI proof and stores when CI is green', async () => {
+    vi.mocked(waitForCiProof).mockResolvedValue({ status: 'pass', reason: 'green' });
+
+    await handlers['store-review-summary'](baseArgs);
+
+    // Proof was consulted with the reviewed head before storage.
+    expect(vi.mocked(waitForCiProof)).toHaveBeenCalledWith(
+      { kind: 'pr', number: 903, repo: 'Garsson-io/kaizen' },
+      { expectedHeadSha: 'abc123' },
+      expect.objectContaining({ timeoutMs: 0 }),
+    );
+    // Storage is side-effect-free: called WITHOUT a CI-options arg (#1222).
     expect(vi.mocked(storeReviewSummary)).toHaveBeenCalledWith(
       { kind: 'pr', number: 903, repo: 'Garsson-io/kaizen' },
       5,
       undefined,
-      { expectedHeadSha: 'abc123' },
     );
     const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r5'),
     );
     expect(sentinelCall).toBeDefined();
-    const payload = JSON.parse(String(sentinelCall![1]));
-    expect(payload).toMatchObject({
-      schemaVersion: 1,
-      prUrl: 'https://github.com/Garsson-io/kaizen/pull/903',
-      round: 5,
-      dimensionsReviewed: ['correctness', 'security'],
-      dimensionCount: 2,
-    });
-    expect(payload.findingCount).toBeGreaterThanOrEqual(0);
-    expect(payload.integrity).toMatch(/^sha256:/);
-    log.mockRestore();
+    expect(JSON.parse(String(sentinelCall![1]))).toMatchObject({ schemaVersion: 1, round: 5 });
+  });
+
+  it('refuses to store a PASS summary and exits 1 when CI is failing', async () => {
+    vi.mocked(waitForCiProof).mockResolvedValue({ status: 'fail', reason: 'TypeScript tests: fail' });
+
+    await expect(handlers['store-review-summary'](baseArgs)).rejects.toThrow('process.exit(1)');
+    expect(vi.mocked(storeReviewSummary)).not.toHaveBeenCalled();
+    expect(vi.mocked(writeFileSync)).not.toHaveBeenCalled();
+  });
+
+  it('refuses to store a PASS summary and exits 1 when the reviewed head is stale', async () => {
+    vi.mocked(waitForCiProof).mockResolvedValue({ status: 'stale', reason: 'reviewed abc123, now def456' });
+
+    await expect(handlers['store-review-summary'](baseArgs)).rejects.toThrow('process.exit(1)');
+    expect(vi.mocked(storeReviewSummary)).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 (ci_pending, retriable — NOT a review FAIL) when CI is still pending', async () => {
+    vi.mocked(waitForCiProof).mockResolvedValue({ status: 'pending', reason: '1 check still running' });
+
+    await expect(handlers['store-review-summary'](baseArgs)).rejects.toThrow('process.exit(2)');
+    expect(vi.mocked(storeReviewSummary)).not.toHaveBeenCalled();
+    // The message must mark this as retriable, not a failure, so the loop doesn't burn a fix round.
+    const errOut = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(errOut).toMatch(/ci_pending/);
+    expect(errOut).toMatch(/NOT a review FAIL/i);
+  });
+
+  it('does NOT gate a FAIL round — stores it without consulting CI', async () => {
+    vi.mocked(deriveStoredRoundVerdict).mockReturnValue('FAIL');
+
+    await handlers['store-review-summary'](baseArgs);
+
+    expect(vi.mocked(waitForCiProof)).not.toHaveBeenCalled();
+    expect(vi.mocked(storeReviewSummary)).toHaveBeenCalled();
+  });
+});
+
+describe('store-review-batch — CI proof gate (#1070/#1221/#1222)', () => {
+  const passBatch = JSON.stringify([{ dimension: 'correctness', verdict: 'pass', summary: 'ok', findings: [] }]);
+
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+  });
+  afterEach(() => { logSpy.mockRestore(); errSpy.mockRestore(); exitSpy.mockRestore(); });
+
+  it('gates BEFORE any storage — failing CI stores neither findings nor summary', async () => {
+    vi.mocked(waitForCiProof).mockResolvedValue({ status: 'fail', reason: 'red' });
+
+    await expect(handlers['store-review-batch']({
+      command: 'store-review-batch', pr: '903', repo: 'org/repo', round: '1', text: passBatch,
+    } as CliArgs)).rejects.toThrow('process.exit(1)');
+
+    expect(vi.mocked(storeReviewBatch)).not.toHaveBeenCalled();
+    expect(vi.mocked(writeFileSync)).not.toHaveBeenCalled();
+  });
+
+  it('stores the batch when CI proof passes', async () => {
+    vi.mocked(waitForCiProof).mockResolvedValue({ status: 'pass', reason: 'green' });
+
+    await handlers['store-review-batch']({
+      command: 'store-review-batch', pr: '903', repo: 'org/repo', round: '1', text: passBatch,
+    } as CliArgs);
+
+    expect(vi.mocked(storeReviewBatch)).toHaveBeenCalled();
   });
 });
 

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -58,14 +58,17 @@ import {
   updatePrSection,
   storeIterationState,
   retrieveIterationState,
+  deriveStoredRoundVerdict,
+  waitForCiProof,
   type ReviewFindingData,
   type StoreReviewSummaryOptions,
 } from './structured-data.js';
+import type { AttachmentTarget } from './section-editor.js';
 import {
   buildReviewSentinelRecord,
   serializeReviewSentinel,
 } from './review-sentinel.js';
-import { normalizeReviewFindingData, validateReviewFindingPayload, summarizeFindingStatuses } from './review-finding-contract.js';
+import { normalizeReviewFindingData, validateReviewFindingPayload, summarizeFindingStatuses, summarizeRound, type RoundVerdict, type RoundRow } from './review-finding-contract.js';
 
 export type CliArgs = Record<string, string> & { command: string };
 type Handler = (a: CliArgs) => Promise<void>;
@@ -183,6 +186,61 @@ function reviewSummaryOptions(a: CliArgs): StoreReviewSummaryOptions {
   };
 }
 
+/** Max seconds the CI proof waits for in-flight CI before treating it as ci_pending. */
+function waitCiSecs(a: CliArgs): number {
+  const raw = a['wait-ci-secs'];
+  if (raw == null) return 300; // default: wait for CI rather than false-fail (#1221)
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 300;
+}
+
+/**
+ * Enforce the CI proof at the storage *action* boundary (#1070 redone for #1221/#1222).
+ * Storage is side-effect-free; this CLI is where "record this round as PASS" actually happens,
+ * so it is the right place to bind the action to CI reality (the #1227 verdict-binding shape).
+ *
+ *   - verdict FAIL → no PASS claim is being made; the proof is irrelevant, never gated.
+ *   - pass / skipped (non-PR) → proceed.
+ *   - pending (after wait-for-CI) → exit 2 with a `ci_pending` marker. This is RETRIABLE and
+ *     must NOT be read as a review FAIL (else it burns a fix round / false-exhausts the loop, #1221).
+ *   - fail / stale → exit 1: refuse to record a PASS over red or stale-head CI.
+ */
+async function enforceCiProof(target: AttachmentTarget, verdict: RoundVerdict, a: CliArgs): Promise<void> {
+  if (verdict === 'FAIL') return;
+  const seconds = waitCiSecs(a);
+  const proof = await waitForCiProof(target, reviewSummaryOptions(a), {
+    timeoutMs: seconds * 1000,
+    intervalMs: 15_000,
+    onPending: (r, elapsed) =>
+      console.error(`store-review: CI ${r.status} (${Math.round(elapsed / 1000)}s/${seconds}s) — ${r.reason}`),
+  });
+  if (proof.status === 'pass' || proof.status === 'skipped') return;
+  if (proof.status === 'pending') {
+    console.error(
+      `store-review: ci_pending — refusing to record a PASS summary while CI is unfinished. ` +
+      `This is NOT a review FAIL: re-run store-review-* once CI completes (or pass --wait-ci-secs to wait longer). ` +
+      `${proof.reason}`,
+    );
+    process.exit(2);
+  }
+  console.error(`store-review: refusing to record a PASS summary — CI ${proof.status}: ${proof.reason}`);
+  process.exit(1);
+}
+
+/**
+ * Derive the round verdict from a validated batch payload WITHOUT storing anything,
+ * so the CI proof can gate the round before the summary is written. Normalizes each
+ * finding the same way storeReviewBatch does, so the gated verdict matches what storage derives.
+ */
+function deriveBatchVerdict(findings: ReviewFindingData[]): RoundVerdict {
+  const rows: RoundRow[] = findings.map(raw => {
+    const f = normalizeReviewFindingData(raw);
+    const s = summarizeFindingStatuses(f.findings);
+    return { dim: f.dimension, verdict: f.verdict, done: s.done, partial: s.partial, missing: s.missing };
+  });
+  return summarizeRound(rows).verdict;
+}
+
 // Review handlers
 
 async function handleNextRound(a: CliArgs): Promise<void> {
@@ -254,7 +312,10 @@ async function handleStoreReviewBatch(a: CliArgs): Promise<void> {
     }
   }
   const findings = parsedBatch as ReviewFindingData[];
-  const result = storeReviewBatch(pr, r, findings, reviewSummaryOptions(a));
+  // CI proof BEFORE any storage (#1070 redone, #1221/#1222): refuse to record a PASS round over
+  // red/stale CI, wait on pending CI. A FAIL round makes no PASS claim and is never gated.
+  await enforceCiProof(pr, deriveBatchVerdict(findings), a);
+  const result = storeReviewBatch(pr, r, findings);
   // #966: Write review sentinel so pr-review-loop.ts gate guard passes.
   // Mirrors handleStoreReviewSummary — batch includes summary, so sentinel must be written here too.
   writeReviewSentinel(a.repo, a.pr, r);
@@ -275,9 +336,13 @@ async function handleStoreReviewSummary(a: CliArgs): Promise<void> {
   // legacy --text/--file) is non-authoritative commentary appended below the derived block.
   const note = (a.note ?? resolveContent(a)) || undefined;
   const r = resolveRound(a);
+  const target = prTarget(a.pr, a.repo);
+  // CI proof at the action boundary (#1070 redone, #1221/#1222). Verdict is derived from the
+  // already-stored findings — never from caller text (#1019).
+  await enforceCiProof(target, deriveStoredRoundVerdict(target, r), a);
   let url: string;
   try {
-    url = storeReviewSummary(prTarget(a.pr, a.repo), r, note, reviewSummaryOptions(a));
+    url = storeReviewSummary(target, r, note);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -25,7 +25,11 @@ import {
   retrieveIterationState,
   updatePrSection,
   normalizeReviewFindingData,
+  verifyReviewCiProof,
+  waitForCiProof,
   type ReviewFindingData,
+  type CiProofRunner,
+  type CiRunResult,
 } from './structured-data.js';
 
 vi.mock('node:child_process', () => ({
@@ -305,88 +309,168 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     const ok = dimComment(2, 'correctness', 'pass', 3, 0, 0); // all DONE → PASS
     ghReturns(ok); // compose: list
     ghReturns(ok); // compose: read
-    ghReturns('abc123'); // gh pr view: current PR head
-    ghReturns(JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' }])); // gh pr checks
     ghReturns(''); // writeAttachment: readAttachment (no existing)
     ghReturns('https://...#issuecomment-sum');
 
-    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes', { expectedHeadSha: 'abc123' });
+    // Storage is side-effect-free now: no CI proof, no --head-sha needed (#1222).
+    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes');
     const body = bodyOfLastCreate();
     expect(body).toContain('## Review Round 2 — PASS');
     expect(body).toContain('### Reviewer notes (non-authoritative');
     expect(body).toContain('rebased onto main');
   });
 
-  describe('CI proof gate (#1070)', () => {
-    const head = 'abc123';
-    const passChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' },
-      { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
-    ]);
-    const pendingChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' },
-    ]);
-    const failChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' },
-    ]);
+  // ── Storage layer is side-effect-free (#1222 defect 2) ─────────────────────
+  it('stores a PASS summary WITHOUT shelling out to gh pr checks or git (#1222)', () => {
+    const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
+    ghReturns(ok); // compose: list
+    ghReturns(ok); // compose: read
+    ghReturns(''); // writeAttachment: readAttachment (no existing)
+    ghReturns('https://...#issuecomment-sum');
 
-    it('stores a derived PASS only when current-head CI is passing', () => {
-      const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view: current PR head
-      ghReturns(passChecks); // gh pr checks
-      ghReturns(''); // writeAttachment: readAttachment (no existing)
-      ghReturns('https://...#issuecomment-sum');
+    storeReviewSummary(pr, 4);
 
-      storeReviewSummary(pr, 4, undefined, { expectedHeadSha: head });
+    // No call shells out to CI proof: `gh pr checks` or `git rev-parse` are the CI-only verbs.
+    const calls = mockGh.mock.calls;
+    const ranChecks = calls.some(([cmd, args]) => Array.isArray(args) && (args as string[]).includes('checks'));
+    const ranGit = calls.some(([cmd]) => cmd === 'git');
+    expect(ranChecks).toBe(false);
+    expect(ranGit).toBe(false);
+  });
+});
 
-      const body = bodyOfLastCreate();
-      expect(body).toContain('## Review Round 4 — PASS');
+// ── verifyReviewCiProof — structured, injectable, never throws (#1070/#1221/#1222) ──
+describe('verifyReviewCiProof', () => {
+  const HEAD = 'abc123';
+  // Build a runner that answers each gh/git invocation from a small spec.
+  function runner(spec: { rev?: CiRunResult; view?: CiRunResult; checks?: CiRunResult }): CiProofRunner {
+    return (command, args) => {
+      if (command === 'git') return spec.rev ?? { status: 0, stdout: HEAD, stderr: '' };
+      if (args.includes('view')) return spec.view ?? { status: 0, stdout: HEAD, stderr: '' };
+      if (args.includes('checks')) return spec.checks ?? { status: 0, stdout: '[]', stderr: '' };
+      return { status: 0, stdout: '', stderr: '' };
+    };
+  }
+  const checks = (entries: Array<{ bucket: string; name?: string }>): CiRunResult =>
+    ({ status: 0, stdout: JSON.stringify(entries.map(e => ({ name: e.name ?? 'check', bucket: e.bucket, state: 'X' }))), stderr: '' });
+
+  it('skips (does not run) for a non-PR target — runner never invoked (#1222)', () => {
+    const calls: string[] = [];
+    const spy: CiProofRunner = (cmd) => { calls.push(cmd); return { status: 0, stdout: '', stderr: '' }; };
+    const res = verifyReviewCiProof(issue, {}, spy);
+    expect(res.status).toBe('skipped');
+    expect(calls).toEqual([]);
+  });
+
+  it('returns pass when all checks are pass/skipping for the reviewed head', () => {
+    const res = verifyReviewCiProof(pr, { expectedHeadSha: HEAD },
+      runner({ checks: checks([{ bucket: 'pass' }, { bucket: 'skipping' }]) }));
+    expect(res.status).toBe('pass');
+  });
+
+  it('returns pending (NOT fail) when a check is still running (#1221)', () => {
+    const res = verifyReviewCiProof(pr, { expectedHeadSha: HEAD },
+      runner({ checks: checks([{ bucket: 'pass' }, { bucket: 'pending' }]) }));
+    expect(res.status).toBe('pending');
+  });
+
+  it('returns pending (NOT fail) when CI has not produced checks yet (#1221)', () => {
+    const res = verifyReviewCiProof(pr, { expectedHeadSha: HEAD },
+      runner({ checks: { status: 0, stdout: '[]', stderr: '' } }));
+    expect(res.status).toBe('pending');
+  });
+
+  it('returns fail when any check failed (a failure dominates a pending one)', () => {
+    const res = verifyReviewCiProof(pr, { expectedHeadSha: HEAD },
+      runner({ checks: checks([{ bucket: 'fail' }, { bucket: 'pending' }]) }));
+    expect(res.status).toBe('fail');
+  });
+
+  it('returns stale when the PR head moved past the reviewed head', () => {
+    const res = verifyReviewCiProof(pr, { expectedHeadSha: HEAD },
+      runner({ view: { status: 0, stdout: 'def456', stderr: '' } }));
+    expect(res.status).toBe('stale');
+    expect(res).toMatchObject({ reviewedHead: HEAD, currentHead: 'def456' });
+  });
+
+  it('treats a transient gh error as pending, not a false FAIL (#1221)', () => {
+    const res = verifyReviewCiProof(pr, { expectedHeadSha: HEAD },
+      runner({ view: { status: 1, stdout: '', stderr: 'network error' } }));
+    expect(res.status).toBe('pending');
+  });
+
+  it('falls back to git rev-parse for the reviewed head when none is passed', () => {
+    const res = verifyReviewCiProof(pr, {},
+      runner({ rev: { status: 0, stdout: HEAD, stderr: '' }, checks: checks([{ bucket: 'pass' }]) }));
+    expect(res.status).toBe('pass');
+  });
+
+  it('never throws on any path (adversarial)', () => {
+    const specs = [
+      runner({ checks: checks([{ bucket: 'fail' }]) }),
+      runner({ view: { status: 1, stdout: '', stderr: 'boom' } }),
+      runner({ checks: { status: 0, stdout: 'not-json', stderr: '' } }),
+      runner({ rev: { status: 1, stdout: '', stderr: 'no git' } }),
+    ];
+    for (const r of specs) {
+      expect(() => verifyReviewCiProof(pr, {}, r)).not.toThrow();
+    }
+  });
+});
+
+// ── waitForCiProof — poll pending until terminal (#1221) ───────────────────────
+describe('waitForCiProof', () => {
+  const HEAD = 'abc123';
+  function scriptedRunner(checkSequence: string[]): CiProofRunner {
+    let i = 0;
+    return (command, args) => {
+      if (command === 'git') return { status: 0, stdout: HEAD, stderr: '' };
+      if (args.includes('view')) return { status: 0, stdout: HEAD, stderr: '' };
+      if (args.includes('checks')) {
+        const bucket = checkSequence[Math.min(i++, checkSequence.length - 1)];
+        return { status: 0, stdout: JSON.stringify([{ name: 'ci', bucket, state: 'X' }]), stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    };
+  }
+
+  it('polls while pending and resolves pass once CI turns green', async () => {
+    let clock = 0;
+    const sleeps: number[] = [];
+    const res = await waitForCiProof(pr, { expectedHeadSha: HEAD }, {
+      runner: scriptedRunner(['pending', 'pending', 'pass']),
+      now: () => clock,
+      sleep: async (ms) => { sleeps.push(ms); clock += ms; },
+      timeoutMs: 100_000,
+      intervalMs: 1000,
     });
+    expect(res.status).toBe('pass');
+    expect(sleeps.length).toBe(2); // slept through the two pending polls
+  });
 
-    it('refuses to store a derived PASS while CI is pending', () => {
-      const ok = dimComment(6, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(pendingChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 6, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*pending|pending.*CI|#1070/i);
+  it('gives up gracefully and returns pending after the timeout', async () => {
+    let clock = 0;
+    const res = await waitForCiProof(pr, { expectedHeadSha: HEAD }, {
+      runner: scriptedRunner(['pending']),
+      now: () => clock,
+      sleep: async (ms) => { clock += ms; },
+      timeoutMs: 5000,
+      intervalMs: 2000,
     });
+    expect(res.status).toBe('pending');
+  });
 
-    it('refuses to store a derived PASS when CI is failing', () => {
-      const ok = dimComment(7, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(failChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 7, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*fail|fail.*CI|#1070/i);
+  it('returns immediately on a terminal result without sleeping', async () => {
+    const sleeps: number[] = [];
+    const res = await waitForCiProof(pr, { expectedHeadSha: HEAD }, {
+      runner: scriptedRunner(['fail']),
+      now: () => 0,
+      sleep: async (ms) => { sleeps.push(ms); },
+      timeoutMs: 100_000,
+      intervalMs: 1000,
     });
-
-    it('refuses to store a derived PASS before CI has produced checks', () => {
-      const ok = dimComment(9, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns('[]'); // gh pr checks: CI has not started
-
-      expect(() => storeReviewSummary(pr, 9, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*not produced checks|#1070/i);
-    });
-
-    it('refuses to store a derived PASS when the reviewed head is stale', () => {
-      const ok = dimComment(8, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns('def456'); // gh pr view: current PR head differs from reviewed head
-
-      expect(() => storeReviewSummary(pr, 8, undefined, { expectedHeadSha: head }))
-        .toThrow(/stale|HEAD|#1070/i);
-    });
+    expect(res.status).toBe('fail');
+    expect(sleeps.length).toBe(0);
   });
 });
 

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -64,10 +64,9 @@ export function storeReviewBatch(
   target: AttachmentTarget,
   round: number,
   findings: ReviewFindingData[],
-  options: StoreReviewSummaryOptions = {},
 ): { urls: string[]; summaryUrl: string } {
   const urls = findings.map(f => storeReviewFinding(target, round, f));
-  const summaryUrl = storeReviewSummary(target, round, undefined, options);
+  const summaryUrl = storeReviewSummary(target, round, undefined);
   return { urls, summaryUrl };
 }
 
@@ -123,54 +122,46 @@ type GhCheck = {
   link?: string;
 };
 
-function spawnText(command: string, args: string[], failureContext: string): string {
+// ── CI proof for passing review summaries (#1070, redone for #1221/#1222) ────
+//
+// PR #1212 (#1070) baked this proof *inside* storeReviewSummary as a throwing
+// side-effect: every pass store shelled out to gh/git, threw on non-PR targets,
+// and false-FAILed the review-fix loop when CI was merely pending. The redo keeps
+// the storage layer side-effect-free and exposes a structured, injectable verifier
+// that the CLI/action boundary consumes (see verifyReviewCiProof / waitForCiProof):
+//   - never throws — the caller branches on the returned status;
+//   - 'pending' is distinct from 'fail', so in-flight CI is *waited on*, not failed (#1221);
+//   - non-PR targets are 'skipped', not thrown (#1222);
+//   - the command runner is injectable, so the proof is unit-testable without shelling out (#1222).
+
+/** Terminal/interim states of the CI proof for a passing review summary. */
+export type CiProofStatus = 'pass' | 'fail' | 'stale' | 'pending' | 'skipped';
+
+export interface CiProofResult {
+  status: CiProofStatus;
+  /** Human-readable explanation — surfaced by the CLI on refusal. */
+  reason: string;
+  /** Reviewed/current HEAD SHAs when resolved (stale diagnostics). */
+  reviewedHead?: string;
+  currentHead?: string;
+  /** Formatted non-green checks (fail/pending diagnostics). */
+  blocking?: string[];
+}
+
+export interface CiRunResult { status: number; stdout: string; stderr: string; }
+
+/** Injectable command runner — lets the proof run without real gh/git in tests. */
+export type CiProofRunner = (command: string, args: string[]) => CiRunResult;
+
+export const defaultCiProofRunner: CiProofRunner = (command, args) => {
   const result = spawnSync(command, args, { encoding: 'utf8' });
-  if (result.error) {
-    throw new Error(`${failureContext}: ${result.error.message}`);
-  }
-  const stdout = (result.stdout ?? '').trim();
-  if ((result.status ?? 0) !== 0 && !stdout) {
-    const stderr = (result.stderr ?? '').trim();
-    throw new Error(`${failureContext}: ${stderr || `${command} exited ${result.status}`}`);
-  }
-  return stdout;
-}
-
-function resolveReviewedHeadSha(expectedHeadSha: string | undefined): string {
-  const explicit = expectedHeadSha?.trim();
-  if (explicit) return explicit;
-  return spawnText(
-    'git',
-    ['rev-parse', 'HEAD'],
-    'store-review-summary: #1070 unable to determine reviewed HEAD; pass --head-sha explicitly',
-  );
-}
-
-function readPrHeadSha(target: AttachmentTarget): string {
-  return spawnText(
-    'gh',
-    ['pr', 'view', String(target.number), '--repo', target.repo, '--json', 'headRefOid', '--jq', '.headRefOid'],
-    'store-review-summary: #1070 unable to read current PR head',
-  );
-}
-
-function readPrChecks(target: AttachmentTarget): GhCheck[] {
-  const stdout = spawnText(
-    'gh',
-    ['pr', 'checks', String(target.number), '--repo', target.repo, '--json', 'name,bucket,state,workflow,link'],
-    'store-review-summary: #1070 unable to read PR checks',
-  );
-  try {
-    const parsed = JSON.parse(stdout);
-    if (!Array.isArray(parsed)) {
-      throw new Error('JSON was not an array');
-    }
-    return parsed as GhCheck[];
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`store-review-summary: #1070 unable to parse PR checks JSON (${msg})`);
-  }
-}
+  if (result.error) return { status: 1, stdout: '', stderr: result.error.message };
+  return {
+    status: result.status ?? 0,
+    stdout: (result.stdout ?? '').trim(),
+    stderr: (result.stderr ?? '').trim(),
+  };
+};
 
 function formatCheck(check: GhCheck): string {
   const workflow = check.workflow ? `${check.workflow} / ` : '';
@@ -180,54 +171,126 @@ function formatCheck(check: GhCheck): string {
   return `${workflow}${name}: ${bucket}${state}`;
 }
 
-function assertReviewSummaryCiPassed(target: AttachmentTarget, options: StoreReviewSummaryOptions): void {
+/**
+ * Verify that a PR's CI proves a passing review summary is safe to store — WITHOUT
+ * throwing and WITHOUT touching the storage layer. Callers (the CLI/action boundary)
+ * branch on the returned status. Pure given an injected runner.
+ *
+ * Status meaning:
+ *   - 'skipped' — non-PR target; CI proof not applicable (#1222).
+ *   - 'stale'   — the reviewed HEAD no longer matches the PR's current HEAD.
+ *   - 'fail'    — at least one check failed/cancelled. Terminal — refuse.
+ *   - 'pending' — CI not finished (or a transient gh hiccup). Retriable — *wait*, don't fail (#1221).
+ *   - 'pass'    — all checks pass/skipping for the reviewed HEAD.
+ */
+export function verifyReviewCiProof(
+  target: AttachmentTarget,
+  options: StoreReviewSummaryOptions = {},
+  runner: CiProofRunner = defaultCiProofRunner,
+): CiProofResult {
   if (target.kind !== 'pr') {
-    throw new Error('store-review-summary: #1070 CI proof requires a PR target');
+    return { status: 'skipped', reason: 'CI proof not applicable for a non-PR target' };
   }
 
-  const reviewedHead = resolveReviewedHeadSha(options.expectedHeadSha);
-  const currentHead = readPrHeadSha(target);
+  let reviewedHead = options.expectedHeadSha?.trim();
+  if (!reviewedHead) {
+    const rev = runner('git', ['rev-parse', 'HEAD']);
+    reviewedHead = rev.stdout.trim();
+    if (rev.status !== 0 || !reviewedHead) {
+      return {
+        status: 'fail',
+        reason: 'unable to determine the reviewed HEAD; pass --head-sha "$(git rev-parse HEAD)" explicitly',
+      };
+    }
+  }
+
+  const view = runner('gh', ['pr', 'view', String(target.number), '--repo', target.repo, '--json', 'headRefOid', '--jq', '.headRefOid']);
+  const currentHead = view.stdout.trim();
+  if (view.status !== 0 || !currentHead) {
+    // Transient gh/network hiccup — retriable, not a real review failure (#1221).
+    return { status: 'pending', reason: `unable to read PR #${target.number} head (${view.stderr || 'no output'}); will retry`, reviewedHead };
+  }
   if (currentHead !== reviewedHead) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary for stale HEAD. ` +
-      `Reviewed ${reviewedHead}, but PR #${target.number} is currently ${currentHead}. ` +
-      `Re-review the current head before storing a pass summary.`,
-    );
+    return {
+      status: 'stale',
+      reason: `reviewed ${reviewedHead}, but PR #${target.number} is currently ${currentHead}; re-review the current head before storing a pass summary`,
+      reviewedHead,
+      currentHead,
+    };
   }
 
-  const checks = readPrChecks(target);
-  if (checks.length === 0) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI has not produced checks for ${currentHead}.`,
-    );
+  const checksRun = runner('gh', ['pr', 'checks', String(target.number), '--repo', target.repo, '--json', 'name,bucket,state,workflow,link']);
+  let checks: GhCheck[] = [];
+  if (checksRun.stdout) {
+    try {
+      const parsed = JSON.parse(checksRun.stdout);
+      if (Array.isArray(parsed)) checks = parsed as GhCheck[];
+    } catch {
+      // Unparseable output — treat as not-ready (retriable), never a hard FAIL.
+      return { status: 'pending', reason: `CI checks for ${currentHead} are not readable yet; will retry`, reviewedHead, currentHead };
+    }
   }
 
-  const blocking = checks.filter(check => {
-    const bucket = check.bucket;
-    return bucket !== 'pass' && bucket !== 'skipping';
-  });
-  if (blocking.length > 0) {
-    const details = blocking.map(formatCheck).join('; ');
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI is not green for ${currentHead}: ${details}`,
-    );
+  // A real failure dominates and is terminal; pending never masks a failed check.
+  const failing = checks.filter(c => c.bucket !== 'pass' && c.bucket !== 'skipping' && c.bucket !== 'pending');
+  if (failing.length > 0) {
+    return {
+      status: 'fail',
+      reason: `CI is not green for ${currentHead}: ${failing.map(formatCheck).join('; ')}`,
+      reviewedHead, currentHead, blocking: failing.map(formatCheck),
+    };
   }
+
+  // No failures: either nothing reported yet, or some checks still running → wait (#1221).
+  const pending = checks.filter(c => c.bucket === 'pending');
+  if (checks.length === 0 || pending.length > 0) {
+    const detail = checks.length === 0 ? 'CI has not produced checks yet' : `${pending.length} check(s) still running`;
+    return {
+      status: 'pending',
+      reason: `${detail} for ${currentHead}`,
+      reviewedHead, currentHead, blocking: pending.map(formatCheck),
+    };
+  }
+
+  return { status: 'pass', reason: `CI green for ${currentHead}`, reviewedHead, currentHead };
 }
 
-function extractSummaryRoundVerdict(summary: string): RoundVerdict | null {
-  const match = summary.match(/^<!-- meta:(\{.*\}) -->/);
-  if (!match) return null;
-  try {
-    const meta = JSON.parse(match[1]) as { round_verdict?: RoundVerdict; verdict?: string };
-    if (meta.round_verdict === 'PASS' || meta.round_verdict === 'PASS_WITH_PARTIALS' || meta.round_verdict === 'FAIL') {
-      return meta.round_verdict;
-    }
-    if (meta.verdict === 'fail') return 'FAIL';
-    if (meta.verdict === 'pass') return 'PASS';
-    return null;
-  } catch {
-    return null;
+export interface WaitForCiProofOptions {
+  runner?: CiProofRunner;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  /** Max time to wait for in-flight CI before returning the last 'pending'. Default 0 = no wait. */
+  timeoutMs?: number;
+  /** Poll interval while CI is pending. Default 15s. */
+  intervalMs?: number;
+  /** Optional progress reporter (the CLI prints to stderr). */
+  onPending?: (result: CiProofResult, elapsedMs: number) => void;
+}
+
+/**
+ * Poll {@link verifyReviewCiProof} while the status is 'pending' until it becomes
+ * terminal or the timeout elapses. This is the wait-for-CI step (#1221): in-flight
+ * CI is a *wait*, not a *fail*. Returns the final (possibly still-'pending') result.
+ */
+export async function waitForCiProof(
+  target: AttachmentTarget,
+  options: StoreReviewSummaryOptions = {},
+  wait: WaitForCiProofOptions = {},
+): Promise<CiProofResult> {
+  const runner = wait.runner ?? defaultCiProofRunner;
+  const sleep = wait.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)));
+  const now = wait.now ?? (() => Date.now());
+  const timeoutMs = wait.timeoutMs ?? 0;
+  const intervalMs = wait.intervalMs ?? 15_000;
+
+  const start = now();
+  let result = verifyReviewCiProof(target, options, runner);
+  while (result.status === 'pending' && now() - start < timeoutMs) {
+    wait.onPending?.(result, now() - start);
+    await sleep(intervalMs);
+    result = verifyReviewCiProof(target, options, runner);
   }
+  return result;
 }
 
 /**
@@ -322,14 +385,13 @@ export function storeReviewFinding(
 }
 
 /**
- * Compose a round summary from all stored dimension findings.
- * Reads each dimension's attachment, parses meta, builds a summary table.
+ * Gather the per-dimension rows for a round from stored findings — the single read
+ * point shared by composeReviewSummary, deriveStoredRoundVerdict, and storeReviewSummary,
+ * so a single store never reads the findings twice.
  */
-export function composeReviewSummary(target: AttachmentTarget, round: number): string {
-  const dims = listReviewDimensions(target, round);
+function gatherRoundRows(target: AttachmentTarget, round: number): RoundRow[] {
   const rows: RoundRow[] = [];
-
-  for (const dim of dims) {
+  for (const dim of listReviewDimensions(target, round)) {
     const content = readReviewFinding(target, round, dim);
     if (!content) continue;
     const meta = parseFindingMeta(content);
@@ -337,7 +399,11 @@ export function composeReviewSummary(target: AttachmentTarget, round: number): s
       rows.push({ dim: meta.dimension, verdict: meta.verdict, done: meta.done, partial: meta.partial, missing: meta.missing });
     }
   }
+  return rows;
+}
 
+/** Render a round summary from pre-gathered rows (no I/O). */
+function composeReviewSummaryFromRows(round: number, rows: RoundRow[]): string {
   const roll = summarizeRound(rows);
   // Header verdict mirrors the three-state rule; the `verdict` field in meta stays pass|fail so
   // downstream consumers (gates, parsers) keep a binary signal — PASS_WITH_PARTIALS maps to pass.
@@ -366,18 +432,19 @@ export function composeReviewSummary(target: AttachmentTarget, round: number): s
 }
 
 /**
+ * Compose a round summary from all stored dimension findings.
+ * Reads each dimension's attachment, parses meta, builds a summary table.
+ */
+export function composeReviewSummary(target: AttachmentTarget, round: number): string {
+  return composeReviewSummaryFromRows(round, gatherRoundRows(target, round));
+}
+
+/**
  * Compute the authoritative round verdict from stored findings — never from caller text.
  * Exposed so the storeReviewSummary guard and external callers share one derivation.
  */
 export function deriveStoredRoundVerdict(target: AttachmentTarget, round: number): RoundVerdict {
-  const rows: RoundRow[] = [];
-  for (const dim of listReviewDimensions(target, round)) {
-    const content = readReviewFinding(target, round, dim);
-    if (!content) continue;
-    const meta = parseFindingMeta(content);
-    if (meta) rows.push({ dim: meta.dimension, verdict: meta.verdict, done: meta.done, partial: meta.partial, missing: meta.missing });
-  }
-  return summarizeRound(rows).verdict;
+  return summarizeRound(gatherRoundRows(target, round)).verdict;
 }
 
 /**
@@ -397,13 +464,15 @@ export function storeReviewSummary(
   target: AttachmentTarget,
   round: number,
   note?: string,
-  options: StoreReviewSummaryOptions = {},
 ): string {
-  const derived = composeReviewSummary(target, round);
-  const roundVerdict = extractSummaryRoundVerdict(derived) ?? deriveStoredRoundVerdict(target, round);
-  if (roundVerdict !== 'FAIL') {
-    assertReviewSummaryCiPassed(target, options);
-  }
+  // Read the findings ONCE; derive both the rendered block and the verdict from the same rows
+  // (no double read, no extra I/O). Verdict is authoritative from stored findings (#1019). The CI
+  // proof that a PASS summary is safe to store lives at the CLI/action boundary (verifyReviewCiProof),
+  // NOT here — storage stays side-effect-free (#1222). No regex parse of the meta block: the
+  // structured derivation via summarizeRound is the single source of truth (#1222 / I29).
+  const rows = gatherRoundRows(target, round);
+  const derived = composeReviewSummaryFromRows(round, rows);
+  const roundVerdict = summarizeRound(rows).verdict;
 
   let content = derived;
 

--- a/src/worktree-isolation.test.ts
+++ b/src/worktree-isolation.test.ts
@@ -63,13 +63,16 @@ describe('kaizen-review-pr SKILL.md — review findings storage contract (#966)'
     expect(skill).toMatch(/store-review-summary/);
   });
 
-  it('requires current-head CI proof when storing a pass summary (#1070)', () => {
+  it('requires current-head CI proof when storing a pass summary (#1070/#1221/#1222)', () => {
     // INVARIANT: the skill must not regress to instruction-only CI checking.
-    // The storage command carries the reviewed head so the CLI can reject
-    // pending, failing, absent, or stale-head CI before writing the sentinel.
+    // The storage command carries the reviewed head so the CLI can verify CI at the
+    // action boundary: refuse on failing/stale CI, WAIT on pending CI, and surface a
+    // retriable ci_pending signal (not a review FAIL) if CI never finishes (#1221/#1222).
     const skill = readFileSync(REVIEW_PR_SKILL, 'utf8');
     expect(skill).toMatch(/--head-sha "\$\(git rev-parse HEAD\)"/);
-    expect(skill).toMatch(/Pending, failing, absent, or stale-head CI refuses storage/);
+    expect(skill).toMatch(/Failing or stale-head CI/);
+    expect(skill).toMatch(/ci_pending/);
+    expect(skill).toMatch(/retriable, \*\*NOT a review FAIL\*\*|retriable, NOT a review FAIL/);
   });
 });
 


### PR DESCRIPTION
## Rescue Context

This is a draft rescue PR for orphaned work from auto-dent batch `disgusted-ant`, run 3.

- Run: `disgusted-ant/run-3`
- Ticket worked on: #1225 — redo the #1070 CI-proof gate correctly after PR #1212 merged a broken implementation.
- Worktree: `/home/aviad/projects/kaizen/.claude/worktrees/2606272010-b97b`
- Branch: `case/260627-k1225-review-ci-proof`
- Rescue commit: `7ce8c16` `rescue(auto-dent): preserve stranded review CI proof work`

## Why It Stopped

The run hit the auto-dent watchdog wall-time limit after 1205 seconds and was terminated with `exit 143` / SIGTERM before it created a PR. The last log activity was another full `npm test` triage command, which the watchdog stopped with `Exit code 137`.

Auto-dent recorded:

- `failure_class`: timeout
- `process_verdict`: pass
- `process_summary`: durable evidence complete
- PR created by the run: none

## Preserved Work

This branch preserves an alternate/in-flight #1225 implementation around review CI proof storage, structured-data tests, CLI behavior, and review skill instructions.

## Rescue Notes

Quality gates were intentionally skipped for this rescue operation, per request. Treat this PR as preserved interrupted work, not validated work.

Refs #1225
Refs #1221
Refs #1222
Refs #1227
Refs #1255
