### PR TITLE
refactor(hooks): route session cleanup through gh-exec

### DIFF
--- a/src/hooks/session-cleanup.test.ts
+++ b/src/hooks/session-cleanup.test.ts
@@ -58,4 +58,54 @@ describe('cleanupMergedReviewStates', () => {
     // Stale file should be pruned by pruneStaleStateFiles
     expect(existsSync(join(TEST_STATE_DIR, 'stale-review'))).toBe(false);
   });
+
+  it('removes review state files for merged PRs', () => {
+    const prUrl = 'https://github.com/org/repo/pull/42';
+    writeState('needs-review-merged', prUrl, 'needs_review', 'feature');
+
+    const cleaned = cleanupMergedReviewStates(TEST_STATE_DIR, {
+      readPrState: vi.fn().mockReturnValue('MERGED'),
+    });
+
+    expect(cleaned).toBe(1);
+    expect(existsSync(join(TEST_STATE_DIR, 'needs-review-merged'))).toBe(false);
+  });
+
+  it('removes review state files for closed PRs', () => {
+    const prUrl = 'https://github.com/org/repo/pull/43';
+    writeState('needs-review-closed', prUrl, 'needs_review', 'feature');
+
+    const cleaned = cleanupMergedReviewStates(TEST_STATE_DIR, {
+      readPrState: vi.fn().mockReturnValue('CLOSED'),
+    });
+
+    expect(cleaned).toBe(1);
+    expect(existsSync(join(TEST_STATE_DIR, 'needs-review-closed'))).toBe(false);
+  });
+
+  it('keeps review state files for open PRs', () => {
+    const prUrl = 'https://github.com/org/repo/pull/44';
+    writeState('needs-review-open', prUrl, 'needs_review', 'feature');
+
+    const cleaned = cleanupMergedReviewStates(TEST_STATE_DIR, {
+      readPrState: vi.fn().mockReturnValue('OPEN'),
+    });
+
+    expect(cleaned).toBe(0);
+    expect(existsSync(join(TEST_STATE_DIR, 'needs-review-open'))).toBe(true);
+  });
+
+  it('ignores PR state lookup failures', () => {
+    const prUrl = 'https://github.com/org/repo/pull/45';
+    writeState('needs-review-failure', prUrl, 'needs_review', 'feature');
+
+    const cleaned = cleanupMergedReviewStates(TEST_STATE_DIR, {
+      readPrState: vi.fn().mockImplementation(() => {
+        throw new Error('gh failed');
+      }),
+    });
+
+    expect(cleaned).toBe(0);
+    expect(existsSync(join(TEST_STATE_DIR, 'needs-review-failure'))).toBe(true);
+  });
 });

--- a/src/hooks/session-cleanup.ts
+++ b/src/hooks/session-cleanup.ts
@@ -2,13 +2,12 @@
  * session-cleanup.ts — SessionStart hook: prunes stale/merged state files.
  *
  * Moved out of find_needs_review_state() hot path in kaizen #452 —
- * was adding ~400ms per PreToolUse call due to gh pr view HTTP roundtrip.
+ * was adding ~400ms per PreToolUse call due to PR-state HTTP roundtrip.
  *
  * Part of kAIzen Agent Control Flow — kaizen #786
  * Bash predecessor deleted in #790.
  */
 
