### PR TITLE
fix(auto-dent): rescue marker-less stranded worktrees via runtag stamp (#1270)

### DIFF
--- a/.claude/hooks/kaizen-capture-worktree-context.sh
+++ b/.claude/hooks/kaizen-capture-worktree-context.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Part of kAIzen Agent Control Flow — see .agents/kaizen/README.md
-# capture-worktree-context.sh — Write .worktree-context.json on PR creation
+# capture-worktree-context.sh — Record run/PR context onto a worktree.
 #
-# PostToolUse hook on Bash: detects successful `gh pr create`, extracts the
-# PR URL/number/title, and merges them into .worktree-context.json in the
-# current worktree. This enables the /agents skill to show which PR each
-# running agent is working on.
+# PostToolUse hook on Bash. Two responsibilities at the worktree choke points:
+#   - `git worktree add case/*`: stamp `kaizen.runtag` on the new worktree so the
+#     auto-dent rescue finalizer can attribute stranded work to its run (#1270).
+#   - `gh pr create`: extract the PR URL/number/title and merge them into
+#     .worktree-context.json so the /agents skill can show each agent's PR.
 #
 # Always exits 0 — advisory, not blocking.
 
@@ -26,6 +27,36 @@ source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true
 
 CMD_LINE=$(strip_heredoc_body "$COMMAND")
+
+# #1270: stamp run attribution on a freshly-created case worktree.
+#
+# When an auto-dent run creates a `case/*` worktree (`git worktree add`), record
+# THIS run's tag on the new worktree via `git config --worktree kaizen.runtag`.
+# That durable, run-scoped signal lets the rescue finalizer recover work stranded
+# *before* the IMPLEMENT stream marker is emitted (crash/SIGKILL) — the
+# crash-before-marker gap that forces manual `[rescue]` PRs. Writing --worktree
+# scope is concurrency-safe (it cannot clobber a sibling worktree's binding).
+#
+# Only acts when KAIZEN_RUN_TAG is present (set by the auto-dent runner) and the
+# created worktree is on a `case/*` branch. A non-case worktree, or a session
+# with no run tag, is left untouched.
+if [ -n "$KAIZEN_RUN_TAG" ] && is_git_command "$CMD_LINE" "worktree"; then
+  # The kaizen case-worktree path always lives under `.claude/worktrees/`; pull
+  # that token out of the command rather than flag-parsing positional args.
+  WT_PATH=$(printf '%s\n' "$CMD_LINE" | tr ' \t' '\n\n' | grep -m1 '\.claude/worktrees/' || true)
+  if [ -n "$WT_PATH" ] && [ -d "$WT_PATH" ]; then
+    WT_BRANCH=$(git -C "$WT_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    case "$WT_BRANCH" in
+      case/*)
+        git -C "$WT_PATH" config extensions.worktreeConfig true 2>/dev/null || true
+        if git -C "$WT_PATH" config --worktree kaizen.runtag "$KAIZEN_RUN_TAG" 2>/dev/null; then
+          echo "kaizen-capture-worktree-context: 🏷️  Stamped kaizen.runtag=$KAIZEN_RUN_TAG on $WT_BRANCH (rescue attribution)." >&2
+        fi
+        ;;
+    esac
+  fi
+  exit 0
+fi
 
 # Only trigger on gh pr create
 if ! is_gh_pr_command "$CMD_LINE" "create"; then

--- a/.claude/hooks/tests/test-capture-worktree-runtag.sh
+++ b/.claude/hooks/tests/test-capture-worktree-runtag.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Tests for the #1270 runtag stamp in kaizen-capture-worktree-context.sh.
+#
+# On a successful `git worktree add case/*`, the hook stamps the per-worktree
+# `kaizen.runtag` from $KAIZEN_RUN_TAG so the auto-dent rescue finalizer can
+# attribute the worktree to its run even if the run crashed before emitting the
+# IMPLEMENT marker. These tests use a REAL temp git repo + worktree so the
+# git-config write path is exercised end to end (no git mock).
+source "$(dirname "$0")/test-helpers.sh"
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/kaizen-capture-worktree-context.sh"
+setup_test_env
+
+# Build a throwaway repo with a real case worktree on a case/* branch.
+# Echoes the worktree path.
+make_case_worktree() {
+  local repo="$1" branch="$2" wt
+  wt="$repo/.claude/worktrees/$(basename "$branch")"
+  git -C "$repo" worktree add -q -b "$branch" "$wt" HEAD 2>/dev/null
+  echo "$wt"
+}
+
+new_repo() {
+  local d
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" config user.email t@t.t
+  git -C "$d" config user.name t
+  git -C "$d" commit -q --allow-empty -m init
+  echo "$d"
+}
+
+run_capture_hook() {
+  # $1 command, rest: env assignments inline via caller
+  local cmd="$1"
+  jq -n --arg cmd "$cmd" \
+    '{tool_input:{command:$cmd}, tool_response:{stdout:"", stderr:"", exit_code:"0"}}' \
+    | bash "$HOOK" 2>/dev/null
+}
+
+echo "=== Stamps kaizen.runtag on a successful case worktree add ==="
+REPO=$(new_repo)
+WT=$(make_case_worktree "$REPO" "case/260628-k9-demo")
+KAIZEN_RUN_TAG="test-batch/run-7" run_capture_hook \
+  "git -C $REPO worktree add -b case/260628-k9-demo $WT HEAD"
+STAMP=$(git -C "$WT" config --worktree --get kaizen.runtag 2>/dev/null || true)
+assert_eq "runtag stamped on case worktree" "test-batch/run-7" "$STAMP"
+rm -rf "$REPO"
+
+echo ""
+echo "=== Does NOT stamp when KAIZEN_RUN_TAG is unset ==="
+REPO=$(new_repo)
+WT=$(make_case_worktree "$REPO" "case/260628-k9-demo")
+run_capture_hook "git -C $REPO worktree add -b case/260628-k9-demo $WT HEAD"
+STAMP=$(git -C "$WT" config --worktree --get kaizen.runtag 2>/dev/null || true)
+assert_eq "no runtag when env unset" "" "$STAMP"
+rm -rf "$REPO"
+
+echo ""
+echo "=== Does NOT stamp a non-case worktree ==="
+REPO=$(new_repo)
+WT="$REPO/.claude/worktrees/worktree-scratch"
+git -C "$REPO" worktree add -q -b worktree-scratch "$WT" HEAD 2>/dev/null
+KAIZEN_RUN_TAG="test-batch/run-7" run_capture_hook \
+  "git -C $REPO worktree add -b worktree-scratch $WT HEAD"
+STAMP=$(git -C "$WT" config --worktree --get kaizen.runtag 2>/dev/null || true)
+assert_eq "no runtag on non-case branch" "" "$STAMP"
+rm -rf "$REPO"
+
+echo ""
+echo "=== A non-worktree command (git push) is a no-op for stamping ==="
+REPO=$(new_repo)
+WT=$(make_case_worktree "$REPO" "case/260628-k9-demo")
+KAIZEN_RUN_TAG="test-batch/run-7" run_capture_hook "git -C $REPO push origin main"
+STAMP=$(git -C "$WT" config --worktree --get kaizen.runtag 2>/dev/null || true)
+assert_eq "git push does not stamp any worktree" "" "$STAMP"
+rm -rf "$REPO"
+
+cleanup_test_env
+print_results

--- a/scripts/auto-dent-rescue.test.ts
+++ b/scripts/auto-dent-rescue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync } from 'fs';
+import { mkdtempSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -250,6 +250,104 @@ describe('rescueRun + collectRunWorktrees', () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'rescue-root-'));
     // No worktrees created under repoRoot/.claude/worktrees → nothing collected.
     const targets = collectRunWorktrees(repoRoot, ['260628-k1-foo', '', '260628-k2-bar']);
+    expect(targets).toEqual([]);
+  });
+});
+
+// --- #1270: union marker cases with runtag-stamped on-disk worktrees ---------
+
+/**
+ * Build a repoRoot with on-disk case worktrees and a fake GitExec that answers
+ * `worktree list`, per-worktree `kaizen.runtag`, and HEAD-branch queries.
+ * `stamps[id]` = the runtag string the worktree carries, or undefined = unstamped.
+ * `heads[id]` = the branch HEAD reports (defaults to `case/<id>-head`).
+ */
+function makeWorktreeRepo(
+  ids: string[],
+  stamps: Record<string, string | undefined>,
+  heads: Record<string, string> = {},
+) {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'rescue-union-'));
+  const wtDir = join(repoRoot, '.claude', 'worktrees');
+  const paths: Record<string, string> = {};
+  for (const id of ids) {
+    const p = join(wtDir, id);
+    mkdirSync(p, { recursive: true });
+    paths[id] = p;
+  }
+  const git: GitExec = (args) => {
+    const a = [...args];
+    const ok = (stdout = '') => ({ stdout, stderr: '', exitCode: 0 });
+    const fail = () => ({ stdout: '', stderr: '', exitCode: 1 });
+    // git -C <repoRoot> worktree list --porcelain
+    if (a.includes('worktree') && a.includes('list')) {
+      const lines = [`worktree ${repoRoot}`, ...ids.map((id) => `worktree ${paths[id]}`)];
+      return ok(lines.join('\n') + '\n');
+    }
+    // git -C <wt> config --worktree --get kaizen.runtag
+    if (a.includes('config') && a.includes('kaizen.runtag')) {
+      const wt = a[a.indexOf('-C') + 1];
+      const id = ids.find((i) => paths[i] === wt);
+      const tag = id ? stamps[id] : undefined;
+      return tag ? ok(tag + '\n') : fail();
+    }
+    // git -C <wt> rev-parse --abbrev-ref HEAD
+    if (a.includes('rev-parse') && a.includes('--abbrev-ref')) {
+      const wt = a[a.indexOf('-C') + 1];
+      const id = ids.find((i) => paths[i] === wt);
+      return ok((id && (heads[id] ?? `case/${id}-head`)) || 'HEAD');
+    }
+    return ok();
+  };
+  return { repoRoot, paths, git };
+}
+
+describe('collectRunWorktrees — #1270 runtag union', () => {
+  it('unions marker cases with on-disk worktrees stamped with this run tag', () => {
+    // A = marker case (also stamped); B = runtag-only (no marker). Both included.
+    const repo = makeWorktreeRepo(['A', 'B'], { A: 'run-X', B: 'run-X' });
+    const targets = collectRunWorktrees(repo.repoRoot, ['A'], { runTag: 'run-X', git: repo.git });
+    const byPath = Object.fromEntries(targets.map((t) => [t.worktree, t.branch]));
+    expect(targets).toHaveLength(2);
+    expect(byPath[repo.paths.A]).toBe('case/A'); // marker branch wins for A
+    expect(byPath[repo.paths.B]).toBe('case/B-head'); // B recovered via runtag
+  });
+
+  it('excludes worktrees stamped with a DIFFERENT run tag (concurrency safety)', () => {
+    const repo = makeWorktreeRepo(['C'], { C: 'other-run/run-2' });
+    const targets = collectRunWorktrees(repo.repoRoot, [], { runTag: 'run-X', git: repo.git });
+    expect(targets).toEqual([]);
+  });
+
+  it('excludes unstamped case worktrees', () => {
+    const repo = makeWorktreeRepo(['D'], { D: undefined });
+    const targets = collectRunWorktrees(repo.repoRoot, [], { runTag: 'run-X', git: repo.git });
+    expect(targets).toEqual([]);
+  });
+
+  it('de-duplicates a case present both as a marker and a runtag match', () => {
+    const repo = makeWorktreeRepo(['A'], { A: 'run-X' });
+    const targets = collectRunWorktrees(repo.repoRoot, ['A'], { runTag: 'run-X', git: repo.git });
+    expect(targets).toHaveLength(1);
+    expect(targets[0].branch).toBe('case/A'); // marker precedence, not the HEAD guess
+  });
+
+  it('derives the branch from the worktree HEAD, not the directory name', () => {
+    const repo = makeWorktreeRepo(['B'], { B: 'run-X' }, { B: 'case/260628-k1270-actual' });
+    const targets = collectRunWorktrees(repo.repoRoot, [], { runTag: 'run-X', git: repo.git });
+    expect(targets).toHaveLength(1);
+    expect(targets[0].branch).toBe('case/260628-k1270-actual');
+  });
+
+  it('skips a runtag-matched worktree whose HEAD is detached', () => {
+    const repo = makeWorktreeRepo(['E'], { E: 'run-X' }, { E: 'HEAD' });
+    const targets = collectRunWorktrees(repo.repoRoot, [], { runTag: 'run-X', git: repo.git });
+    expect(targets).toEqual([]);
+  });
+
+  it('does not scan when no runTag/git is supplied (marker-only back-compat)', () => {
+    const repo = makeWorktreeRepo(['B'], { B: 'run-X' });
+    const targets = collectRunWorktrees(repo.repoRoot, []);
     expect(targets).toEqual([]);
   });
 });

