### PR TITLE
fix(auto-dent): rescue skips redundant PR on already-merged branch (I7) (#1284)

### DIFF
--- a/scripts/auto-dent-rescue.test.ts
+++ b/scripts/auto-dent-rescue.test.ts
@@ -77,6 +77,47 @@ describe('decideRescueAction', () => {
     expect(a.kind).toBe('push-existing');
     expect(a.commitDirty).toBe(true);
   });
+
+  // #1284 supersede guard / #1282 regression: a branch whose most-recent PR
+  // merged with no open PR must NOT get a fresh rescue PR even with work ahead
+  // of base — pushing to a merged branch violates I7.
+  it('does nothing when the most-recent PR merged with no open PR (I7 supersede)', () => {
+    const a = decideRescueAction({
+      commitsAheadBase: 3,
+      unpushedCommits: 0,
+      dirtyTotal: 2,
+      existingOpenPr: null,
+      mostRecentMerged: true,
+    });
+    expect(a.kind).toBe('none');
+    expect(a.commitDirty).toBe(false);
+    expect(a.reason).toMatch(/merged|I7/i);
+  });
+
+  // The supersede guard must not fire when an open PR exists — that path keeps
+  // precedence and still extends the open PR.
+  it('still extends an open PR even if mostRecentMerged is mistakenly set', () => {
+    const a = decideRescueAction({
+      commitsAheadBase: 5,
+      unpushedCommits: 2,
+      dirtyTotal: 0,
+      existingOpenPr: 'https://x/pr/1',
+      mostRecentMerged: true,
+    });
+    expect(a.kind).toBe('push-existing');
+  });
+
+  // A merged branch with NO work is also `none` — same outcome, distinct reason.
+  it('does nothing for a merged branch with no work', () => {
+    const a = decideRescueAction({
+      commitsAheadBase: 0,
+      unpushedCommits: 0,
+      dirtyTotal: 0,
+      existingOpenPr: null,
+      mostRecentMerged: true,
+    });
+    expect(a.kind).toBe('none');
+  });
 });
 
 describe('formatRescueReport', () => {
@@ -135,11 +176,27 @@ function makeFakeGit(cfg: FakeGitConfig, log: string[][]): GitExec {
   };
 }
 
-function makeFakeGh(prList: string | null, ghLog: string[][]): (args: string[]) => string {
+/**
+ * Fake `gh`. `pr` describes the most-recent PR on the branch as `queryBranchPrState`
+ * sees it (`{ number, state, url }`):
+ *   - a bare string  → an OPEN PR at that url (back-compat for existing callers)
+ *   - an object      → an explicit state (e.g. MERGED) for supersede-guard tests
+ *   - null           → no PR on the branch
+ */
+function makeFakeGh(
+  pr: string | { number?: number; state: 'OPEN' | 'MERGED' | 'CLOSED'; url: string } | null,
+  ghLog: string[][],
+): (args: string[]) => string {
+  const summary =
+    pr == null
+      ? null
+      : typeof pr === 'string'
+        ? { number: 1, state: 'OPEN' as const, url: pr }
+        : { number: pr.number ?? 1, state: pr.state, url: pr.url };
   return (args) => {
     ghLog.push([...args]);
     if (args[0] === 'pr' && args[1] === 'list') {
-      return prList ? JSON.stringify([{ url: prList }]) : '[]';
+      return summary ? JSON.stringify([summary]) : '[]';
     }
     if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/x/pull/999';
     if (args[0] === 'pr' && args[1] === 'comment') return '';
@@ -205,6 +262,28 @@ describe('rescueTarget orchestration', () => {
     );
     expect(out.action).toBe('none');
     expect(out.pushed).toBe(false);
+    expect(gitLog.some((a) => a.includes('push'))).toBe(false);
+    expect(ghLog.some((a) => a[1] === 'create' || a[1] === 'comment')).toBe(false);
+  });
+
+  // #1282 end-to-end: a branch whose most-recent PR already MERGED (and no open
+  // PR) must produce NO push and NO PR create — the rescue declines to add a
+  // redundant draft on a merged branch.
+  it('does nothing when the branch already has a merged PR (no open PR)', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      ctx,
+      {
+        git: makeFakeGit({ aheadBase: 3 }, gitLog),
+        gh: makeFakeGh({ state: 'MERGED', url: 'https://x/pr/1280' }, ghLog),
+        readDirty: makeReadDirty(2),
+      },
+    );
+    expect(out.action).toBe('none');
+    expect(out.pushed).toBe(false);
+    expect(out.prUrl).toBeUndefined();
     expect(gitLog.some((a) => a.includes('push'))).toBe(false);
     expect(ghLog.some((a) => a[1] === 'create' || a[1] === 'comment')).toBe(false);
   });

--- a/scripts/auto-dent-rescue.ts
+++ b/scripts/auto-dent-rescue.ts
@@ -16,8 +16,13 @@
  * output clearly as NOT-VALIDATED. A rescue failure is recorded but never
  * hides the original run failure.
  *
- * DRY (#1164): reuses `readDirtyFiles`/`GitExec` from src/hooks/lib/git-state.ts
- * and `gh` from src/lib/gh-exec.ts — no new porcelain parser or gh wrapper.
+ * DRY (#1164): reuses `readDirtyFiles`/`GitExec` from src/hooks/lib/git-state.ts,
+ * `gh` from src/lib/gh-exec.ts, and `queryBranchPrState` from src/lib/github-pr.ts
+ * — no new porcelain parser, gh wrapper, or second branch-PR query mechanism.
+ *
+ * Gate correctness (#1284): the branch-PR query also surfaces the I7 "merged
+ * branch" state, so the rescue path refuses to open a redundant PR on a branch
+ * whose PR already merged (the #1282/#1280 supersede race).
  */
 
 import { existsSync } from 'node:fs';
@@ -29,7 +34,7 @@ import {
   type DirtyState,
 } from '../src/hooks/lib/git-state.js';
 import { gh as defaultGh } from '../src/lib/gh-exec.js';
-import { findOpenPrUrlForBranch } from '../src/lib/github-pr.js';
+import { queryBranchPrState } from '../src/lib/github-pr.js';
 
 /** Quality gates a rescue deliberately skips — surfaced in the rescue report. */
 export const SKIPPED_GATES: readonly string[] = [
@@ -82,6 +87,15 @@ export interface RescueDecisionInput {
   dirtyTotal: number;
   /** URL of an open PR already targeting this branch, or null. */
   existingOpenPr: string | null;
+  /**
+   * True when the most-recent PR for the branch is MERGED and there is no open
+   * PR — the I7 "merged branch" state. Pushing to or opening a PR on such a
+   * branch is forbidden (CLAUDE.md branch hygiene), and in the rescue path it
+   * is the #1282 supersede race: the branch's PR merged seconds before the
+   * rescue ran, so an open-only lookup saw no PR and would manufacture a
+   * redundant draft. Defaults to false.
+   */
+  mostRecentMerged?: boolean;
 }
 
 export interface RescueAction {
@@ -111,6 +125,19 @@ export function decideRescueAction(input: RescueDecisionInput): RescueAction {
           reason: `extend existing PR ${input.existingOpenPr} (${input.unpushedCommits} unpushed, ${input.dirtyTotal} dirty)`,
         }
       : { kind: 'none', commitDirty: false, reason: 'open PR already has all work; nothing to rescue' };
+  }
+  // I7 supersede guard: a branch whose most-recent PR merged with no newer open
+  // PR must never be pushed to or get a fresh PR (CLAUDE.md branch hygiene). This
+  // is the #1282 race — the branch's PR (#1280) merged 12s before the rescue ran,
+  // so an open-only lookup saw no PR and would otherwise manufacture a redundant
+  // draft for work already on main. The open-PR path above keeps precedence (an
+  // open PR means mostRecentMerged is false), so a healthy PR is unaffected.
+  if (input.mostRecentMerged) {
+    return {
+      kind: 'none',
+      commitDirty: false,
+      reason: 'branch already has a merged PR and no open PR — work shipped; not pushing to a merged branch (I7)',
+    };
   }
   const hasWork = input.commitsAheadBase > 0 || input.dirtyTotal > 0;
   return hasWork
@@ -240,9 +267,13 @@ export function rescueTarget(target: RescueTarget, ctx: RescueContext, deps: Res
 
   const commitsAheadBase = countRevList(git, target.worktree, `${base}..HEAD`);
   const unpushedCommits = countRevList(git, target.worktree, '@{u}..HEAD');
-  const existingOpenPr = findOpenPrUrlForBranch({ gh, repo: ctx.repo, branch: target.branch }) ?? null;
+  // One branch-PR query (shared helper) yields BOTH the open-PR push target and
+  // the merged-branch supersede signal — no second, open-only query mechanism.
+  const prState = queryBranchPrState({ gh, repo: ctx.repo, branch: target.branch });
+  const existingOpenPr = prState.openUrl ?? null;
+  const mostRecentMerged = prState.mostRecent?.state === 'MERGED' && !prState.hasOpen;
 
-  const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr });
+  const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr, mostRecentMerged });
   outcome.action = action.kind;
   if (action.kind === 'none') {
     log?.(`${target.branch}: ${action.reason}`);


### PR DESCRIPTION
## The strand that wouldn't stay rescued

The auto-dent **rescue finalizer** (#1255/#1270) exists to retire one specific chore: the manual `[rescue]` PR. When a run dies abnormally, it preserves the stranded worktree so an operator never has to file a recovery PR by hand. It worked — except it started manufacturing the very PRs it was meant to eliminate.

## Discovery

PR **#1282** (`[rescue] handsome-lynx/run-3`) was opened at `21:55:47Z` on branch `case/260628-k1270-rescue-runtag-attribution`. PR **#1280** had *merged that exact branch* at `21:55:35Z` — **12 seconds earlier**. The rescue created a redundant draft for work that was already on `main`.

The cause is structural, not a one-off. `rescueTarget` resolved branch PR state with `findOpenPrUrlForBranch` — an **open-only** query. A branch whose PR merged seconds ago has no *open* PR, so the lookup returned `null`, `decideRescueAction` fell through to `create-draft`, and a redundant PR was born. This is also a clean **I7** violation: *"no push to a branch whose most-recent PR merged with no newer open PR."* The rescue path was the one push site in the repo not honoring it.

An open-only blind spot will keep missing just-merged branches on every future supersede race (the #1252–#1260 / #1282 pileup class).

## The fix

**One query, two answers.** The richer `queryBranchPrState` helper (`src/lib/github-pr.ts`) already classifies the most-recent PR as MERGED/CLOSED/OPEN and reports `hasOpen`/`openUrl`. Swapping the open-only call for it gives `rescueTarget` *both* the open-PR push target **and** the merged-branch supersede signal from a single query — no second branch-PR mechanism to drift (the #1164 DRY class).

**An I7-aware guard.** `decideRescueAction` gains a `mostRecentMerged` input. When the most-recent PR merged with no open PR, it returns `kind: 'none'` (reason cites I7) instead of opening a redundant PR. The existing open-PR `push-existing` path keeps precedence — an open PR means `mostRecentMerged` is false, so healthy PRs are untouched.

## Evidence

`scripts/auto-dent-rescue.test.ts` — 30/30 green, including new prevention tests:

| Behavior | Level |
|----------|-------|
| merged-no-open branch → `none` (reason cites I7) — #1282 regression | Unit |
| open PR present → `push-existing` unchanged (guard inert) | Unit |
| no PR + work → `create-draft` unchanged | Unit |
| merged branch end-to-end → no push, no `pr create`/`comment` | Unit (injected gh) |

`npx tsc --noEmit` clean. `github-pr` + `pr-review-loop` suites green (43/43). The 7 full-suite failures are pre-existing e2e/reflect **load-timeouts** under the concurrent batch (kaizen-reflect passes 23/23 in isolation) — untouched by this two-file diff.

## Impact

The rescue finalizer stops re-creating the manual `[rescue]` PRs it was built to retire, and the rescue push path now honors I7 like every other push site. Superseded PR **#1282** is closed as part of this work.

Closes #1284
Parent: #1164
Refs: #1270, #1280, #1282, #374

Run tag: handsome-lynx/run-4