-import { execSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { readHookInput } from './hook-io.js';
@@ -17,14 +16,25 @@ import {
   parseStateFile,
   pruneStaleStateFiles,
 } from './state-utils.js';
+import { gh } from '../lib/gh-exec.js';
+
+interface CleanupMergedReviewStatesOptions {
+  readPrState?: (prUrl: string) => string;
+}
+
+function defaultReadPrState(prUrl: string): string {
+  return gh(['pr', 'view', prUrl, '--json', 'state', '--jq', '.state'], 5000);
+}
 
 /**
  * Clean up state files for PRs that have been merged or closed.
- * Uses gh pr view to check PR state — only runs at session start, not hot path.
+ * Uses shared gh-exec helper to check PR state — only runs at session start, not hot path.
  */
 export function cleanupMergedReviewStates(
   stateDir: string = DEFAULT_STATE_DIR,
+  opts: CleanupMergedReviewStatesOptions = {},
 ): number {
+  const readPrState = opts.readPrState ?? defaultReadPrState;
   // First prune stale files by age
   pruneStaleStateFiles(stateDir);
 
@@ -40,11 +50,7 @@ export function cleanupMergedReviewStates(
       if (state.STATUS !== 'needs_review') continue;
       if (!state.PR_URL) continue;
 
-      // Check if PR is merged or closed
-      const prState = execSync(
-        `gh pr view "${state.PR_URL}" --json state --jq .state`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 },
-      ).trim();
+      const prState = readPrState(state.PR_URL).trim();
 
       if (prState === 'MERGED' || prState === 'CLOSED') {
         unlinkSync(filepath);

--- a/src/lib/gh-exec-invariant.test.ts
+++ b/src/lib/gh-exec-invariant.test.ts
@@ -22,8 +22,6 @@ const OPT_OUT = new Set<string>([
   'src/hooks/pr-kaizen-clear.ts',
   // PR quality hook still shells through an injected exec seam for gh metadata.
   'src/hooks/pr-quality-checks.ts',
-  // SessionStart cleanup still checks PR state through gh directly.
-  'src/hooks/session-cleanup.ts',
   // Worktree cleanup still shells through an injected exec seam for gh PR lists.
   'src/worktree-du.ts',
 ]);


### PR DESCRIPTION
## Story

Once upon a time, `src/lib/gh-exec.ts` was the shared GitHub CLI boundary for mechanistic `gh` calls.

Every day, `session-cleanup.ts` still used its own `execSync` shell string to inspect PR state at SessionStart. PR #1296 made that drift visible by putting the file on the `gh-exec` invariant allowlist.

One day, issue #1298 scoped the next shrinking step: remove the `session-cleanup.ts` opt-out without mixing in the larger remaining callers.

Because of that, this PR replaces the direct shell-string call with a small default PR-state reader backed by `gh(['pr', 'view', ...], 5000)`.

Because of that, the cleanup logic now has an injectable seam for tests, so merged, closed, open, and lookup-failure behavior is explicit instead of only indirectly exercised.

Until finally, `src/hooks/session-cleanup.ts` is no longer in the `gh-exec` invariant `OPT_OUT` set, and the focused invariant test stays green.

And ever since, the remaining direct-gh surface is smaller and measurable: `pr-kaizen-clear`, `pr-quality-checks`, and `worktree-du` are the only allowlisted production callers left.

Closes #1298
Parent: #1164
Refs: #1294, #1296

## Architecture

```text
cleanupMergedReviewStates(stateDir, opts)
  ├─ pruneStaleStateFiles(stateDir)
  ├─ parse each needs_review state file
  ├─ readPrState(prUrl)
  │    └─ defaultReadPrState(prUrl)
  │         └─ gh(['pr', 'view', prUrl, '--json', 'state', '--jq', '.state'], 5000)
  └─ unlink state file when PR state is MERGED or CLOSED
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use strict `gh(args)` instead of `ghExec(cmd)` | The call site already knows the argv shape and should avoid shell parsing/interpolation | Slightly more explicit argument list |
| Inject `readPrState` into `cleanupMergedReviewStates` | Tests can cover cleanup behavior without mocking child_process or GitHub | Adds a small options object to an internal hook function |
| Migrate only `session-cleanup.ts` | This is a scope-matched allowlist shrink with focused tests | Remaining direct-gh callers stay as explicit future work |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/session-cleanup.ts` | Replaces direct `execSync(gh ...)` with shared `gh-exec` helper usage and a test seam |
| `src/hooks/session-cleanup.test.ts` | Adds behavior coverage for MERGED, CLOSED, OPEN, and lookup failure paths |
| `src/lib/gh-exec-invariant.test.ts` | Removes `session-cleanup.ts` from the direct-gh allowlist |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|----------|-------------|-------|--------|----------|
| 1 | `cleanupMergedReviewStates` removes needs-review state files when the PR state reader returns `MERGED` or `CLOSED`. | code | Unit | Tested | `src/hooks/session-cleanup.test.ts` merged/closed cases expect cleaned count `1` and deleted files. |
| 2 | `cleanupMergedReviewStates` preserves needs-review state files when the PR state reader returns `OPEN`. | code | Unit | Tested | `src/hooks/session-cleanup.test.ts` open case expects cleaned count `0` and file retained. |
| 3 | `cleanupMergedReviewStates` remains best-effort when PR state lookup throws. | code | Unit | Tested | `src/hooks/session-cleanup.test.ts` failure case expects no throw, cleaned count `0`, and file retained. |
| 4 | `session-cleanup.ts` no longer contributes to the direct-gh allowlist. | code | Unit | Tested | `src/lib/gh-exec-invariant.test.ts` passes after removing the opt-out. |
| 5 | The canonical `gh-exec` helper behavior remains intact. | code | Unit | Tested | Existing `src/lib/gh-exec.test.ts` passes in the focused run. |

## Validation

- [x] RED: `npm test -- --run src/hooks/session-cleanup.test.ts` failed on merged/closed cleanup paths because the production function ignored the new seam and returned cleaned count `0`.
- [x] GREEN: `npm test -- --run src/hooks/session-cleanup.test.ts src/lib/gh-exec-invariant.test.ts src/lib/gh-exec.test.ts` -> 31 passed.
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `rg -n "execSync|spawnSync|exec\(|gh pr view|gh pr" src/hooks/session-cleanup.ts` -> no matches.

## Known Limitations

This PR does not migrate the remaining allowlisted direct-gh callers in `src/hooks/pr-kaizen-clear.ts`, `src/hooks/pr-quality-checks.ts`, or `src/worktree-du.ts`. The invariant continues to track those as shrinking follow-up work.
