### PR TITLE
refactor(hooks): route PR quality metadata through gh-exec

### DIFF
--- a/src/hooks/pr-quality-checks.test.ts
+++ b/src/hooks/pr-quality-checks.test.ts
@@ -45,11 +45,30 @@ describe('getChangedFiles', () => {
   });
 
   it('uses gh pr diff for merge', () => {
-    const exec = (cmd: string) => {
-      if (cmd.includes('gh pr diff')) return 'src/c.ts\nsrc/d.ts';
+    const gh = (args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'diff') return 'src/c.ts\nsrc/d.ts';
       return '';
     };
-    expect(getChangedFiles('gh pr merge 42', true, exec)).toEqual(['src/c.ts', 'src/d.ts']);
+    expect(getChangedFiles('gh pr merge 42', true, () => '', gh)).toEqual(['src/c.ts', 'src/d.ts']);
+  });
+
+  it('uses argv-style gh args for merge PR diff', () => {
+    const ghCalls: string[][] = [];
+    const gh = (args: string[]) => {
+      ghCalls.push(args);
+      return 'src/c.ts\nsrc/d.ts';
+    };
+
+    expect(getChangedFiles('gh pr merge 42 --repo Garsson-io/kaizen', true, () => '', gh))
+      .toEqual(['src/c.ts', 'src/d.ts']);
+    expect(ghCalls).toEqual([[
+      'pr',
+      'diff',
+      '42',
+      '--name-only',
+      '--repo',
+      'Garsson-io/kaizen',
+    ]]);
   });
 
   it('falls back to git diff on merge if gh pr diff fails', () => {
@@ -59,6 +78,18 @@ describe('getChangedFiles', () => {
       return '';
     };
     expect(getChangedFiles('gh pr merge 42', true, exec)).toEqual(['src/e.ts']);
+  });
+
+  it('falls back to git diff when argv-style gh PR diff returns empty', () => {
+    const execCalls: string[] = [];
+    const exec = (cmd: string) => {
+      execCalls.push(cmd);
+      if (cmd.includes('git diff')) return 'src/e.ts';
+      return '';
+    };
+
+    expect(getChangedFiles('gh pr merge 42', true, exec, () => '')).toEqual(['src/e.ts']);
+    expect(execCalls).toEqual(['git diff --name-only main...HEAD']);
   });
 });
 
@@ -165,20 +196,61 @@ describe('checkVerification', () => {
   });
 
   it('shows post-merge verification on pr_merge', () => {
-    const exec = (cmd: string) => {
-      if (cmd.includes('gh pr view')) return '## Verification\n- Run npm test\n- Check output';
+    const gh = (args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'view') return '## Verification\n- Run npm test\n- Check output';
       return '';
     };
-    const msg = checkVerification('gh pr merge 42', 'pr_merge', exec);
+    const msg = checkVerification('gh pr merge 42', 'pr_merge', () => '', gh);
     expect(msg).toContain('POST-MERGE VERIFICATION REQUIRED');
   });
 
+  it('uses argv-style gh args to fetch explicit merge PR body', () => {
+    const ghCalls: string[][] = [];
+    const gh = (args: string[]) => {
+      ghCalls.push(args);
+      return '## Verification\n- Run npm test';
+    };
+
+    const msg = checkVerification('gh pr merge 42', 'pr_merge', () => '', gh);
+
+    expect(msg).toContain('POST-MERGE VERIFICATION REQUIRED');
+    expect(ghCalls).toEqual([[
+      'pr',
+      'view',
+      '42',
+      '--json',
+      'body',
+      '--jq',
+      '.body',
+    ]]);
+  });
+
+  it('uses argv-style gh args to fetch current PR body when merge command has no number', () => {
+    const ghCalls: string[][] = [];
+    const gh = (args: string[]) => {
+      ghCalls.push(args);
+      return '## Verification\n- Run npm test';
+    };
+
+    const msg = checkVerification('gh pr merge --squash', 'pr_merge', () => '', gh);
+
+    expect(msg).toContain('POST-MERGE VERIFICATION REQUIRED');
+    expect(ghCalls).toEqual([[
+      'pr',
+      'view',
+      '--json',
+      'body',
+      '--jq',
+      '.body',
+    ]]);
+  });
+
   it('warns when merge PR has no verification section', () => {
-    const exec = (cmd: string) => {
-      if (cmd.includes('gh pr view')) return '## Summary\nSome changes';
+    const gh = (args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'view') return '## Summary\nSome changes';
       return '';
     };
-    const msg = checkVerification('gh pr merge 42', 'pr_merge', exec);
+    const msg = checkVerification('gh pr merge 42', 'pr_merge', () => '', gh);
     expect(msg).toContain('no Verification section');
   });
 
