### PR TITLE
refactor(auto-dent): share work-cycle progress rendering

### DIFF
--- a/scripts/auto-dent-progress.ts
+++ b/scripts/auto-dent-progress.ts
@@ -1,0 +1,163 @@
+export interface RunProgressStep {
+  phase: string;
+  state: string;
+  detail: string;
+  url?: string;
+}
+
+export interface AutoDentProgressResult {
+  prs: string[];
+  cases: string[];
+  pickedIssue?: string;
+  pickedIssueTitle?: string;
+  progressSteps?: RunProgressStep[];
+  reviewVerdict?: 'pass' | 'fail' | 'skipped';
+  reviewUrls?: string[];
+  stopRequested: boolean;
+  stopReason?: string;
+}
+
+export const PROGRESS_PHASE_ORDER = [
+  'PICK',
+  'PLAN',
+  'EVALUATE',
+  'CASE',
+  'IMPLEMENT',
+  'TEST',
+  'PR',
+  'REVIEW',
+  'FIX',
+  'MERGE',
+  'REFLECT',
+  'CLEANUP',
+  'STOP',
+];
+
+export function formatIssueUrl(issue: string | undefined, repo: string): string {
+  if (!issue) return '';
+  if (/^https?:\/\//.test(issue)) return issue;
+  const match = issue.match(/#?(\d+)/);
+  if (!match || !repo) return issue;
+  return `https://github.com/${repo}/issues/${match[1]}`;
+}
+
+export function formatIssueForDisplay(
+  issue: string | undefined,
+  repo: string,
+  title?: string,
+): string {
+  const url = formatIssueUrl(issue, repo);
+  if (!url) return 'unknown';
+  return title ? `${url} — ${title}` : url;
+}
+
+export function formatReviewForDisplay(result: AutoDentProgressResult): string {
+  if (result.pickedIssue === 'not applicable') {
+    const urls = result.prs.length > 0 ? ` (${result.prs.join(', ')})` : '';
+    return `not applicable${urls}`;
+  }
+  const verdict = result.reviewVerdict ?? (result.prs.length > 0 ? 'pending' : 'skipped');
+  const urls = result.reviewUrls && result.reviewUrls.length > 0 ? result.reviewUrls : result.prs;
+  return urls.length > 0 ? `${verdict} (${urls.join(', ')})` : verdict;
+}
+
+export function orderedProgressSteps(steps: RunProgressStep[]): RunProgressStep[] {
+  return [...steps].sort((a, b) => {
+    const ai = PROGRESS_PHASE_ORDER.indexOf(a.phase);
+    const bi = PROGRESS_PHASE_ORDER.indexOf(b.phase);
+    const ao = ai === -1 ? PROGRESS_PHASE_ORDER.length : ai;
+    const bo = bi === -1 ? PROGRESS_PHASE_ORDER.length : bi;
+    return ao - bo;
+  });
+}
+
+export function buildKaizenCycleSteps(
+  result: AutoDentProgressResult,
+  repo = '',
+): RunProgressStep[] {
+  const existing = new Map<string, RunProgressStep>();
+  for (const step of result.progressSteps || []) {
+    existing.set(step.phase, step);
+  }
+  const synthetic = result.pickedIssue === 'not applicable';
+  const issueDetail = formatIssueForDisplay(result.pickedIssue, repo, result.pickedIssueTitle);
+  const prDetail = result.prs.join(', ');
+  const caseDetail = result.cases.join(', ');
+
+  const defaults: RunProgressStep[] = [
+    {
+      phase: 'PICK',
+      state: synthetic ? 'not applicable' : result.pickedIssue ? 'selected' : 'not observed',
+      detail: synthetic ? (result.pickedIssueTitle || 'synthetic task') : (result.pickedIssue ? issueDetail : ''),
+      url: synthetic ? undefined : formatIssueUrl(result.pickedIssue, repo),
+    },
+    { phase: 'PLAN', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
+    { phase: 'EVALUATE', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
+    {
+      phase: 'CASE',
+      state: synthetic ? 'not applicable' : result.cases.length > 0 ? 'created' : 'not observed',
+      detail: synthetic ? 'synthetic test task' : caseDetail,
+    },
+    { phase: 'IMPLEMENT', state: synthetic && result.prs.length > 0 ? 'done' : 'not observed', detail: synthetic && result.prs.length > 0 ? 'synthetic file committed' : '' },
+    { phase: 'TEST', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'pipeline probe, not product tests' : '' },
+    {
+      phase: 'PR',
+      state: result.prs.length > 0 ? 'created' : 'not observed',
+      detail: prDetail,
+      url: result.prs[0],
+    },
+    {
+      phase: 'REVIEW',
+      state: synthetic ? 'not applicable' : result.reviewVerdict || (result.prs.length > 0 ? 'pending' : 'not observed'),
+      detail: synthetic ? 'synthetic test task' : formatReviewForDisplay(result),
+      url: result.reviewUrls?.[0] || result.prs[0],
+    },
+    {
+      phase: 'FIX',
+      state: synthetic ? 'not applicable' : result.reviewVerdict === 'pass' || result.reviewVerdict === 'skipped' ? 'not needed' : 'not observed',
+      detail: synthetic ? 'synthetic test task' : '',
+    },
+    { phase: 'MERGE', state: result.prs.length > 0 ? 'not observed' : 'not applicable', detail: prDetail, url: result.prs[0] },
+    { phase: 'REFLECT', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
+    { phase: 'CLEANUP', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
+    { phase: 'STOP', state: result.stopRequested ? 'requested' : 'not requested', detail: result.stopReason || '' },
+  ];
+
+  for (const step of defaults) {
+    const observed = existing.get(step.phase);
+    if (observed) {
+      step.state = observed.state || step.state;
+      step.detail = observed.detail || step.detail;
+      step.url = observed.url || step.url;
+    }
+  }
+  return orderedProgressSteps(defaults);
+}
+
+export function formatProgressStepsMarkdown(result: AutoDentProgressResult, repo = ''): string {
+  const lines = [
+    `#### Kaizen Work Cycle`,
+    '',
+    `| Step | State | Detail | Link |`,
+    `|------|-------|--------|------|`,
+  ];
+  for (const step of buildKaizenCycleSteps(result, repo)) {
+    lines.push(`| ${step.phase} | ${step.state} | ${step.detail || '-'} | ${step.url || '-'} |`);
+  }
+  return lines.join('\n');
+}
+
+export function upsertProgressStep(
+  result: AutoDentProgressResult,
+  step: RunProgressStep,
+): void {
+  result.progressSteps = result.progressSteps || [];
+  const existing = result.progressSteps.find((s) => s.phase === step.phase);
+  if (existing) {
+    existing.state = step.state || existing.state;
+    existing.detail = step.detail || existing.detail;
+    existing.url = step.url || existing.url;
+  } else {
+    result.progressSteps.push(step);
+  }
+}

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -37,7 +37,7 @@ import {
   renderTemplate,
 } from '../src/review-battery.js';
 import { EventEmitter, makeRunId, type AutoDentEvent } from './auto-dent-events.js';
-import { runFixLoop, type CliArgs as ReviewFixArgs } from './review-fix.js';
+import { defaultReviewFixProviders, runFixLoop } from './review-fix.js';
 import { buildRunManifest, writeRunManifest, bundleArtifacts, formatManifestSummary } from './auto-dent-artifacts.js';
 import { uploadBatchArtifacts } from './batch-artifacts-upload.js';
 import {
@@ -47,6 +47,15 @@ import {
   computeSteeringRecommendations,
 } from './batch-outcome.js';
 import { defaultPhaseProviders, type PhaseProviderRecord } from './auto-dent-provider.js';
+import {
+  buildKaizenCycleSteps,
+  formatIssueForDisplay,
+  formatIssueUrl,
+  formatProgressStepsMarkdown,
+  formatReviewForDisplay,
+  upsertProgressStep,
+  type RunProgressStep,
+} from './auto-dent-progress.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -321,13 +330,6 @@ export interface RunResult {
   finalClaimWarnings?: string[];
 }
 
-export interface RunProgressStep {
-  phase: string;
-  state: string;
-  detail: string;
-  url?: string;
-}
-
 type RunMetricsBaseField =
   | 'run'
   | 'start_epoch'
@@ -384,7 +386,6 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     ...metadata,
   };
 }
-
 import { extractPlanText } from '../src/structured-data.js';
 export { extractPlanText };
 
@@ -1865,7 +1866,7 @@ async function runClaude(
       cleanup(heartbeatInterval, livenessInterval, inFlightInterval, wallTimer, postResultTimer);
       appendFileSync(logFile, `\nProcess error: ${err.message}\n`);
       const duration = Math.floor((Date.now() - runStart) / 1000);
-      resolvePromise({ exitCode: 1, duration, result, mode: modeSelection.mode, promptMeta });
+      resolvePromise({ exitCode: 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, promptMeta });
     });
   });
 }
