### PR TITLE
refactor(worktree): route open PR listing through gh-exec

### DIFF
--- a/src/lib/gh-exec-invariant.test.ts
+++ b/src/lib/gh-exec-invariant.test.ts
@@ -22,8 +22,6 @@ const OPT_OUT = new Set<string>([
   'src/hooks/pr-kaizen-clear.ts',
   // PR quality hook still shells through an injected exec seam for gh metadata.
   'src/hooks/pr-quality-checks.ts',
-  // Worktree cleanup still shells through an injected exec seam for gh PR lists.
-  'src/worktree-du.ts',
 ]);
 
 function repoRelative(path: string): string {

--- a/src/worktree-du.test.ts
+++ b/src/worktree-du.test.ts
@@ -7,6 +7,7 @@ import {
   analyzeWorktrees,
   analyzeBranches,
   cleanupWorktrees,
+  listOpenPullRequests,
   parseCliArgs,
   type Deps,
   type LockFile,
@@ -18,6 +19,7 @@ import type { ProjectPaths } from "./lib/resolve-project-root.js";
 function makeDeps(overrides: Partial<Deps> = {}): Deps {
   return {
     exec: () => "",
+    gh: () => "",
     pidAlive: () => false,
     now: () => Date.now(),
     readFile: () => "",
@@ -30,6 +32,60 @@ function makeDeps(overrides: Partial<Deps> = {}): Deps {
     ...overrides,
   };
 }
+
+describe("listOpenPullRequests", () => {
+  it("uses configured host repo with argv-style gh args", () => {
+    let ghArgs: string[] = [];
+    const deps = makeDeps({
+      readFile: (path) => {
+        if (path.endsWith("kaizen.config.json")) {
+          return JSON.stringify({ host: { repo: "Garsson-io/kaizen" } });
+        }
+        return "";
+      },
+      gh: (args) => {
+        ghArgs = args;
+        return "  #1  main  Test PR";
+      },
+    });
+
+    expect(listOpenPullRequests(makePaths("/repo"), deps)).toBe("  #1  main  Test PR");
+    expect(ghArgs).toEqual([
+      "pr",
+      "list",
+      "--repo",
+      "Garsson-io/kaizen",
+      "--state",
+      "open",
+      "--json",
+      "number,title,headBranch",
+      "--jq",
+      '.[] | "  #\\(.number)  \\(.headBranch)  \\(.title)"',
+    ]);
+  });
+
+  it("falls back to normalized origin remote when config cannot be read", () => {
+    let ghArgs: string[] = [];
+    const deps = makeDeps({
+      readFile: () => {
+        throw new Error("missing config");
+      },
+      exec: (cmd) => {
+        if (cmd.includes("remote get-url origin")) {
+          return "git@github.com:Garsson-io/kaizen.git";
+        }
+        return "";
+      },
+      gh: (args) => {
+        ghArgs = args;
+        return "";
+      },
+    });
+
+    expect(listOpenPullRequests(makePaths("/repo"), deps)).toBe("");
+    expect(ghArgs).toContain("Garsson-io/kaizen");
+  });
+});
 
 function makePaths(root = "/project"): ProjectPaths {
   return {
@@ -464,4 +520,3 @@ describe("cleanupWorktrees — deletion sentinel", () => {
     expect(sentinel).toContain("wt-abc");
   });
 });
-

--- a/src/worktree-du.ts
+++ b/src/worktree-du.ts
@@ -9,6 +9,7 @@
 import { execSync } from "child_process";
 import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
+import { gh as runGh } from "./lib/gh-exec.js";
 import { resolveProjectPaths, type ProjectPaths } from "./lib/resolve-project-root.js";
 
 // ── Types ──
@@ -55,6 +56,7 @@ interface BranchSummary {
 
 export interface Deps {
   exec: (cmd: string) => string;
+  gh: (args: string[], timeoutMs?: number) => string;
   pidAlive: (pid: number) => boolean;
   now: () => number;
   readFile: (path: string) => string;
@@ -69,6 +71,7 @@ export interface Deps {
 export function defaultDeps(): Deps {
   return {
     exec: (cmd) => execSync(cmd, { encoding: "utf8" }).trim(),
+    gh: (args, timeoutMs) => runGh(args, timeoutMs),
     pidAlive: (pid) => {
       try { process.kill(pid, 0); return true; } catch { return false; }
     },
@@ -678,22 +681,36 @@ function dockerCmd(deps: Deps): string {
   }
 }
 
+export function listOpenPullRequests(paths: ProjectPaths, deps: Deps): string {
+  let repo: string;
+  try {
+    repo = JSON.parse(deps.readFile(join(paths.projectRoot, "kaizen.config.json"))).host?.repo ?? "";
+  } catch {
+    repo = deps.exec(`git -C "${paths.projectRoot}" remote get-url origin`)
+      .replace(/.*github\.com[:/]/, "").replace(/\.git$/, "");
+  }
+
+  return deps.gh([
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--json",
+    "number,title,headBranch",
+    "--jq",
+    '.[] | "  #\\(.number)  \\(.headBranch)  \\(.title)"',
+  ]);
+}
+
 function printExternalAnalysis(paths: ProjectPaths, deps: Deps) {
   // PRs
   console.log("");
   console.log(`${BOLD}Open PRs${NC}`);
   console.log("");
   try {
-    let repo: string;
-    try {
-      repo = JSON.parse(deps.readFile(join(paths.projectRoot, "kaizen.config.json"))).host?.repo ?? "";
-    } catch {
-      repo = deps.exec(`git -C "${paths.projectRoot}" remote get-url origin`)
-        .replace(/.*github\.com[:/]/, "").replace(/\.git$/, "");
-    }
-    const prs = deps.exec(
-      `gh pr list --repo "${repo}" --state open --json number,title,headBranch --jq '.[] | "  #\\(.number)  \\(.headBranch)  \\(.title)"'`,
-    );
+    const prs = listOpenPullRequests(paths, deps);
     console.log(prs || "  (none)");
   } catch {
     console.log("  (none)");


### PR DESCRIPTION
## Story

Once upon a time, `src/worktree-du.ts` reported worktree disk state and included an external-analysis section listing open PRs.

Every day, that open-PR listing used its own `deps.exec('gh pr list ...')` command string while the rest of the DRY sweep moved GitHub CLI calls toward `src/lib/gh-exec.ts`.

One day, the `gh-exec` invariant made `worktree-du.ts` one of the remaining allowlisted direct-gh callers, and issue #1301 scoped the smallest useful migration.

Because of that, this PR adds a `Deps.gh(args)` boundary backed by `gh-exec` and extracts `listOpenPullRequests(paths, deps)` for the open-PR listing.

Because of that, configured `host.repo` and remote-origin fallback behavior are now tested through argv-style gh args instead of command-string matching.

Until finally, `src/worktree-du.ts` leaves the `gh-exec` invariant allowlist and the focused invariant test stays green.

And ever since, the remaining direct-gh production allowlist is down to `pr-kaizen-clear` and `pr-quality-checks`.

Closes #1301
Parent: #1164
Refs: #1294, #1296, #1299

## Architecture

```text
printExternalAnalysis(paths, deps)
  └─ listOpenPullRequests(paths, deps)
       ├─ read host.repo from kaizen.config.json
       ├─ fallback: git remote get-url origin -> owner/repo
       └─ deps.gh(['pr', 'list', '--repo', repo, ...])
            └─ defaultDeps().gh -> gh-exec gh(args)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add `Deps.gh(args)` | Keeps `worktree-du` testable while moving GitHub CLI execution to the shared helper | Expands the dependency interface by one method |
| Export `listOpenPullRequests` | Lets tests prove repo resolution and argv shape directly | Slightly larger public surface inside this internal script module |
| Keep git/docker/du commands on `deps.exec` | This PR is only about GitHub CLI duplication | Shell command cleanup remains separate work |
| Migrate only `worktree-du.ts` | Small, scope-matched allowlist shrink | `pr-kaizen-clear` and `pr-quality-checks` remain explicit future work |

## What's In This PR

| File | Purpose |
|---|---|
| `src/worktree-du.ts` | Adds `Deps.gh`, routes open-PR listing through `gh-exec`, and extracts `listOpenPullRequests` |
| `src/worktree-du.test.ts` | Adds tests for configured repo, remote fallback, and argv-style `gh` args |
| `src/lib/gh-exec-invariant.test.ts` | Removes `src/worktree-du.ts` from the direct-gh allowlist |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|----------|-------------|-------|--------|----------|
| 1 | Open-PR listing uses configured `host.repo` from `kaizen.config.json`. | code | Unit | Tested | `src/worktree-du.test.ts` asserts `deps.gh` receives `--repo Garsson-io/kaizen`. |
| 2 | Open-PR listing falls back to normalized origin remote repo when config cannot be read. | code | Unit | Tested | `src/worktree-du.test.ts` supplies `git@github.com:Garsson-io/kaizen.git` and asserts normalized repo reaches `deps.gh`. |
| 3 | Open-PR listing uses argv-style `gh` helper rather than shell command strings. | code | Unit | Tested | Tests inspect `args`; grep finds no direct-gh source pattern in `worktree-du.ts`. |
| 4 | `worktree-du.ts` no longer contributes to the direct-gh allowlist. | code | Unit | Tested | `src/lib/gh-exec-invariant.test.ts` passes after removing the opt-out. |
| 5 | Existing worktree cleanup behavior remains intact. | code | Unit | Tested | Existing `src/worktree-du.test.ts` suite passes in the focused run. |

## Validation

- [x] RED: `npm test -- --run src/worktree-du.test.ts` failed because `listOpenPullRequests` was not implemented/exported.
- [x] GREEN: `npm test -- --run src/worktree-du.test.ts src/lib/gh-exec-invariant.test.ts src/lib/gh-exec.test.ts` -> 58 passed.
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `rg -n "gh pr|exec\\(.*gh|execSync\\(.*gh|spawnSync\\(.*gh" src/worktree-du.ts src/lib/gh-exec-invariant.test.ts` -> no `worktree-du.ts` matches.

## Known Limitations

This PR does not migrate `src/hooks/pr-kaizen-clear.ts` or `src/hooks/pr-quality-checks.ts`. They remain the only production files in the `gh-exec` invariant allowlist.