@@ -299,8 +371,11 @@ describe('runQualityChecks', () => {
   it('runs test coverage and verification for gh pr merge', () => {
     const result = runQualityChecks('gh pr merge 42', {
       exec: (cmd) => {
-        if (cmd.includes('gh pr diff')) return 'src/a.ts';
-        if (cmd.includes('gh pr view')) return '## Verification\n- check';
+        return '';
+      },
+      gh: (args) => {
+        if (args[0] === 'pr' && args[1] === 'diff') return 'src/a.ts';
+        if (args[0] === 'pr' && args[1] === 'view') return '## Verification\n- check';
         return '';
       },
     });

--- a/src/hooks/pr-quality-checks.ts
+++ b/src/hooks/pr-quality-checks.ts
@@ -27,6 +27,7 @@ import {
   isGitCommand,
   stripHeredocBody,
 } from './parse-command.js';
+import { gh as runGh } from '../lib/gh-exec.js';
 
 type CommandType = 'pr_create' | 'pr_merge' | 'git_commit' | 'none';
 
@@ -39,6 +40,7 @@ export function detectCommandType(cmdLine: string): CommandType {
 
 interface RunnerOptions {
   exec?: (cmd: string) => string;
+  gh?: (args: string[]) => string;
   fileExists?: (path: string) => boolean;
   readFile?: (path: string) => string;
   hookDir?: string;
@@ -52,20 +54,31 @@ const defaultExec = (cmd: string): string => {
   }
 };
 
+const defaultGh = (args: string[]): string => {
+  try {
+    return runGh(args);
+  } catch {
+    return '';
+  }
+};
+
 /** Get changed files for the current PR/branch. */
 export function getChangedFiles(
   cmdLine: string,
   isMerge: boolean,
   exec: (cmd: string) => string,
+  gh: (args: string[]) => string = defaultGh,
 ): string[] {
   let raw: string;
   if (isMerge) {
-    // Try gh pr diff first for merge commands
     const prNumMatch = cmdLine.match(/gh\s+pr\s+merge\s+(\d+)/);
     const prArg = prNumMatch?.[1] ?? '';
     const repoMatch = cmdLine.match(/--repo\s+(\S+)/);
-    const repoFlag = repoMatch ? `--repo ${repoMatch[1]}` : '';
-    raw = exec(`gh pr diff ${prArg} --name-only ${repoFlag}`.trim());
+    const args = ['pr', 'diff'];
+    if (prArg) args.push(prArg);
+    args.push('--name-only');
+    if (repoMatch) args.push('--repo', repoMatch[1]);
+    raw = gh(args);
     if (!raw) {
       raw = exec('git diff --name-only main...HEAD');
     }
@@ -188,6 +201,7 @@ export function checkVerification(
   command: string,
   cmdType: CommandType,
   exec: (cmd: string) => string,
+  gh: (args: string[]) => string = defaultGh,
 ): string {
   if (cmdType === 'pr_create') {
     // Check for verification markers in the command (heredoc body)
@@ -208,12 +222,13 @@ CI pr-policy check will block merge if this is missing.`;
     // For merge: fetch PR body and show verification steps
     const cmdLine = stripHeredocBody(command);
     const prNumMatch = cmdLine.match(/gh\s+pr\s+merge\s+(\d+)/);
-    let prBody: string;
+    let args: string[];
     if (prNumMatch) {
-      prBody = exec(`gh pr view ${prNumMatch[1]} --json body --jq '.body'`);
+      args = ['pr', 'view', prNumMatch[1], '--json', 'body', '--jq', '.body'];
     } else {
-      prBody = exec("gh pr view --json body --jq '.body'");
+      args = ['pr', 'view', '--json', 'body', '--jq', '.body'];
     }
+    const prBody = gh(args);
 
     if (!prBody) return '';
 
@@ -379,6 +394,7 @@ export function runQualityChecks(
   opts: RunnerOptions = {},
 ): QualityCheckOutput {
   const exec = opts.exec ?? defaultExec;
+  const gh = opts.gh ?? defaultGh;
   const cmdLine = stripHeredocBody(command);
   const cmdType = detectCommandType(cmdLine);
 
@@ -390,7 +406,7 @@ export function runQualityChecks(
   const isPrCommand = cmdType === 'pr_create' || cmdType === 'pr_merge';
 
   if (isPrCommand) {
-    const changedFiles = getChangedFiles(cmdLine, isMerge, exec);
+    const changedFiles = getChangedFiles(cmdLine, isMerge, exec, gh);
 
     // Test coverage check (pr_create and pr_merge)
     const coverageResult = checkTestCoverage(changedFiles, opts);
@@ -398,7 +414,7 @@ export function runQualityChecks(
     if (coverageMsg) messages.push(coverageMsg);
 
     // Verification check
-    const verificationMsg = checkVerification(command, cmdType, exec);
+    const verificationMsg = checkVerification(command, cmdType, exec, gh);
     if (verificationMsg) messages.push(verificationMsg);
 
     // Practices checklist (pr_create only)

--- a/src/lib/gh-exec-invariant.test.ts
+++ b/src/lib/gh-exec-invariant.test.ts
@@ -20,8 +20,6 @@ const CANONICAL_HELPER = 'src/lib/gh-exec.ts';
 const OPT_OUT = new Set<string>([
   // stdin-based PR comment posting; migrate after gh-exec grows stdin support.
   'src/hooks/pr-kaizen-clear.ts',
-  // PR quality hook still shells through an injected exec seam for gh metadata.
-  'src/hooks/pr-quality-checks.ts',
 ]);
 
 function repoRelative(path: string): string {


### PR DESCRIPTION
## Story

Once upon a time, `pr-quality-checks.ts` consolidated four advisory PR-quality hooks into one TypeScript hook.

Every day, it still fetched PR metadata through injected shell command strings: `gh pr diff ...` for changed files and `gh pr view ...` for post-merge verification text.

One day, the `gh-exec` invariant shrink left `pr-quality-checks.ts` as one of only two remaining production opt-outs. Issue #1304 scoped the next migration: move PR metadata lookups to argv-style `gh-exec` without changing the advisory hook behavior.

Because of that, this PR adds a `RunnerOptions.gh(args)` seam backed by `src/lib/gh-exec.ts` and threads it through `runQualityChecks`, `getChangedFiles`, and `checkVerification`.

Because of that, tests now assert the actual `gh` argv arrays for PR diff and PR body lookup, while preserving git fallback and verification warnings.

Until finally, `src/hooks/pr-quality-checks.ts` leaves the `gh-exec` invariant allowlist and the focused invariant test stays green.

And ever since, the production direct-gh allowlist has one file left: `src/hooks/pr-kaizen-clear.ts`, whose remaining PR comment path needs stdin support or a dedicated comment helper.

Closes #1304
Parent: #1164
Refs: #1294, #1296, #1299, #1303

## Architecture

```text
runQualityChecks(command, opts)
  ├─ exec = opts.exec ?? defaultExec     # git/staged-file shell commands
  ├─ gh = opts.gh ?? defaultGh           # GitHub CLI argv boundary
  ├─ getChangedFiles(cmdLine, isMerge, exec, gh)
  │    ├─ gh(['pr', 'diff', pr?, '--name-only', '--repo', repo?])
  │    └─ fallback exec('git diff --name-only main...HEAD')
  └─ checkVerification(command, cmdType, exec, gh)
       └─ gh(['pr', 'view', pr?, '--json', 'body', '--jq', '.body'])
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add `RunnerOptions.gh(args)` | Keeps existing tests and hook seams injectable while using the shared GitHub CLI boundary | Expands the options interface by one method |
| Keep `exec` for git commands | This PR is specifically about GitHub CLI duplication, not every shell command | Generic shell cleanup remains separate work |
| Use strict `gh(args)` rather than `ghExec(cmd)` | The call sites already know the argv shape and should avoid shell-string parsing | Slightly more explicit argument assembly |
| Migrate only `pr-quality-checks.ts` | Scope-matched allowlist shrink with focused tests | `pr-kaizen-clear.ts` remains explicit future work |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/pr-quality-checks.ts` | Adds `RunnerOptions.gh`, routes PR diff/body metadata through `gh-exec`, preserves git fallback |
| `src/hooks/pr-quality-checks.test.ts` | Adds argv assertions and updates legacy gh-metadata tests to use the new seam |
| `src/lib/gh-exec-invariant.test.ts` | Removes `pr-quality-checks.ts` from the direct-gh allowlist |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|----------|-------------|-------|--------|----------|
| 1 | Merge changed-file lookup uses argv-style `gh pr diff` with PR number and repo flag. | code | Unit | Tested | `src/hooks/pr-quality-checks.test.ts` asserts `['pr','diff','42','--name-only','--repo','Garsson-io/kaizen']`. |
| 2 | Merge changed-file lookup falls back to `git diff --name-only main...HEAD` when gh returns empty/fails. | code | Unit | Tested | Test asserts only the git diff exec path runs after empty `gh`. |
| 3 | Post-merge verification fetches PR body through argv-style `gh pr view` for explicit PR number. | code | Unit | Tested | Test asserts `['pr','view','42','--json','body','--jq','.body']`. |
| 4 | Post-merge verification fetches current PR body through argv-style `gh pr view` when no PR number is present. | code | Unit | Tested | Test asserts `['pr','view','--json','body','--jq','.body']`. |
| 5 | `pr-quality-checks.ts` no longer contributes to the direct-gh allowlist. | code | Unit | Tested | `src/lib/gh-exec-invariant.test.ts` passes after removing the opt-out. |
| 6 | Existing advisory checks remain intact. | code | Unit | Tested | Existing `src/hooks/pr-quality-checks.test.ts` suite passes with `runQualityChecks` threading `opts.gh`. |

## Validation

- [x] RED: `npm test -- --run src/hooks/pr-quality-checks.test.ts` failed on the new argv seam tests because production still ignored `gh` and used `exec('gh ...')`.
- [x] GREEN: `npm test -- --run src/hooks/pr-quality-checks.test.ts src/lib/gh-exec-invariant.test.ts src/lib/gh-exec.test.ts` -> 71 passed.
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `rg -n "execSync|spawnSync|exec\\(|gh pr|gh issue" src/hooks/pr-quality-checks.ts src/lib/gh-exec-invariant.test.ts` -> no direct-gh command strings in `pr-quality-checks.ts`; remaining `exec` hits are generic git shell paths.

## Known Limitations

This PR does not migrate `src/hooks/pr-kaizen-clear.ts`. Its remaining PR comment path uses stdin (`gh pr comment --body-file -`) and needs helper stdin support or a dedicated comment helper before the final allowlist entry can be removed.
