### PR TITLE
revert(review): remove broken #1070 CI-proof gate from storage layer (#1225)

### DIFF
--- a/.agents/skills/kaizen-review-pr/SKILL.md
+++ b/.agents/skills/kaizen-review-pr/SKILL.md
@@ -226,13 +226,14 @@ follow-up issue. If any dimension still has MISSING findings, the round is FAIL 
 Store the round summary (required to advance to next round or close the gate):
 ```bash
 npx tsx src/cli-structured-data.ts store-review-summary \
-  --pr <PR_NUMBER> --repo <owner/repo> --round <N> --head-sha "$(git rev-parse HEAD)"
+  --pr <PR_NUMBER> --repo <owner/repo> --round <N>
 ```
 
-For a derived PASS or PASS-with-partials verdict, `store-review-summary` now verifies the PR's
-current HEAD matches `--head-sha` and that `gh pr checks` is green for that HEAD before it writes
-the summary/sentinel (#1070). Pending, failing, absent, or stale-head CI refuses storage; re-run
-review on the current head after CI passes.
+`store-review-summary` is a deterministic local-storage primitive: it derives the verdict from the
+stored per-dimension findings (#1019) and writes the summary/sentinel with no network calls. CI must
+still be green before you treat a round as truly PASS — wait for `gh pr checks` to finish on the
+current HEAD and re-run review if the push changed the diff. (CI-proof enforcement at storage time
+was reverted as wrong-layer/deadlock-prone — see #1225/#1221/#1222; re-implementation tracked in #1070.)
 
 Add `--note "<context>"` only for non-verdict commentary (e.g. "rebased onto main, re-ran tests").
 Read back the derived verdict with `read-review-summary --pr <N> --repo <repo> --round <N>` — the

--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -251,8 +251,10 @@ describe('store-review-batch — review sentinel', () => {
   });
 });
 
-describe('store-review-summary — CI head proof', () => {
-  it('passes --head-sha through to summary storage before writing the sentinel (#1070)', async () => {
+describe('store-review-summary — pure storage, then sentinel', () => {
+  // Post-#1225 revert: the CLI no longer threads a `--head-sha` / CI-proof option into storage.
+  // storeReviewSummary is invoked with (target, round, note) only, then the sentinel is written.
+  it('calls storeReviewSummary with no CI option and writes the sentinel', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     await handlers['store-review-summary']({
@@ -260,14 +262,12 @@ describe('store-review-summary — CI head proof', () => {
       pr: '903',
       repo: 'Garsson-io/kaizen',
       round: '5',
-      ['head-sha']: 'abc123',
     } as CliArgs);
 
     expect(vi.mocked(storeReviewSummary)).toHaveBeenCalledWith(
       { kind: 'pr', number: 903, repo: 'Garsson-io/kaizen' },
       5,
       undefined,
-      { expectedHeadSha: 'abc123' },
     );
     const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
       ([path]) => typeof path === 'string' && path.includes('.reviewed-r5'),

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -59,7 +59,6 @@ import {
   storeIterationState,
   retrieveIterationState,
   type ReviewFindingData,
-  type StoreReviewSummaryOptions,
 } from './structured-data.js';
 import {
   buildReviewSentinelRecord,
@@ -177,12 +176,6 @@ function writeReviewSentinel(repo: string, pr: string | undefined, round: number
   }
 }
 
-function reviewSummaryOptions(a: CliArgs): StoreReviewSummaryOptions {
-  return {
-    expectedHeadSha: a['head-sha'],
-  };
-}
-
 // Review handlers
 
 async function handleNextRound(a: CliArgs): Promise<void> {
@@ -254,7 +247,7 @@ async function handleStoreReviewBatch(a: CliArgs): Promise<void> {
     }
   }
   const findings = parsedBatch as ReviewFindingData[];
-  const result = storeReviewBatch(pr, r, findings, reviewSummaryOptions(a));
+  const result = storeReviewBatch(pr, r, findings);
   // #966: Write review sentinel so pr-review-loop.ts gate guard passes.
   // Mirrors handleStoreReviewSummary — batch includes summary, so sentinel must be written here too.
   writeReviewSentinel(a.repo, a.pr, r);
@@ -277,7 +270,7 @@ async function handleStoreReviewSummary(a: CliArgs): Promise<void> {
   const r = resolveRound(a);
   let url: string;
   try {
-    url = storeReviewSummary(prTarget(a.pr, a.repo), r, note, reviewSummaryOptions(a));
+    url = storeReviewSummary(prTarget(a.pr, a.repo), r, note);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -305,88 +305,31 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     const ok = dimComment(2, 'correctness', 'pass', 3, 0, 0); // all DONE → PASS
     ghReturns(ok); // compose: list
     ghReturns(ok); // compose: read
-    ghReturns('abc123'); // gh pr view: current PR head
-    ghReturns(JSON.stringify([{ name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' }])); // gh pr checks
     ghReturns(''); // writeAttachment: readAttachment (no existing)
     ghReturns('https://...#issuecomment-sum');
 
-    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes', { expectedHeadSha: 'abc123' });
+    storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes');
     const body = bodyOfLastCreate();
     expect(body).toContain('## Review Round 2 — PASS');
     expect(body).toContain('### Reviewer notes (non-authoritative');
     expect(body).toContain('rebased onto main');
   });
 
-  describe('CI proof gate (#1070)', () => {
-    const head = 'abc123';
-    const passChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pass', state: 'SUCCESS' },
-      { name: 'auto-merge', bucket: 'skipping', state: 'SKIPPED' },
-    ]);
-    const pendingChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'pending', state: 'IN_PROGRESS' },
-    ]);
-    const failChecks = JSON.stringify([
-      { name: 'TypeScript tests + coverage', bucket: 'fail', state: 'FAILURE' },
-    ]);
+  // The #1070 CI-proof gate that previously lived here was reverted (#1225): storing a derived PASS
+  // is a pure, deterministic local-storage operation again — it does NOT shell out to `gh pr view`
+  // or `gh pr checks`, and never throws on a passing verdict or a non-PR target. CI-proof belongs in
+  // the review-fix loop (which can poll/wait for CI), not in this storage primitive (#1221/#1222).
+  it('stores a derived PASS with no network/process side-effects (post-#1225 revert)', () => {
+    const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
+    ghReturns(ok); // compose: list
+    ghReturns(ok); // compose: read
+    ghReturns(''); // writeAttachment: readAttachment (no existing) — only storage calls, no pr view/checks
+    ghReturns('https://...#issuecomment-sum');
 
-    it('stores a derived PASS only when current-head CI is passing', () => {
-      const ok = dimComment(4, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view: current PR head
-      ghReturns(passChecks); // gh pr checks
-      ghReturns(''); // writeAttachment: readAttachment (no existing)
-      ghReturns('https://...#issuecomment-sum');
+    storeReviewSummary(pr, 4);
 
-      storeReviewSummary(pr, 4, undefined, { expectedHeadSha: head });
-
-      const body = bodyOfLastCreate();
-      expect(body).toContain('## Review Round 4 — PASS');
-    });
-
-    it('refuses to store a derived PASS while CI is pending', () => {
-      const ok = dimComment(6, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(pendingChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 6, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*pending|pending.*CI|#1070/i);
-    });
-
-    it('refuses to store a derived PASS when CI is failing', () => {
-      const ok = dimComment(7, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns(failChecks); // gh pr checks
-
-      expect(() => storeReviewSummary(pr, 7, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*fail|fail.*CI|#1070/i);
-    });
-
-    it('refuses to store a derived PASS before CI has produced checks', () => {
-      const ok = dimComment(9, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns(head); // gh pr view
-      ghReturns('[]'); // gh pr checks: CI has not started
-
-      expect(() => storeReviewSummary(pr, 9, undefined, { expectedHeadSha: head }))
-        .toThrow(/CI.*not produced checks|#1070/i);
-    });
-
-    it('refuses to store a derived PASS when the reviewed head is stale', () => {
-      const ok = dimComment(8, 'correctness', 'pass', 2, 0, 0);
-      ghReturns(ok); // compose: list
-      ghReturns(ok); // compose: read
-      ghReturns('def456'); // gh pr view: current PR head differs from reviewed head
-
-      expect(() => storeReviewSummary(pr, 8, undefined, { expectedHeadSha: head }))
-        .toThrow(/stale|HEAD|#1070/i);
-    });
+    const body = bodyOfLastCreate();
+    expect(body).toContain('## Review Round 4 — PASS');
   });
 });
 

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -330,6 +330,31 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
 
     const body = bodyOfLastCreate();
     expect(body).toContain('## Review Round 4 — PASS');
+
+    // The reverted #1070 gate shelled out to `gh pr view --json headRefOid`, `gh pr checks`,
+    // and `git rev-parse HEAD` on every PASS store (#1221/#1222). Assert directly that NONE of
+    // those CI-proof calls were made — only attachment read/write gh calls are allowed.
+    const ciProofCall = mockGh.mock.calls.find(([cmd, args]) => {
+      if (!Array.isArray(args)) return false;
+      if (cmd === 'git' && args.includes('rev-parse') && args.includes('HEAD')) return true;
+      if (args.includes('checks')) return true; // gh pr checks
+      if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid')) return true;
+      return false;
+    });
+    expect(ciProofCall).toBeUndefined();
+  });
+
+  it('stores a derived PASS on a non-PR (issue) target without throwing (#1222 defect 1)', () => {
+    // The reverted gate did `if (target.kind !== 'pr') throw`, so storing a PASS summary on an
+    // issue target — a valid AttachmentTarget — regressed to a throw. The revert restores it.
+    const ok = dimComment(3, 'correctness', 'pass', 2, 0, 0);
+    ghReturns(ok); // compose: list
+    ghReturns(ok); // compose: read
+    ghReturns(''); // writeAttachment: readAttachment (no existing)
+    ghReturns('https://...#issuecomment-sum'); // createComment
+
+    // Pre-revert this threw via `if (target.kind !== 'pr') throw`; now it stores like any target.
+    expect(() => storeReviewSummary(issue, 3)).not.toThrow();
   });
 });
 

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -14,7 +14,6 @@
  */
 
 import YAML from 'yaml';
-import { spawnSync } from 'node:child_process';
 import {
   listAttachments,
   readAttachment,
@@ -64,10 +63,9 @@ export function storeReviewBatch(
   target: AttachmentTarget,
   round: number,
   findings: ReviewFindingData[],
-  options: StoreReviewSummaryOptions = {},
 ): { urls: string[]; summaryUrl: string } {
   const urls = findings.map(f => storeReviewFinding(target, round, f));
-  const summaryUrl = storeReviewSummary(target, round, undefined, options);
+  const summaryUrl = storeReviewSummary(target, round, undefined);
   return { urls, summaryUrl };
 }
 
@@ -105,114 +103,6 @@ export function extractPlanText(text: string): string | undefined {
 export type { ReviewFinding, ReviewFindingData } from './review-finding-contract.js';
 
 const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MISSING: '❌' };
-
-export type StoreReviewSummaryOptions = {
-  /**
-   * The commit SHA that was reviewed. If omitted, the current local HEAD is used.
-   * Passing this explicitly lets review tooling prove CI belongs to the same
-   * commit it reviewed even if the local worktree has moved.
-   */
-  expectedHeadSha?: string;
-};
-
-type GhCheck = {
-  name?: string;
-  bucket?: string;
-  state?: string;
-  workflow?: string;
-  link?: string;
-};
-
-function spawnText(command: string, args: string[], failureContext: string): string {
-  const result = spawnSync(command, args, { encoding: 'utf8' });
-  if (result.error) {
-    throw new Error(`${failureContext}: ${result.error.message}`);
-  }
-  const stdout = (result.stdout ?? '').trim();
-  if ((result.status ?? 0) !== 0 && !stdout) {
-    const stderr = (result.stderr ?? '').trim();
-    throw new Error(`${failureContext}: ${stderr || `${command} exited ${result.status}`}`);
-  }
-  return stdout;
-}
-
-function resolveReviewedHeadSha(expectedHeadSha: string | undefined): string {
-  const explicit = expectedHeadSha?.trim();
-  if (explicit) return explicit;
-  return spawnText(
-    'git',
-    ['rev-parse', 'HEAD'],
-    'store-review-summary: #1070 unable to determine reviewed HEAD; pass --head-sha explicitly',
-  );
-}
-
-function readPrHeadSha(target: AttachmentTarget): string {
-  return spawnText(
-    'gh',
-    ['pr', 'view', String(target.number), '--repo', target.repo, '--json', 'headRefOid', '--jq', '.headRefOid'],
-    'store-review-summary: #1070 unable to read current PR head',
-  );
-}
-
-function readPrChecks(target: AttachmentTarget): GhCheck[] {
-  const stdout = spawnText(
-    'gh',
-    ['pr', 'checks', String(target.number), '--repo', target.repo, '--json', 'name,bucket,state,workflow,link'],
-    'store-review-summary: #1070 unable to read PR checks',
-  );
-  try {
-    const parsed = JSON.parse(stdout);
-    if (!Array.isArray(parsed)) {
-      throw new Error('JSON was not an array');
-    }
-    return parsed as GhCheck[];
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`store-review-summary: #1070 unable to parse PR checks JSON (${msg})`);
-  }
-}
-
-function formatCheck(check: GhCheck): string {
-  const workflow = check.workflow ? `${check.workflow} / ` : '';
-  const name = check.name ?? '(unnamed check)';
-  const bucket = check.bucket ?? 'unknown';
-  const state = check.state ? ` (${check.state})` : '';
-  return `${workflow}${name}: ${bucket}${state}`;
-}
-
-function assertReviewSummaryCiPassed(target: AttachmentTarget, options: StoreReviewSummaryOptions): void {
-  if (target.kind !== 'pr') {
-    throw new Error('store-review-summary: #1070 CI proof requires a PR target');
-  }
-
-  const reviewedHead = resolveReviewedHeadSha(options.expectedHeadSha);
-  const currentHead = readPrHeadSha(target);
-  if (currentHead !== reviewedHead) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary for stale HEAD. ` +
-      `Reviewed ${reviewedHead}, but PR #${target.number} is currently ${currentHead}. ` +
-      `Re-review the current head before storing a pass summary.`,
-    );
-  }
-
-  const checks = readPrChecks(target);
-  if (checks.length === 0) {
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI has not produced checks for ${currentHead}.`,
-    );
-  }
-
-  const blocking = checks.filter(check => {
-    const bucket = check.bucket;
-    return bucket !== 'pass' && bucket !== 'skipping';
-  });
-  if (blocking.length > 0) {
-    const details = blocking.map(formatCheck).join('; ');
-    throw new Error(
-      `store-review-summary: #1070 refusing to store a passing review summary because CI is not green for ${currentHead}: ${details}`,
-    );
-  }
-}
 
 function extractSummaryRoundVerdict(summary: string): RoundVerdict | null {
   const match = summary.match(/^<!-- meta:(\{.*\}) -->/);
@@ -397,13 +287,9 @@ export function storeReviewSummary(
   target: AttachmentTarget,
   round: number,
   note?: string,
-  options: StoreReviewSummaryOptions = {},
 ): string {
   const derived = composeReviewSummary(target, round);
   const roundVerdict = extractSummaryRoundVerdict(derived) ?? deriveStoredRoundVerdict(target, round);
-  if (roundVerdict !== 'FAIL') {
-    assertReviewSummaryCiPassed(target, options);
-  }
 
   let content = derived;
 

--- a/src/worktree-isolation.test.ts
+++ b/src/worktree-isolation.test.ts
@@ -63,13 +63,13 @@ describe('kaizen-review-pr SKILL.md — review findings storage contract (#966)'
     expect(skill).toMatch(/store-review-summary/);
   });
 
-  it('requires current-head CI proof when storing a pass summary (#1070)', () => {
-    // INVARIANT: the skill must not regress to instruction-only CI checking.
-    // The storage command carries the reviewed head so the CLI can reject
-    // pending, failing, absent, or stale-head CI before writing the sentinel.
+  it('does not instruct storage-time CI proof via --head-sha (reverted #1070/#1225)', () => {
+    // The #1070 storage-layer CI gate was reverted (#1225): it deadlocked the review-fix loop
+    // (#1221) and added network side-effects + a non-PR throw inside a pure storage primitive
+    // (#1222). The skill must NOT thread --head-sha into store-review-summary; CI-proof belongs
+    // in the review-fix loop, not the storage command.
     const skill = readFileSync(REVIEW_PR_SKILL, 'utf8');
-    expect(skill).toMatch(/--head-sha "\$\(git rev-parse HEAD\)"/);
-    expect(skill).toMatch(/Pending, failing, absent, or stale-head CI refuses storage/);
+    expect(skill).not.toMatch(/--head-sha/);
   });
 });
 


### PR DESCRIPTION
## The problem

`store-review-summary` is supposed to be a boring, deterministic local-storage primitive: derive a
verdict from the stored per-dimension findings, write a comment, done. PR #1212 (#1070, authored by
Codex, merged while its own review battery was FAIL) buried a **CI-proof gate**
(`assertReviewSummaryCiPassed`) inside it — so storing a PASS summary now shelled out to live
`gh pr view`/`gh pr checks`/`git rev-parse` and threw unless CI was green *at that instant*.

That single misplaced gate spawned a cluster of regressions:

- **#1221** — the CI check is synchronous and point-in-time with no polling. The review-fix loop
  runs the battery right after a push *while CI is still in progress*, so a genuine PASS round throws
  → false-FAIL / deadlock.
- **#1222** — three defects in one: (1) it throws on non-PR targets that previously stored fine;
  (2) it injects network/process side-effects into a pure storage function (auth-dependent, flaky,
  non-deterministic — every unmocked test now hits the live `gh` CLI); (3) it does JSON/regex
  parsing in the storage layer (I29).
- **#1225** — umbrella: #1070's real goal ("don't declare PASS before CI is green") is **not met** by
  the shipped code. Fix correctly **or revert**.

## The discovery

The defect isn't a bug to patch — it's an **architecture** error. CI-proof is a *temporal* check
(wait for CI, then assert) and belongs in the review-fix loop, which can poll. A storage primitive
has no business waiting on the network. Every attempt to "fix it in place" (four abandoned rescue
PRs — #1253/#1258/#1259/#1260 — all targeting #1225) inherits the wrong-layer constraint. #1225
explicitly sanctions revert, and revert is the correct move.

## The change

Revert the gate out of the storage layer:

- Remove `assertReviewSummaryCiPassed` + its call site, and the dead helpers it pulled in
  (`spawnText`, `resolveReviewedHeadSha`, `readPrHeadSha`, `readPrChecks`, `formatCheck`), the
  `GhCheck` type, `StoreReviewSummaryOptions`/`expectedHeadSha`, the `--head-sha` CLI plumbing, and
  the now-unused `spawnSync` import.
- `storeReviewSummary`/`storeReviewBatch` are deterministic local-storage primitives again — no
  network, no throw on a passing verdict, no throw on a non-PR target.
- **Preserved**: the separate #1019 fail-closed note-guard (`assertsPass`) — a note can still never
  narrate PASS over a derived FAIL. That guard is unrelated and stays.
- `kaizen-review-pr` SKILL.md drops the storage-time CI-proof instruction.

## The evidence

| Behavior | Level | Where |
|----------|-------|-------|
| Storing a derived PASS does NO `gh pr view`/`gh pr checks` calls | Unit | `structured-data.test.ts` — new "no network/process side-effects" test |
| #1019 fabrication guard still throws PASS-note-over-FAIL | Unit | `structured-data.test.ts` (preserved, green) |
| CLI no longer threads a CI option; sentinel still written | Unit | `cli-structured-data.test.ts` (rewritten) |
| Skill must not instruct `--head-sha` | Unit | `worktree-isolation.test.ts` (invariant flipped) |
| Deleted the gate's harmful-behavior tests (the throws ARE the deadlock) | Unit | `structured-data.test.ts` `CI proof gate (#1070)` block removed |
| Build + affected suites green | Integration | `npm run build`; 67/67 in the three affected files |

(The full-suite run had 6 unrelated `src/e2e/` session-simulator + 1 `kaizen-reflect` timeout under
batch load — none import the changed modules; `kaizen-reflect` passes in isolation. Documented
load-flakiness, not a regression.)

## The impact

The review-fix loop can store PASS summaries again without deadlocking; issue-target review storage
works; the storage layer is deterministic and test-friendly. Four abandoned rescue PRs that were
chasing this in-place are now obsolete.

Closes #1225
Closes #1221
Closes #1222
Refs #1070
