### PR TITLE
refactor(rescue,review-loop): share branch open-PR lookup helper (#1271)

### DIFF
--- a/scripts/auto-dent-rescue.ts
+++ b/scripts/auto-dent-rescue.ts
@@ -28,7 +28,7 @@ import {
   type GitExec,
   type DirtyState,
 } from '../src/hooks/lib/git-state.js';
-import { gh as defaultGh } from '../src/lib/gh-exec.js';
+import { gh as defaultGh, findOpenPrUrlForBranch } from '../src/lib/gh-exec.js';
 
 /** Quality gates a rescue deliberately skips — surfaced in the rescue report. */
 export const SKIPPED_GATES: readonly string[] = [
@@ -209,16 +209,6 @@ function countRevList(git: GitExec, worktree: string, range: string): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-function findOpenPrForBranch(gh: (args: string[]) => string, repo: string, branch: string): string | null {
-  try {
-    const out = gh(['pr', 'list', '--repo', repo, '--head', branch, '--state', 'open', '--json', 'url']);
-    const arr = JSON.parse(out || '[]') as Array<{ url?: string }>;
-    return arr[0]?.url ?? null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Rescue a single run worktree. Best-effort: every git/gh step is guarded so a
  * rescue failure is recorded in the outcome but never thrown — the original run
@@ -249,7 +239,8 @@ export function rescueTarget(target: RescueTarget, ctx: RescueContext, deps: Res
 
   const commitsAheadBase = countRevList(git, target.worktree, `${base}..HEAD`);
   const unpushedCommits = countRevList(git, target.worktree, '@{u}..HEAD');
-  const existingOpenPr = findOpenPrForBranch(gh, ctx.repo, target.branch);
+  // Shared lookup (#1271); rescue policy maps "no PR" to null.
+  const existingOpenPr = findOpenPrUrlForBranch(target.branch, { repo: ctx.repo, ghExec: gh }) ?? null;
 
   const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr });
   outcome.action = action.kind;

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -46,6 +46,7 @@ import {
   prUrlToStateKey,
   writeStateFile,
 } from './state-utils.js';
+import { findOpenPrUrlForBranch } from '../lib/gh-exec.js';
 
 export const MAX_ROUNDS = 4;
 export const SMALL_PUSH_THRESHOLD = 15;
@@ -208,19 +209,13 @@ function findStateByStatuses(
 }
 
 /** Query gh for the open PR URL on the given branch. Returns undefined on failure.
- *  Set KAIZEN_PR_LOOKUP_DISABLED=1 to skip (for testing environments). */
+ *  Set KAIZEN_PR_LOOKUP_DISABLED=1 to skip (for testing environments).
+ *  Command construction + parsing are shared with the rescue path via
+ *  `findOpenPrUrlForBranch` (#1271); this wrapper keeps the env opt-out and the
+ *  ambient-repo policy. */
 function defaultLookupPrUrlForBranch(branch: string): string | undefined {
   if (process.env.KAIZEN_PR_LOOKUP_DISABLED === '1') return undefined;
-  try {
-    const out = execSync(
-      `gh pr list --head "${branch}" --state open --json url --limit 1`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-    ).trim();
-    const parsed = JSON.parse(out) as Array<{ url: string }>;
-    return parsed[0]?.url;
-  } catch {
-    return undefined;
-  }
+  return findOpenPrUrlForBranch(branch);
 }
 
 // ── Core logic (extracted for testability) ───────────────────────────

--- a/src/lib/gh-exec.test.ts
+++ b/src/lib/gh-exec.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { gh } from './gh-exec.js';
+import { gh, findOpenPrUrlForBranch } from './gh-exec.js';
 
 vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(),
@@ -41,5 +41,43 @@ describe('gh — shared GitHub CLI helper', () => {
   it('returns empty string when stdout is null/undefined', () => {
     mockSpawn.mockReturnValueOnce({ status: 0, stdout: null, stderr: '', signal: null, pid: 0, output: [] } as any);
     expect(gh(['issue', 'view', '1'])).toBe('');
+  });
+});
+
+describe('findOpenPrUrlForBranch — shared branch open-PR lookup (#1271)', () => {
+  it('returns the first open PR url on a successful parse', () => {
+    const exec = () => JSON.stringify([{ url: 'https://github.com/o/r/pull/7' }]);
+    expect(findOpenPrUrlForBranch('case/x', { ghExec: exec })).toBe('https://github.com/o/r/pull/7');
+  });
+
+  it('returns undefined when no open PR exists (empty array)', () => {
+    expect(findOpenPrUrlForBranch('case/x', { ghExec: () => '[]' })).toBeUndefined();
+  });
+
+  it('returns undefined on malformed (non-JSON) output without throwing', () => {
+    expect(findOpenPrUrlForBranch('case/x', { ghExec: () => 'not json' })).toBeUndefined();
+  });
+
+  it('returns undefined when the executor throws (failed lookup)', () => {
+    const exec = () => { throw new Error('gh failed'); };
+    expect(findOpenPrUrlForBranch('case/x', { ghExec: exec })).toBeUndefined();
+  });
+
+  it('scopes the lookup with --repo when a repo is given (rescue policy)', () => {
+    let captured: string[] = [];
+    const exec = (args: string[]) => { captured = args; return '[]'; };
+    findOpenPrUrlForBranch('case/x', { repo: 'owner/repo', ghExec: exec });
+    expect(captured.slice(0, 2)).toEqual(['pr', 'list']);
+    expect(captured).toEqual(expect.arrayContaining(['--head', 'case/x', '--state', 'open', '--json', 'url']));
+    const i = captured.indexOf('--repo');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(captured[i + 1]).toBe('owner/repo');
+  });
+
+  it('omits --repo for the ambient-repo review-loop fallback path', () => {
+    let captured: string[] = [];
+    const exec = (args: string[]) => { captured = args; return '[]'; };
+    findOpenPrUrlForBranch('case/x', { ghExec: exec });
+    expect(captured).not.toContain('--repo');
   });
 });

--- a/src/lib/gh-exec.ts
+++ b/src/lib/gh-exec.ts
@@ -19,3 +19,40 @@ export function gh(args: string[], timeoutMs: number = 30_000): string {
   }
   return result.stdout?.trim() ?? '';
 }
+
+/**
+ * Look up the URL of the first OPEN PR whose head is `branch`.
+ *
+ * Single shared implementation of the "does this branch already have an open
+ * PR?" question that both the auto-dent rescue path
+ * (`scripts/auto-dent-rescue.ts`) and the PR review-loop fallback
+ * (`src/hooks/pr-review-loop.ts`) ask. Command construction + JSON parsing live
+ * here; callers keep their own policy (null vs undefined, env opt-out, whether
+ * to scope by `--repo`). See #1271 — and #973/#1255 for why the two paths must
+ * not drift.
+ *
+ * Returns `undefined` on empty result, malformed output, or any executor
+ * failure — never throws.
+ *
+ * @param opts.repo    Scope the lookup to a specific `owner/repo` (rescue runs
+ *                     against an explicit repo; the review-loop hook uses the
+ *                     ambient repo and omits this).
+ * @param opts.ghExec  Override the gh executor (arg array → stdout string).
+ *                     Defaults to {@link gh}. Used for test injection and so the
+ *                     rescue path can pass its own guarded executor.
+ */
+export function findOpenPrUrlForBranch(
+  branch: string,
+  opts: { repo?: string; ghExec?: (args: string[]) => string } = {},
+): string | undefined {
+  const exec = opts.ghExec ?? gh;
+  const args = ['pr', 'list', '--head', branch, '--state', 'open', '--json', 'url', '--limit', '1'];
+  if (opts.repo) args.push('--repo', opts.repo);
+  try {
+    const out = exec(args);
+    const arr = JSON.parse(out || '[]') as Array<{ url?: string }>;
+    return arr[0]?.url;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Problem

Two runtime paths independently answered the same question — *"does this branch already have an open PR, and what is its URL?"*

- `scripts/auto-dent-rescue.ts` had a local `findOpenPrForBranch(gh, repo, branch)` used to decide whether stranded work should extend an existing PR or open a draft.
- `src/hooks/pr-review-loop.ts` had `defaultLookupPrUrlForBranch(branch)` as the fallback when `gh pr create` returns empty stdout (#973).

Both built the same `gh pr list --head … --state open --json url` command and parsed `arr[0]?.url`, but in separate modules with separate command construction (one an injected arg-array executor, the other a raw `execSync` shell string) and separate error handling. This is exactly the branch/PR runtime mechanism that drifts after fixes like #973 and #1255 — two copies, two chances to diverge.

## Discovery

The shapes were nearly identical, differing only in *policy*, not in *mechanism*:

| | rescue | review-loop |
|---|--------|-------------|
| Executor | injected `(args[])=>string` | raw `execSync` shell string |
| `--repo` | yes (explicit repo) | no (ambient repo) |
| Miss → | `null` | `undefined` |
| Opt-out | — | `KAIZEN_PR_LOOKUP_DISABLED=1` |

The mechanism (command + JSON parse + swallow-errors) is shared; the differences are all caller policy. And `src/lib/gh-exec.ts` already hosts the shared `gh(args[])` executor whose signature exactly matches rescue's injected `gh` — a natural home.

## Solution

Extract one helper, `findOpenPrUrlForBranch(branch, opts)`, into `src/lib/gh-exec.ts`:

```ts
findOpenPrUrlForBranch(branch, { repo?, ghExec? }): string | undefined
```

It owns command construction (`pr list --head … --state open --json url --limit 1`, appending `--repo` when given) and JSON parsing, returning `undefined` on empty/malformed/failed lookups — never throwing.

Callers keep their policy:
- **rescue** passes `{ repo, ghExec: gh }` and maps the result to `null` to preserve its `string | null` contract.
- **review-loop** keeps the `KAIZEN_PR_LOOKUP_DISABLED=1` opt-out in its wrapper, then delegates with the ambient repo. As a bonus it moves off a raw `execSync` shell string onto the spawnSync-based shared `gh()` — no shell, same result.

## Evidence

Six new focused unit tests on the shared helper (successful parse, empty result, malformed output, executor throws, repo-scoped args, ambient/no-`--repo` args). Existing rescue and review-loop suites — including the `KAIZEN_PR_LOOKUP_DISABLED=1` skip test and the `lookupPrUrlForBranch` injection seam — stay green, proving the policy at each call site is unchanged.

`npx vitest run src/lib/gh-exec.test.ts scripts/auto-dent-rescue.test.ts src/hooks/pr-review-loop.test.ts` → **63 passed**. `tsc --noEmit` clean.

### Behaviors × Levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Shared helper parses first open-PR url | ✅ | | | | |
| Malformed / failed lookup → `undefined` (no throw) | ✅ | | | | |
| Repo-scoped vs ambient arg construction | ✅ | | | | |
| Rescue uses shared helper, decision unchanged | | ✅ | | | |
| Review-loop fallback + `KAIZEN_PR_LOOKUP_DISABLED` preserved | | ✅ | | | |

## Impact

One lookup mechanism instead of two. The next fix to branch/PR lookup (auth, pagination, `gh` flag changes) lands in one place and both the rescue path and the review-loop gate fallback inherit it — closing the drift seam that #973/#1255 kept reopening.

Closes #1271
Refs #973, #1255, #1269

Run tag: handsome-lynx/run-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
