### PR TITLE
feat(auto-dent): rescue stranded work on abnormal run exit (#1255)

### DIFF
--- a/scripts/auto-dent-rescue.test.ts
+++ b/scripts/auto-dent-rescue.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  classifyRunExit,
+  decideRescueAction,
+  formatRescueReport,
+  buildRescueTitle,
+  rescueTarget,
+  rescueRun,
+  collectRunWorktrees,
+  SKIPPED_GATES,
+  type GitExec,
+} from './auto-dent-rescue.js';
+import type { GitExecResult } from '../src/hooks/lib/git-state.js';
+
+describe('classifyRunExit', () => {
+  it('treats wall-clock timeout as abnormal with a timeout reason', () => {
+    const c = classifyRunExit({ exitCode: 143, timedOut: true, stopRequested: false });
+    expect(c.abnormal).toBe(true);
+    expect(c.reason).toMatch(/timeout/i);
+  });
+
+  it('treats a non-zero exit as abnormal', () => {
+    const c = classifyRunExit({ exitCode: 1, timedOut: false, stopRequested: false });
+    expect(c.abnormal).toBe(true);
+    expect(c.reason).toMatch(/exit.*1/);
+  });
+
+  it('treats an intentional agent stop as not abnormal', () => {
+    const c = classifyRunExit({ exitCode: 0, timedOut: false, stopRequested: true });
+    expect(c.abnormal).toBe(false);
+    expect(c.reason).toMatch(/stop/i);
+  });
+
+  it('treats a clean exit as not abnormal', () => {
+    const c = classifyRunExit({ exitCode: 0, timedOut: false, stopRequested: false });
+    expect(c.abnormal).toBe(false);
+    expect(c.reason).toMatch(/clean/i);
+  });
+});
+
+describe('decideRescueAction', () => {
+  it('does nothing when there is no PR and no work', () => {
+    const a = decideRescueAction({ commitsAheadBase: 0, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: null });
+    expect(a.kind).toBe('none');
+  });
+
+  it('creates a draft PR when there is no PR but commits ahead', () => {
+    const a = decideRescueAction({ commitsAheadBase: 3, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: null });
+    expect(a.kind).toBe('create-draft');
+    expect(a.commitDirty).toBe(false);
+  });
+
+  it('creates a draft PR and commits dirty when only dirty files exist', () => {
+    const a = decideRescueAction({ commitsAheadBase: 0, unpushedCommits: 0, dirtyTotal: 2, existingOpenPr: null });
+    expect(a.kind).toBe('create-draft');
+    expect(a.commitDirty).toBe(true);
+  });
+
+  // Regression guard: a healthy open PR (commits ahead of main but already
+  // pushed, nothing dirty) must NOT receive a spurious rescue comment.
+  it('does nothing for a healthy open PR with no unpushed or dirty work', () => {
+    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: 'https://x/pr/1' });
+    expect(a.kind).toBe('none');
+  });
+
+  it('pushes to the existing PR when there are unpushed commits', () => {
+    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 2, dirtyTotal: 0, existingOpenPr: 'https://x/pr/1' });
+    expect(a.kind).toBe('push-existing');
+    expect(a.commitDirty).toBe(false);
+  });
+
+  it('pushes to the existing PR and commits dirty when files are dirty', () => {
+    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 0, dirtyTotal: 1, existingOpenPr: 'https://x/pr/1' });
+    expect(a.kind).toBe('push-existing');
+    expect(a.commitDirty).toBe(true);
+  });
+});
+
+describe('formatRescueReport', () => {
+  it('marks output as not-validated and lists context + skipped gates', () => {
+    const body = formatRescueReport({
+      runTag: 'handsome-lynx/run-1',
+      runId: 'handsome-lynx-r1',
+      worktree: '/wt/case-x',
+      branch: 'case/x',
+      failureReason: 'timeout (wall-clock watchdog SIGTERM)',
+      commitsAhead: 2,
+      dirtyTotal: 3,
+      pickedIssue: '#1255',
+    });
+    expect(body).toMatch(/NOT VALIDATED/i);
+    expect(body).toContain('handsome-lynx-r1');
+    expect(body).toContain('/wt/case-x');
+    expect(body).toContain('case/x');
+    expect(body).toMatch(/timeout/);
+    expect(body).toContain('#1255');
+    for (const gate of SKIPPED_GATES) expect(body).toContain(gate);
+  });
+});
+
+describe('buildRescueTitle', () => {
+  it('includes the rescue marker and run tag', () => {
+    const t = buildRescueTitle('handsome-lynx/run-1', '#1255');
+    expect(t).toContain('[rescue]');
+    expect(t).toContain('handsome-lynx/run-1');
+    expect(t).toContain('#1255');
+  });
+});
+
+// --- Orchestration with injected fakes ------------------------------------
+
+interface FakeGitConfig {
+  aheadBase?: number;
+  unpushed?: number;
+  pushExit?: number;
+}
+
+function makeFakeGit(cfg: FakeGitConfig, log: string[][]): GitExec {
+  return (args) => {
+    log.push([...args]);
+    const joined = args.join(' ');
+    const ok = (stdout = ''): GitExecResult => ({ stdout, stderr: '', exitCode: 0 });
+    if (joined.includes('rev-list') && joined.includes('origin/main..HEAD')) return ok(String(cfg.aheadBase ?? 0));
+    if (joined.includes('rev-list') && joined.includes('@{u}..HEAD')) return ok(String(cfg.unpushed ?? 0));
+    if (joined.includes('status --porcelain')) return ok('');
+    if (joined.includes('push')) {
+      return cfg.pushExit && cfg.pushExit !== 0
+        ? { stdout: '', stderr: 'remote rejected', exitCode: cfg.pushExit }
+        : ok();
+    }
+    return ok();
+  };
+}
+
+function makeFakeGh(prList: string | null, ghLog: string[][]): (args: string[]) => string {
+  return (args) => {
+    ghLog.push([...args]);
+    if (args[0] === 'pr' && args[1] === 'list') {
+      return prList ? JSON.stringify([{ url: prList }]) : '[]';
+    }
+    if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/x/pull/999';
+    if (args[0] === 'pr' && args[1] === 'comment') return '';
+    return '';
+  };
+}
+
+function makeReadDirty(total: number) {
+  return () => ({
+    verified: { staged: [], modified: [], untracked: [], total },
+    raw: '',
+    gitDir: '',
+    perFileDiff: [],
+  });
+}
+
+describe('rescueTarget orchestration', () => {
+  const worktree = mkdtempSync(join(tmpdir(), 'rescue-wt-'));
+  const ctx = { repo: 'owner/repo', runTag: 'b/run-1', runId: 'b-r1', failureReason: 'timeout' };
+
+  it('creates a draft PR when work is stranded with no PR', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      ctx,
+      { git: makeFakeGit({ aheadBase: 2 }, gitLog), gh: makeFakeGh(null, ghLog), readDirty: makeReadDirty(1) },
+    );
+    expect(out.action).toBe('create-draft');
+    expect(out.pushed).toBe(true);
+    expect(out.prUrl).toBe('https://github.com/x/pull/999');
+    // committed dirty (add + commit), pushed with --no-verify
+    expect(gitLog.some((a) => a.includes('add'))).toBe(true);
+    expect(gitLog.some((a) => a.includes('commit'))).toBe(true);
+    expect(gitLog.some((a) => a.includes('push') && a.includes('--no-verify'))).toBe(true);
+    expect(ghLog.some((a) => a[1] === 'create' && a.includes('--draft'))).toBe(true);
+  });
+
+  it('comments on the existing PR and pushes when extending it', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      ctx,
+      { git: makeFakeGit({ aheadBase: 5, unpushed: 2 }, gitLog), gh: makeFakeGh('https://x/pr/1', ghLog), readDirty: makeReadDirty(0) },
+    );
+    expect(out.action).toBe('push-existing');
+    expect(out.prUrl).toBe('https://x/pr/1');
+    expect(ghLog.some((a) => a[1] === 'comment')).toBe(true);
+    expect(ghLog.some((a) => a[1] === 'create')).toBe(false);
+  });
+
+  // Category prevention: a healthy run worktree with an open PR and no new work
+  // produces NO git write and NO gh write — the system never manufactures noise.
+  it('does nothing for a healthy open PR with no new work', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      ctx,
+      { git: makeFakeGit({ aheadBase: 5, unpushed: 0 }, gitLog), gh: makeFakeGh('https://x/pr/1', ghLog), readDirty: makeReadDirty(0) },
+    );
+    expect(out.action).toBe('none');
+    expect(out.pushed).toBe(false);
+    expect(gitLog.some((a) => a.includes('push'))).toBe(false);
+    expect(ghLog.some((a) => a[1] === 'create' || a[1] === 'comment')).toBe(false);
+  });
+
+  it('records a push failure without throwing (never hides the original failure)', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      ctx,
+      { git: makeFakeGit({ aheadBase: 2, pushExit: 1 }, gitLog), gh: makeFakeGh(null, ghLog), readDirty: makeReadDirty(0) },
+    );
+    expect(out.action).toBe('create-draft');
+    expect(out.pushed).toBe(false);
+    expect(out.error).toMatch(/push failed/);
+    expect(ghLog.some((a) => a[1] === 'create')).toBe(false);
+  });
+
+  it('returns none for a worktree that no longer exists', () => {
+    const out = rescueTarget(
+      { worktree: join(tmpdir(), 'does-not-exist-xyz'), branch: 'case/gone' },
+      ctx,
+      { git: makeFakeGit({}, []), gh: makeFakeGh(null, []), readDirty: makeReadDirty(0) },
+    );
+    expect(out.action).toBe('none');
+    expect(out.pushed).toBe(false);
+  });
+});
+
+describe('rescueRun + collectRunWorktrees', () => {
+  it('rescues each provided target', () => {
+    const worktree = mkdtempSync(join(tmpdir(), 'rescue-multi-'));
+    const outs = rescueRun(
+      [{ worktree, branch: 'case/a' }],
+      { repo: 'o/r', runTag: 'b/run-1', runId: 'b-r1', failureReason: 'timeout' },
+      { git: makeFakeGit({ aheadBase: 1 }, []), gh: makeFakeGh(null, []), readDirty: makeReadDirty(0) },
+    );
+    expect(outs).toHaveLength(1);
+    expect(outs[0].action).toBe('create-draft');
+  });
+
+  it('only collects worktrees that exist on disk', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'rescue-root-'));
+    // No worktrees created under repoRoot/.claude/worktrees → nothing collected.
+    const targets = collectRunWorktrees(repoRoot, ['260628-k1-foo', '', '260628-k2-bar']);
+    expect(targets).toEqual([]);
+  });
+});

