### PR TITLE
refactor(github): share tolerant gh exec adapter

### DIFF
--- a/scripts/auto-dent-github.ts
+++ b/scripts/auto-dent-github.ts
@@ -8,71 +8,11 @@
  * (logging warnings rather than throwing).
  */
 
-import { gh } from '../src/lib/gh-exec.js';
+import { ghExec, parseGhCommandArgs } from '../src/lib/gh-exec.js';
 import type { RunResult } from './auto-dent-run.js';
 
-// GitHub CLI wrapper (tolerant of failures)
-
-/**
- * Parse a shell-style command string into an array of arguments.
- * Handles double-quoted strings (with JSON/shell escape sequences) and
- * single-quoted strings. Does NOT interpret backticks or $() substitutions —
- * that is exactly the point: user-controlled data (e.g. markdown backtick
- * code-spans in --body) never reaches a shell.
- */
-export function parseShellArgs(cmd: string): string[] {
-  const args: string[] = [];
-  let current = '';
-  let i = 0;
-  while (i < cmd.length) {
-    const c = cmd[i];
-    if (c === ' ' || c === '\t') {
-      if (current !== '') { args.push(current); current = ''; }
-      i++;
-    } else if (c === '"') {
-      i++;
-      while (i < cmd.length && cmd[i] !== '"') {
-        if (cmd[i] === '\\' && i + 1 < cmd.length) {
-          const esc = cmd[i + 1];
-          if (esc === '"' || esc === '\\' || esc === '/') { current += esc; i += 2; }
-          else if (esc === 'n') { current += '\n'; i += 2; }
-          else if (esc === 'r') { current += '\r'; i += 2; }
-          else if (esc === 't') { current += '\t'; i += 2; }
-          else { current += '\\'; current += esc; i += 2; }
-        } else {
-          current += cmd[i]; i++;
-        }
-      }
-      i++;
-    } else if (c === "'") {
-      i++;
-      while (i < cmd.length && cmd[i] !== "'") { current += cmd[i]; i++; }
-      i++;
-    } else {
-      current += c; i++;
-    }
-  }
-  if (current !== '') args.push(current);
-  return args;
-}
-
-/**
- * Execute a gh CLI command without going through a shell.
- * Parses the command string into args, then delegates to gh() from
- * gh-exec.ts. Swallows errors (returns '') for backward compatibility.
- */
-export function ghExec(cmd: string): string {
-  const args = parseShellArgs(cmd);
-  const [_bin, ...rest] = args;
-  try {
-    return gh(rest);
-  } catch (e: any) {
-    console.log(
-      `  [hygiene] warning: ${cmd.slice(0, 80)}... -> ${e.message?.split('\n')[0] || 'failed'}`,
-    );
-    return '';
-  }
-}
+export { ghExec };
+export const parseShellArgs = parseGhCommandArgs;
 
 // Issue label lookup
 

--- a/src/lib/gh-exec.test.ts
+++ b/src/lib/gh-exec.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { gh } from './gh-exec.js';
+import { gh, ghExec, parseGhCommandArgs } from './gh-exec.js';
 
 vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(),
