### PR TITLE
refactor(auto-dent): share ctl state reader

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { mkdtempSync, writeFileSync, existsSync, readFileSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -21,6 +21,7 @@ import {
   computeAggregateStats,
   formatAggregateStats,
   buildSteerOutput,
+  discoverBatches,
   DEFAULT_WATCHDOG_THRESHOLD_SEC,
   type BatchInfo,
   type WatchdogResult,
@@ -39,6 +40,39 @@ function makeBatchInfo(overrides: Partial<BatchInfo> = {}): BatchInfo {
     ...overrides,
   };
 }
+
+describe('discoverBatches', () => {
+  it('uses the canonical auto-dent state reader with backup fallback (#1264)', () => {
+    const logsDir = mkdtempSync(join(tmpdir(), 'ctl-state-test-'));
+    try {
+      const batchDir = join(logsDir, 'batch-corrupt-primary');
+      const stateFile = join(batchDir, 'state.json');
+      const state = makeBatchState({
+        batch_id: 'batch-from-backup',
+        guidance: 'fallback control state',
+      });
+      mkdirSync(batchDir, { recursive: true });
+      writeFileSync(stateFile, '{corrupt json');
+      writeFileSync(`${stateFile}.bak`, JSON.stringify(state));
+
+      const batches = discoverBatches(logsDir);
+
+      expect(batches).toHaveLength(1);
+      expect(batches[0].batchId).toBe('batch-from-backup');
+      expect(batches[0].state.guidance).toBe('fallback control state');
+
+      const source = readFileSync(
+        new URL('./auto-dent-ctl.ts', import.meta.url),
+        'utf8',
+      );
+      expect(source).not.toContain("JSON.parse(readFileSync(stateFile, 'utf8'))");
+      expect(source).toMatch(/readState,/);
+      expect(source).toContain("from './auto-dent-run.js'");
+    } finally {
+      rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('formatBatchStatus', () => {
   it('shows basic batch info', () => {

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -23,7 +23,7 @@ import { readdirSync, readFileSync, existsSync, writeFileSync, appendFileSync } 
 import { join } from 'path';
 import { execSync } from 'child_process';
 import type { BatchState, RunMetrics } from './auto-dent-run.js';
-import { checkMergeStatus, cleanupSupersededPRs, loadPromptTemplate, renderTemplate } from './auto-dent-run.js';
+import { checkMergeStatus, cleanupSupersededPRs, loadPromptTemplate, readState, renderTemplate } from './auto-dent-run.js';
 import {
   scoreBatch,
   scoreRunMetrics,
@@ -116,7 +116,7 @@ export function discoverBatches(logsDir: string): BatchInfo[] {
     if (!existsSync(stateFile)) continue;
 
     try {
-      const state: BatchState = JSON.parse(readFileSync(stateFile, 'utf8'));
+      const state = readState(stateFile);
       const haltFile = join(dir, 'HALT');
       batches.push({
         batchId: state.batch_id || entry,
@@ -1331,7 +1331,7 @@ Cross-batch learning (#586):
         console.error('Usage: auto-dent-ctl.ts halt-state <state-file>');
         process.exit(1);
       }
-      const state: BatchState = JSON.parse(readFileSync(stateFile, 'utf8'));
+      const state = readState(stateFile);
       console.log(formatLastState(state));
       break;
     }


### PR DESCRIPTION
Closes #1264

Related: #1262

## Story

Once upon a time, auto-dent had a canonical backup-aware state reader in `auto-dent-run.ts`. Every day, the runtime loop and planning pre-pass used that shared reader to recover from a corrupt `state.json` when `state.json.bak` was still valid.

One day, the control CLI still had two direct `JSON.parse(readFileSync(stateFile, 'utf8'))` paths for the same `BatchState` file: batch discovery and `halt-state`. That meant operational tooling could skip or fail on a batch that the runtime could recover.

Because of that, this PR wires `auto-dent-ctl.ts` through the shared `readState` helper for batch state files.

Because of that, `discoverBatches` and `halt-state` now share the same backup fallback behavior as the runtime and planning pre-pass.

Until finally, a focused regression test corrupts `state.json`, writes a valid `.bak`, and verifies `discoverBatches` still finds the batch from the backup.

And ever since, auto-dent has one state-read mechanism across run, plan, and control paths instead of three subtly different ones.

## Architecture

```text
state.json / state.json.bak
        |
        v
auto-dent-run.ts readState
        |
        +--> auto-dent.ts runtime loop
        +--> auto-dent-plan.ts planning pre-pass
        +--> auto-dent-ctl.ts control/discovery/halt-state
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Import `readState` from `auto-dent-run.ts` | `auto-dent-ctl.ts` already imports runtime helpers from that module, so this keeps the existing dependency direction. | Leaves broader state I/O ownership in `auto-dent-run.ts`; extracting a dedicated state module can be a later larger refactor. |
| Keep corrupt-without-backup behavior fail-closed for discovery | Existing discovery skipped unreadable state files; shared `readState` still throws when both primary and backup are unavailable. | The CLI now recovers more cases without masking unrecoverable corruption. |
| Add a source guard in the focused test | The risk is reintroducing direct state parsing later. | Source guard is structural, but paired with backup-fallback behavior proof. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-ctl.ts` | Uses shared `readState` for `discoverBatches` and `halt-state`. |
| `scripts/auto-dent-ctl.test.ts` | Adds backup-fallback regression and no-direct-parse guard. |

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Control CLI uses canonical state reader | Tested by source guard | N/A | N/A | N/A | N/A |
| Batch discovery recovers from corrupt primary + valid backup | Tested by focused unit regression | N/A | N/A | N/A | N/A |
| Existing control/state behavior remains stable | Tested by focused control/run test suite | N/A | N/A | N/A | N/A |

## Validation

- [x] `npm test -- --run scripts/auto-dent-ctl.test.ts scripts/auto-dent-run.test.ts` passed: 2 files, 372 tests.
- [x] Duplicate scan passed: `auto-dent-ctl.ts` no longer directly parses `stateFile` with `JSON.parse(readFileSync(stateFile, 'utf8'))` and imports `readState` from `auto-dent-run.ts`.
- [x] Plan and test plan stored on #1264.

## Known Limitations

This PR completes the control-CLI state-reader DRY slice. It does not extract `BatchState` I/O into a standalone module; that would be a broader boundary cleanup across `auto-dent-run.ts`, `auto-dent.ts`, `auto-dent-plan.ts`, and `auto-dent-ctl.ts`.
