### PR TITLE
refactor(github): share non-throwing gh result helper

### DIFF
--- a/src/hooks/lib/issue-ref-verifier.ts
+++ b/src/hooks/lib/issue-ref-verifier.ts
@@ -16,7 +16,7 @@
  *                    a flaky network must never deadlock a run.
  */
 
-import { spawnSync } from 'node:child_process';
+import { ghResult } from '../../lib/gh-exec.js';
 
 export type RefStatus = 'exists' | 'missing' | 'unverifiable';
 
@@ -32,18 +32,7 @@ export type GhRunner = (args: string[]) => {
   stderr: string;
 };
 
-const defaultRunner: GhRunner = (args) => {
-  const r = spawnSync('gh', args, {
-    encoding: 'utf8',
-    timeout: 15_000,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  return {
-    status: r.status ?? 1,
-    stdout: r.stdout ?? '',
-    stderr: r.stderr ?? '',
-  };
-};
+const defaultRunner: GhRunner = (args) => ghResult(args, 15_000);
 
 /**
  * Parse an issue/PR reference. Accepts: a full github URL, `owner/repo#N`,

--- a/src/lib/gh-exec.test.ts
+++ b/src/lib/gh-exec.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { gh, ghExec, parseGhCommandArgs } from './gh-exec.js';
+import { gh, ghExec, ghResult, parseGhCommandArgs } from './gh-exec.js';
 
 vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(),
@@ -9,6 +9,77 @@ vi.mock('node:child_process', () => ({
 const mockSpawn = vi.mocked(spawnSync);
 
 beforeEach(() => vi.clearAllMocks());
+
+describe('ghResult — non-throwing shared GitHub CLI helper', () => {
+  it('returns normalized status/stdout/stderr on success', () => {
+    mockSpawn.mockReturnValueOnce({
+      status: 0,
+      stdout: '  hello world  \n',
+      stderr: '  note  \n',
+      signal: null,
+      pid: 0,
+      output: [],
+    } as any);
+
+    expect(ghResult(['issue', 'view', '1'])).toEqual({
+      status: 0,
+      stdout: 'hello world',
+      stderr: 'note',
+    });
+  });
+
+  it('preserves non-zero status without throwing', () => {
+    mockSpawn.mockReturnValueOnce({
+      status: 2,
+      stdout: '  partial  \n',
+      stderr: '  permission denied  \n',
+      signal: null,
+      pid: 0,
+      output: [],
+    } as any);
+
+    expect(ghResult(['issue', 'view', '999'])).toEqual({
+      status: 2,
+      stdout: 'partial',
+      stderr: 'permission denied',
+    });
+  });
+
+  it('normalizes timeout/null status to status 1', () => {
+    mockSpawn.mockReturnValueOnce({
+      status: null,
+      stdout: '',
+      stderr: '',
+      signal: 'SIGTERM',
+      pid: 0,
+      output: [],
+    } as any);
+
+    expect(ghResult(['issue', 'view', '1'])).toEqual({
+      status: 1,
+      stdout: '',
+      stderr: '',
+    });
+  });
+
+  it('passes custom timeout to spawnSync', () => {
+    mockSpawn.mockReturnValueOnce({
+      status: 0,
+      stdout: 'ok',
+      stderr: '',
+      signal: null,
+      pid: 0,
+      output: [],
+    } as any);
+
+    ghResult(['issue', 'list'], 15_000);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gh',
+      ['issue', 'list'],
+      expect.objectContaining({ timeout: 15_000 }),
+    );
+  });
+});
 
 describe('gh — shared GitHub CLI helper', () => {
   it('returns trimmed stdout on success', () => {

--- a/src/lib/gh-exec.ts
+++ b/src/lib/gh-exec.ts
@@ -7,17 +7,33 @@
 
 import { spawnSync } from 'node:child_process';
 
-/** Run a gh CLI command and return trimmed stdout. Throws on non-zero exit. */
-export function gh(args: string[], timeoutMs: number = 30_000): string {
+export interface GhResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run a gh CLI command and return status/stdout/stderr without throwing. */
+export function ghResult(args: string[], timeoutMs: number = 30_000): GhResult {
   const result = spawnSync('gh', args, {
     encoding: 'utf8',
     timeout: timeoutMs,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout?.trim() ?? '',
+    stderr: result.stderr?.trim() ?? '',
+  };
+}
+
+/** Run a gh CLI command and return trimmed stdout. Throws on non-zero exit. */
+export function gh(args: string[], timeoutMs: number = 30_000): string {
+  const result = ghResult(args, timeoutMs);
   if (result.status !== 0) {
-    throw new Error(`gh ${args.slice(0, 3).join(' ')} failed: ${result.stderr?.trim()}`);
+    throw new Error(`gh ${args.slice(0, 3).join(' ')} failed: ${result.stderr}`);
   }
-  return result.stdout?.trim() ?? '';
+  return result.stdout;
 }
 
 /**


### PR DESCRIPTION
## Story

Once upon a time, `src/lib/gh-exec.ts` owned the shared strict and tolerant GitHub CLI helpers. Every day, callers that wanted stdout could use `gh(args)` or the migration-oriented `ghExec(cmd)` without owning `spawnSync("gh", ...)` themselves.

One day, the DRY sweep found one remaining status-preserving GitHub probe in `src/hooks/lib/issue-ref-verifier.ts`. That verifier needs to distinguish `exists`, `missing`, and `unverifiable`, so it cannot use the throwing `gh(args)` helper directly. It had a local `defaultRunner` with its own `spawnSync("gh", ...)` defaults.

Because of that, this PR adds `ghResult(args, timeoutMs)` to `src/lib/gh-exec.ts`: a shared non-throwing helper that returns `{ status, stdout, stderr }`. The strict `gh(args)` helper now delegates through it, so throwing and non-throwing paths share one spawn implementation and normalization rule.

Because of that, `issue-ref-verifier` keeps its injectable `GhRunner` contract and fail-open semantics, but its default runner now calls `ghResult(args, 15_000)` instead of owning a local child-process wrapper.

Until finally, focused tests prove the new helper on success, non-zero exit, timeout/null-status normalization, and custom timeout, while the verifier tests still pass for `exists`, `missing`, and `unverifiable`.

And ever since, status-preserving GitHub probes have the same shared owner as strict GitHub CLI execution.

Closes #1283

Parent: #1164
Related: #1277, #1279

## Architecture

```text
shared gh execution
  ghResult(args, timeout) -> spawnSync("gh", argv) -> { status, stdout, stderr }
      ^
      |
  gh(args, timeout) -> throws on non-zero, returns stdout on success

issue-ref-verifier default runner
  verifyIssueRef(...) -> ghResult(args, 15_000) -> status-based exists/missing/unverifiable
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add `ghResult` instead of weakening `gh` | `verifyIssueRef` needs non-throwing status inspection, while existing `gh` callers rely on exceptions | One more public helper, but it is the lower-level primitive both paths share |
| Make `gh` delegate through `ghResult` | Keeps spawn defaults and stdout/stderr normalization in one place | Error formatting now uses already-trimmed stderr |
| Preserve `GhRunner` injection | Existing verifier tests and fail-open modeling stay simple | The verifier still has a small default-runner adapter for timeout selection |

## What Changed

| File | Purpose |
|---|---|
| `src/lib/gh-exec.ts` | Adds `GhResult`/`ghResult()` and makes `gh()` delegate through it |
| `src/lib/gh-exec.test.ts` | Adds focused coverage for non-throwing result behavior |
| `src/hooks/lib/issue-ref-verifier.ts` | Removes direct `spawnSync` ownership and uses `ghResult(args, 15_000)` as the default runner |

## Test Plan (Behaviors x Levels)

| Behavior | L0 Static | L1 Unit | L2 CI | Status |
|---|---|---|---|---|
| Shared non-throwing gh result helper preserves status/stdout/stderr | Export shape and grep guard show one spawn owner | `src/lib/gh-exec.test.ts` covers success, non-zero, timeout/null-status, and timeout option | Normal CI tests/typecheck | Tested |
| Strict `gh(args)` still throws/returns stdout | `gh()` delegates through `ghResult` | Existing `gh` tests pass unchanged | Normal CI tests/typecheck | Tested |
| Issue-ref verifier semantics stay unchanged | Diff only changes default runner plumbing | `src/hooks/lib/issue-ref-verifier.test.ts` covers exists/missing/unverifiable paths through injected runners | Normal CI tests/typecheck | Tested |

## Validation

- RED: `npm test -- --run src/lib/gh-exec.test.ts` failed because `ghResult` was not exported.
- GREEN: `npm test -- --run src/lib/gh-exec.test.ts src/hooks/lib/issue-ref-verifier.test.ts` passed, 32 tests.
- GREEN: `npm run typecheck` passed.
- GREEN: `rg -n "spawnSync\('gh'|spawnSync\(\"gh\"|from 'node:child_process'" src/lib/gh-exec.ts src/hooks/lib/issue-ref-verifier.ts` shows direct child-process gh execution only in `src/lib/gh-exec.ts`.
- GREEN: `git diff --check` passed.

## Known Limitations

This PR only consolidates the status-preserving issue-ref verifier path. Other unrelated hook/script `execSync gh ...` call sites remain separate follow-up slices.
