### PR TITLE
fix(auto-dent): gate rescue create-draft on closed picked issue (#1300)

### DIFF
--- a/scripts/auto-dent-rescue.test.ts
+++ b/scripts/auto-dent-rescue.test.ts
@@ -141,6 +141,51 @@ describe('decideRescueAction', () => {
     });
     expect(a.kind).toBe('none');
   });
+
+  // #1300 closed-issue guard: a picked issue that is already closed makes the
+  // would-be draft moot — work resolved/superseded elsewhere. None, even with
+  // work ahead of base AND an abnormal exit (the would-be create-draft case).
+  it('does nothing when the picked issue is already closed (#1300)', () => {
+    const a = decideRescueAction({
+      commitsAheadBase: 3,
+      unpushedCommits: 0,
+      dirtyTotal: 2,
+      existingOpenPr: null,
+      pickedIssueClosed: true,
+      abnormal: true,
+    });
+    expect(a.kind).toBe('none');
+    expect(a.commitDirty).toBe(false);
+    expect(a.reason).toMatch(/closed|#1300/i);
+  });
+
+  // The closed-issue guard must NOT touch the push-existing path: an open PR
+  // keeps precedence and is extended even if the issue is marked closed.
+  it('still extends an open PR even if pickedIssueClosed is set (#1300)', () => {
+    const a = decideRescueAction({
+      commitsAheadBase: 5,
+      unpushedCommits: 2,
+      dirtyTotal: 0,
+      existingOpenPr: 'https://x/pr/1',
+      pickedIssueClosed: true,
+      abnormal: false,
+    });
+    expect(a.kind).toBe('push-existing');
+  });
+
+  // An OPEN (or unknown -> false) picked issue with stranded work + abnormal
+  // exit still produces create-draft — the guard is closed-only, fail-open.
+  it('still creates a draft when the picked issue is open/unknown (#1300)', () => {
+    const a = decideRescueAction({
+      commitsAheadBase: 3,
+      unpushedCommits: 0,
+      dirtyTotal: 0,
+      existingOpenPr: null,
+      pickedIssueClosed: false,
+      abnormal: true,
+    });
+    expect(a.kind).toBe('create-draft');
+  });
 });
 
 describe('formatRescueReport', () => {
@@ -209,6 +254,10 @@ function makeFakeGit(cfg: FakeGitConfig, log: string[][]): GitExec {
 function makeFakeGh(
   pr: string | { number?: number; state: 'OPEN' | 'MERGED' | 'CLOSED'; url: string } | null,
   ghLog: string[][],
+  // #1300: the state `gh issue view` reports for the picked issue. Defaults to
+  // unknown ('{}' → null → fail-open), so existing tests that never set a picked
+  // issue are unaffected.
+  issueState?: 'OPEN' | 'CLOSED',
 ): (args: string[]) => string {
   const summary =
     pr == null
@@ -223,6 +272,9 @@ function makeFakeGh(
     }
     if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/x/pull/999';
     if (args[0] === 'pr' && args[1] === 'comment') return '';
+    if (args[0] === 'issue' && args[1] === 'view') {
+      return issueState ? JSON.stringify({ state: issueState }) : '{}';
+    }
     return '';
   };
 }
@@ -342,6 +394,48 @@ describe('rescueTarget orchestration', () => {
     expect(out.prUrl).toBeUndefined();
     expect(gitLog.some((a) => a.includes('push'))).toBe(false);
     expect(ghLog.some((a) => a[1] === 'create' || a[1] === 'comment')).toBe(false);
+  });
+
+  // #1300 end-to-end: stranded work, no PR, abnormal exit — but the picked issue
+  // is already CLOSED (resolved by another path). The rescue must decline: NO
+  // push, NO gh pr create. It still queried the issue state (issue view called).
+  it('does nothing when the picked issue is already closed (#1300)', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      { ...ctx, pickedIssue: '#1225' },
+      {
+        git: makeFakeGit({ aheadBase: 3 }, gitLog),
+        gh: makeFakeGh(null, ghLog, 'CLOSED'),
+        readDirty: makeReadDirty(2),
+      },
+    );
+    expect(out.action).toBe('none');
+    expect(out.pushed).toBe(false);
+    expect(out.prUrl).toBeUndefined();
+    expect(gitLog.some((a) => a.includes('push'))).toBe(false);
+    expect(ghLog.some((a) => a[1] === 'create' || a[1] === 'comment')).toBe(false);
+    expect(ghLog.some((a) => a[0] === 'issue' && a[1] === 'view')).toBe(true);
+  });
+
+  // #1300 regression: an OPEN picked issue with stranded work still creates the
+  // draft — the guard is closed-only and must never block a legitimate rescue.
+  it('still creates a draft when the picked issue is open (#1300)', () => {
+    const gitLog: string[][] = [];
+    const ghLog: string[][] = [];
+    const out = rescueTarget(
+      { worktree, branch: 'case/x' },
+      { ...ctx, pickedIssue: '#1300' },
+      {
+        git: makeFakeGit({ aheadBase: 2 }, gitLog),
+        gh: makeFakeGh(null, ghLog, 'OPEN'),
+        readDirty: makeReadDirty(1),
+      },
+    );
+    expect(out.action).toBe('create-draft');
+    expect(out.pushed).toBe(true);
+    expect(ghLog.some((a) => a[1] === 'create' && a.includes('--draft'))).toBe(true);
   });
 
   it('records a push failure without throwing (never hides the original failure)', () => {

--- a/scripts/auto-dent-rescue.ts
+++ b/scripts/auto-dent-rescue.ts
@@ -34,7 +34,7 @@ import {
   type DirtyState,
 } from '../src/hooks/lib/git-state.js';
 import { gh as defaultGh } from '../src/lib/gh-exec.js';
-import { queryBranchPrState } from '../src/lib/github-pr.js';
+import { parseIssueNumber, queryBranchPrState, queryIssueState } from '../src/lib/github-pr.js';
 
 /** Quality gates a rescue deliberately skips — surfaced in the rescue report. */
 export const SKIPPED_GATES: readonly string[] = [
@@ -107,6 +107,19 @@ export interface RescueDecisionInput {
    * redundant draft. Defaults to false.
    */
   mostRecentMerged?: boolean;
+  /**
+   * True when the run's picked issue is already CLOSED. The work a fresh draft
+   * rescue PR would preserve has been resolved/superseded by another path — a
+   * revert, a sibling run, or a manual close. This is the live #1225 cluster:
+   * #1225 ("redo the gate correctly OR revert") was closed by *revert* (#1297),
+   * yet three draft rescue PRs to redo it (#1258–#1260) sat open as orphans
+   * nobody reconciled. Opening a brand-new draft for resolved work manufactures
+   * exactly that orphan. Symmetric sibling of `mostRecentMerged`: it gates ONLY
+   * `create-draft`; `push-existing` (extending an already-open PR) ignores it.
+   * Fail-open: an unknown issue state must arrive here as false, never true.
+   * Defaults to false. (#1300)
+   */
+  pickedIssueClosed?: boolean;
 }
 
 export interface RescueAction {
@@ -153,6 +166,20 @@ export function decideRescueAction(input: RescueDecisionInput): RescueAction {
   const hasWork = input.commitsAheadBase > 0 || input.dirtyTotal > 0;
   if (!hasWork) {
     return { kind: 'none', commitDirty: false, reason: 'no commits ahead and no dirty files' };
+  }
+  // #1300 closed-issue guard: a fresh draft rescue PR exists to preserve work
+  // that would otherwise vanish, but when the picked issue is already CLOSED the
+  // work is moot — resolved/superseded by another path (revert, sibling run,
+  // manual close). The live cluster: #1225 closed by revert (#1297), leaving
+  // draft rescues #1258–#1260 open as orphans nobody reconciled. Symmetric with
+  // the mostRecentMerged (I7) guard above. The open-PR path keeps precedence, so
+  // an in-flight PR is unaffected; this only stops manufacturing a new orphan.
+  if (input.pickedIssueClosed) {
+    return {
+      kind: 'none',
+      commitDirty: false,
+      reason: 'picked issue already closed — work resolved/superseded by another path; not manufacturing an orphan rescue draft (#1300)',
+    };
   }
   // #1289: only an ABNORMAL termination (watchdog timeout / non-zero exit) strands
   // work that warrants manufacturing a brand-new draft rescue PR. A clean exit or
@@ -306,7 +333,19 @@ export function rescueTarget(target: RescueTarget, ctx: RescueContext, deps: Res
   const existingOpenPr = prState.openUrl ?? null;
   const mostRecentMerged = prState.mostRecent?.state === 'MERGED' && !prState.hasOpen;
 
-  const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr, mostRecentMerged, abnormal: ctx.abnormal });
+  // #1300: a brand-new draft (the only path the closed-issue guard gates) is
+  // only on the table when there's no open PR. Query the picked issue's state
+  // just then — never on the push-existing path — and fail open: a null/unknown
+  // state leaves pickedIssueClosed false, so a legitimate rescue is never blocked.
+  let pickedIssueClosed = false;
+  if (!existingOpenPr) {
+    const issueNumber = parseIssueNumber(ctx.pickedIssue);
+    if (issueNumber != null) {
+      pickedIssueClosed = queryIssueState({ gh, repo: ctx.repo, issue: issueNumber }) === 'CLOSED';
+    }
+  }
+
+  const action = decideRescueAction({ commitsAheadBase, unpushedCommits, dirtyTotal, existingOpenPr, mostRecentMerged, pickedIssueClosed, abnormal: ctx.abnormal });
   outcome.action = action.kind;
   if (action.kind === 'none') {
     log?.(`${target.branch}: ${action.reason}`);

--- a/src/lib/github-pr.test.ts
+++ b/src/lib/github-pr.test.ts
@@ -3,7 +3,10 @@ import {
   findOpenPrUrlForBranch,
   parseBranchPrQueryResult,
   parseFirstPrUrl,
+  parseIssueNumber,
+  parseIssueState,
   queryBranchPrState,
+  queryIssueState,
 } from './github-pr.js';
 
 describe('parseFirstPrUrl', () => {
@@ -139,5 +142,80 @@ describe('queryBranchPrState', () => {
     });
 
     expect(result).toEqual({ mostRecent: null, hasOpen: false });
+  });
+});
+
+describe('parseIssueNumber', () => {
+  it('extracts the number from #N, bare N, and a URL', () => {
+    expect(parseIssueNumber('#1225')).toBe(1225);
+    expect(parseIssueNumber('1225')).toBe(1225);
+    expect(parseIssueNumber('https://github.com/o/r/issues/1225')).toBe(1225);
+  });
+
+  it('returns null for empty, missing, or digit-free tokens', () => {
+    expect(parseIssueNumber(undefined)).toBeNull();
+    expect(parseIssueNumber(null)).toBeNull();
+    expect(parseIssueNumber('')).toBeNull();
+    expect(parseIssueNumber('not an issue')).toBeNull();
+  });
+});
+
+describe('parseIssueState', () => {
+  it('maps OPEN and CLOSED case-insensitively', () => {
+    expect(parseIssueState(JSON.stringify({ state: 'OPEN' }))).toBe('OPEN');
+    expect(parseIssueState(JSON.stringify({ state: 'CLOSED' }))).toBe('CLOSED');
+    expect(parseIssueState(JSON.stringify({ state: 'closed' }))).toBe('CLOSED');
+  });
+
+  it('returns null for malformed, empty, or unexpected state (fail-open)', () => {
+    expect(parseIssueState('')).toBeNull();
+    expect(parseIssueState('{not json')).toBeNull();
+    expect(parseIssueState(JSON.stringify({ state: 'MERGED' }))).toBeNull();
+    expect(parseIssueState(JSON.stringify({}))).toBeNull();
+  });
+});
+
+describe('queryIssueState', () => {
+  it('runs a repo-scoped issue view and returns the parsed state', () => {
+    const calls: string[][] = [];
+    const result = queryIssueState({
+      repo: 'owner/repo',
+      issue: 1225,
+      gh: (args) => {
+        calls.push(args);
+        return JSON.stringify({ state: 'CLOSED' });
+      },
+    });
+
+    expect(result).toBe('CLOSED');
+    expect(calls).toEqual([[
+      'issue', 'view', '1225',
+      '--repo', 'owner/repo',
+      '--json', 'state',
+    ]]);
+  });
+
+  it('returns null without calling gh when repo or issue is missing', () => {
+    const calls: string[][] = [];
+    const gh = (args: string[]) => {
+      calls.push(args);
+      return JSON.stringify({ state: 'OPEN' });
+    };
+
+    expect(queryIssueState({ repo: '', issue: 1, gh })).toBeNull();
+    expect(queryIssueState({ repo: 'owner/repo', issue: NaN, gh })).toBeNull();
+    expect(calls).toEqual([]);
+  });
+
+  it('returns null when gh throws (fail-open)', () => {
+    const result = queryIssueState({
+      repo: 'owner/repo',
+      issue: 1225,
+      gh: () => {
+        throw new Error('gh unavailable');
+      },
+    });
+
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/github-pr.ts
+++ b/src/lib/github-pr.ts
@@ -106,3 +106,63 @@ export function queryBranchPrState(options: QueryBranchPrStateOptions): BranchPr
     return emptyBranchPrQueryResult();
   }
 }
+
+export type IssueState = 'OPEN' | 'CLOSED';
+
+/**
+ * Extract a GitHub issue number from a loose token — `#1225`, `1225`, or a
+ * URL like `https://github.com/o/r/issues/1225`. Returns the first run of
+ * digits as a number, or null when the token carries none. Deliberately
+ * permissive: callers pass values pulled from phase markers / config where the
+ * `#` prefix and URL form both occur.
+ */
+export function parseIssueNumber(token: string | undefined | null): number | null {
+  if (!token) return null;
+  const match = /(\d+)/.exec(token);
+  if (!match) return null;
+  const n = parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Parse an issue's state from `gh issue view --json state` output. Returns
+ * 'OPEN'/'CLOSED', or null for malformed/empty/unexpected output. Fail-open by
+ * design: a null result means "state unknown", which callers must treat as
+ * "do not block" — never as "closed".
+ */
+export function parseIssueState(output: string): IssueState | null {
+  try {
+    const parsed = JSON.parse(output || '{}') as { state?: unknown };
+    const raw = typeof parsed.state === 'string' ? parsed.state.toUpperCase() : null;
+    return raw === 'OPEN' || raw === 'CLOSED' ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface QueryIssueStateOptions {
+  repo: string;
+  issue: number;
+  /** Injectable gh runner for tests and callers that already own gh wiring. */
+  gh?: GhRunner;
+}
+
+/**
+ * Query a single issue's state via gh. Sibling of {@link queryBranchPrState} —
+ * one DRY boundary for gh issue-state lookups, no second gh wrapper. Returns
+ * null on any failure (missing repo/issue, gh throw, malformed output) so the
+ * caller fails open: an unknown state must never be mistaken for CLOSED.
+ */
+export function queryIssueState(options: QueryIssueStateOptions): IssueState | null {
+  if (!options.repo || !Number.isFinite(options.issue)) return null;
+  const runGh = options.gh ?? defaultGh;
+  try {
+    return parseIssueState(runGh([
+      'issue', 'view', String(options.issue),
+      '--repo', options.repo,
+      '--json', 'state',
+    ]));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

The auto-dent rescue finalizer (#1255) preserves stranded work as a draft `[rescue]` PR. Its `create-draft` decision learned two outcome guards over time — don't push to an already-merged branch (I7, #1284), and only manufacture a draft for crash/timeout-stranded work (#1289) — but it never checked **whether the target issue was still open**.

So when an issue is resolved by a path *other than* the rescued branch, the finalizer keeps opening drafts to "redo" already-resolved work. That draft is an orphan nobody reconciles.

## Discovery

This is a live cluster, not a hypothetical. Issue #1225 was framed "redo the #1070 CI-proof gate correctly **OR revert**" — and the project chose **revert** (#1297, already merged this batch). Yet three draft rescue PRs to *redo* it — **#1258, #1259, #1260** — still sit open against a now-closed issue. The batch guidance to "finish the rescue PRs" couldn't be met because the finalizer is structurally able to keep producing them.

The root cause is the #943/#1227 family: a verdict ("this issue still needs work") is *implied* by `create-draft`, but no mechanism honors the actual issue lifecycle. The merged-branch guard (#1284) and abnormal-exit guard (#1289) are the same shape — the closed-issue guard is their missing sibling.

## Solution

A closed-issue guard, symmetric with the existing `mostRecentMerged` (I7) guard:

- **`queryIssueState`** in `src/lib/github-pr.ts` — a sibling of `queryBranchPrState`. One DRY boundary for gh issue-state lookups (no second gh wrapper; routes through the shared `gh-exec` adapter, so the gh-exec invariant still holds). Returns `null` on any failure — **fail-open**: an unknown state is never mistaken for CLOSED.
- **`decideRescueAction`** returns `none` when `pickedIssueClosed` is set. It gates **only** `create-draft`; `push-existing` (extending an already-open PR) is unaffected and keeps precedence.
- **`rescueTarget`** queries the picked issue's state *only when there is no open PR* (the sole path the guard can affect) and passes the result in. An unresolvable issue number or null state leaves the guard off.
- The three orphan drafts #1258/#1259/#1260 are closed alongside this change (their target #1225 is closed).

## Evidence

`npx vitest run src/lib/github-pr.test.ts scripts/auto-dent-rescue.test.ts` → **56 passed**; `gh-exec-invariant` → **6 passed**; `tsc --noEmit` clean.

### Behaviors × Levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| `parseIssueState` maps OPEN/CLOSED/lowercase, null on malformed/unexpected | ✅ | | | | |
| `parseIssueNumber` extracts `#N`/`N`/URL, null on garbage | ✅ | | | | |
| `queryIssueState` fail-open: null when gh throws / repo/issue missing | ✅ | | | | |
| `decideRescueAction` → `none` when picked issue closed (+ work + abnormal) | ✅ | | | | |
| closed-issue guard does NOT touch `push-existing` (open PR keeps precedence) | ✅ | | | | |
| open/unknown picked issue still → `create-draft` (fail-open regression) | ✅ | | | | |
| `rescueTarget`: closed picked issue → no push, no `pr create`; issue queried | | ✅ | | | |
| `rescueTarget`: open picked issue → create-draft as before (regression) | | ✅ | | | |

## Impact

The finalizer can no longer manufacture an orphan rescue draft for an issue that has already been resolved by a revert / sibling run / manual close. Combined with the I7 (#1284) and abnormal-exit (#1289) guards, every `create-draft` is now bound to all three outcome signals — branch not merged, exit abnormal, **and issue still open** — closing the last "computed-but-not-bound" gap in the rescue create-draft path.

Closes #1300
Parent: #1164
Refs: #1225, #1258, #1259, #1260, #1284, #1289, #943
