### PR TITLE
refactor(auto-dent): share planning state reader

### DIFF
--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -27,7 +27,7 @@ import {
   type BatchPlan,
   type PlanItem,
 } from './auto-dent-plan.js';
-import type { BatchState } from './auto-dent-run.js';
+import { readState, type BatchState } from './auto-dent-run.js';
 import { makeBatchState } from './auto-dent-test-utils.js';
 
 function mkItem(overrides: Partial<PlanItem> & { issue: string; title: string }): PlanItem {
@@ -260,6 +260,35 @@ describe('provider-aware planning (#1146)', () => {
     expect(formatPlanningFailure({ provider: 'codex', billing: 'subscription-cli' }, 'could not extract plan JSON')).toBe(
       '  [plan:codex] could not extract plan JSON',
     );
+  });
+});
+
+describe('state reading', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'plan-state-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('uses the canonical auto-dent state reader with backup fallback (#1262)', () => {
+    const stateFile = join(tmpDir, 'state.json');
+    const fallback = makeState({ guidance: 'fallback state' });
+    writeFileSync(stateFile, '{corrupt json');
+    writeFileSync(`${stateFile}.bak`, JSON.stringify(fallback));
+
+    expect(readState(stateFile).guidance).toBe('fallback state');
+
+    const source = readFileSync(
+      new URL('./auto-dent-plan.ts', import.meta.url),
+      'utf8',
+    );
+    expect(source).not.toMatch(/function readState\(/);
+    expect(source).toMatch(/readState,/);
+    expect(source).toContain("from './auto-dent-run.js'");
   });
 });
 

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -26,6 +26,7 @@ import {
   buildTemplateVars,
   renderTemplate,
   loadPromptTemplate,
+  readState,
 } from './auto-dent-run.js';
 import { buildCodexExecArgs, parseCodexJsonl } from './auto-dent-codex.js';
 import type { PhaseProvider } from './auto-dent-provider.js';
@@ -134,10 +135,6 @@ const RawPlanThemeInputSchema = z.object({
 
 export function validatePlanningOutputContract(raw: unknown): boolean {
   return PlanningOutputSchema.safeParse(raw).success;
-}
-
-function readState(stateFile: string): BatchState {
-  return JSON.parse(readFileSync(stateFile, 'utf8'));
 }
 
 function getRepoRoot(): string {


### PR DESCRIPTION
Closes #1262

Parent: #1242

## Story

Once upon a time, auto-dent had a canonical state reader in `auto-dent-run.ts` that handles corrupt primary state by falling back to `<state>.bak`. Every day, the planning pre-pass read the same `BatchState` file before generating `plan.json`.

One day, the duplication scan found that `auto-dent-plan.ts` had its own local `readState` copy. It parsed `state.json` directly and skipped the backup fallback. That meant the run loop and planning pre-pass could drift on state recovery behavior.

Because of that, this PR removes the local planning reader and imports the shared `readState` from `auto-dent-run.ts`.

Because of that, the planning pre-pass now gets the same backup recovery behavior as the rest of auto-dent state I/O.

Until finally, a focused regression test corrupts `state.json`, writes a valid `.bak`, verifies the canonical reader recovers it, and pins `auto-dent-plan.ts` to importing from `auto-dent-run.ts` instead of redefining `readState`.

And ever since, there is one state-read mechanism for auto-dent batch state instead of two subtly different ones.

## Architecture

```text
state.json / state.json.bak
        |
        v
auto-dent-run.ts readState
        |
        +--> auto-dent.ts runtime loop
        |
        +--> auto-dent-plan.ts planning pre-pass
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Import `readState` from `auto-dent-run.ts` | `auto-dent-plan.ts` already imports runtime prompt helpers from that module, so this does not introduce a new dependency direction. | Keeps state I/O centralized in the existing runtime module. |
| Add a source-pinning assertion | The behavior is used by `main()`, which would otherwise require spawning the planning pre-pass. | The test combines behavioral proof of backup fallback with a source-level guard against reintroducing the local helper. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-plan.ts` | Removes local `readState`; imports the canonical reader. |
| `scripts/auto-dent-plan.test.ts` | Adds regression coverage for backup fallback and no local planning reader. |

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Planning pre-pass uses canonical state reader | Tested by source guard and shared reader import | N/A | N/A | N/A | N/A |
| Backup fallback behavior is preserved for planning state | Tested with corrupt primary + valid `.bak` | N/A | N/A | N/A | N/A |
| Existing planning/run state tests still pass | Tested by focused Vitest command | N/A | N/A | N/A | N/A |

## Validation

- [x] `npm test -- --run scripts/auto-dent-plan.test.ts scripts/auto-dent-run.test.ts` passed: 2 files, 385 tests.
- [x] Duplicate scan passed: `scripts/auto-dent-plan.ts` no longer defines `function readState(` and imports `readState` from `./auto-dent-run.js`.
- [x] Plan and test plan stored on #1262.

## Known Limitations

This PR only unifies planning pre-pass state reads. It does not move all `BatchState` ownership out of `auto-dent-run.ts`; that would be a larger module-boundary refactor and should be a separate issue if needed.
