### PR TITLE
refactor(auto-dent): share analyze state reader

### DIFF
--- a/scripts/auto-dent-analyze.test.ts
+++ b/scripts/auto-dent-analyze.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { mkdtempSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import {
   analyzeRunLog,
@@ -275,6 +275,30 @@ describe('analyzeBatch', () => {
 
     const result = analyzeBatch(batchDir);
     expect(result.batchId).toBe('test-batch-id');
+  });
+
+  it('reads batch ID from backup state when primary state is corrupt', () => {
+    const batchDir = createTmpBatch([
+      [initMsg(), userMsg('2026-03-22T22:00:00.000Z')],
+    ]);
+    writeFileSync(join(batchDir, 'state.json'), '{not valid json');
+    writeFileSync(
+      join(batchDir, 'state.json.bak'),
+      JSON.stringify({ batch_id: 'backup-batch-id' }),
+    );
+
+    const result = analyzeBatch(batchDir);
+    expect(result.batchId).toBe('backup-batch-id');
+  });
+
+  it('falls back to directory batch ID when corrupt state has no backup', () => {
+    const batchDir = createTmpBatch([
+      [initMsg(), userMsg('2026-03-22T22:00:00.000Z')],
+    ]);
+    writeFileSync(join(batchDir, 'state.json'), '{not valid json');
+
+    const result = analyzeBatch(batchDir);
+    expect(result.batchId).toBe(basename(batchDir));
   });
 });
 
@@ -883,6 +907,32 @@ describe('integration: regression detection in batch analysis', () => {
     expect(result.runs[0].promptHash).toBe('abc123def456');
     expect(result.runs[1].promptTemplate).toBe('explore-gaps.md');
     expect(result.runs[1].promptHash).toBe('789abc012def');
+  });
+
+  it('enriches prompt metadata from backup state when primary state is corrupt', () => {
+    const batchDir = createTmpBatch([
+      [
+        initMsg(),
+        userMsg('2026-03-22T22:00:00.000Z'),
+        assistantToolUse('Edit', { file_path: '/a.ts' }),
+        userMsg('2026-03-22T22:00:30.000Z'),
+      ],
+    ]);
+
+    writeFileSync(join(batchDir, 'state.json'), '{not valid json');
+    writeFileSync(
+      join(batchDir, 'state.json.bak'),
+      JSON.stringify({
+        batch_id: 'test-batch',
+        run_history: [
+          { run: 1, prompt_template: 'backup-template.md', prompt_hash: 'backup123' },
+        ],
+      }),
+    );
+
+    const result = analyzeBatch(batchDir);
+    expect(result.runs[0].promptTemplate).toBe('backup-template.md');
+    expect(result.runs[0].promptHash).toBe('backup123');
   });
 
   it('handles missing state.json gracefully for prompt enrichment', () => {

--- a/scripts/auto-dent-analyze.ts
+++ b/scripts/auto-dent-analyze.ts
@@ -18,6 +18,7 @@
 import { readdirSync, readFileSync, existsSync } from 'fs';
 import { join, basename, resolve } from 'path';
 import { execSync } from 'child_process';
+import { readState, type BatchState } from './auto-dent-run.js';
 
 // Types
 
@@ -656,6 +657,17 @@ export function computeToolPhaseFractions(
   return fractions;
 }
 
+function readBatchState(batchDir: string): BatchState | undefined {
+  const stateFile = join(batchDir, 'state.json');
+  if (!existsSync(stateFile) && !existsSync(`${stateFile}.bak`)) return undefined;
+
+  try {
+    return readState(stateFile);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Analyze an entire batch directory.
  */
@@ -667,24 +679,19 @@ export function analyzeBatch(batchDir: string): BatchAnalysis {
   const runs = logFiles.map((f) => analyzeRunLog(join(batchDir, f)));
 
   // Enrich runs with prompt metadata from state.json run_history (#602)
-  const stateFilePath = join(batchDir, 'state.json');
-  if (existsSync(stateFilePath)) {
-    try {
-      const stateData = JSON.parse(readFileSync(stateFilePath, 'utf8'));
-      const history: Array<{ run: number; prompt_template?: string; prompt_hash?: string }> = stateData.run_history || [];
-      for (const run of runs) {
-        // Extract run number from filename (e.g., "run-5-230323120000.log" → 5)
-        const runNumMatch = basename(run.runFile).match(/^run-(\d+)/);
-        if (runNumMatch) {
-          const runNum = parseInt(runNumMatch[1], 10);
-          const metrics = history.find(h => h.run === runNum);
-          if (metrics) {
-            run.promptTemplate = metrics.prompt_template;
-            run.promptHash = metrics.prompt_hash;
-          }
-        }
+  const stateData = readBatchState(batchDir);
+  const history: Array<{ run: number; prompt_template?: string; prompt_hash?: string }> = stateData?.run_history || [];
+  for (const run of runs) {
+    // Extract run number from filename (e.g., "run-5-230323120000.log" -> 5)
+    const runNumMatch = basename(run.runFile).match(/^run-(\d+)/);
+    if (runNumMatch) {
+      const runNum = parseInt(runNumMatch[1], 10);
+      const metrics = history.find(h => h.run === runNum);
+      if (metrics) {
+        run.promptTemplate = metrics.prompt_template;
+        run.promptHash = metrics.prompt_hash;
       }
-    } catch { /* state.json may be malformed, skip enrichment */ }
+    }
   }
 
   // Cold-start statistics
@@ -749,13 +756,7 @@ export function analyzeBatch(batchDir: string): BatchAnalysis {
 
   // Extract batch ID from state.json or dir name
   let batchId = basename(batchDir);
-  const stateFile = join(batchDir, 'state.json');
-  if (existsSync(stateFile)) {
-    try {
-      const state = JSON.parse(readFileSync(stateFile, 'utf8'));
-      if (state.batch_id) batchId = state.batch_id;
-    } catch { /* use dir name */ }
-  }
+  if (stateData?.batch_id) batchId = stateData.batch_id;
 
   // Completeness aggregate
   const avgCompleteness = runs.length > 0


### PR DESCRIPTION
## Story

Auto-dent state reading has been moving toward one canonical path. Runtime, planning, and ctl now use `readState`, but the analysis CLI still parsed `state.json` directly in two spots.

That meant a corrupt primary state file with a valid `.bak` behaved differently in analysis than in the rest of the system: prompt metadata and batch id extraction could silently disappear.

This PR routes analyze batch state through the shared `readState` helper, keeps the old graceful fallback when no usable state exists, and adds regression coverage for backup recovery.

Closes #1267

## Changes

- Add a small `readBatchState` wrapper in `auto-dent-analyze.ts` that delegates to shared `readState`.
- Reuse that parsed state for prompt metadata enrichment and batch id extraction.
- Cover corrupt-primary/valid-backup recovery for both metadata paths.
- Cover corrupt state with no backup still falling back to the directory batch id.

## Test Plan

- [x] `npm test -- --run scripts/auto-dent-analyze.test.ts scripts/auto-dent-run.test.ts`
- [x] `npm run typecheck`
- [x] `rg -n "JSON\.parse\(readFileSync\((stateFile|stateFilePath), 'utf8'\\)|readState" scripts/auto-dent-analyze.ts scripts/auto-dent-analyze.test.ts`\n- [x] `git diff --check`