### PR TITLE
refactor(auto-dent): reuse ghResult for summary comments

### DIFF
--- a/scripts/auto-dent.test.ts
+++ b/scripts/auto-dent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mkdtempSync, readFileSync, existsSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -12,6 +12,7 @@ import {
   stopDecision,
   writeBatchSummary,
   formatBatchSummary,
+  postStructuredSummary,
   type AutoDentOptions,
 } from './auto-dent.js';
 import { readState, writeState, type BatchState } from './auto-dent-run.js';
@@ -255,5 +256,57 @@ describe('batch summary', () => {
     expect(formatted).toContain('auto-dent — Batch Summary');
     expect(formatted).toContain('PRs created: none');
     expect(formatted).toContain('Runs:      0');
+  });
+});
+
+describe('postStructuredSummary', () => {
+  it('posts generated batch summary through the shared ghResult-compatible seam', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'auto-dent-summary-test-'));
+    try {
+      writeFileSync(join(dir, 'events.jsonl'), '{}\n');
+      const postIssueComment = vi.fn(() => ({ status: 0, stdout: '', stderr: '' }));
+
+      postStructuredSummary('scripts', dir, '1286', 'Garsson-io/kaizen', {
+        generateSummary: () => 'summary body',
+        postIssueComment,
+        log: () => {},
+      });
+
+      expect(postIssueComment).toHaveBeenCalledWith([
+        'issue',
+        'comment',
+        '1286',
+        '--repo',
+        'Garsson-io/kaizen',
+        '--body',
+        'summary body',
+      ]);
+      expect(readFileSync(join(dir, 'batch-summary-report.md'), 'utf8')).toBe(
+        'summary body\n',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps writing the summary report when posting fails non-fatally', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'auto-dent-summary-test-'));
+    try {
+      writeFileSync(join(dir, 'events.jsonl'), '{}\n');
+      const lines: string[] = [];
+
+      postStructuredSummary('scripts', dir, '1286', 'Garsson-io/kaizen', {
+        generateSummary: () => 'summary body',
+        postIssueComment: () => ({ status: 1, stdout: '', stderr: 'gh error' }),
+        log: (line) => lines.push(line),
+      });
+
+      expect(lines).toContain('>>> Summary posting skipped (non-fatal).');
+      expect(readFileSync(join(dir, 'batch-summary-report.md'), 'utf8')).toBe(
+        'summary body\n',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/auto-dent.ts
+++ b/scripts/auto-dent.ts
@@ -16,6 +16,7 @@ import {
 } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { uniqueNamesGenerator, adjectives, animals } from 'unique-names-generator';
+import { ghResult, type GhResult } from '../src/lib/gh-exec.js';
 import { readState, writeState, type BatchState } from './auto-dent-run.js';
 
 export interface AutoDentOptions {
@@ -47,6 +48,12 @@ export interface BudgetStatus {
 export interface StopDecision {
   stop: boolean;
   reason: string;
+}
+
+export interface PostStructuredSummaryDeps {
+  generateSummary?: (scriptDir: string, logDir: string) => string;
+  postIssueComment?: (args: string[]) => GhResult;
+  log?: (line: string) => void;
 }
 
 const DEFAULT_OPTIONS: AutoDentOptions = {
@@ -463,31 +470,38 @@ function runPlanningPrepass(scriptDir: string, stateFile: string, logDir: string
   console.log('');
 }
 
-function postStructuredSummary(scriptDir: string, logDir: string, progressIssue: string, kaizenRepo: string): void {
+export function postStructuredSummary(
+  scriptDir: string,
+  logDir: string,
+  progressIssue: string,
+  kaizenRepo: string,
+  deps: PostStructuredSummaryDeps = {},
+): void {
+  const log = deps.log ?? console.log;
   if (!existsSync(join(logDir, 'events.jsonl'))) {
-    console.log('>>> No events.jsonl found — skipping structured summary.');
+    log('>>> No events.jsonl found — skipping structured summary.');
     return;
   }
-  console.log('>>> Generating structured batch summary from events.jsonl...');
+  log('>>> Generating structured batch summary from events.jsonl...');
   let summary = '';
   try {
-    summary = execFileSync('npx', ['tsx', join(scriptDir, 'batch-summary.ts'), logDir], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
+    summary = (deps.generateSummary ?? ((s, l) =>
+      execFileSync('npx', ['tsx', join(s, 'batch-summary.ts'), l], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })))(scriptDir, logDir).trim();
   } catch {
     summary = '';
   }
   if (summary && progressIssue && kaizenRepo) {
-    console.log(`>>> Posting batch summary to ${progressIssue}...`);
-    const status = spawnSync('gh', ['issue', 'comment', progressIssue, '--repo', kaizenRepo, '--body', summary], {
-      stdio: 'ignore',
-    });
-    if ((status.status ?? 1) !== 0) console.log('>>> Summary posting skipped (non-fatal).');
+    log(`>>> Posting batch summary to ${progressIssue}...`);
+    const postIssueComment = deps.postIssueComment ?? ghResult;
+    const status = postIssueComment(['issue', 'comment', progressIssue, '--repo', kaizenRepo, '--body', summary]);
+    if ((status.status ?? 1) !== 0) log('>>> Summary posting skipped (non-fatal).');
   }
   if (summary) {
     writeFileSync(join(logDir, 'batch-summary-report.md'), `${summary}\n`);
-    console.log(`>>> Structured summary saved to ${join(logDir, 'batch-summary-report.md')}`);
+    log(`>>> Structured summary saved to ${join(logDir, 'batch-summary-report.md')}`);
   }
 }
 


### PR DESCRIPTION
## Story

Once upon a time, Auto-dent generated structured batch summaries from `events.jsonl` and posted them back to the progress issue at the end of a run. Every day, that final post used a local `spawnSync("gh", ["issue", "comment", ...])` call inside `scripts/auto-dent.ts`.

One day, the GitHub CLI DRY pass added the shared status-preserving `ghResult(args)` helper in #1283. That made the Auto-dent summary poster stand out as another status-only `gh` process wrapper with its own ownership and drift risk.

Because of that, this PR moves the summary comment post onto `ghResult`. The batch summary path still treats posting as best-effort: a non-zero status logs `>>> Summary posting skipped (non-fatal).`, and a generated summary still lands in `batch-summary-report.md`.

Because of that, `postStructuredSummary` is now exported with a narrow dependency seam for summary generation, comment posting, and logging. The production default uses `ghResult`; the test seam avoids invoking real `gh` or the full Auto-dent runner.

Until finally, focused tests prove the exact `gh issue comment` argv, prove failed posting stays non-fatal, and prove the report file is still written.

And ever since, Auto-dent structured-summary posting uses the same shared GitHub CLI result helper as the other status-preserving gh paths.

Closes #1286

Parent: #1164
Related: #1277, #1279, #1283

## Architecture

```text
auto-dent finalization
  postStructuredSummary(...)
    -> generate batch summary from events.jsonl
    -> ghResult(["issue", "comment", progressIssue, "--repo", repo, "--body", summary])
    -> write batch-summary-report.md when summary exists
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use `ghResult` for posting | The operation is best-effort and only needs status, not thrown errors | Keeps a status check in Auto-dent, but removes process ownership |
| Export `postStructuredSummary` | Lets the summary posting behavior be tested directly without invoking the full runner | Exposes one previously private helper for testable ownership |
| Add a narrow dependency seam | Avoids real `gh` and real summary generation in unit tests | Adds a small options object, limited to this helper |

## What Changed

| File | Purpose |
|---|---|
| `scripts/auto-dent.ts` | Imports `ghResult`, exports `postStructuredSummary`, replaces direct `spawnSync("gh")` with the shared helper, and preserves non-fatal behavior |
| `scripts/auto-dent.test.ts` | Adds focused tests for exact posting argv and failed-post report persistence |

## Test Plan (Behaviors x Levels)

| Behavior | L0 Static | L1 Unit | L2 CI | Status |
|---|---|---|---|---|
| Summary posting uses shared gh result helper | Grep guard shows no `spawnSync("gh")` in `scripts/auto-dent.ts` | `postStructuredSummary` test asserts exact issue-comment argv through the posting seam | Normal CI tests/typecheck | Tested |
| Posting failure remains non-fatal | Diff preserves the skipped-message path | Unit test returns status 1 and asserts skipped message plus report write | Normal CI tests/typecheck | Tested |
| Existing gh helper behavior remains stable | `src/lib/gh-exec.ts` remains the direct spawn owner | Existing `src/lib/gh-exec.test.ts` passes | Normal CI tests/typecheck | Tested |

## Validation

- RED: `npm test -- --run scripts/auto-dent.test.ts` failed because `postStructuredSummary` was not exported.
- GREEN: `npm test -- --run scripts/auto-dent.test.ts src/lib/gh-exec.test.ts` passed, 34 tests.
- GREEN: `npm run typecheck` passed.
- GREEN: `rg -n "spawnSync\('gh'|spawnSync\(\"gh\"|ghResult\(" scripts/auto-dent.ts scripts/auto-dent.test.ts src/lib/gh-exec.ts` shows direct `spawnSync('gh')` only in `src/lib/gh-exec.ts`.
- GREEN: `git diff --check` passed.

## Known Limitations

This PR only consolidates the final structured-summary progress-comment path. Other hook/script GitHub CLI shell-string call sites remain separate follow-up refactor slices.
