### PR TITLE
test: guard gh-exec helper adoption

### DIFF
--- a/src/lib/gh-exec-invariant.test.ts
+++ b/src/lib/gh-exec-invariant.test.ts
@@ -1,0 +1,163 @@
+/**
+ * gh-exec-invariant.test.ts — category-prevention lint for #1294.
+ *
+ * Fails loudly if production TypeScript under src/ invokes the GitHub CLI directly
+ * instead of routing through src/lib/gh-exec.ts.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+interface Violation {
+  file: string;
+}
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const SRC_DIR = join(REPO_ROOT, 'src');
+const CANONICAL_HELPER = 'src/lib/gh-exec.ts';
+
+const OPT_OUT = new Set<string>([
+  // stdin-based PR comment posting; migrate after gh-exec grows stdin support.
+  'src/hooks/pr-kaizen-clear.ts',
+  // PR quality hook still shells through an injected exec seam for gh metadata.
+  'src/hooks/pr-quality-checks.ts',
+  // SessionStart cleanup still checks PR state through gh directly.
+  'src/hooks/session-cleanup.ts',
+  // Worktree cleanup still shells through an injected exec seam for gh PR lists.
+  'src/worktree-du.ts',
+]);
+
+function repoRelative(path: string): string {
+  return relative(REPO_ROOT, path).replace(/\\/g, '/');
+}
+
+function isProductionTsFile(file: string): boolean {
+  if (!file.endsWith('.ts')) return false;
+  if (file.endsWith('.test.ts')) return false;
+  if (file.endsWith('.d.ts')) return false;
+  return true;
+}
+
+function collectProductionSrcFiles(dir: string = SRC_DIR): Map<string, string> {
+  const files = new Map<string, string>();
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      for (const [file, content] of collectProductionSrcFiles(fullPath)) {
+        files.set(file, content);
+      }
+      continue;
+    }
+
+    const rel = repoRelative(fullPath);
+    if (!isProductionTsFile(rel)) continue;
+    if (rel === CANONICAL_HELPER) continue;
+    files.set(rel, readFileSync(fullPath, 'utf-8'));
+  }
+  return files;
+}
+
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+}
+
+function hasDirectGhSubprocessCall(content: string): boolean {
+  const withoutComments = stripComments(content);
+
+  if (/\bexec(?:Sync)?\s*\(\s*[`'"][^`'"]*\bgh\b/.test(withoutComments)) {
+    return true;
+  }
+
+  if (/\bexecFile(?:Sync)?\s*\(\s*[`'"]gh[`'"]/.test(withoutComments)) {
+    return true;
+  }
+
+  if (/\bspawn(?:Sync)?\s*\(\s*[`'"]gh[`'"]/.test(withoutComments)) {
+    return true;
+  }
+
+  return false;
+}
+
+function findDirectGhViolations(files: Map<string, string>): Violation[] {
+  return Array.from(files.entries())
+    .filter(([, content]) => hasDirectGhSubprocessCall(content))
+    .map(([file]) => ({ file }));
+}
+
+function unallowlistedViolations(
+  violations: Violation[],
+  allowlist: Set<string>,
+): Violation[] {
+  return violations.filter(v => !allowlist.has(v.file));
+}
+
+function staleAllowlistEntries(
+  violations: Violation[],
+  allowlist: Set<string>,
+): string[] {
+  const violationFiles = new Set(violations.map(v => v.file));
+  return Array.from(allowlist).filter(f => !violationFiles.has(f));
+}
+
+describe('gh-exec invariant scanner', () => {
+  it('detects direct gh subprocess calls in synthetic fixtures', () => {
+    const violations = findDirectGhViolations(new Map([
+      ['src/hooks/bad-shell.ts', "execSync(`gh pr view 1`)"],
+      ['src/hooks/bad-argv.ts', "spawnSync('gh', ['pr', 'view', '1'])"],
+      ['src/hooks/bad-injected-exec.ts', "deps.exec('gh pr list --state open')"],
+    ]));
+
+    expect(violations.map(v => v.file).sort()).toEqual([
+      'src/hooks/bad-argv.ts',
+      'src/hooks/bad-injected-exec.ts',
+      'src/hooks/bad-shell.ts',
+    ]);
+  });
+
+  it('fails when a direct gh caller is not allowlisted', () => {
+    const violations = findDirectGhViolations(new Map([
+      ['src/hooks/new-direct-gh.ts', "execSync('gh issue view 1')"],
+    ]));
+
+    expect(unallowlistedViolations(violations, OPT_OUT)).toEqual([
+      { file: 'src/hooks/new-direct-gh.ts' },
+    ]);
+  });
+
+  it('fails stale allowlist entries after migration', () => {
+    const violations = findDirectGhViolations(new Map([
+      ['src/hooks/pr-kaizen-clear.ts', "execSync('gh pr comment 1')"],
+    ]));
+    const allowlist = new Set([
+      'src/hooks/pr-kaizen-clear.ts',
+      'src/hooks/migrated.ts',
+    ]);
+
+    expect(staleAllowlistEntries(violations, allowlist)).toEqual([
+      'src/hooks/migrated.ts',
+    ]);
+  });
+
+  it('finds production source files and excludes the canonical helper', () => {
+    const files = collectProductionSrcFiles();
+
+    expect(files.size).toBeGreaterThan(50);
+    expect(files.has(CANONICAL_HELPER)).toBe(false);
+  });
+
+  it('current production tree has no unallowlisted direct gh subprocess calls', () => {
+    const violations = findDirectGhViolations(collectProductionSrcFiles());
+
+    expect(unallowlistedViolations(violations, OPT_OUT)).toEqual([]);
+  });
+
+  it('OPT_OUT entries correspond to current direct-gh violations', () => {
+    const violations = findDirectGhViolations(collectProductionSrcFiles());
+
+    expect(staleAllowlistEntries(violations, OPT_OUT)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Story

Once upon a time, `src/lib/gh-exec.ts` became the shared boundary for mechanistic GitHub CLI calls.

Every day, the codebase could still add direct `gh` subprocess calls elsewhere because nothing enforced that boundary. The recent DRY pass kept migrating one file at a time: branch PR-state, issue-ref verification, `kaizen-reflect`, and `pr-kaizen-clear` metadata.

One day, issue #1294 named the category failure: this was an O(N) migration with no terminal state. Every new direct `execSync(`gh ...`)` could refill the backlog.

Because of that, this PR adds `src/lib/gh-exec-invariant.test.ts`: a ratcheting Vitest invariant modeled after the existing `git-state` invariant.

Because of that, the test now proves three things: synthetic direct-gh callers fail when unallowlisted, stale allowlist entries fail after migration, and the current production tree only contains the known opt-outs.

Until finally, new production TypeScript under `src/` cannot add direct GitHub CLI subprocess/command execution without tripping `npm test`.

And ever since, future gh-helper migration work has a measurable shrinking allowlist instead of relying on repeated grep sweeps.

Closes #1294
Parent: #1164

## Architecture

```text
gh-exec-invariant.test.ts
  ├─ collectProductionSrcFiles(src/)
  │    ├─ excludes *.test.ts and *.d.ts
  │    └─ excludes src/lib/gh-exec.ts (canonical helper)
  ├─ findDirectGhViolations(files)
  │    ├─ exec/execSync shell strings containing gh
  │    ├─ execFile/execFileSync('gh', ...)
  │    ├─ spawn/spawnSync('gh', ...)
  │    └─ injected .exec('gh ...') command strings
  ├─ unallowlistedViolations(...)
  └─ staleAllowlistEntries(...)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Put the invariant in `src/lib` | The canonical helper is `src/lib/gh-exec.ts`, and the scan covers all production `src/` files | Not physically beside `git-state-invariant.test.ts`, but follows the same ratchet pattern |
| Seed an allowlist | The current tree still has four known direct-gh callers; the guard should prevent regression before all migrations finish | Remaining migrations become explicit allowlist-removal work |
| Fail stale allowlist entries | Prevents the allowlist from becoming permanent documentation debt | Each future migration must remove its opt-out entry |
| Include injected `.exec('gh ...')` | Current offenders include injectable shell executors, not only raw `execSync` | Slightly broader than the issue's first examples, matching real code evidence |

## Current Allowlist

| File | Why still allowed |
|---|---|
| `src/hooks/pr-kaizen-clear.ts` | `gh pr comment --body-file -` needs stdin support or a dedicated comment helper |
| `src/hooks/pr-quality-checks.ts` | Existing hook shell-exec seam still fetches PR diff/body metadata |
| `src/hooks/session-cleanup.ts` | SessionStart cleanup still checks PR state through direct gh |
| `src/worktree-du.ts` | Worktree cleanup still shells through an injected exec seam for gh PR lists |

## What's In This PR

| File | Purpose |
|---|---|
| `src/lib/gh-exec-invariant.test.ts` | Adds the scanner, allowlist ratchet, synthetic failure tests, and current-tree invariant |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|----------|-------------|-------|--------|----------|
| 1 | Production source scan detects direct `gh` subprocess/command execution outside the canonical helper. | code | Unit | Tested | Synthetic fixtures cover `execSync(`gh ...`)`, `spawnSync('gh', ...)`, and `deps.exec('gh ...')`. |
| 2 | Current production tree permits only known allowlisted direct-gh callers. | code | Unit | Tested | Current-tree scan expects no unallowlisted violations. |
| 3 | Allowlist entries are ratcheted and cannot remain after migration. | code | Unit | Tested | Synthetic stale allowlist fixture returns the migrated entry as stale. |
| 4 | Canonical `gh-exec.ts` remains exempt. | code | Unit | Tested | Current-tree scan excludes `src/lib/gh-exec.ts`; existing helper tests pass. |

## Validation

- [x] RED: initial invariant scanner returned no violations; synthetic violation tests failed as expected.
- [x] GREEN: `npm test -- --run src/lib/gh-exec-invariant.test.ts src/lib/gh-exec.test.ts` -> 23 passed.
- [x] `npm run typecheck`
- [x] `git diff --check`

## Known Limitations

This PR does not migrate the four allowlisted callers. It turns them into explicit shrinking-work items and blocks new direct-gh production callers from appearing unnoticed.