--- a/scripts/auto-dent-rescue.ts
+++ b/scripts/auto-dent-rescue.ts
@@ -1,0 +1,344 @@
+/**
+ * auto-dent-rescue.ts — Failure rescue finalizer for auto-dent runs (#1255).
+ *
+ * When an auto-dent run terminates abnormally (wall-clock watchdog SIGTERM,
+ * crash, non-zero exit) before the PR phase, any committed-but-unpushed or
+ * dirty work in the run's case worktree is stranded with no PR. Operators then
+ * have to file a *manual* "[rescue]" PR (the #1252–#1260 symptom cluster).
+ *
+ * This module binds the run finalizer to a best-effort, gate-skipping rescue:
+ *   - existing open PR for the branch  → commit dirty as-is, push to the PR
+ *   - no PR but worktree has work      → commit dirty as-is, push, open a DRAFT PR
+ *   - nothing rescueable               → do nothing (never manufacture noise)
+ *
+ * The rescue explicitly SKIPS every quality gate (review battery, plan
+ * substance, dirty-file gate, lifecycle/process verdict, tests) and marks its
+ * output clearly as NOT-VALIDATED. A rescue failure is recorded but never
+ * hides the original run failure.
+ *
+ * DRY (#1164): reuses `readDirtyFiles`/`GitExec` from src/hooks/lib/git-state.ts
+ * and `gh` from src/lib/gh-exec.ts — no new porcelain parser or gh wrapper.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  createDefaultGitExec,
+  readDirtyFiles,
+  type GitExec,
+  type DirtyState,
+} from '../src/hooks/lib/git-state.js';
+import { gh as defaultGh } from '../src/lib/gh-exec.js';
+
+/** Quality gates a rescue deliberately skips — surfaced in the rescue report. */
+export const SKIPPED_GATES: readonly string[] = [
+  'review battery',
+  'plan substance gate',
+  'dirty-file gate (files committed as-is)',
+  'lifecycle / process verdict',
+  'test gate',
+];
+
+export interface RunExitInfo {
+  exitCode: number;
+  timedOut: boolean;
+  stopRequested: boolean;
+}
+
+export interface RunExitClassification {
+  /** True for watchdog timeout / non-zero exit — terminal, work likely stranded. */
+  abnormal: boolean;
+  /** Human reason used in the rescue report. */
+  reason: string;
+}
+
+/**
+ * Classify a run's exit into the failure reason shown in the rescue report.
+ * Timeout is authoritative (it is the dominant strand cause, #686), then a
+ * non-zero exit, then an intentional agent stop, then a clean exit.
+ */
+export function classifyRunExit(info: RunExitInfo): RunExitClassification {
+  if (info.timedOut) {
+    return { abnormal: true, reason: 'timeout (wall-clock watchdog SIGTERM)' };
+  }
+  if (info.exitCode !== 0) {
+    return { abnormal: true, reason: `abnormal exit (code ${info.exitCode})` };
+  }
+  if (info.stopRequested) {
+    return { abnormal: false, reason: 'agent requested stop' };
+  }
+  return { abnormal: false, reason: 'clean exit' };
+}
+
+export type RescueKind = 'none' | 'push-existing' | 'create-draft';
+
+export interface RescueDecisionInput {
+  /** Commits on the branch ahead of the base (origin/main). */
+  commitsAheadBase: number;
+  /** Commits ahead of the remote tracking branch (work not yet pushed). */
+  unpushedCommits: number;
+  /** Content-verified dirty (staged + modified + untracked) file count. */
+  dirtyTotal: number;
+  /** URL of an open PR already targeting this branch, or null. */
+  existingOpenPr: string | null;
+}
+
+export interface RescueAction {
+  kind: RescueKind;
+  /** Whether dirty files must be committed as-is before pushing. */
+  commitDirty: boolean;
+  reason: string;
+}
+
+/**
+ * Decide what to do with a run worktree. The gate-correctness core:
+ *
+ * - With an existing open PR, committed+pushed work is ALREADY on the PR, so we
+ *   act only when there is *unpushed* work or *dirty* files. A healthy PR with
+ *   no new work yields `none` — we never post a spurious rescue comment.
+ * - With no PR, any work ahead of base (or dirty) means the run produced work
+ *   that would otherwise vanish → open a draft rescue PR.
+ */
+export function decideRescueAction(input: RescueDecisionInput): RescueAction {
+  const commitDirty = input.dirtyTotal > 0;
+  if (input.existingOpenPr) {
+    const needsPush = input.unpushedCommits > 0 || input.dirtyTotal > 0;
+    return needsPush
+      ? {
+          kind: 'push-existing',
+          commitDirty,
+          reason: `extend existing PR ${input.existingOpenPr} (${input.unpushedCommits} unpushed, ${input.dirtyTotal} dirty)`,
+        }
+      : { kind: 'none', commitDirty: false, reason: 'open PR already has all work; nothing to rescue' };
+  }
+  const hasWork = input.commitsAheadBase > 0 || input.dirtyTotal > 0;
+  return hasWork
+    ? {
+        kind: 'create-draft',
+        commitDirty,
+        reason: `no PR for branch with rescueable work (${input.commitsAheadBase} commits ahead, ${input.dirtyTotal} dirty)`,
+      }
+    : { kind: 'none', commitDirty: false, reason: 'no commits ahead and no dirty files' };
+}
+
+export interface RescueReportInput {
+  runTag: string;
+  runId: string;
+  worktree: string;
+  branch: string;
+  failureReason: string;
+  commitsAhead: number;
+  dirtyTotal: number;
+  skippedGates?: readonly string[];
+  pickedIssue?: string;
+}
+
+/**
+ * Format the rescue PR body / comment. The banner makes it impossible to
+ * mistake rescued output for validated, review-passed work.
+ */
+export function formatRescueReport(input: RescueReportInput): string {
+  const gates = input.skippedGates ?? SKIPPED_GATES;
+  const lines = [
+    '## ⚠️ FAILED-RUN RESCUE — NOT VALIDATED WORK',
+    '',
+    'This branch was preserved by the auto-dent rescue finalizer after the run',
+    'terminated before the normal PR phase. **No quality gate has passed.** Treat',
+    'this as raw, unreviewed work that needs a human (or a fresh run) to validate,',
+    'finish, or discard.',
+    '',
+    '| Field | Value |',
+    '|-------|-------|',
+    `| Failure reason | ${input.failureReason} |`,
+    `| Run tag | ${input.runTag} |`,
+    `| Run id | ${input.runId} |`,
+    `| Worktree | \`${input.worktree}\` |`,
+    `| Branch | \`${input.branch}\` |`,
+    `| Commits ahead of base | ${input.commitsAhead} |`,
+    `| Dirty files committed as-is | ${input.dirtyTotal} |`,
+  ];
+  if (input.pickedIssue) lines.push(`| Picked issue | ${input.pickedIssue} |`);
+  lines.push('', '### Gates skipped by the rescue path', '');
+  for (const g of gates) lines.push(`- ${g}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Build the rescue PR title. */
+export function buildRescueTitle(runTag: string, pickedIssue?: string): string {
+  const suffix = pickedIssue ? ` ${pickedIssue}` : '';
+  return `[rescue] ${runTag} — stranded work preserved (NOT validated)${suffix}`;
+}
+
+export interface RescueTarget {
+  worktree: string;
+  branch: string;
+}
+
+export interface RescueContext {
+  /** Host repo (owner/name) for PR operations. */
+  repo: string;
+  runTag: string;
+  runId: string;
+  failureReason: string;
+  pickedIssue?: string;
+  /** Base branch for create-draft and the ahead-of-base count. Default 'origin/main'. */
+  base?: string;
+}
+
+export interface RescueDeps {
+  git: GitExec;
+  gh: (args: string[]) => string;
+  readDirty: (dir: string) => DirtyState;
+  log?: (msg: string) => void;
+}
+
+export interface RescueOutcome {
+  branch: string;
+  worktree: string;
+  action: RescueKind;
+  prUrl?: string;
+  pushed: boolean;
+  error?: string;
+}
+
+function countRevList(git: GitExec, worktree: string, range: string): number {
+  const r = git(['-C', worktree, 'rev-list', '--count', range]);
+  if (r.exitCode !== 0) return 0;
+  const n = parseInt(r.stdout.trim(), 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function findOpenPrForBranch(gh: (args: string[]) => string, repo: string, branch: string): string | null {
+  try {
+    const out = gh(['pr', 'list', '--repo', repo, '--head', branch, '--state', 'open', '--json', 'url']);
+    const arr = JSON.parse(out || '[]') as Array<{ url?: string }>;
+    return arr[0]?.url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rescue a single run worktree. Best-effort: every git/gh step is guarded so a
+ * rescue failure is recorded in the outcome but never thrown — the original run
+ * failure must remain the headline (#1255).
+ */
+export function rescueTarget(target: RescueTarget, ctx: RescueContext, deps: RescueDeps): RescueOutcome {
+  const { git, gh, readDirty, log } = deps;
+  const base = ctx.base ?? 'origin/main';
+  const outcome: RescueOutcome = {
+    branch: target.branch,
+    worktree: target.worktree,
+    action: 'none',
+    pushed: false,
+  };
+
+  if (!existsSync(target.worktree)) {
+    return outcome; // worktree already gone — nothing to rescue
+  }
+
+  let dirtyTotal = 0;
+  try {
+    dirtyTotal = readDirty(target.worktree).verified.total;
+  } catch {
+    // Fall back to a raw porcelain count if the verified reader fails.
+    const r = git(['-C', target.worktree, 'status', '--porcelain']);
+    dirtyTotal = r.stdout.split('\n').filter(Boolean).length;
+  }
+
+  const commitsAheadBase = countRevList(git, target.worktree, `${base}..HEAD`);
+  const unpushedCommits = countRevList(git, target.worktree, '@{u}..HEAD');
+  const existingOpenPr = findOpenPrForBranch(gh, ctx.repo, target.branch);
+
+  const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr });
+  outcome.action = action.kind;
+  if (action.kind === 'none') {
+    log?.(`${target.branch}: ${action.reason}`);
+    return outcome;
+  }
+  log?.(`${target.branch}: ${action.reason}`);
+
+  try {
+    if (action.commitDirty) {
+      git(['-C', target.worktree, 'add', '-A']);
+      const commit = git([
+        '-C', target.worktree, 'commit', '--no-verify', '-m',
+        `[rescue] preserve stranded work as-is (${ctx.failureReason})`,
+      ]);
+      if (commit.exitCode !== 0 && !/nothing to commit/i.test(commit.stdout + commit.stderr)) {
+        throw new Error(`commit failed: ${commit.stderr.trim() || commit.stdout.trim()}`);
+      }
+    }
+
+    // Push with --no-verify: the rescue path intentionally bypasses the
+    // pre-push gate so abnormal-run work is never lost behind a gate.
+    const push = git(['-C', target.worktree, 'push', '--no-verify', '-u', 'origin', target.branch]);
+    if (push.exitCode !== 0) {
+      throw new Error(`push failed: ${push.stderr.trim() || push.stdout.trim()}`);
+    }
+    outcome.pushed = true;
+
+    const report = formatRescueReport({
+      runTag: ctx.runTag,
+      runId: ctx.runId,
+      worktree: target.worktree,
+      branch: target.branch,
+      failureReason: ctx.failureReason,
+      commitsAhead: commitsAheadBase,
+      dirtyTotal,
+      pickedIssue: ctx.pickedIssue,
+    });
+
+    if (action.kind === 'push-existing' && existingOpenPr) {
+      gh(['pr', 'comment', existingOpenPr, '--repo', ctx.repo, '--body', report]);
+      outcome.prUrl = existingOpenPr;
+    } else {
+      const url = gh([
+        'pr', 'create', '--repo', ctx.repo, '--draft',
+        '--head', target.branch,
+        '--base', (ctx.base ?? 'origin/main').replace(/^origin\//, ''),
+        '--title', buildRescueTitle(ctx.runTag, ctx.pickedIssue),
+        '--body', report,
+      ]);
+      outcome.prUrl = url.trim();
+    }
+    log?.(`${target.branch}: rescued via ${action.kind} → ${outcome.prUrl ?? '(no url)'}`);
+  } catch (err) {
+    outcome.error = err instanceof Error ? err.message : String(err);
+    log?.(`${target.branch}: rescue failed — ${outcome.error}`);
+  }
+
+  return outcome;
+}
+
+/** Rescue all of a run's worktrees. */
+export function rescueRun(targets: RescueTarget[], ctx: RescueContext, deps: RescueDeps): RescueOutcome[] {
+  return targets.map((t) => rescueTarget(t, ctx, deps));
+}
+
+/**
+ * Derive the rescue targets for THIS run from the case ids it created. Scoped
+ * to the run's own worktrees only — never scans the whole worktree tree, so a
+ * concurrent agent's WIP can't be swept up. Existence is checked in rescueTarget.
+ */
+export function collectRunWorktrees(repoRoot: string, cases: string[]): RescueTarget[] {
+  const targets: RescueTarget[] = [];
+  for (const caseId of cases) {
+    if (!caseId) continue;
+    const worktree = join(repoRoot, '.claude', 'worktrees', caseId);
+    if (!existsSync(worktree)) continue;
+    targets.push({ worktree, branch: `case/${caseId}` });
+  }
+  return targets;
+}
+
+/** Default deps wiring the shared primitives (used by the finalizer). */
+export function defaultRescueDeps(log?: (msg: string) => void): RescueDeps {
+  return {
+    git: createDefaultGitExec(),
+    gh: (args) => defaultGh(args),
+    readDirty: (dir) => readDirtyFiles(dir),
+    log,
+  };
+}

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -182,6 +182,12 @@ import {
   type ProcessEvidence,
   type ProcessVerdict,
 } from './auto-dent-lifecycle.js';
+import {
+  classifyRunExit,
+  collectRunWorktrees,
+  rescueRun,
+  defaultRescueDeps,
+} from './auto-dent-rescue.js';
 
 // Types
 
@@ -199,6 +205,12 @@ export interface BatchState {
   host_repo: string;
   run: number;
   prs: string[];
+  /**
+   * Draft "[rescue]" PRs created by the failure finalizer (#1255). Kept SEPARATE
+   * from `prs` so unvalidated, gate-skipped rescue output never inflates the
+   * batch's success metrics. Absent on older state files.
+   */
+  rescue_prs?: string[];
   issues_filed: string[];
   issues_closed: string[];
   cases: string[];
@@ -2804,6 +2816,53 @@ async function main(): Promise<void> {
   if (result.stopRequested) {
     freshState.stop_reason = `agent requested stop: ${result.stopReason}`;
     console.log(`>>> Claude requested batch stop: ${result.stopReason}`);
+  }
+
+  // #1255: rescue stranded work. If a run worktree has commits ahead of main or
+  // dirty files, preserve it — push to an existing PR, or open a clearly-marked
+  // DRAFT rescue PR (gates skipped) — so abnormal termination never strands
+  // rescueable work the way it forced the #1252–#1260 manual rescues. Scoped to
+  // THIS run's own case worktrees; best-effort and fully guarded so a rescue
+  // failure can never hide or block the original run outcome.
+  try {
+    const targets = collectRunWorktrees(repoRoot, result.cases);
+    if (targets.length > 0) {
+      const { reason: failureReason } = classifyRunExit({
+        exitCode,
+        timedOut: Boolean(result.timedOut),
+        stopRequested: Boolean(result.stopRequested),
+      });
+      const outcomes = rescueRun(
+        targets,
+        {
+          repo: state.host_repo || state.kaizen_repo,
+          runTag,
+          runId,
+          failureReason,
+          pickedIssue,
+        },
+        defaultRescueDeps((m) => console.log(`  [rescue] ${m}`)),
+      );
+      let rescuedCount = 0;
+      for (const o of outcomes) {
+        if (o.action === 'none') continue;
+        appendFileSync(
+          logFile,
+          `rescue=${o.branch} action=${o.action} pr=${o.prUrl || ''} pushed=${o.pushed} err=${o.error || ''}\n`,
+        );
+        if (o.prUrl && o.action === 'create-draft' && !o.error) {
+          if (!freshState.rescue_prs) freshState.rescue_prs = [];
+          if (!freshState.rescue_prs.includes(o.prUrl)) freshState.rescue_prs.push(o.prUrl);
+        }
+        if (o.pushed || o.prUrl) rescuedCount++;
+      }
+      if (rescuedCount > 0) {
+        console.log(`  ${color.yellow('[rescue]')} preserved ${rescuedCount} stranded worktree(s) — NOT validated work`);
+      }
+    }
+  } catch (err) {
+    // Rescue must never hide the original run failure (#1255).
+    console.warn(`  [rescue] best-effort rescue failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   writeState(stateFile, freshState);


### PR DESCRIPTION
## The problem

Auto-dent batch `double-barracuda` ran three sessions on 2026-06-27. All three hit the
wall-clock watchdog (`exit 143`, SIGTERM) after ~20 minutes. The batch summary said **"PRs
created: none"** — but every run worktree held real, rescueable work on a case branch. A human
had to come along afterward and hand-file draft "[rescue]" PRs (#1252, #1253, #1254 — and a
second sweep produced #1258, #1259, #1260). Six manual rescue PRs for one root cause.

The cause is a missing seam in `auto-dent-run.ts`: the finalizer extracts `result.prs` from the
agent's log, and on early termination that list is empty. The function then runs straight to
`writeState(); process.exit(exitCode)` — there is **no step that preserves committed-but-unpushed
or dirty work**. The only durable trace is logs and a local worktree that batch cleanup or
worktree pruning will eventually destroy. This is also the mechanism behind #1006 ("completed
work vanishes — branches with ready commits never get PRed").

## The discovery

The per-run wall-clock timeout (#354/#686) is enforced by the run process *itself* — it spawns the
`claude`/`codex` child and SIGTERMs **that child** on timeout, setting `result.timedOut`. The run
process survives and reliably reaches its finalizer. So the rescue belongs exactly there, where
`result.cases`, `result.prs`, `result.timedOut`, and `exitCode` are all known — no new watchdog or
signal plumbing required.

The tricky part is **gate correctness**: an open PR's commits are "ahead of main" until the PR
merges, so a naive "ahead of base" check would post a spurious rescue comment on every healthy PR.
The decision must distinguish *unpushed* work (not yet on the PR) from *committed-and-pushed* work
(already on the PR).

## The solution

A new module `scripts/auto-dent-rescue.ts` with a pure, unit-tested core and an injected-dependency
orchestrator, wired into the run finalizer:

- **`classifyRunExit`** → the human failure reason (`timeout` / `exit N` / `agent stop` / `clean`).
- **`decideRescueAction`** → the gate-correctness core:
  - existing open PR: act only on **unpushed commits or dirty files** → `push-existing`; a healthy
    PR yields `none` (no spurious comment).
  - no PR + any work ahead of base or dirty → `create-draft`.
- **`formatRescueReport`** / **`buildRescueTitle`** → output banner-marked **"FAILED-RUN RESCUE —
  NOT VALIDATED WORK"**, listing the failure reason, run id/tag, worktree, branch, counts, and the
  explicit list of skipped gates.
- **`rescueTarget` / `rescueRun`** → commit dirty as-is, push `--no-verify` (the rescue path
  intentionally bypasses the pre-push gate), then open a `--draft` PR or comment on the existing PR.
  Every git/gh step is guarded: a rescue failure is recorded in the outcome and **never thrown**, so
  the original run failure stays the headline.

Discovery is scoped to **this run's own case worktrees** (`collectRunWorktrees` from `result.cases`),
so a concurrent agent's WIP can never be swept up. Created draft PRs land in a new
`BatchState.rescue_prs` field kept **separate from `prs`** so unvalidated, gate-skipped output never
inflates the batch's success metrics.

**DRY (#1164):** reuses `readDirtyFiles`/`GitExec` from `src/hooks/lib/git-state.ts` and `gh` from
`src/lib/gh-exec.ts` — no new git-porcelain parser or gh wrapper is introduced.

## The evidence

`scripts/auto-dent-rescue.test.ts` — 19 new tests, all green; build clean; full `auto-dent` suite
(372 tests across rescue/run/lifecycle) green.

| Behavior | Unit | Integration | System |
|---|:--:|:--:|:--:|
| Exit classification (timeout / exit / stop / clean) | ✅ | — | — |
| Rescue decision & **gate correctness** (healthy PR → none) | ✅ | ✅ | — |
| Report formatting (NOT-VALIDATED banner, skipped gates) | ✅ | — | — |
| Orchestration (commit / push --no-verify / draft PR / comment) | — | ✅ | — |
| Rescue-failure isolation (push fails → recorded, not thrown) | — | ✅ | — |
| Run-scoped discovery (only on-disk case worktrees) | — | ✅ | — |

The category-prevention test that matters most: *a healthy open PR with no new work produces no git
write and no gh write* — the system never manufactures rescue noise for runs that succeeded.

The remaining full-suite failures are pre-existing E2E session timeouts under parallel load
(`setup-e2e`, `synthetic-workflow`); they reference neither auto-dent nor this module and pass in
isolation with a longer timeout.

## The impact

Abnormal auto-dent termination no longer strands work. The manual "[rescue]" PR — the symptom that
spawned #1252–#1260 — becomes automatic, correctly gated, and clearly labeled. Operators get a
draft PR with the failure reason and skipped-gate list instead of work silently rotting in a
worktree.

Closes #1255
Refs #1006, #1164, #1265

Run tag: handsome-lynx/run-1
