### PR TITLE
refactor(github): reuse gh-exec in issue backend

### DIFF
--- a/src/issue-backend.test.ts
+++ b/src/issue-backend.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -86,5 +86,56 @@ describe("createIssueBackend", () => {
   it("defaults to github for unknown backend", () => {
     const backend = createIssueBackend({ backend: "github" });
     expect(backend.name).toBe("github");
+  });
+});
+
+describe("GitHubBackend gh execution", () => {
+  it("passes GitHub issue create arguments through the shared argv-based gh helper", async () => {
+    vi.resetModules();
+    const spawnSync = vi.fn(() => ({
+      status: 0,
+      stdout: "https://github.com/Garsson-io/kaizen/issues/42\n",
+      stderr: "",
+    }));
+    const execSync = vi.fn(() => "https://github.com/Garsson-io/kaizen/issues/42");
+    vi.doMock("node:child_process", () => ({ spawnSync, execSync }));
+
+    try {
+      const { GitHubBackend: MockedGitHubBackend } = await import("./issue-backend.js");
+
+      const result = new MockedGitHubBackend().create({
+        repo: "Garsson-io/kaizen",
+        title: "Title with spaces; $(touch nope)",
+        body: "Body with `backticks` and \"quotes\"",
+        labels: ["kaizen", "needs review"],
+      });
+
+      expect(result).toEqual({
+        number: 42,
+        url: "https://github.com/Garsson-io/kaizen/issues/42",
+      });
+      expect(spawnSync).toHaveBeenCalledWith("gh", [
+        "issue",
+        "create",
+        "--repo",
+        "Garsson-io/kaizen",
+        "--title",
+        "Title with spaces; $(touch nope)",
+        "--body",
+        "Body with `backticks` and \"quotes\"",
+        "--label",
+        "kaizen",
+        "--label",
+        "needs review",
+      ], {
+        encoding: "utf8",
+        timeout: 30_000,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      expect(execSync).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
   });
 });

--- a/src/issue-backend.ts
+++ b/src/issue-backend.ts
@@ -30,6 +30,7 @@ import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
+import { gh } from "./lib/gh-exec.js";
 
 // ── Types ──
 
@@ -122,10 +123,6 @@ function shellExec(bin: string, args: string[]): string {
 export class GitHubBackend implements IssueBackend {
   readonly name = "github";
 
-  private gh(args: string[]): string {
-    return shellExec("gh", args);
-  }
-
   create(opts: CreateIssueOpts): CreateResult {
     const args = ["issue", "create"];
     if (opts.repo) args.push("--repo", opts.repo);
@@ -134,7 +131,7 @@ export class GitHubBackend implements IssueBackend {
     for (const label of opts.labels ?? []) {
       args.push("--label", label);
     }
-    const url = this.gh(args);
+    const url = gh(args);
     const match = url.match(/\/(\d+)$/);
     return { number: match ? parseInt(match[1], 10) : 0, url };
   }
@@ -152,7 +149,7 @@ export class GitHubBackend implements IssueBackend {
     const jsonFields = opts.json ?? ["number", "title", "state", "labels", "body", "url", "createdAt", "updatedAt"];
     args.push("--json", jsonFields.join(","));
 
-    const output = this.gh(args);
+    const output = gh(args);
     if (!output) return [];
     return (JSON.parse(output) as any[]).map(parseRawIssue);
   }
@@ -161,7 +158,7 @@ export class GitHubBackend implements IssueBackend {
     const args = ["issue", "view", String(number)];
     if (repo) args.push("--repo", repo);
     args.push("--json", "number,title,state,labels,body,url,createdAt,updatedAt,closedAt");
-    return parseRawIssue(JSON.parse(this.gh(args)));
+    return parseRawIssue(JSON.parse(gh(args)));
   }
 
   edit(opts: EditIssueOpts): void {
@@ -174,26 +171,26 @@ export class GitHubBackend implements IssueBackend {
       args.push("--remove-label", label);
     }
     if (opts.body !== undefined) args.push("--body", opts.body);
-    this.gh(args);
+    gh(args);
   }
 
   comment(opts: CommentOpts): void {
     const args = ["issue", "comment", String(opts.number)];
     if (opts.repo) args.push("--repo", opts.repo);
     args.push("--body", opts.body);
-    this.gh(args);
+    gh(args);
   }
 
   close(number: number, repo?: string): void {
     const args = ["issue", "close", String(number)];
     if (repo) args.push("--repo", repo);
-    this.gh(args);
+    gh(args);
   }
 
   reopen(number: number, repo?: string): void {
     const args = ["issue", "reopen", String(number)];
     if (repo) args.push("--repo", repo);
-    this.gh(args);
+    gh(args);
   }
 }
 


### PR DESCRIPTION
## Story

Once upon a time, Kaizen had a shared GitHub CLI helper in `src/lib/gh-exec.ts` for strict argv-based `gh` calls. Every day, new GitHub tooling could use that helper and avoid shell-string command construction.

One day, the #1164 DRY sweep and the #1277 gh-exec consolidation exposed one remaining GitHub-specific duplicate: `GitHubBackend` still had a private `gh(args)` method that routed through `shellExec("gh", args)` and `execSync`.

Because of that, this PR moves the GitHub issue backend onto the shared strict `gh(args)` helper and removes the private wrapper. The generic `shellExec` path stays in place for `CustomCliBackend`, where arbitrary non-GitHub CLIs are still in scope.

Because of that, the new regression test proves issue titles, bodies, repos, and labels with spaces and shell metacharacters are passed as literal argv entries to `spawnSync("gh", ...)`, not rebuilt into a shell command.

Until finally, local verification shows the issue backend tests and gh-exec tests pass together, typecheck passes, and the grep guard finds no remaining `GitHubBackend` private gh wrapper patterns.

And ever since, GitHub issue backend execution follows the same single owned primitive as other shared GitHub CLI code.

Closes #1279

Parent: #1164
Related: #1277

## Architecture

```text
GitHubBackend
  -> src/lib/gh-exec.ts gh(args)
       -> spawnSync("gh", argv)

CustomCliBackend
  -> shellExec(customCli, args)
       -> execSync(command string)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use `gh(args)` directly in `GitHubBackend` | Removes the duplicate GitHub-specific wrapper and keeps one owner for strict gh execution | `GitHubBackend` now imports the shared lib directly |
| Leave `shellExec` for `CustomCliBackend` | Custom backends can target arbitrary binaries, not just `gh` | Generic CLI execution remains a separate path by design |
| Test argv behavior through mocked `spawnSync` | Proves spaces and shell metacharacters stay literal | Test uses module reset/mock mechanics to isolate the import path |

## What Changed

| File | Purpose |
|---|---|
| `src/issue-backend.ts` | Imports `gh` from `src/lib/gh-exec.ts`, removes `GitHubBackend.gh()`, and replaces `this.gh(args)` calls with `gh(args)` |
| `src/issue-backend.test.ts` | Adds a regression test proving `GitHubBackend.create()` uses argv-based `spawnSync("gh", ...)` and not `execSync` |

## Test Plan (Behaviors x Levels)

| Behavior | L0 Static | L1 Unit | L2 Integration/CI | Status |
|---|---|---|---|---|
| `GitHubBackend` uses shared argv-based `gh(args)` | Grep guard for removed private wrapper patterns | `src/issue-backend.test.ts` mocks `spawnSync` and asserts exact argv | Normal CI test/typecheck jobs | Tested |
| `CustomCliBackend` remains generic | Diff review keeps `shellExec(this.cli, args)` unchanged | Existing backend factory/config tests remain green | Normal CI test/typecheck jobs | Tested |
| Shared gh helper remains stable | `src/lib/gh-exec.ts` unchanged except as dependency | Existing `src/lib/gh-exec.test.ts` passes | Normal CI test/typecheck jobs | Tested |

## Validation

- RED: `npm test -- --run src/issue-backend.test.ts` failed because `spawnSync` had 0 calls on the old implementation.
- GREEN: `npm test -- --run src/issue-backend.test.ts src/lib/gh-exec.test.ts` passed, 22 tests.
- GREEN: `npm run typecheck` passed.
- GREEN: `rg -n "private gh\(|shellExec\(\"gh\"|this\.gh\(" src/issue-backend.ts src/lib/gh-exec.ts src/issue-backend.test.ts` returned no matches.
- GREEN: `git diff --check` passed.

## Known Limitations

This PR only removes the `GitHubBackend` duplicate helper. Other unrelated `execSync gh ...` call sites in hooks/scripts remain out of scope for separate small refactor slices.
