### PR TITLE
refactor(github): share branch PR lookup

### DIFF
--- a/scripts/auto-dent-rescue.test.ts
+++ b/scripts/auto-dent-rescue.test.ts
@@ -175,6 +175,7 @@ describe('rescueTarget orchestration', () => {
     expect(gitLog.some((a) => a.includes('add'))).toBe(true);
     expect(gitLog.some((a) => a.includes('commit'))).toBe(true);
     expect(gitLog.some((a) => a.includes('push') && a.includes('--no-verify'))).toBe(true);
+    expect(ghLog.some((a) => a[0] === 'pr' && a[1] === 'list' && a.includes('--repo') && a.includes('owner/repo'))).toBe(true);
     expect(ghLog.some((a) => a[1] === 'create' && a.includes('--draft'))).toBe(true);
   });
 

--- a/scripts/auto-dent-rescue.ts
+++ b/scripts/auto-dent-rescue.ts
@@ -29,6 +29,7 @@ import {
   type DirtyState,
 } from '../src/hooks/lib/git-state.js';
 import { gh as defaultGh } from '../src/lib/gh-exec.js';
+import { findOpenPrUrlForBranch } from '../src/lib/github-pr.js';
 
 /** Quality gates a rescue deliberately skips — surfaced in the rescue report. */
 export const SKIPPED_GATES: readonly string[] = [
@@ -209,16 +210,6 @@ function countRevList(git: GitExec, worktree: string, range: string): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-function findOpenPrForBranch(gh: (args: string[]) => string, repo: string, branch: string): string | null {
-  try {
-    const out = gh(['pr', 'list', '--repo', repo, '--head', branch, '--state', 'open', '--json', 'url']);
-    const arr = JSON.parse(out || '[]') as Array<{ url?: string }>;
-    return arr[0]?.url ?? null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Rescue a single run worktree. Best-effort: every git/gh step is guarded so a
  * rescue failure is recorded in the outcome but never thrown — the original run
@@ -249,7 +240,7 @@ export function rescueTarget(target: RescueTarget, ctx: RescueContext, deps: Res
 
   const commitsAheadBase = countRevList(git, target.worktree, `${base}..HEAD`);
   const unpushedCommits = countRevList(git, target.worktree, '@{u}..HEAD');
-  const existingOpenPr = findOpenPrForBranch(gh, ctx.repo, target.branch);
+  const existingOpenPr = findOpenPrUrlForBranch({ gh, repo: ctx.repo, branch: target.branch }) ?? null;
 
   const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr });
   outcome.action = action.kind;

--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -187,6 +187,25 @@ describe('pr-review-loop: PR create', () => {
     expect(decision.action).toBe('ignore');
     expect(decision.reason).toBe('no_pr_url_from_create');
   });
+
+  it('does not run branch PR fallback when KAIZEN_PR_LOOKUP_DISABLED=1', () => {
+    const previous = process.env.KAIZEN_PR_LOOKUP_DISABLED;
+    process.env.KAIZEN_PR_LOOKUP_DISABLED = '1';
+    try {
+      const decision = processHookInput(
+        {
+          tool_input: { command: 'gh pr create --title test' },
+          tool_response: { stdout: '', stderr: '', exit_code: '0' },
+        },
+        { stateDir: testStateDir, branch: 'case/test-disabled', repoFromGit: 'Garsson-io/kaizen' },
+      );
+      expect(decision.action).toBe('ignore');
+      expect(decision.reason).toBe('no_pr_url_from_create');
+    } finally {
+      if (previous === undefined) delete process.env.KAIZEN_PR_LOOKUP_DISABLED;
+      else process.env.KAIZEN_PR_LOOKUP_DISABLED = previous;
+    }
+  });
 });
 
 describe('pr-review-loop: two repos', () => {

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -30,6 +30,7 @@ import {
   type ReviewSentinelInput,
   type ReviewSentinelValidation,
 } from '../review-sentinel.js';
+import { findOpenPrUrlForBranch } from '../lib/github-pr.js';
 import { type HookInput, readHookInput, writeHookOutput } from './hook-io.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import {
@@ -211,16 +212,7 @@ function findStateByStatuses(
  *  Set KAIZEN_PR_LOOKUP_DISABLED=1 to skip (for testing environments). */
 function defaultLookupPrUrlForBranch(branch: string): string | undefined {
   if (process.env.KAIZEN_PR_LOOKUP_DISABLED === '1') return undefined;
-  try {
-    const out = execSync(
-      `gh pr list --head "${branch}" --state open --json url --limit 1`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-    ).trim();
-    const parsed = JSON.parse(out) as Array<{ url: string }>;
-    return parsed[0]?.url;
-  } catch {
-    return undefined;
-  }
+  return findOpenPrUrlForBranch({ branch });
 }
 
 // ── Core logic (extracted for testability) ───────────────────────────
@@ -237,7 +229,7 @@ export interface ProcessOptions {
   /** Override review sentinel check for testing (#920) */
   checkReviewSentinel?: (prUrl: string, round: string, stateDir: string) => boolean;
   /** Fallback: look up PR URL for branch when stdout/stderr are empty (#973).
-   *  Default: `gh pr list --head <branch> --json url --limit 1` */
+   *  Default uses the shared open-PR branch lookup helper. */
   lookupPrUrlForBranch?: (branch: string) => string | undefined;
 }
 

--- a/src/lib/github-pr.test.ts
+++ b/src/lib/github-pr.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { findOpenPrUrlForBranch, parseFirstPrUrl } from './github-pr.js';
+
+describe('parseFirstPrUrl', () => {
+  it('returns the first PR URL from gh JSON output', () => {
+    expect(parseFirstPrUrl(JSON.stringify([{ url: 'https://github.com/o/r/pull/1' }]))).toBe(
+      'https://github.com/o/r/pull/1',
+    );
+  });
+
+  it('returns undefined for empty, malformed, or missing-url output', () => {
+    expect(parseFirstPrUrl('[]')).toBeUndefined();
+    expect(parseFirstPrUrl('{not json')).toBeUndefined();
+    expect(parseFirstPrUrl(JSON.stringify([{ number: 1 }]))).toBeUndefined();
+  });
+});
+
+describe('findOpenPrUrlForBranch', () => {
+  it('runs a repo-scoped open PR branch lookup and returns the first URL', () => {
+    const calls: string[][] = [];
+    const result = findOpenPrUrlForBranch({
+      repo: 'owner/repo',
+      branch: 'case/branch',
+      gh: (args) => {
+        calls.push(args);
+        return JSON.stringify([{ url: 'https://github.com/owner/repo/pull/123' }]);
+      },
+    });
+
+    expect(result).toBe('https://github.com/owner/repo/pull/123');
+    expect(calls).toEqual([[
+      'pr', 'list',
+      '--repo', 'owner/repo',
+      '--head', 'case/branch',
+      '--state', 'open',
+      '--json', 'url',
+      '--limit', '1',
+    ]]);
+  });
+
+  it('omits --repo when the caller wants gh to infer the repository', () => {
+    const calls: string[][] = [];
+    findOpenPrUrlForBranch({
+      branch: 'case/branch',
+      gh: (args) => {
+        calls.push(args);
+        return '[]';
+      },
+    });
+
+    expect(calls[0]).not.toContain('--repo');
+    expect(calls[0]).toContain('--head');
+  });
+
+  it('returns undefined when gh throws', () => {
+    const result = findOpenPrUrlForBranch({
+      branch: 'case/branch',
+      gh: () => {
+        throw new Error('gh unavailable');
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/lib/github-pr.ts
+++ b/src/lib/github-pr.ts
@@ -1,0 +1,35 @@
+import { gh as defaultGh } from './gh-exec.js';
+
+export type GhRunner = (args: string[]) => string;
+
+export interface FindOpenPrUrlForBranchOptions {
+  branch: string;
+  /** Optional repo (`owner/name`). Omit to let gh infer the current repo. */
+  repo?: string;
+  /** Injectable gh runner for tests and callers that already own gh wiring. */
+  gh?: GhRunner;
+}
+
+export function parseFirstPrUrl(output: string): string | undefined {
+  try {
+    const parsed = JSON.parse(output || '[]') as unknown;
+    if (!Array.isArray(parsed)) return undefined;
+    const url = (parsed[0] as { url?: unknown } | undefined)?.url;
+    return typeof url === 'string' && url.length > 0 ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function findOpenPrUrlForBranch(options: FindOpenPrUrlForBranchOptions): string | undefined {
+  const runGh = options.gh ?? defaultGh;
+  const args = ['pr', 'list'];
+  if (options.repo) args.push('--repo', options.repo);
+  args.push('--head', options.branch, '--state', 'open', '--json', 'url', '--limit', '1');
+
+  try {
+    return parseFirstPrUrl(runGh(args));
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Story

Once upon a time, auto-dent had one branch-to-PR fallback in the review loop: when `gh pr create` succeeded but produced no visible URL, the hook queried GitHub for the current branch so the review gate would still be created.

Every day, that fallback lived as a private parser inside `src/hooks/pr-review-loop.ts`, which was fine while it was the only runtime path asking that question.

One day, PR #1269 added abnormal-run rescue. Rescue needs the same answer: does this branch already have an open PR, or should we create a draft rescue PR? It added a second local `gh pr list --head ... --json url` parser in `scripts/auto-dent-rescue.ts`.

Because of that, this PR extracts a shared `src/lib/github-pr.ts` helper for “first open PR URL for branch.” The helper owns command construction, JSON parsing, repo-scoped lookup, and tolerant failure behavior.

Because of that, rescue and the review loop keep their separate policies but stop drifting on the mechanism. Rescue still converts no result to `null`; the review loop still honors `KAIZEN_PR_LOOKUP_DISABLED=1` and test injection.

Until finally, the focused tests prove the parser, repo-scoped rescue lookup, review-loop fallback behavior, and disabled-env behavior all work.

And ever since, the next branch-PR runtime path has a small reusable primitive instead of another private `gh pr list` parser.

Closes #1271

Related: #973, #1255, #1269

## Architecture

```text
review-loop fallback ─┐
                      ├─ findOpenPrUrlForBranch({ branch, repo?, gh? })
rescue finalizer   ───┘            │
                                   └─ parseFirstPrUrl(gh JSON)
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Put the helper in `src/lib/github-pr.ts` | Both hooks and scripts can import `src/lib`; hooks should not depend on `scripts/` modules | Adds a small new lib file |
| Return `undefined` from the shared helper | Matches JS optional lookup style and keeps failure tolerant | Rescue converts to `null` for its existing decision input |
| Keep `KAIZEN_PR_LOOKUP_DISABLED` in the review loop | That is caller policy for test environments, not generic GitHub behavior | The wrapper function remains, but no longer owns parsing/command shape |

## What Changed

| File | Purpose |
| --- | --- |
| `src/lib/github-pr.ts` | Shared branch open-PR lookup and parser |
| `src/lib/github-pr.test.ts` | Parser, failure tolerance, and command construction tests |
| `scripts/auto-dent-rescue.ts` | Uses shared lookup instead of local parser |
| `scripts/auto-dent-rescue.test.ts` | Guards repo-scoped rescue lookup |
| `src/hooks/pr-review-loop.ts` | Uses shared lookup for default fallback |
| `src/hooks/pr-review-loop.test.ts` | Guards disabled fallback behavior |

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration | System | Status |
| --- | --- | --- | --- | --- |
| Shared parser returns first valid open PR URL and tolerates empty/malformed output | `src/lib/github-pr.test.ts` | N/A | N/A | Tested |
| Rescue uses repo-scoped branch lookup without a local parser | `scripts/auto-dent-rescue.test.ts` | N/A | N/A | Tested |
| PR review loop preserves fallback lookup and disabled-env behavior | `src/hooks/pr-review-loop.test.ts` | N/A | N/A | Tested |
| No duplicate local branch open-PR helpers remain in touched runtime modules | grep guard | N/A | N/A | Tested |

## Validation

- [x] `npm test -- --run src/lib/github-pr.test.ts scripts/auto-dent-rescue.test.ts src/hooks/pr-review-loop.test.ts` — 3 files, 57 tests passed
- [x] `npm run typecheck`
- [x] `rg -n "function findOpenPrForBranch|gh pr list --head|pr list.*--head|defaultLookupPrUrlForBranch|findOpenPrUrlForBranch" scripts/auto-dent-rescue.ts src/hooks/pr-review-loop.ts src/lib/github-pr.ts src/lib/github-pr.test.ts`
- [x] `git diff --check`

## Known Limitations

This only unifies the branch open-PR lookup used by rescue and the review-loop fallback. Other GitHub PR operations in the codebase still have their own higher-level policies and are intentionally out of scope for this PR.