### PR TITLE
refactor(hooks): route pr-kaizen-clear gh metadata through helper

### DIFF
--- a/src/hooks/pr-kaizen-clear.test.ts
+++ b/src/hooks/pr-kaizen-clear.test.ts
@@ -1049,6 +1049,33 @@ describe('detectPrdWithoutFiledIssues', () => {
 });
 
 describe('processHookInput PRD blocking gate (kaizen #683, upgraded from #694)', () => {
+  it('loads PR files through the gh argv seam when no getPrFiles override is supplied', () => {
+    const gh = vi.fn((args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'diff') {
+        return 'docs/prd-agent-diagnosis.md\nsrc/foo.ts';
+      }
+      return '';
+    });
+    const input = noActionInput('docs-only', 'PRD creation only');
+
+    const result = processHookInput(input, {
+      stateDir: testStateDir,
+      postComment: () => {},
+      gh,
+    });
+
+    expect(result).toContain('BLOCKED');
+    expect(result).toContain('PRD but filed no actionable issues');
+    expect(gh).toHaveBeenCalledWith([
+      'pr',
+      'diff',
+      '42',
+      '--repo',
+      'Garsson-io/kaizen',
+      '--name-only',
+    ]);
+  });
+
   it('blocks gate when PRD in diff and KAIZEN_NO_ACTION', () => {
     const input = noActionInput('docs-only', 'PRD creation only');
     const result = processHookInput(input, {
@@ -1110,6 +1137,54 @@ describe('processHookInput PRD blocking gate (kaizen #683, upgraded from #694)',
       'utf-8',
     );
     expect(stateContent).toContain('needs_pr_kaizen');
+  });
+});
+
+describe('processHookInput auto-close PR metadata gh seam', () => {
+  it('loads merged PR state and body through the gh argv seam after clearing', () => {
+    const gh = vi.fn((args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'diff') {
+        return 'src/hooks/pr-kaizen-clear.ts';
+      }
+      if (args[0] === 'pr' && args[1] === 'view' && args.includes('state')) {
+        return 'MERGED';
+      }
+      if (args[0] === 'pr' && args[1] === 'view' && args.includes('body')) {
+        return 'No linked kaizen issues in this fixture';
+      }
+      return '';
+    });
+    const input = noActionInput('trivial-refactor', 'metadata path only');
+
+    const result = processHookInput(input, {
+      stateDir: testStateDir,
+      postComment: () => {},
+      gh,
+    });
+
+    expect(result).toContain('gate cleared');
+    expect(gh).toHaveBeenCalledWith([
+      'pr',
+      'view',
+      '42',
+      '--repo',
+      'Garsson-io/kaizen',
+      '--json',
+      'state',
+      '--jq',
+      '.state',
+    ]);
+    expect(gh).toHaveBeenCalledWith([
+      'pr',
+      'view',
+      '42',
+      '--repo',
+      'Garsson-io/kaizen',
+      '--json',
+      'body',
+      '--jq',
+      '.body',
+    ]);
   });
 });
 

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -18,6 +18,7 @@
 import { execSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { gh } from '../lib/gh-exec.js';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import { verifyIssueRef, type RefStatus } from './lib/issue-ref-verifier.js';
@@ -49,6 +50,8 @@ interface Impediment {
   reason?: string;
   impact_minutes?: number;
 }
+
+type GhRunner = (args: string[]) => string;
 
 // ── Audit logging ────────────────────────────────────────────────────
 
@@ -433,15 +436,12 @@ function defaultPostComment(prUrl: string, comment: string): void {
 // ── PRD detection (kaizen #694) ───────────────────────────────────────
 
 /** List changed files in a PR (best-effort). */
-function defaultGetPrFiles(prUrl: string): string[] {
+function defaultGetPrFiles(prUrl: string, ghRun: GhRunner = gh): string[] {
   const prNum = prUrl.match(/(\d+)$/)?.[1];
   const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
   if (!prNum || !repo) return [];
   try {
-    const out = execSync(
-      `gh pr diff ${prNum} --repo "${repo}" --name-only`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 15000 },
-    ).trim();
+    const out = ghRun(['pr', 'diff', prNum, '--repo', repo, '--name-only']).trim();
     return out ? out.split('\n').map(f => f.trim()).filter(Boolean) : [];
   } catch {
     return [];
@@ -479,6 +479,7 @@ export function processHookInput(
     stateDir?: string;
     postComment?: (prUrl: string, comment: string) => void;
     getPrFiles?: (prUrl: string) => string[];
+    gh?: GhRunner;
     /** Outcome predicate for filed/incident refs (injected in tests). */
     verifyRef?: (ref: string) => RefStatus;
   } = {},
@@ -493,6 +494,7 @@ export function processHookInput(
   const cmdLine = stripHeredocBody(command);
   const stateDir =
     options.stateDir ?? process.env.STATE_DIR ?? DEFAULT_STATE_DIR;
+  const ghRun = options.gh ?? gh;
 
   // ── Trigger 0: KAIZEN_UNFINISHED (kaizen #775) ────────────────
   // Check BEFORE the kaizen gate check — KAIZEN_UNFINISHED clears ALL gates
@@ -690,7 +692,8 @@ export function processHookInput(
     }
 
     // PRD-without-issues BLOCKING check (kaizen #683, upgraded from #694 advisory)
-    const getPrFiles = options.getPrFiles ?? defaultGetPrFiles;
+    const getPrFiles =
+      options.getPrFiles ?? ((prUrl: string) => defaultGetPrFiles(prUrl, ghRun));
     try {
       const files = getPrFiles(gatePrUrl);
       const prdBlock = detectPrdWithoutFiledIssues(
@@ -741,7 +744,7 @@ export function processHookInput(
 
     // Auto-close kaizen issues (best-effort)
     try {
-      autoCloseKaizenIssues(gatePrUrl);
+      autoCloseKaizenIssues(gatePrUrl, ghRun);
     } catch {}
 
     output.push(
@@ -754,20 +757,24 @@ export function processHookInput(
 }
 
 /** Auto-close kaizen issues referenced in a merged PR body. */
-function autoCloseKaizenIssues(prUrl: string): void {
+function autoCloseKaizenIssues(prUrl: string, ghRun: GhRunner = gh): void {
   const prNum = prUrl.match(/(\d+)$/)?.[1];
   const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
   if (!prNum || !repo) return;
 
   let prState: string;
   try {
-    prState = execSync(
-      `gh pr view ${prNum} --repo "${repo}" --json state --jq .state`,
-      {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
-    ).trim();
+    prState = ghRun([
+      'pr',
+      'view',
+      prNum,
+      '--repo',
+      repo,
+      '--json',
+      'state',
+      '--jq',
+      '.state',
+    ]).trim();
   } catch {
     return;
   }
@@ -775,13 +782,17 @@ function autoCloseKaizenIssues(prUrl: string): void {
 
   let prBody: string;
   try {
-    prBody = execSync(
-      `gh pr view ${prNum} --repo "${repo}" --json body --jq .body`,
-      {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
-    ).trim();
+    prBody = ghRun([
+      'pr',
+      'view',
+      prNum,
+      '--repo',
+      repo,
+      '--json',
+      'body',
+      '--jq',
+      '.body',
+    ]).trim();
   } catch {
     return;
   }


### PR DESCRIPTION
## Story

Once upon a time, `pr-kaizen-clear` owned several PR reflection-gate responsibilities: PRD-file detection, reflection audit comments, persistence, and auto-closing linked kaizen issues.

Every day, those behaviors worked, but three PR metadata lookups still built direct `gh` shell strings inside the hook: one `gh pr diff` call for changed files and two `gh pr view` calls for merged state and PR body.

One day, the DRY sweep found those call sites while following the prior `gh-exec` consolidation work. They were the same runtime mechanism as the recently migrated `kaizen-reflect` metadata calls, but still lived as local `execSync(`gh ...`)` strings in this hook.

Because of that, this PR threads a narrow `GhRunner` seam through `processHookInput()` and routes only the PR metadata lookups through the shared argv-based `gh(args)` helper.

Because of that, focused tests now prove both default paths use exact argv arrays: PRD-file detection calls `pr diff`, and auto-close metadata calls `pr view` for state and body.

Until finally, `pr-kaizen-clear.ts` no longer has shell-string `gh pr diff` or `gh pr view` metadata execution sites. The remaining `gh pr comment --body-file -` call is intentionally left alone because it requires stdin support that the shared helper does not yet provide.

And ever since, another reflection-gate hook follows the shared GitHub CLI execution pattern instead of preserving a local process wrapper.

Closes #1293
Parent: #1164
Related: #1294

## Architecture

```text
processHookInput()
  ├─ ghRun = options.gh ?? gh
  ├─ defaultGetPrFiles(prUrl, ghRun)
  │    └─ ghRun(['pr', 'diff', prNum, '--repo', repo, '--name-only'])
  └─ autoCloseKaizenIssues(prUrl, ghRun)
       ├─ ghRun(['pr', 'view', prNum, '--repo', repo, '--json', 'state', '--jq', '.state'])
       └─ ghRun(['pr', 'view', prNum, '--repo', repo, '--json', 'body', '--jq', '.body'])
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add `gh?: GhRunner` to `processHookInput()` options | Tests the default hook paths without invoking the real GitHub CLI | Adds one narrow seam to an already seamful hook |
| Use strict `gh(args)` rather than `ghExec(commandString)` | The target is removing command-string construction, not adapting it | Best-effort behavior stays in local try/catch blocks |
| Leave `defaultPostComment()` on `execSync` | It uses `--body-file -` and stdin; the helper has no stdin option yet | One `gh pr comment` shell call remains as explicitly deferred work |
| Leave issue `view/close` calls alone | This PR is scoped to PR metadata lookups | Related issue-helper cleanup remains future work |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/pr-kaizen-clear.ts` | Imports shared `gh`, adds `GhRunner`, and routes PR diff/state/body metadata lookups through argv arrays |
| `src/hooks/pr-kaizen-clear.test.ts` | Adds default-path tests proving PRD detection and auto-close metadata use exact argv calls |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|----------|-------------|-------|--------|----------|
| 1 | Default PRD detection obtains changed files via the gh metadata path. | code | Unit | Tested | `src/hooks/pr-kaizen-clear.test.ts` asserts `['pr','diff','42','--repo','Garsson-io/kaizen','--name-only']` and still blocks no-action PRD clearing. |
| 2 | Auto-close metadata obtains merged PR state via the gh argv path. | code | Unit | Tested | `src/hooks/pr-kaizen-clear.test.ts` asserts `['pr','view','42','--repo','Garsson-io/kaizen','--json','state','--jq','.state']`. |
| 3 | Auto-close metadata obtains PR body via the gh argv path. | code | Unit | Tested | `src/hooks/pr-kaizen-clear.test.ts` asserts `['pr','view','42','--repo','Garsson-io/kaizen','--json','body','--jq','.body']`. |
| 4 | Shared `gh` remains the process boundary for argv-based GitHub CLI calls. | code | Unit | Tested | `src/lib/gh-exec.test.ts` existing helper tests pass. |

## Validation

- [x] RED: focused suite failed before production change because the injected `gh` runner was ignored.
- [x] GREEN: `npm test -- --run src/hooks/pr-kaizen-clear.test.ts src/lib/gh-exec.test.ts` -> 111 passed.
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `rg -n 'gh pr diff|gh pr view' src/hooks/pr-kaizen-clear.ts src/hooks/pr-kaizen-clear.test.ts src/lib/gh-exec.ts` -> no matches.
- [x] Broader guard `rg -n 'gh pr diff|gh pr view|execSync\(`gh' ...` now reports only the intentionally deferred `gh pr comment --body-file -` call.

## Known Limitations

This PR does not migrate stdin-based comment posting or issue auto-close `gh issue` commands. `#1294` now tracks the broader need for a regression guard so this migration series stops being an unbounded one-file-at-a-time cleanup.
