### PR TITLE
refactor(hooks): route kaizen-reflect gh calls through helper

### DIFF
--- a/src/hooks/kaizen-reflect.test.ts
+++ b/src/hooks/kaizen-reflect.test.ts
@@ -117,6 +117,40 @@ describe('processHookInput', () => {
       expect(output).toContain('post-merge steps');
     });
 
+    it('loads merge changed files through the gh argv seam', () => {
+      const gh = vi.fn((args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'diff') {
+          return 'src/hooks/kaizen-reflect.ts\nsrc/lib/gh-exec.ts';
+        }
+        if (args[0] === 'pr' && args[1] === 'view') {
+          return 'Shared gh helper';
+        }
+        return '';
+      });
+      const input = makeInput({
+        command: 'gh pr merge 42 --repo Garsson-io/kaizen --squash',
+        stdout: '✓ Pull request merged',
+      });
+
+      const output = processHookInput(input, {
+        ...defaultOpts,
+        changedFiles: undefined,
+        gh,
+        sendNotification: vi.fn(),
+      });
+
+      expect(output).toContain('src/hooks/kaizen-reflect.ts');
+      expect(output).toContain('src/lib/gh-exec.ts');
+      expect(gh).toHaveBeenCalledWith([
+        'pr',
+        'diff',
+        '42',
+        '--name-only',
+        '--repo',
+        'Garsson-io/kaizen',
+      ]);
+    });
+
     it('sends Telegram notification on merge', () => {
       const sendNotification = vi.fn();
       const input = makeInput({
@@ -130,6 +164,46 @@ describe('processHookInput', () => {
       expect(sendNotification).toHaveBeenCalledTimes(1);
       expect(sendNotification).toHaveBeenCalledWith(
         expect.stringContaining('PR merged'),
+      );
+    });
+
+    it('loads merge notification title through the gh argv seam', () => {
+      const sendNotification = vi.fn();
+      const gh = vi.fn((args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'diff') {
+          return 'src/hooks/kaizen-reflect.ts';
+        }
+        if (args[0] === 'pr' && args[1] === 'view') {
+          return 'Use shared gh helper';
+        }
+        return '';
+      });
+      const input = makeInput({
+        command:
+          'gh pr merge https://github.com/Garsson-io/kaizen/pull/42 --squash',
+        stdout: '✓ Pull request merged',
+      });
+
+      processHookInput(input, {
+        ...defaultOpts,
+        changedFiles: undefined,
+        gh,
+        sendNotification,
+      });
+
+      expect(gh).toHaveBeenCalledWith([
+        'pr',
+        'view',
+        '42',
+        '--repo',
+        'Garsson-io/kaizen',
+        '--json',
+        'title',
+        '--jq',
+        '.title',
+      ]);
+      expect(sendNotification).toHaveBeenCalledWith(
+        expect.stringContaining('Use shared gh helper'),
       );
     });
   });

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -15,6 +15,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { gh } from '../lib/gh-exec.js';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import {
@@ -34,6 +35,8 @@ import {
   emitSessionEvent,
 } from './session-telemetry.js';
 import { analyzeHookTelemetry } from './telemetry-analysis.js';
+
+type GhRunner = (args: string[]) => string;
 
 /** Detect the GitHub repo from the origin remote URL. */
 function detectGhRepo(): string | undefined {
@@ -62,22 +65,20 @@ function getCurrentBranch(): string {
 }
 
 /** Get changed files for context. */
-function getChangedFiles(cmdLine: string, isMerge: boolean): string {
+function getChangedFiles(cmdLine: string, isMerge: boolean, ghRun: GhRunner = gh): string {
   try {
     if (isMerge) {
       const prNum = cmdLine.match(/gh\s+pr\s+merge\s+(\d+)/)?.[1];
       const repo = extractRepoFlag(cmdLine) ?? detectGhRepo();
-      const repoFlag = repo ? `--repo ${repo}` : '';
+      const args = ['pr', 'diff'];
       if (prNum) {
-        return execSync(`gh pr diff ${prNum} --name-only ${repoFlag}`, {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-        }).trim();
+        args.push(prNum);
       }
-      return execSync(`gh pr diff --name-only ${repoFlag}`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
+      args.push('--name-only');
+      if (repo) {
+        args.push('--repo', repo);
+      }
+      return ghRun(args).trim();
     }
     return execSync('git diff --name-only main...HEAD', {
       encoding: 'utf-8',
@@ -140,16 +141,23 @@ function sendTelegramIpc(text: string, projectDir?: string): void {
 }
 
 /** Get PR title via gh CLI. */
-function getPrTitle(prUrl: string): string {
+function getPrTitle(prUrl: string, ghRun: GhRunner = gh): string {
   const prNum = prUrl.match(/(\d+)$/)?.[1];
   const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
   if (!prNum || !repo) return 'unknown';
   try {
     return (
-      execSync(`gh pr view ${prNum} --repo ${repo} --json title --jq .title`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim() || 'unknown'
+      ghRun([
+        'pr',
+        'view',
+        prNum,
+        '--repo',
+        repo,
+        '--json',
+        'title',
+        '--jq',
+        '.title',
+      ]).trim() || 'unknown'
     );
   } catch {
     return 'unknown';
@@ -314,6 +322,7 @@ export function processHookInput(
     repoFromGit?: string;
     mainCheckout?: string;
     changedFiles?: string;
+    gh?: GhRunner;
     sendNotification?: (text: string) => void;
     telemetryDir?: string;
   } = {},
@@ -350,7 +359,8 @@ export function processHookInput(
   if (isReflectionDone(prUrl, stateDir)) return null;
 
   const branch = options.branch ?? getCurrentBranch();
-  const changed = options.changedFiles ?? getChangedFiles(cmdLine, isMerge);
+  const ghRun = options.gh ?? gh;
+  const changed = options.changedFiles ?? getChangedFiles(cmdLine, isMerge, ghRun);
 
   // Write state file for the kaizen gate
   const stateKey = prUrlToStateKey(prUrl);
@@ -399,7 +409,7 @@ export function processHookInput(
   );
 
   // Send Telegram notification for merges
-  const prTitle = getPrTitle(prUrl);
+  const prTitle = getPrTitle(prUrl, ghRun);
   const notifyText = `✅ PR merged: ${prTitle}\n${prUrl}\nBranch: ${branch}\n\nCheck CLAUDE.md post-merge procedure for deploy steps.`;
   if (options.sendNotification) {
     options.sendNotification(notifyText);


### PR DESCRIPTION
## Story

Once upon a time, `kaizen-reflect` handled PR merge reflection with a mix of hook logic and direct shell-string GitHub CLI calls.

Every day, the hook still worked, but its `gh pr diff` and `gh pr view` paths stayed outside the shared `src/lib/gh-exec.ts` helper introduced by the recent GitHub CLI cleanup work.

One day, the DRY sweep found those remaining call sites in `src/hooks/kaizen-reflect.ts`: PR diff lookup and PR title lookup still constructed `execSync(`gh ...`)` strings directly.

Because of that, this PR threads a narrow `GhRunner` seam through `processHookInput()` and routes the two GitHub metadata lookups through the shared argv-based `gh(args)` helper. Non-gh `execSync` paths are intentionally unchanged.

Because of that, focused merge-path tests now prove that changed files and notification titles are obtained through exact argv calls, while the existing shared helper tests still prove the actual process boundary uses `spawnSync('gh', args, ...)`.

Until finally, `kaizen-reflect.ts` has no remaining `gh pr diff` / `gh pr view` shell-string execution sites, and the hook keeps the same best-effort fallback behavior.

And ever since, this hook follows the same GitHub CLI execution pattern as the rest of the consolidation work.

Closes #1290
Parent: #1164

## Architecture

```text
processHookInput()
  ├─ ghRun = options.gh ?? gh
  ├─ getChangedFiles(cmdLine, isMerge, ghRun)
  │    └─ ghRun(['pr', 'diff', ...]) for merge metadata
  └─ getPrTitle(prUrl, ghRun)
       └─ ghRun(['pr', 'view', ...]) for notification title
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Inject `gh?: GhRunner` at `processHookInput()` | Tests the real hook workflow without spawning the GitHub CLI | Adds one narrow test seam to options |
| Use strict `gh(args)` rather than `ghExec(commandString)` | This issue is about removing shell-string construction, not adapting it | Keeps fallback handling in `kaizen-reflect` catch blocks |
| Leave git/sentinel `execSync` calls alone | Scope is only duplicated GitHub CLI process calls | Other shell paths remain future cleanup candidates |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/kaizen-reflect.ts` | Imports shared `gh`, adds `GhRunner`, and routes PR diff/title metadata through argv arrays |
| `src/hooks/kaizen-reflect.test.ts` | Adds merge-path tests for exact `gh pr diff` and `gh pr view` argv calls |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|----------|-------------|-------|--------|----------|
| 1 | Merge reflection obtains changed files via the default gh metadata path and includes them in output. | code | Unit | Tested | `src/hooks/kaizen-reflect.test.ts` asserts `['pr','diff','42','--name-only','--repo','Garsson-io/kaizen']` and output filenames. |
| 2 | Merge notification title comes from the gh argv metadata path without shell-string construction. | code | Unit | Tested | `src/hooks/kaizen-reflect.test.ts` asserts `['pr','view','42','--repo','Garsson-io/kaizen','--json','title','--jq','.title']` and notification title. |
| 3 | Shared `gh` remains the single process boundary for argv-based GitHub CLI calls. | code | Unit | Tested | `src/lib/gh-exec.test.ts` existing helper tests pass. |

## Validation

- [x] RED: focused suite failed before production change because the injected `gh` runner was ignored.
- [x] GREEN: `HOOK_TIMING_SENTINEL_DISABLED=true npm test -- --run src/hooks/kaizen-reflect.test.ts src/lib/gh-exec.test.ts` -> 42 passed.
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `rg -n 'gh pr diff|gh pr view|execSync\(`gh' src/hooks/kaizen-reflect.ts src/hooks/kaizen-reflect.test.ts src/lib/gh-exec.ts` -> no matches.

## Known Limitations

This PR does not migrate other hook files with shell-string `gh` calls. It intentionally covers only `kaizen-reflect` so the behavior stays reviewable and the branch remains scope-matched to #1290.