--- a/scripts/auto-dent-rescue.ts
+++ b/scripts/auto-dent-rescue.ts
@@ -308,20 +308,100 @@ export function rescueRun(targets: RescueTarget[], ctx: RescueContext, deps: Res
   return targets.map((t) => rescueTarget(t, ctx, deps));
 }
 
+/** Git config key carrying the run that created/owns a case worktree (#1270). */
+export const RUNTAG_CONFIG_KEY = 'kaizen.runtag';
+
+export interface CollectRunWorktreesOptions {
+  /**
+   * This run's tag. When set together with `git`, on-disk case worktrees stamped
+   * with this exact runtag are unioned in — covering worktrees created *before*
+   * the `IMPLEMENT` marker was emitted (the #1270 crash-before-marker strand).
+   */
+  runTag?: string;
+  /** Git runner used to enumerate worktrees and read their per-worktree runtag. */
+  git?: GitExec;
+}
+
 /**
- * Derive the rescue targets for THIS run from the case ids it created. Scoped
- * to the run's own worktrees only — never scans the whole worktree tree, so a
- * concurrent agent's WIP can't be swept up. Existence is checked in rescueTarget.
+ * Read a worktree's durable run attribution stamp (`kaizen.runtag`, written at
+ * `git worktree add` time by the capture-worktree-context hook). Returns the tag
+ * or `null`. A worktree with no stamp, or whose `--worktree` config can't be
+ * read, yields `null` — it is never attributed to any run.
  */
