### PR TITLE
refactor(hooks): share pre-push PR state query

### DIFF
--- a/src/hooks/pre-push.test.ts
+++ b/src/hooks/pre-push.test.ts
@@ -473,8 +473,8 @@ describe('defaultQueryPrState — error handling', () => {
 
   it('security: does NOT execute shell metacharacters in branch name', () => {
     // Branch name containing $() would execute if interpolated into a shell.
-    // With execFileSync + args array, the metacharacters are passed verbatim
-    // to gh as a literal arg — gh returns an empty PR list or error.
+    // The shared gh helper uses an argv array, so metacharacters are passed
+    // verbatim to gh as a literal arg — gh returns an empty PR list or error.
     const maliciousBranch = 'feat/$(touch /tmp/.kaizen-pre-push-injection-test)';
     const result = defaultQueryPrState('owner/repo', maliciousBranch);
     // Assertion: function returns cleanly (no exception, empty result — gh either

--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -11,7 +11,7 @@
  *     → agent-env gate (exit 0 for humans; shell-level shortcut)
  *     → exec npx tsx src/hooks/pre-push.ts
  *       → parseStdin (git pre-push protocol)
- *       → queryPrState (gh pr list)
+ *       → queryPrState (shared branch PR-state query)
  *       → decide → { allow_silent | allow_gate | deny }
  *       → writeStateFile + emit GateSignal on allow_gate
  *       → exit non-zero with recovery message on deny
@@ -26,10 +26,11 @@
  */
 
 import { appendFileSync, existsSync, readFileSync } from 'node:fs';
-import { execFileSync, execSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { DEFAULT_STATE_DIR, ensureStateDir, parseStateFile, prUrlToStateKey, writeStateFile } from './state-utils.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
+import { queryBranchPrState, type BranchPrQueryResult } from '../lib/github-pr.js';
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -67,12 +68,8 @@ export interface PrePushDecision {
   context?: Record<string, unknown>;
 }
 
-/** Result of `gh pr list --state all` on a branch. */
-export interface PrQueryResult {
-  mostRecent: { number: number; state: 'MERGED' | 'CLOSED' | 'OPEN'; url: string } | null;
-  hasOpen: boolean;
-  openUrl?: string;
-}
+/** Branch PR-state query result used by the pre-push decision. */
+export type PrQueryResult = BranchPrQueryResult;
 
 export interface PrePushOptions {
   stateDir?: string;
@@ -249,47 +246,11 @@ export function getCurrentBranch(): string {
 }
 
 /**
- * Default PR-state query via `gh`. Returns empty result on any failure.
- *
- * Uses execFileSync with explicit arg array (not shell interpolation) so
- * branch names containing shell metacharacters (`$`, backticks, `$()`)
- * cannot trigger command injection. Git refname rules forbid space/colon/
- * tilde/caret/backslash/glob but permit `$` and backticks — so the attack
- * surface via a maliciously-named branch is real without this guard.
+ * Default PR-state query via the shared argv-based gh helper. Returns an
+ * empty result on any failure.
  */
 export function defaultQueryPrState(repo: string, branch: string): PrQueryResult {
-  if (!repo || !branch) return { mostRecent: null, hasOpen: false };
-  try {
-    const out = execFileSync(
-      'gh',
-      [
-        'pr', 'list',
-        '--repo', repo,
-        '--head', branch,
-        '--state', 'all',
-        '--json', 'number,state,url',
-        '--limit', '5',
-      ],
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-    ).trim();
-    const prs = JSON.parse(out) as Array<{ number: number; state: string; url: string }>;
-    if (prs.length === 0) return { mostRecent: null, hasOpen: false };
-
-    const open = prs.find(p => p.state === 'OPEN');
-    const mostRecent = prs[0]; // gh returns newest first
-
-    return {
-      mostRecent: {
-        number: mostRecent.number,
-        state: mostRecent.state as 'MERGED' | 'CLOSED' | 'OPEN',
-        url: mostRecent.url,
-      },
-      hasOpen: !!open,
-      openUrl: open?.url,
-    };
-  } catch {
-    return { mostRecent: null, hasOpen: false };
-  }
+  return queryBranchPrState({ repo, branch });
 }
 
 // ── Trace ─────────────────────────────────────────────────────────────

--- a/src/lib/github-pr.test.ts
+++ b/src/lib/github-pr.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { findOpenPrUrlForBranch, parseFirstPrUrl } from './github-pr.js';
+import {
+  findOpenPrUrlForBranch,
+  parseBranchPrQueryResult,
+  parseFirstPrUrl,
+  queryBranchPrState,
+} from './github-pr.js';
 
 describe('parseFirstPrUrl', () => {
   it('returns the first PR URL from gh JSON output', () => {
@@ -61,5 +66,78 @@ describe('findOpenPrUrlForBranch', () => {
     });
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('parseBranchPrQueryResult', () => {
+  it('derives mostRecent, hasOpen, and openUrl from newest-first gh output', () => {
+    const result = parseBranchPrQueryResult(JSON.stringify([
+      { number: 3, state: 'MERGED', url: 'https://github.com/o/r/pull/3' },
+      { number: 2, state: 'OPEN', url: 'https://github.com/o/r/pull/2' },
+      { number: 1, state: 'CLOSED', url: 'https://github.com/o/r/pull/1' },
+    ]));
+
+    expect(result).toEqual({
+      mostRecent: { number: 3, state: 'MERGED', url: 'https://github.com/o/r/pull/3' },
+      hasOpen: true,
+      openUrl: 'https://github.com/o/r/pull/2',
+    });
+  });
+
+  it('returns an empty result for empty, malformed, or missing-field output', () => {
+    expect(parseBranchPrQueryResult('[]')).toEqual({ mostRecent: null, hasOpen: false });
+    expect(parseBranchPrQueryResult('{not json')).toEqual({ mostRecent: null, hasOpen: false });
+    expect(parseBranchPrQueryResult(JSON.stringify([{ number: 1, state: 'OPEN' }]))).toEqual({
+      mostRecent: null,
+      hasOpen: false,
+    });
+  });
+});
+
+describe('queryBranchPrState', () => {
+  it('runs a repo-scoped all-state branch PR query', () => {
+    const calls: string[][] = [];
+    const result = queryBranchPrState({
+      repo: 'owner/repo',
+      branch: 'case/branch',
+      gh: (args) => {
+        calls.push(args);
+        return JSON.stringify([{ number: 4, state: 'OPEN', url: 'https://github.com/owner/repo/pull/4' }]);
+      },
+    });
+
+    expect(result.openUrl).toBe('https://github.com/owner/repo/pull/4');
+    expect(calls).toEqual([[
+      'pr', 'list',
+      '--repo', 'owner/repo',
+      '--head', 'case/branch',
+      '--state', 'all',
+      '--json', 'number,state,url',
+      '--limit', '5',
+    ]]);
+  });
+
+  it('returns an empty result when repo or branch is missing', () => {
+    const calls: string[][] = [];
+    const gh = (args: string[]) => {
+      calls.push(args);
+      return '[]';
+    };
+
+    expect(queryBranchPrState({ repo: '', branch: 'case/branch', gh })).toEqual({ mostRecent: null, hasOpen: false });
+    expect(queryBranchPrState({ repo: 'owner/repo', branch: '', gh })).toEqual({ mostRecent: null, hasOpen: false });
+    expect(calls).toEqual([]);
+  });
+
+  it('returns an empty result when gh throws', () => {
+    const result = queryBranchPrState({
+      repo: 'owner/repo',
+      branch: 'case/branch',
+      gh: () => {
+        throw new Error('gh unavailable');
+      },
+    });
+
+    expect(result).toEqual({ mostRecent: null, hasOpen: false });
   });
 });

--- a/src/lib/github-pr.ts
+++ b/src/lib/github-pr.ts
@@ -10,6 +10,31 @@ export interface FindOpenPrUrlForBranchOptions {
   gh?: GhRunner;
 }
 
+export type BranchPrState = 'MERGED' | 'CLOSED' | 'OPEN';
+
+export interface BranchPrSummary {
+  number: number;
+  state: BranchPrState;
+  url: string;
+}
+
+export interface BranchPrQueryResult {
+  mostRecent: BranchPrSummary | null;
+  hasOpen: boolean;
+  openUrl?: string;
+}
+
+export interface QueryBranchPrStateOptions {
+  repo: string;
+  branch: string;
+  /** Injectable gh runner for tests and callers that already own gh wiring. */
+  gh?: GhRunner;
+}
+
+export function emptyBranchPrQueryResult(): BranchPrQueryResult {
+  return { mostRecent: null, hasOpen: false };
+}
+
 export function parseFirstPrUrl(output: string): string | undefined {
   try {
     const parsed = JSON.parse(output || '[]') as unknown;
@@ -18,6 +43,36 @@ export function parseFirstPrUrl(output: string): string | undefined {
     return typeof url === 'string' && url.length > 0 ? url : undefined;
   } catch {
     return undefined;
+  }
+}
+
+function normalizeBranchPrSummary(input: unknown): BranchPrSummary | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+  const raw = input as Record<string, unknown>;
+  const state = raw.state;
+  if (state !== 'MERGED' && state !== 'CLOSED' && state !== 'OPEN') return undefined;
+  if (typeof raw.number !== 'number' || !Number.isFinite(raw.number)) return undefined;
+  if (typeof raw.url !== 'string' || raw.url.length === 0) return undefined;
+  return { number: raw.number, state, url: raw.url };
+}
+
+export function parseBranchPrQueryResult(output: string): BranchPrQueryResult {
+  try {
+    const parsed = JSON.parse(output || '[]') as unknown;
+    if (!Array.isArray(parsed)) return emptyBranchPrQueryResult();
+    const prs = parsed
+      .map((item) => normalizeBranchPrSummary(item))
+      .filter((item): item is BranchPrSummary => item != null);
+    if (prs.length === 0) return emptyBranchPrQueryResult();
+
+    const open = prs.find((pr) => pr.state === 'OPEN');
+    return {
+      mostRecent: prs[0],
+      hasOpen: open != null,
+      ...(open ? { openUrl: open.url } : {}),
+    };
+  } catch {
+    return emptyBranchPrQueryResult();
   }
 }
 
@@ -31,5 +86,23 @@ export function findOpenPrUrlForBranch(options: FindOpenPrUrlForBranchOptions): 
     return parseFirstPrUrl(runGh(args));
   } catch {
     return undefined;
+  }
+}
+
+export function queryBranchPrState(options: QueryBranchPrStateOptions): BranchPrQueryResult {
+  if (!options.repo || !options.branch) return emptyBranchPrQueryResult();
+
+  const runGh = options.gh ?? defaultGh;
+  try {
+    return parseBranchPrQueryResult(runGh([
+      'pr', 'list',
+      '--repo', options.repo,
+      '--head', options.branch,
+      '--state', 'all',
+      '--json', 'number,state,url',
+      '--limit', '5',
+    ]));
+  } catch {
+    return emptyBranchPrQueryResult();
   }
 }


### PR DESCRIPTION
## Story

Once upon a time, the pre-push hook owned the merged-branch safety gate. To decide whether a push should open a review gate or be denied as a push to an already-merged branch, it queried GitHub for all PRs on the branch and parsed the result locally.

Every day, that worked, but it was a private copy of the same branch-to-PR lookup family that rescue and review-loop now share through `src/lib/github-pr.ts`.

One day, PR #1273 centralized the simpler “first open PR URL for branch” lookup. That left pre-push as the remaining branch PR-list parser: same GitHub API shape, same tolerant failure policy, but a separate command construction and schema.

Because of that, this PR extends `src/lib/github-pr.ts` with the richer branch PR-state query: parse newest-first PR arrays, derive `mostRecent`, `hasOpen`, and `openUrl`, and run the repo-scoped `gh pr list --state all` query via the shared argv-based gh helper.

Because of that, `pre-push.ts` keeps its merged-branch policy exactly where it belongs, in `decide`, while delegating GitHub PR-list mechanics to the shared library.

Until finally, the helper tests prove the shared schema and command shape, and the existing pre-push tests prove no-gh fallback, malicious branch-name safety, open PR gating, merged branch denial, and injected-query policy behavior still pass.

And ever since, branch PR-list mechanics have one reusable owner instead of one helper for rescue/review-loop and another private implementation inside pre-push.

Closes #1275

Related: #1271, #1273, #1032, #1059

## Architecture

```text
pre-push defaultQueryPrState(repo, branch)
        │
        ▼
queryBranchPrState({ repo, branch })
        │
        ├─ gh([pr, list, --repo, repo, --head, branch, --state, all, ...])
        ▼
parseBranchPrQueryResult(output)
        │
        └─ { mostRecent, hasOpen, openUrl }
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Keep `decide` in `pre-push.ts` | Merged-branch blocking is hook policy, not generic GitHub parsing | `pre-push.ts` still exposes `defaultQueryPrState`, but it is now a thin adapter |
| Put the richer parser beside `findOpenPrUrlForBranch` | Both are branch PR-list schemas and should drift together | `github-pr.ts` becomes a slightly broader GitHub PR helper |
| Return the same empty result on failures | Preserves current pre-push behavior for missing gh, bad output, or empty repo/branch | Fail-closed merged-branch detection is not introduced in this refactor |

## What Changed

| File | Purpose |
| --- | --- |
| `src/lib/github-pr.ts` | Adds shared branch PR-state types, parser, empty result, and query helper |
| `src/lib/github-pr.test.ts` | Covers parser derivation, malformed output, command construction, empty inputs, and thrown gh |
| `src/hooks/pre-push.ts` | Delegates `defaultQueryPrState` to `queryBranchPrState` and aliases the shared result type |
| `src/hooks/pre-push.test.ts` | Updates the injection-safety comment to match the shared argv helper |

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration | System | Status |
| --- | --- | --- | --- | --- |
| Shared branch PR-state parser derives newest `mostRecent`, `hasOpen`, and `openUrl` | `src/lib/github-pr.test.ts` | N/A | N/A | Tested |
| Shared query builds repo-scoped `gh pr list --state all --json number,state,url --limit 5` and tolerates gh failures | `src/lib/github-pr.test.ts` | N/A | N/A | Tested |
| Pre-push default query preserves no-gh and shell-metacharacter branch safety behavior | `src/hooks/pre-push.test.ts` | N/A | N/A | Tested |
| Pre-push policy remains unchanged because `decide` and injected query tests still pass | `src/hooks/pre-push.test.ts` | N/A | N/A | Tested |
| No private pre-push `gh pr list` parser remains | grep guard | N/A | N/A | Tested |

## Validation

- [x] RED first: `npm test -- --run src/lib/github-pr.test.ts` failed because `parseBranchPrQueryResult` / `queryBranchPrState` did not exist
- [x] `npm test -- --run src/lib/github-pr.test.ts src/hooks/pre-push.test.ts` — 2 files, 59 tests passed
- [x] `npm run typecheck`
- [x] `rg -n "execFileSync|gh pr list|queryBranchPrState|parseBranchPrQueryResult|defaultQueryPrState" src/hooks/pre-push.ts src/lib/github-pr.ts src/lib/github-pr.test.ts src/hooks/pre-push.test.ts`
- [x] `git diff --check`

## Known Limitations

This PR centralizes branch PR-list mechanics only. Higher-level PR operations in `auto-dent-github.ts` still have their own policy-specific wrappers and are left for separate, scope-matched refactors if they show similar drift.