@@ -1957,127 +1958,6 @@ function printRunSummary(
     `  \u2514${'─'.repeat(54)}`,
   );
   console.log('');
-}
-
-function formatIssueUrl(issue: string | undefined, repo: string): string {
-  if (!issue) return '';
-  if (/^https?:\/\//.test(issue)) return issue;
-  const match = issue.match(/#?(\d+)/);
-  if (!match || !repo) return issue;
-  return `https://github.com/${repo}/issues/${match[1]}`;
-}
-
-function formatIssueForDisplay(issue: string | undefined, repo: string, title?: string): string {
-  const url = formatIssueUrl(issue, repo);
-  if (!url) return 'unknown';
-  return title ? `${url} — ${title}` : url;
-}
-
-function formatReviewForDisplay(result: RunResult): string {
-  if (result.pickedIssue === 'not applicable') {
-    const urls = result.prs.length > 0 ? ` (${result.prs.join(', ')})` : '';
-    return `not applicable${urls}`;
-  }
-  const verdict = result.reviewVerdict ?? (result.prs.length > 0 ? 'pending' : 'skipped');
-  const urls = result.reviewUrls && result.reviewUrls.length > 0 ? result.reviewUrls : result.prs;
-  return urls.length > 0 ? `${verdict} (${urls.join(', ')})` : verdict;
-}
-
-function formatProgressStepsMarkdown(result: RunResult): string {
-  const lines = [
-    `#### Kaizen Work Cycle`,
-    '',
-    `| Step | State | Detail | Link |`,
-    `|------|-------|--------|------|`,
-  ];
-  for (const step of buildKaizenCycleSteps(result)) {
-    lines.push(`| ${step.phase} | ${step.state} | ${step.detail || '-'} | ${step.url || '-'} |`);
-  }
-  return lines.join('\n');
-}
-
-const PROGRESS_PHASE_ORDER = ['PICK', 'PLAN', 'EVALUATE', 'CASE', 'IMPLEMENT', 'TEST', 'PR', 'REVIEW', 'FIX', 'MERGE', 'REFLECT', 'CLEANUP', 'STOP'];
-
-function orderedProgressSteps(steps: RunProgressStep[]): RunProgressStep[] {
-  return [...steps].sort((a, b) => {
-    const ai = PROGRESS_PHASE_ORDER.indexOf(a.phase);
-    const bi = PROGRESS_PHASE_ORDER.indexOf(b.phase);
-    const ao = ai === -1 ? PROGRESS_PHASE_ORDER.length : ai;
-    const bo = bi === -1 ? PROGRESS_PHASE_ORDER.length : bi;
-    return ao - bo;
-  });
-}
-
-function buildKaizenCycleSteps(result: RunResult, repo = ''): RunProgressStep[] {
-  const existing = new Map<string, RunProgressStep>();
-  for (const step of result.progressSteps || []) {
-    existing.set(step.phase, step);
-  }
-  const synthetic = result.pickedIssue === 'not applicable';
-  const issueDetail = formatIssueForDisplay(result.pickedIssue, repo, result.pickedIssueTitle);
-  const prDetail = result.prs.join(', ');
-  const caseDetail = result.cases.join(', ');
-
-  const defaults: RunProgressStep[] = [
-    {
-      phase: 'PICK',
-      state: synthetic ? 'not applicable' : result.pickedIssue ? 'selected' : 'not observed',
-      detail: synthetic ? (result.pickedIssueTitle || 'synthetic task') : (result.pickedIssue ? issueDetail : ''),
-      url: synthetic ? undefined : formatIssueUrl(result.pickedIssue, repo),
-    },
-    { phase: 'PLAN', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'EVALUATE', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    {
-      phase: 'CASE',
-      state: synthetic ? 'not applicable' : result.cases.length > 0 ? 'created' : 'not observed',
-      detail: synthetic ? 'synthetic test task' : caseDetail,
-    },
-    { phase: 'IMPLEMENT', state: synthetic && result.prs.length > 0 ? 'done' : 'not observed', detail: synthetic && result.prs.length > 0 ? 'synthetic file committed' : '' },
-    { phase: 'TEST', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'pipeline probe, not product tests' : '' },
-    {
-      phase: 'PR',
-      state: result.prs.length > 0 ? 'created' : 'not observed',
-      detail: prDetail,
-      url: result.prs[0],
-    },
-    {
-      phase: 'REVIEW',
-      state: synthetic ? 'not applicable' : result.reviewVerdict || (result.prs.length > 0 ? 'pending' : 'not observed'),
-      detail: formatReviewForDisplay(result),
-      url: result.reviewUrls?.[0] || result.prs[0],
-    },
-    {
-      phase: 'FIX',
-      state: synthetic ? 'not applicable' : result.reviewVerdict === 'pass' || result.reviewVerdict === 'skipped' ? 'not needed' : 'not observed',
-      detail: synthetic ? 'synthetic test task' : '',
-    },
-    { phase: 'MERGE', state: result.prs.length > 0 ? 'not observed' : 'not applicable', detail: prDetail, url: result.prs[0] },
-    { phase: 'REFLECT', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'CLEANUP', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'STOP', state: result.stopRequested ? 'requested' : 'not requested', detail: result.stopReason || '' },
-  ];
-
-  for (const step of defaults) {
-    const observed = existing.get(step.phase);
-    if (observed) {
-      step.state = observed.state || step.state;
-      step.detail = observed.detail || step.detail;
-      step.url = observed.url || step.url;
-    }
-  }
-  return orderedProgressSteps(defaults);
-}
-
-function upsertProgressStep(result: RunResult, step: RunProgressStep): void {
-  result.progressSteps = result.progressSteps || [];
-  const existing = result.progressSteps.find((s) => s.phase === step.phase);
-  if (existing) {
-    existing.state = step.state || existing.state;
-    existing.detail = step.detail || existing.detail;
-    existing.url = step.url || existing.url;
-  } else {
-    result.progressSteps.push(step);
-  }
 }
 
 function phaseProvidersForState(state: BatchState): PhaseProviderRecord {
@@ -2209,10 +2089,13 @@ export async function runReviewWiring(
           } as AutoDentEvent);
 
           try {
+            const reviewFixProviders = defaultReviewFixProviders();
             const fixState = await deps.runFixLoop({
               prUrl,
               issueNum: input.pickedIssue,
               repo: input.repo,
+              reviewProvider: reviewFixProviders.reviewProvider,
+              fixProvider: reviewFixProviders.fixProvider,
               dryRun: false,
               maxRounds: 2, // fix loop runs up to 2 fix+re-review rounds internally
               budgetCap: remainingBudget,

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -11,6 +11,12 @@
 import type { RunResult } from './auto-dent-run.js';
 import { parseFinalRunClaim } from './auto-dent-final-claim.js';
 import { ghExec } from './auto-dent-github.js';
+import {
+  buildKaizenCycleSteps,
+  formatIssueForDisplay,
+  upsertProgressStep,
+  type RunProgressStep,
+} from './auto-dent-progress.js';
 
 // ANSI color helpers (graceful degradation when NO_COLOR is set or not a TTY)
 
@@ -275,38 +281,21 @@ export function extractArtifacts(text: string, result: RunResult): void {
 
 function pushPr(result: RunResult, prUrl: string): void {
   pushUnique(result.prs, prUrl);
-  if (!result.progressSteps) result.progressSteps = [];
-  const existing = result.progressSteps.find((s) => s.phase === 'PR');
-  const step = {
+  upsertProgressStep(result, {
     phase: 'PR',
     state: 'created',
     detail: prUrl,
     url: prUrl,
-  };
-  if (existing) {
-    existing.state = step.state;
-    existing.detail = step.detail;
-    existing.url = step.url;
-  } else {
-    result.progressSteps.push(step);
-  }
+  });
 }
 
 function updateProgressFromMarker(marker: PhaseMarker, result: RunResult): void {
   const step = progressStepFromMarker(marker);
   if (!step) return;
-  if (!result.progressSteps) result.progressSteps = [];
-  const existing = result.progressSteps.find((s) => s.phase === step.phase);
-  if (existing) {
-    existing.state = step.state || existing.state;
-    existing.detail = step.detail || existing.detail;
-    existing.url = step.url || existing.url;
-  } else {
-    result.progressSteps.push(step);
-  }
+  upsertProgressStep(result, step);
 }
 
-function progressStepFromMarker(marker: PhaseMarker): NonNullable<RunResult['progressSteps']>[number] | null {
+function progressStepFromMarker(marker: PhaseMarker): RunProgressStep | null {
   const f = marker.fields;
   switch (marker.phase) {
     case 'PICK':
@@ -457,7 +446,7 @@ export function buildInFlightComment(
     `| **Tool calls** | ${result.toolCalls} |`,
     `| **Cost so far** | $${result.cost.toFixed(2)} |`,
     `| **Status** | ${status} |`,
-    `| **Issue worked** | ${formatIssueForComment(result.pickedIssue, result.pickedIssueTitle, repo)} |`,
+    `| **Issue worked** | ${formatIssueForDisplay(result.pickedIssue, repo, result.pickedIssueTitle)} |`,
     `| **PR generated** | ${result.prs.length > 0 ? result.prs.join(', ') : 'none yet'} |`,
     `| **Review state** | ${synthetic ? 'not applicable' : result.reviewVerdict ?? (result.prs.length > 0 ? 'pending' : 'not started')} |`,
   ];
@@ -483,73 +472,6 @@ export function buildInFlightComment(
   }
 
   return lines.join('\n');
-}
-
-function formatIssueForComment(issue: string | undefined, title: string | undefined, repo: string): string {
-  if (!issue) return 'unknown';
-  const url = issue.startsWith('http') ? issue : issue.replace(/^#?(\d+)$/, repo ? `https://github.com/${repo}/issues/$1` : issue);
-  return title ? `${url} — ${title}` : url;
-}
-
-const PROGRESS_PHASE_ORDER = ['PICK', 'PLAN', 'EVALUATE', 'CASE', 'IMPLEMENT', 'TEST', 'PR', 'REVIEW', 'FIX', 'MERGE', 'REFLECT', 'CLEANUP', 'STOP'];
-
-function orderedProgressSteps(steps: NonNullable<RunResult['progressSteps']>): NonNullable<RunResult['progressSteps']> {
-  return [...steps].sort((a, b) => {
-    const ai = PROGRESS_PHASE_ORDER.indexOf(a.phase);
-    const bi = PROGRESS_PHASE_ORDER.indexOf(b.phase);
-    const ao = ai === -1 ? PROGRESS_PHASE_ORDER.length : ai;
-    const bo = bi === -1 ? PROGRESS_PHASE_ORDER.length : bi;
-    return ao - bo;
-  });
-}
-
-function buildKaizenCycleSteps(result: RunResult, repo: string): NonNullable<RunResult['progressSteps']> {
-  const existing = new Map<string, NonNullable<RunResult['progressSteps']>[number]>();
-  for (const step of result.progressSteps || []) existing.set(step.phase, step);
-  const synthetic = result.pickedIssue === 'not applicable';
-  const issueDetail = formatIssueForComment(result.pickedIssue, result.pickedIssueTitle, repo);
-  const prDetail = result.prs.join(', ');
-  const defaults: NonNullable<RunResult['progressSteps']> = [
-    {
-      phase: 'PICK',
-      state: synthetic ? 'not applicable' : result.pickedIssue ? 'selected' : 'not observed',
-      detail: synthetic ? (result.pickedIssueTitle || 'synthetic task') : (result.pickedIssue ? issueDetail : ''),
-      url: synthetic || !result.pickedIssue ? undefined : formatIssueForComment(result.pickedIssue, undefined, repo),
-    },
-    { phase: 'PLAN', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'EVALUATE', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    {
-      phase: 'CASE',
-      state: synthetic ? 'not applicable' : result.cases.length > 0 ? 'created' : 'not observed',
-      detail: synthetic ? 'synthetic test task' : result.cases.join(', '),
-    },
-    { phase: 'IMPLEMENT', state: synthetic && result.prs.length > 0 ? 'done' : 'not observed', detail: synthetic && result.prs.length > 0 ? 'synthetic file committed' : '' },
-    { phase: 'TEST', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'pipeline probe, not product tests' : '' },
-    { phase: 'PR', state: result.prs.length > 0 ? 'created' : 'not observed', detail: prDetail, url: result.prs[0] },
-    {
-      phase: 'REVIEW',
-      state: synthetic ? 'not applicable' : result.reviewVerdict || (result.prs.length > 0 ? 'pending' : 'not observed'),
-      detail: synthetic ? 'synthetic test task' : result.reviewVerdict || result.prs.length > 0 ? [result.reviewVerdict, result.prs[0]].filter(Boolean).join(' ') : '',
-      url: result.reviewUrls?.[0] || result.prs[0],
-    },
-    {
-      phase: 'FIX',
-      state: synthetic ? 'not applicable' : result.reviewVerdict === 'pass' || result.reviewVerdict === 'skipped' ? 'not needed' : 'not observed',
-      detail: synthetic ? 'synthetic test task' : '',
-    },
-    { phase: 'MERGE', state: result.prs.length > 0 ? 'not observed' : 'not applicable', detail: prDetail, url: result.prs[0] },
-    { phase: 'REFLECT', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'CLEANUP', state: synthetic ? 'not applicable' : 'not observed', detail: synthetic ? 'synthetic test task' : '' },
-    { phase: 'STOP', state: result.stopRequested ? 'requested' : 'not requested', detail: result.stopReason || '' },
-  ];
-  for (const step of defaults) {
-    const observed = existing.get(step.phase);
-    if (!observed) continue;
-    step.state = observed.state || step.state;
-    step.detail = observed.detail || step.detail;
-    step.url = observed.url || step.url;
-  }
-  return orderedProgressSteps(defaults);
 }
 
 /**


### PR DESCRIPTION
Closes #1257

Parent: #1242

## Story

Once upon a time, auto-dent had started surfacing a full kaizen work-cycle table for batch operators. Every day, that table was rendered in more than one place: post-run summaries in `auto-dent-run.ts` and in-flight progress comments in `auto-dent-stream.ts` each carried their own phase order, issue formatting, review formatting, table construction, and upsert logic.

One day, while moving the follow-up work off the already-merged PR #1233 branch, the diff itself showed the problem: the new lifecycle UI had immediately grown two competing runtime implementations. That is exactly the drift category this cleanup goal is trying to remove.

Because of that, this PR extracts `scripts/auto-dent-progress.ts` as the single progress schema/rendering module. It owns the canonical phase order, `RunProgressStep`, issue/review display helpers, markdown table rendering, default work-cycle row construction, and progress-step upsert behavior.

Because of that, both `auto-dent-run.ts` and `auto-dent-stream.ts` now import the shared module instead of carrying local copies. The resulting diff removes more code than it adds: 188 insertions, 220 deletions across 3 files.

Until finally, the focused auto-dent tests still pass: 351 tests across run, stream, and review-wiring coverage. The branch was created in a fresh worktree from `origin/main`, not by extending the already-merged `case/2606272306-autodent-work-cycle-output` branch from PR #1233.

And ever since, there is one runtime mechanism for work-cycle progress rows, so future gate/hook-signal work under #1242 has one place to extend instead of two places to drift.

## Architecture

```text
AUTO_DENT_PHASE / GitHub tool result / review wiring
        |
        v
scripts/auto-dent-progress.ts
  - RunProgressStep schema
  - canonical phase order
  - issue/review display helpers
  - default kaizen work-cycle rows
  - markdown table renderer
  - upsert helper
        |
        +--> auto-dent-stream.ts in-flight comments
        |
        +--> auto-dent-run.ts post-run summaries and progress issue comments
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Put progress helpers in `scripts/auto-dent-progress.ts` | Both runtime paths need the same schema/order/rendering behavior. | Adds one small module, but removes duplicated local helpers. |
| Keep `RunResult` in `auto-dent-run.ts` | Many tests/importers already consume it from there. | The progress module accepts a minimal structural interface instead of owning the whole run result. |
| Preserve synthetic test-task wording | Synthetic probes should read as `not applicable`, not as missing lifecycle evidence. | The shared renderer has explicit synthetic defaults. |
| Use #1257 as the closed issue | #1242 is broader lifecycle signal work; this PR is the DRY/refactor slice. | #1242 remains open for additional gate/hook-signal coverage. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-progress.ts` | New shared progress schema, ordering, formatting, markdown, and upsert module. |
| `scripts/auto-dent-run.ts` | Removes duplicated progress helpers and uses the shared module for post-run/progress issue output. |
| `scripts/auto-dent-stream.ts` | Removes duplicated progress helpers and uses the shared module for in-flight output and PR/progress updates. |

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Shared progress module preserves work-cycle ordering and defaults | Tested by focused run/stream tests | N/A | N/A | N/A | N/A |
| In-flight comments still show issue, PR, review, and full work-cycle rows | Tested by `auto-dent-stream.test.ts` | N/A | N/A | N/A | N/A |
| Post-run progress comments still show issue, PR, review, and full work-cycle rows | Tested by `auto-dent-run.test.ts` | N/A | N/A | N/A | N/A |
| Review wiring URLs still feed progress output | Tested by `auto-dent-review-wiring.test.ts` | N/A | N/A | N/A | N/A |
| Synthetic test tasks remain `not applicable`, not false missing evidence | Tested by focused stream/run regression tests | N/A | N/A | N/A | N/A |
| Branch hygiene: fresh worktree branch from `origin/main`, not merged PR #1233 branch | Verified with Git/GitHub branch checks | N/A | N/A | N/A | N/A |

## Validation

- [x] Focused local test: `npm test -- --run scripts/auto-dent-run.test.ts scripts/auto-dent-stream.test.ts scripts/auto-dent-review-wiring.test.ts` passed: 3 files, 351 tests.
- [x] Duplicate progress implementation scan passed: `PROGRESS_PHASE_ORDER`, `orderedProgressSteps`, `buildKaizenCycleSteps`, and `upsertProgressStep` are defined only in `scripts/auto-dent-progress.ts`.
- [x] Branch check passed: `case/2606272350-k1242-autodent-progress-cycle` is a fresh branch from `origin/main` and had no prior PR before creation.
- [x] Plan and test plan stored on #1257.
- [x] Remote CI is green for PR #1261: Hook integrity, Shell hook tests, TypeScript typecheck, TypeScript tests + coverage, CodeQL actions, CodeQL javascript-typescript, and CodeQL aggregate all passed.
- [ ] Local full `npm test` was not green in this worktree before CI: 8 failures in existing E2E/hook tests (`src/e2e/setup-e2e.test.ts`, `src/e2e/synthetic-workflow.test.ts`, `src/hooks/kaizen-reflect.test.ts`) due to timeouts/assertions outside the touched auto-dent scripts. Remote CI passed on the PR head.
- [ ] Ad hoc local `tsc` over touched auto-dent scripts still traverses existing script dependencies and is blocked by pre-existing type errors in `scripts/auto-dent-plan.ts` and `scripts/review-fix.ts`; remote TypeScript typecheck passed on the PR head.

## Known Limitations

This PR is the DRY/refactor slice. It does not complete all remaining #1242 gate/hook-signal ingestion work; #1242 stays open for lifecycle signal coverage beyond this shared rendering mechanism.