-export function collectRunWorktrees(repoRoot: string, cases: string[]): RescueTarget[] {
-  const targets: RescueTarget[] = [];
+function readWorktreeRunTag(git: GitExec, worktree: string): string | null {
+  const r = git(['-C', worktree, 'config', '--worktree', '--get', RUNTAG_CONFIG_KEY]);
+  if (r.exitCode !== 0) return null;
+  const tag = r.stdout.trim();
+  return tag.length > 0 ? tag : null;
+}
+
+/** Resolve a worktree's current branch from HEAD; null on detached/error. */
+function readWorktreeBranch(git: GitExec, worktree: string): string | null {
+  const r = git(['-C', worktree, 'rev-parse', '--abbrev-ref', 'HEAD']);
+  if (r.exitCode !== 0) return null;
+  const b = r.stdout.trim();
+  return b && b !== 'HEAD' ? b : null;
+}
+
+/**
+ * Enumerate the absolute paths of every git worktree under
+ * `<repoRoot>/.claude/worktrees`. Uses `git worktree list --porcelain` so the
+ * set is authoritative (no directory-name guessing). Returns [] on any failure.
+ */
+function listManagedWorktrees(git: GitExec, repoRoot: string): string[] {
+  const r = git(['-C', repoRoot, 'worktree', 'list', '--porcelain']);
+  if (r.exitCode !== 0) return [];
+  const prefix = join(repoRoot, '.claude', 'worktrees');
+  const paths: string[] = [];
+  for (const line of r.stdout.split('\n')) {
+    const m = /^worktree (.+)$/.exec(line.trim());
+    if (m && m[1].startsWith(prefix)) paths.push(m[1]);
+  }
+  return paths;
+}
+
+/**
+ * Derive the rescue targets for THIS run.
+ *
+ * Base set: the case ids the run reported through `IMPLEMENT` stream markers
+ * (`cases`). This is scoped to the run's own worktrees only.
+ *
+ * #1270 union: when `opts.runTag` + `opts.git` are supplied, also include any
+ * on-disk managed worktree whose per-worktree `kaizen.runtag` equals this run's
+ * tag. This recovers worktrees created *before* the marker was emitted (the
+ * crash-before-marker strand that previously forced manual `[rescue]` PRs).
+ *
+ * Concurrency safety is structural: a worktree stamped with a *different*
+ * runtag — or with no stamp at all — is never attributed to this run, so a
+ * sibling run's in-progress WIP can never be swept up. Targets are de-duplicated
+ * by worktree path, with the marker-derived branch taking precedence.
+ */
+export function collectRunWorktrees(
+  repoRoot: string,
+  cases: string[],
+  opts: CollectRunWorktreesOptions = {},
+): RescueTarget[] {
+  const byPath = new Map<string, RescueTarget>();
+
   for (const caseId of cases) {
     if (!caseId) continue;
     const worktree = join(repoRoot, '.claude', 'worktrees', caseId);
     if (!existsSync(worktree)) continue;
-    targets.push({ worktree, branch: `case/${caseId}` });
+    byPath.set(worktree, { worktree, branch: `case/${caseId}` });
   }
-  return targets;
+
+  if (opts.runTag && opts.git) {
+    const git = opts.git;
+    for (const worktree of listManagedWorktrees(git, repoRoot)) {
+      if (byPath.has(worktree) || !existsSync(worktree)) continue;
+      if (readWorktreeRunTag(git, worktree) !== opts.runTag) continue;
+      const branch = readWorktreeBranch(git, worktree);
+      if (!branch) continue; // detached/unknown — can't safely push
+      byPath.set(worktree, { worktree, branch });
+    }
+  }
+
+  return [...byPath.values()];
 }
 
 /** Default deps wiring the shared primitives (used by the finalizer). */

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -188,6 +188,7 @@ import {
   rescueRun,
   defaultRescueDeps,
 } from './auto-dent-rescue.js';
+import { createDefaultGitExec } from '../src/hooks/lib/git-state.js';
 
 // Types
 
@@ -1750,12 +1751,22 @@ async function runClaude(
   const maxRunMs =
     (state.max_run_seconds || DEFAULT_MAX_RUN_SECONDS) * 1000;
 
+  // #1270: expose this run's identity to the spawned agent. The
+  // capture-worktree-context hook reads KAIZEN_RUN_TAG to stamp every case
+  // worktree the agent creates, giving the rescue finalizer a durable,
+  // run-scoped attribution signal independent of stream markers.
+  // (Local names are agent-prefixed to stay clear of the canonical post-run
+  // `runId` declaration guarded by the #1128 regression test.)
+  const agentRunTag = `${state.batch_id}/run-${runNum}`;
+  const agentRunId = makeRunId(state.batch_id, runNum);
+
   return new Promise((resolvePromise) => {
     let processExited = false;
 
     const child = spawn('claude', args, {
       cwd: repoRoot,
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, KAIZEN_RUN_TAG: agentRunTag, KAIZEN_RUN_ID: agentRunId },
     });
 
     const cleanup = (...timers: (ReturnType<typeof setInterval> | ReturnType<typeof setTimeout> | undefined)[]) => {
@@ -2825,7 +2836,14 @@ async function main(): Promise<void> {
   // THIS run's own case worktrees; best-effort and fully guarded so a rescue
   // failure can never hide or block the original run outcome.
   try {
-    const targets = collectRunWorktrees(repoRoot, result.cases);
+    // #1270: union the marker-reported cases with any on-disk case worktree
+    // stamped with THIS run's tag, so work stranded *before* the IMPLEMENT
+    // marker (crash/SIGKILL) is still rescued. The runtag scan is run-scoped and
+    // concurrency-safe — a sibling run's worktrees carry a different tag.
+    const targets = collectRunWorktrees(repoRoot, result.cases, {
+      runTag,
+      git: createDefaultGitExec(),
+    });
     if (targets.length > 0) {
       const { reason: failureReason } = classifyRunExit({
         exitCode,


### PR DESCRIPTION
## The problem

The #1255 rescue finalizer was built to end the era of manual `[rescue]` PRs — when an auto-dent run dies abnormally with stranded work, it preserves that work as a clearly-marked draft PR instead of letting it vanish. But it had a blind spot.

The finalizer only knows about worktrees the agent *reported* through the `IMPLEMENT | case=… branch=…` stream marker (`result.cases`). If a run is SIGKILLed (wall-clock watchdog) or crashes **after** `git worktree add case/…` but **before** emitting that marker, `result.cases` is empty — so the rescue never sees the worktree, and the work is stranded anyway. This is the exact `double-barracuda/run-3` shape that #1255 documented, and it kept the `#1252–#1260` manual-rescue cluster alive.

## Why the obvious fix is wrong

"Just scan every `case/*` worktree" is unsafe. Many auto-dent batches run concurrently (the live tree routinely has 15+ case worktrees from different runs). A blind scan would sweep up a sibling run's in-progress WIP and commit/push it under a rescue banner.

## The fix — durable run attribution stamped at creation time

The root cause is that the rescue's only attribution signal (the stream marker) is produced *late* and only if the agent survives to emit it. So we give each case worktree a durable, run-scoped signal the instant it is created:

1. **Runner** (`auto-dent-run.ts`) exports `KAIZEN_RUN_TAG` / `KAIZEN_RUN_ID` into the spawned agent's environment.
2. **Stamp** (`kaizen-capture-worktree-context.sh`, PostToolUse-on-Bash) detects a successful `git worktree add case/*` and writes `git config --worktree kaizen.runtag "$KAIZEN_RUN_TAG"` on the new worktree. `--worktree` scope is concurrency-safe (it can't clobber a sibling), and editing a hook body hot-reloads — no plugin.json change, no restart.
3. **Union** (`collectRunWorktrees` in `auto-dent-rescue.ts`) now unions the marker cases with any on-disk managed worktree whose `kaizen.runtag` equals *this* run's tag, de-duplicated, with the branch derived from the worktree's actual `HEAD`.

Concurrency safety is structural, not heuristic: a worktree stamped with a **different** runtag — or with **no** stamp — is never attributed to this run.

## Evidence

- `scripts/auto-dent-rescue.test.ts` — 7 new unit tests: union of marker + runtag worktrees; foreign-runtag exclusion (concurrency safety); unstamped exclusion; marker/runtag de-dup; HEAD-derived branch (not directory-name guess); detached-HEAD skip; marker-only back-compat.
- `.claude/hooks/tests/test-capture-worktree-runtag.sh` — exercises the **real** `git config --worktree` stamp path against a throwaway repo+worktree: stamps a case worktree when the env var is set, no-ops when unset, no-ops on a non-`case/*` branch, no-ops on a non-worktree command.
- Full `npx tsc --noEmit` clean; `auto-dent-rescue` + `auto-dent-run` + `auto-dent-events` suites green (352 tests); hook integrity check passes. (Two unrelated `src/e2e/synthetic-workflow` + `setup-e2e` cases flake under full-suite parallel load and pass in isolation — known `project_fleet_load_test_flakiness`; the hook addition takes the fast path when `KAIZEN_RUN_TAG` is unset, so it cannot affect those sessions.)

## Behaviors × levels

| Behavior | Unit | Integration | System |
|----------|:----:|:-----------:|:------:|
| Union marker cases + runtag-stamped worktrees | ✅ | | |
| Foreign-runtag worktree excluded (concurrency) | ✅ | | |
| Unstamped / detached worktree excluded | ✅ | | |
| Marker+runtag de-dup; HEAD-derived branch | ✅ | | |
| Hook stamps runtag on `git worktree add case/*` | | ✅ (shell) | |
| Hook no-ops without env / on non-case / non-worktree | | ✅ (shell) | |

## Impact

Closes the last structural gap that forced manual `[rescue]` PRs: work stranded *before* the IMPLEMENT marker is now recovered automatically and safely, while concurrent runs stay isolated.

Closes #1270
Refs #1255, #1269, #1006

Run tag: handsome-lynx/run-3
