### PR TITLE
fix(auto-dent): gate rescue create-draft on abnormal exit (#1289)

### DIFF
--- a/scripts/auto-dent-rescue.test.ts
+++ b/scripts/auto-dent-rescue.test.ts
@@ -43,44 +43,64 @@ describe('classifyRunExit', () => {
 
 describe('decideRescueAction', () => {
   it('does nothing when there is no PR and no work', () => {
-    const a = decideRescueAction({ commitsAheadBase: 0, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: null });
+    const a = decideRescueAction({ commitsAheadBase: 0, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: null, abnormal: true });
     expect(a.kind).toBe('none');
   });
 
-  it('creates a draft PR when there is no PR but commits ahead', () => {
-    const a = decideRescueAction({ commitsAheadBase: 3, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: null });
+  it('creates a draft PR when an abnormal exit stranded commits with no PR', () => {
+    const a = decideRescueAction({ commitsAheadBase: 3, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: null, abnormal: true });
     expect(a.kind).toBe('create-draft');
     expect(a.commitDirty).toBe(false);
   });
 
-  it('creates a draft PR and commits dirty when only dirty files exist', () => {
-    const a = decideRescueAction({ commitsAheadBase: 0, unpushedCommits: 0, dirtyTotal: 2, existingOpenPr: null });
+  it('creates a draft PR and commits dirty when an abnormal exit left only dirty files', () => {
+    const a = decideRescueAction({ commitsAheadBase: 0, unpushedCommits: 0, dirtyTotal: 2, existingOpenPr: null, abnormal: true });
     expect(a.kind).toBe('create-draft');
     expect(a.commitDirty).toBe(true);
+  });
+
+  // #1289 core: a CLEAN exit that ends with worktree commits and no PR is
+  // intentional (discovery output / agent stopped on purpose) — never manufacture
+  // a spurious "NOT VALIDATED" draft for it. This is the over-eager inverse gate
+  // the exit classification was built to honor but was previously discarded.
+  it('does nothing when a clean exit left commits ahead with no PR (#1289)', () => {
+    const a = decideRescueAction({ commitsAheadBase: 3, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: null, abnormal: false });
+    expect(a.kind).toBe('none');
+    expect(a.commitDirty).toBe(false);
+    expect(a.reason).toMatch(/clean exit|#1289/i);
+  });
+
+  it('does nothing when a clean exit left only dirty files with no PR (#1289)', () => {
+    const a = decideRescueAction({ commitsAheadBase: 0, unpushedCommits: 0, dirtyTotal: 2, existingOpenPr: null, abnormal: false });
+    expect(a.kind).toBe('none');
+    expect(a.commitDirty).toBe(false);
   });
 
   // Regression guard: a healthy open PR (commits ahead of main but already
   // pushed, nothing dirty) must NOT receive a spurious rescue comment.
   it('does nothing for a healthy open PR with no unpushed or dirty work', () => {
-    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: 'https://x/pr/1' });
+    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 0, dirtyTotal: 0, existingOpenPr: 'https://x/pr/1', abnormal: true });
     expect(a.kind).toBe('none');
   });
 
-  it('pushes to the existing PR when there are unpushed commits', () => {
-    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 2, dirtyTotal: 0, existingOpenPr: 'https://x/pr/1' });
+  // push-existing is exit-agnostic: extending an already-open PR with unpushed
+  // work is correct whether the run crashed or stopped cleanly (#1289).
+  it('pushes to the existing PR when there are unpushed commits (even on a clean exit)', () => {
+    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 2, dirtyTotal: 0, existingOpenPr: 'https://x/pr/1', abnormal: false });
     expect(a.kind).toBe('push-existing');
     expect(a.commitDirty).toBe(false);
   });
 
-  it('pushes to the existing PR and commits dirty when files are dirty', () => {
-    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 0, dirtyTotal: 1, existingOpenPr: 'https://x/pr/1' });
+  it('pushes to the existing PR and commits dirty when files are dirty (even on a clean exit)', () => {
+    const a = decideRescueAction({ commitsAheadBase: 5, unpushedCommits: 0, dirtyTotal: 1, existingOpenPr: 'https://x/pr/1', abnormal: false });
     expect(a.kind).toBe('push-existing');
     expect(a.commitDirty).toBe(true);
   });
 
   // #1284 supersede guard / #1282 regression: a branch whose most-recent PR
   // merged with no open PR must NOT get a fresh rescue PR even with work ahead
-  // of base — pushing to a merged branch violates I7.
+  // of base — pushing to a merged branch violates I7. The I7 guard takes
+  // precedence over create-draft even when the exit was abnormal.
   it('does nothing when the most-recent PR merged with no open PR (I7 supersede)', () => {
     const a = decideRescueAction({
       commitsAheadBase: 3,
@@ -88,6 +108,7 @@ describe('decideRescueAction', () => {
       dirtyTotal: 2,
       existingOpenPr: null,
       mostRecentMerged: true,
+      abnormal: true,
     });
     expect(a.kind).toBe('none');
     expect(a.commitDirty).toBe(false);
@@ -103,6 +124,7 @@ describe('decideRescueAction', () => {
       dirtyTotal: 0,
       existingOpenPr: 'https://x/pr/1',
       mostRecentMerged: true,
+      abnormal: false,
     });
     expect(a.kind).toBe('push-existing');
   });
@@ -115,6 +137,7 @@ describe('decideRescueAction', () => {
       dirtyTotal: 0,
       existingOpenPr: null,
       mostRecentMerged: true,
+      abnormal: true,
     });
     expect(a.kind).toBe('none');
   });
@@ -215,7 +238,7 @@ function makeReadDirty(total: number) {
 
 describe('rescueTarget orchestration', () => {
   const worktree = mkdtempSync(join(tmpdir(), 'rescue-wt-'));
-  const ctx = { repo: 'owner/repo', runTag: 'b/run-1', runId: 'b-r1', failureReason: 'timeout' };
+  const ctx = { repo: 'owner/repo', runTag: 'b/run-1', runId: 'b-r1', failureReason: 'timeout', abnormal: true };
 
   it('creates a draft PR when work is stranded with no PR', () => {
     const gitLog: string[][] = [];
@@ -234,6 +257,39 @@ describe('rescueTarget orchestration', () => {
     expect(gitLog.some((a) => a.includes('push') && a.includes('--no-verify'))).toBe(true);
     expect(ghLog.some((a) => a[0] === 'pr' && a[1] === 'list' && a.includes('--repo') && a.includes('owner/repo'))).toBe(true);
     expect(ghLog.some((a) => a[1] === 'create' && a.includes('--draft'))).toBe(true);
+  });
+
+  // #1289 end-to-end: a CLEAN-exit worktree (ctx.abnormal=false) with commits and
+  // no PR must produce NO git push and NO gh pr create — the rescue declines to
+  // manufacture a spurious "NOT VALIDATED" draft for work nobody abandoned.
+  it('does nothing for a clean-exit worktree with commits and no PR (#1289)', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      { ...ctx, abnormal: false, failureReason: 'clean exit' },
+      { git: makeFakeGit({ aheadBase: 2 }, gitLog), gh: makeFakeGh(null, ghLog), readDirty: makeReadDirty(1) },
+    );
+    expect(out.action).toBe('none');
+    expect(out.pushed).toBe(false);
+    expect(out.prUrl).toBeUndefined();
+    expect(gitLog.some((a) => a.includes('push'))).toBe(false);
+    expect(ghLog.some((a) => a[1] === 'create' || a[1] === 'comment')).toBe(false);
+  });
+
+  // Even on a clean exit, an already-open PR is extended (push-existing is
+  // exit-agnostic): committed-but-unpushed work still belongs on the PR.
+  it('extends an open PR with unpushed work even on a clean exit (#1289)', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      { ...ctx, abnormal: false, failureReason: 'clean exit' },
+      { git: makeFakeGit({ aheadBase: 5, unpushed: 2 }, gitLog), gh: makeFakeGh('https://x/pr/1', ghLog), readDirty: makeReadDirty(0) },
+    );
+    expect(out.action).toBe('push-existing');
+    expect(out.prUrl).toBe('https://x/pr/1');
+    expect(ghLog.some((a) => a[1] === 'comment')).toBe(true);
   });
 
   it('comments on the existing PR and pushes when extending it', () => {
@@ -318,7 +374,7 @@ describe('rescueRun + collectRunWorktrees', () => {
     const worktree = mkdtempSync(join(tmpdir(), 'rescue-multi-'));
     const outs = rescueRun(
       [{ worktree, branch: 'case/a' }],
-      { repo: 'o/r', runTag: 'b/run-1', runId: 'b-r1', failureReason: 'timeout' },
+      { repo: 'o/r', runTag: 'b/run-1', runId: 'b-r1', failureReason: 'timeout', abnormal: true },
       { git: makeFakeGit({ aheadBase: 1 }, []), gh: makeFakeGh(null, []), readDirty: makeReadDirty(0) },
     );
     expect(outs).toHaveLength(1);

--- a/scripts/auto-dent-rescue.ts
+++ b/scripts/auto-dent-rescue.ts
@@ -88,6 +88,17 @@ export interface RescueDecisionInput {
   /** URL of an open PR already targeting this branch, or null. */
   existingOpenPr: string | null;
   /**
+   * Whether the run terminated abnormally (`classifyRunExit().abnormal`): a
+   * watchdog timeout or non-zero exit, where work was likely STRANDED. A clean
+   * exit / intentional agent stop is NOT abnormal. This is required (not
+   * defaulted) so every caller must bind the computed classification at this
+   * choke point — the #943/#1227 "computed-but-not-bound" guard. It gates ONLY
+   * `create-draft`: manufacturing a brand-new draft rescue PR is justified only
+   * when termination stranded the work. `push-existing` (extending an already
+   * open PR) is exit-agnostic and ignores this field. (#1289)
+   */
+  abnormal: boolean;
+  /**
    * True when the most-recent PR for the branch is MERGED and there is no open
    * PR — the I7 "merged branch" state. Pushing to or opening a PR on such a
    * branch is forbidden (CLAUDE.md branch hygiene), and in the rescue path it
@@ -140,13 +151,28 @@ export function decideRescueAction(input: RescueDecisionInput): RescueAction {
     };
   }
   const hasWork = input.commitsAheadBase > 0 || input.dirtyTotal > 0;
-  return hasWork
-    ? {
-        kind: 'create-draft',
-        commitDirty,
-        reason: `no PR for branch with rescueable work (${input.commitsAheadBase} commits ahead, ${input.dirtyTotal} dirty)`,
-      }
-    : { kind: 'none', commitDirty: false, reason: 'no commits ahead and no dirty files' };
+  if (!hasWork) {
+    return { kind: 'none', commitDirty: false, reason: 'no commits ahead and no dirty files' };
+  }
+  // #1289: only an ABNORMAL termination (watchdog timeout / non-zero exit) strands
+  // work that warrants manufacturing a brand-new draft rescue PR. A clean exit or
+  // intentional agent stop that ends with worktree commits and no PR is deliberate
+  // (discovery output, an explore/contemplate run, or an agent that stopped on
+  // purpose) — opening a spurious "NOT VALIDATED" draft for it is the over-eager
+  // inverse of the strand failure. Leave it alone. The `push-existing` path above
+  // keeps precedence and is exit-agnostic: extending an already-open PR is always safe.
+  if (!input.abnormal) {
+    return {
+      kind: 'none',
+      commitDirty: false,
+      reason: 'clean exit with worktree commits and no PR — intentional stop / discovery output, not manufacturing a draft (#1289)',
+    };
+  }
+  return {
+    kind: 'create-draft',
+    commitDirty,
+    reason: `abnormal exit stranded work with no PR (${input.commitsAheadBase} commits ahead, ${input.dirtyTotal} dirty)`,
+  };
 }
 
 export interface RescueReportInput {
@@ -209,6 +235,13 @@ export interface RescueContext {
   runTag: string;
   runId: string;
   failureReason: string;
+  /**
+   * Whether the run terminated abnormally (`classifyRunExit().abnormal`). Bound
+   * from the run's exit classification and forwarded to `decideRescueAction` so a
+   * brand-new draft rescue PR is only manufactured for crash/timeout-stranded
+   * work, never for a clean-exit worktree (#1289).
+   */
+  abnormal: boolean;
   pickedIssue?: string;
   /** Base branch for create-draft and the ahead-of-base count. Default 'origin/main'. */
   base?: string;
@@ -273,7 +306,7 @@ export function rescueTarget(target: RescueTarget, ctx: RescueContext, deps: Res
   const existingOpenPr = prState.openUrl ?? null;
   const mostRecentMerged = prState.mostRecent?.state === 'MERGED' && !prState.hasOpen;
 
-  const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr, mostRecentMerged });
+  const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr, mostRecentMerged, abnormal: ctx.abnormal });
   outcome.action = action.kind;
   if (action.kind === 'none') {
     log?.(`${target.branch}: ${action.reason}`);

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2845,7 +2845,7 @@ async function main(): Promise<void> {
       git: createDefaultGitExec(),
     });
     if (targets.length > 0) {
-      const { reason: failureReason } = classifyRunExit({
+      const { reason: failureReason, abnormal } = classifyRunExit({
         exitCode,
         timedOut: Boolean(result.timedOut),
         stopRequested: Boolean(result.stopRequested),
@@ -2857,6 +2857,9 @@ async function main(): Promise<void> {
           runTag,
           runId,
           failureReason,
+          // #1289: bind the exit classification to the rescue gate so a clean-exit
+          // worktree with commits never gets a spurious "NOT VALIDATED" draft PR.
+          abnormal,
           pickedIssue,
         },
         defaultRescueDeps((m) => console.log(`  [rescue] ${m}`)),


### PR DESCRIPTION
## Problem

Auto-dent's rescue finalizer (#1255/#1270) exists to preserve work stranded by an abnormal run termination — a watchdog timeout or crash that leaves committed work in a case worktree with no PR. But it fired on the wrong signal: it opened a "NOT VALIDATED" draft rescue PR for **any** run-tagged worktree with commits ahead of `main` and no open PR — **regardless of how the run exited**.

So a clean-exit run that legitimately ends without a PR — an explore/contemplate run that built a case worktree, or an agent that intentionally stopped mid-task — got a spurious draft PR opened against its branch. That pollutes the PR list with drafts for work nobody abandoned, can collide with the same-issue supersede races already seen in #1271/#1273/#1282, and conflates discovery output with stranded implementation.

## Discovery

The classification needed to prevent this already existed. `classifyRunExit()` computes `abnormal: true|false`:

- timeout / non-zero exit → `abnormal: true` (work likely stranded)
- `stopRequested` / clean exit → `abnormal: false` (intentional)

But `decideRescueAction()` never received it. It chose `push-existing` / `create-draft` / `none` purely from git state, and the call site in `auto-dent-run.ts` destructured only `reason` from `classifyRunExit()` — the `abnormal` boolean was discarded. This is the #943/#1227 **computed-but-not-bound** category: a classification exists, but no mechanism honors it at the choke point.

## Solution

Bind the classification to the gate.

- `abnormal: boolean` is now a **required** field on `RescueDecisionInput` and `RescueContext`. Required, not defaulted — a silent default would re-open the same gap; now a future caller *must* consult the classification or the build fails.
- `decideRescueAction`: when there is work but no PR and no merged-branch state, `create-draft` fires **only** when `abnormal === true`. A clean exit with worktree commits and no PR yields `none` — left alone.
- `push-existing` stays **exit-agnostic**: extending an already-open PR with committed-but-unpushed work is correct whether the run crashed or stopped cleanly. The I7 merged-branch supersede guard (#1284) keeps precedence over `create-draft`.
- The call site in `auto-dent-run.ts` now keeps `abnormal` and forwards it into the rescue context.

## Evidence

- `npx vitest run scripts/auto-dent-rescue.test.ts` → **34 passed** (7 new/updated, covering clean-exit→none for commits and dirty, exit-agnostic push-existing, and the I7-wins-over-create-draft case).
- **Mutation check**: deleting the new `!abnormal` guard fails exactly the 3 new `#1289` tests — they witness the behavior, not just exercise it.
- `npx tsc --noEmit` clean — the required-field change surfaces any unbound caller at compile time (category prevention).

### Behaviors × Levels

| Behavior | Unit | Integration | System |
|---|---|---|---|
| clean exit + commits, no PR → none | ✅ decideRescueAction + rescueTarget | — | — |
| clean exit + dirty, no PR → none | ✅ | — | — |
| abnormal exit + work, no PR → create-draft | ✅ | — | — |
| open PR + unpushed → push-existing (any exit) | ✅ | ✅ rescueTarget | — |
| merged branch (I7) wins over create-draft | ✅ | — | — |

## Impact

Rescue now fires only for genuinely stranded work. Clean-exit discovery and intentional-stop runs no longer manufacture spurious "NOT VALIDATED" drafts — directly serving this batch's goal of correct gate handling and not abandoning (or over-rescuing) work. The required-field binding makes the classification impossible to discard again.

Closes #1289
Parent: #1272
Refs: #943, #1227, #1255, #1270, #1284

Run tag: handsome-lynx/run-6