@@ -41,5 +41,56 @@ describe('gh — shared GitHub CLI helper', () => {
   it('returns empty string when stdout is null/undefined', () => {
     mockSpawn.mockReturnValueOnce({ status: 0, stdout: null, stderr: '', signal: null, pid: 0, output: [] } as any);
     expect(gh(['issue', 'view', '1'])).toBe('');
+  });
+});
+
+describe('parseGhCommandArgs — shared gh command-string parser', () => {
+  it('splits simple commands and quoted strings', () => {
+    expect(parseGhCommandArgs('gh issue create --title "My Title"')).toEqual([
+      'gh', 'issue', 'create', '--title', 'My Title',
+    ]);
+  });
+
+  it('handles JSON-style escapes inside double-quoted strings', () => {
+    expect(parseGhCommandArgs('gh issue create --body "line1\\nline2"')).toEqual([
+      'gh', 'issue', 'create', '--body', 'line1\nline2',
+    ]);
+    expect(parseGhCommandArgs('gh issue create --body "say \\"hello\\""')).toEqual([
+      'gh', 'issue', 'create', '--body', 'say "hello"',
+    ]);
+  });
+
+  it('keeps backticks and command substitutions literal', () => {
+    expect(parseGhCommandArgs('gh issue create --body "see `branch` and $(echo hack)"')).toEqual([
+      'gh', 'issue', 'create', '--body', 'see `branch` and $(echo hack)',
+    ]);
+  });
+
+  it('handles single-quoted strings and repeated spaces', () => {
+    expect(parseGhCommandArgs("gh  issue  create --title 'My Title'")).toEqual([
+      'gh', 'issue', 'create', '--title', 'My Title',
+    ]);
+  });
+});
+
+describe('ghExec — tolerant shared gh command-string adapter', () => {
+  it('returns trimmed stdout on success', () => {
+    mockSpawn.mockReturnValueOnce({ status: 0, stdout: '  ok  \n', stderr: '', signal: null, pid: 0, output: [] } as any);
+    expect(ghExec('gh issue list')).toBe('ok');
+  });
+
+  it('returns empty string on failure instead of throwing', () => {
+    mockSpawn.mockReturnValueOnce({ status: 1, stdout: '', stderr: 'gh error', signal: null, pid: 0, output: [] } as any);
+    expect(ghExec('gh issue list')).toBe('');
+  });
+
+  it('delegates via argv without shell interpretation', () => {
+    mockSpawn.mockReturnValueOnce({ status: 0, stdout: '', stderr: '', signal: null, pid: 0, output: [] } as any);
+    ghExec('gh issue create --body "has `backtick` and $(echo hack)"');
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gh',
+      ['issue', 'create', '--body', 'has `backtick` and $(echo hack)'],
+      expect.objectContaining({ encoding: 'utf8' }),
+    );
   });
 });

--- a/src/lib/gh-exec.ts
+++ b/src/lib/gh-exec.ts
@@ -19,3 +19,62 @@ export function gh(args: string[], timeoutMs: number = 30_000): string {
   }
   return result.stdout?.trim() ?? '';
 }
+
+/**
+ * Parse a shell-style `gh ...` command string into argv without invoking a shell.
+ *
+ * Handles single quotes, double quotes, and common JSON-style escapes inside
+ * double quotes. It deliberately treats backticks and `$()` as literal text.
+ */
+export function parseGhCommandArgs(cmd: string): string[] {
+  const args: string[] = [];
+  let current = '';
+  let i = 0;
+  while (i < cmd.length) {
+    const c = cmd[i];
+    if (c === ' ' || c === '\t') {
+      if (current !== '') { args.push(current); current = ''; }
+      i++;
+    } else if (c === '"') {
+      i++;
+      while (i < cmd.length && cmd[i] !== '"') {
+        if (cmd[i] === '\\' && i + 1 < cmd.length) {
+          const esc = cmd[i + 1];
+          if (esc === '"' || esc === '\\' || esc === '/') { current += esc; i += 2; }
+          else if (esc === 'n') { current += '\n'; i += 2; }
+          else if (esc === 'r') { current += '\r'; i += 2; }
+          else if (esc === 't') { current += '\t'; i += 2; }
+          else { current += '\\'; current += esc; i += 2; }
+        } else {
+          current += cmd[i]; i++;
+        }
+      }
+      i++;
+    } else if (c === "'") {
+      i++;
+      while (i < cmd.length && cmd[i] !== "'") { current += cmd[i]; i++; }
+      i++;
+    } else {
+      current += c; i++;
+    }
+  }
+  if (current !== '') args.push(current);
+  return args;
+}
+
+/**
+ * Tolerant `gh ...` command-string adapter. Prefer `gh(args)` for new code; use
+ * this when migrating older command-string call sites that must remain best-effort.
+ */
+export function ghExec(cmd: string): string {
+  const args = parseGhCommandArgs(cmd);
+  const [_bin, ...rest] = args;
+  try {
+    return gh(rest);
+  } catch (e: any) {
+    console.log(
+      `  [gh] warning: ${cmd.slice(0, 80)}... -> ${e.message?.split('\n')[0] || 'failed'}`,
+    );
+    return '';
+  }
+}


### PR DESCRIPTION
## Story

Once upon a time, `src/lib/gh-exec.ts` was the shared GitHub CLI primitive: pass argv in, get trimmed stdout or an exception out.

Every day, `scripts/auto-dent-github.ts` used that strict helper but still carried its own generic command-string parser and tolerant `ghExec(cmd)` wrapper. That made an auto-dent policy module the owner of reusable GitHub CLI plumbing.

One day, the branch PR lookup work moved shared GitHub mechanisms into `src/lib/github-pr.ts`. The same ownership smell remained here: future code that needed tolerant `gh ...` command-string execution would either import from a script module or copy the parser again.

Because of that, this PR moves the reusable parser and tolerant wrapper into `src/lib/gh-exec.ts` as `parseGhCommandArgs(cmd)` and `ghExec(cmd)`.

Because of that, `auto-dent-github.ts` stops defining the adapter locally. It imports the shared functions, re-exports `ghExec`, and preserves `parseShellArgs` as a compatibility alias for existing callers/tests.

Until finally, focused tests prove the shared parser keeps quotes, JSON escapes, backticks, and `$()` literal; the tolerant adapter returns stdout or `""` as before; and auto-dent-github’s public imports remain compatible.

And ever since, GitHub CLI execution has one shared home for both strict argv calls and tolerant command-string migration paths.

Closes #1277

Related: #1271, #1275, #600

## Architecture

```text
legacy command-string call sites
        │
        ▼
ghExec("gh issue view ...")
        │
        ├─ parseGhCommandArgs(cmd)
        ▼
gh(args)  // shared spawnSync argv helper
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Move parser/wrapper into `src/lib/gh-exec.ts` | It is generic GitHub CLI plumbing, not auto-dent policy | `gh-exec.ts` now owns strict and tolerant execution forms |
| Keep `parseShellArgs` as an auto-dent alias | Preserves existing public imports and tests while changing ownership | One compatibility export remains in `auto-dent-github.ts` |
| Avoid migrating every command string in this PR | Keeps scope to ownership/DRY refactor | Future direct-argv cleanup can be scoped separately |

## What Changed

| File | Purpose |
| --- | --- |
| `src/lib/gh-exec.ts` | Adds shared `parseGhCommandArgs` and tolerant `ghExec` |
| `src/lib/gh-exec.test.ts` | Adds shared parser and tolerant wrapper coverage |
| `scripts/auto-dent-github.ts` | Imports/re-exports shared adapter and removes local implementation |

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration | System | Status |
| --- | --- | --- | --- | --- |
| Shared parser preserves quoted strings, JSON escapes, literal backticks, and literal `$()` | `src/lib/gh-exec.test.ts` | N/A | N/A | Tested |
| Shared tolerant `ghExec(cmd)` trims stdout, returns `""` on failure, and delegates via argv to `gh()` | `src/lib/gh-exec.test.ts` | N/A | N/A | Tested |
| `auto-dent-github.ts` public parser/wrapper imports remain compatible | `scripts/auto-dent-github.test.ts` | N/A | N/A | Tested |
| No local parser/tolerant wrapper implementation remains in `auto-dent-github.ts` | grep guard | N/A | N/A | Tested |

## Validation

- [x] RED first: `npm test -- --run src/lib/gh-exec.test.ts` failed because `parseGhCommandArgs` / shared `ghExec` did not exist
- [x] `npm test -- --run src/lib/gh-exec.test.ts scripts/auto-dent-github.test.ts` — 2 files, 106 tests passed
- [x] `npm run typecheck`
- [x] `rg -n "function parseShellArgs|function ghExec|parseGhCommandArgs|ghExec\(" src/lib/gh-exec.ts scripts/auto-dent-github.ts src/lib/gh-exec.test.ts scripts/auto-dent-github.test.ts`
- [x] `git diff --check`

## Known Limitations

This PR changes helper ownership only. It does not rewrite every `auto-dent-github.ts` command-string call site into direct argv arrays; that can happen later if the remaining command strings show enough risk to justify the larger migration.