### PR TITLE
refactor(hooks): finish gh-exec ratchet

### DIFF
--- a/src/hooks/pr-kaizen-clear.test.ts
+++ b/src/hooks/pr-kaizen-clear.test.ts
@@ -43,6 +43,7 @@ import {
   detectPrdWithoutFiledIssues,
   extractBgResults,
   formatReflectionComment,
+  defaultPostComment,
   hasPrdFiles,
   matchesWaiverBlocklist,
   processHookInput,
@@ -535,6 +536,29 @@ describe('processHookInput: reflection persistence (kaizen #388)', () => {
 
   afterEach(() => {
     fs.rmSync(unitStateDir, { recursive: true, force: true });
+  });
+
+  it('posts default reflection comments through argv-style gh with stdin body', () => {
+    const gh = vi.fn(() => '');
+
+    defaultPostComment(
+      'https://github.com/Garsson-io/kaizen/pull/42',
+      'comment body',
+      gh,
+    );
+
+    expect(gh).toHaveBeenCalledWith([
+      'pr',
+      'comment',
+      '42',
+      '--repo',
+      'Garsson-io/kaizen',
+      '--body-file',
+      '-',
+    ], {
+      input: 'comment body',
+      timeoutMs: 15_000,
+    });
   });
 
   it('calls postComment with formatted reflection on valid impediments', () => {
@@ -1141,7 +1165,7 @@ describe('processHookInput PRD blocking gate (kaizen #683, upgraded from #694)',
 });
 
 describe('processHookInput auto-close PR metadata gh seam', () => {
-  it('loads merged PR state and body through the gh argv seam after clearing', () => {
+  it('loads merged PR state/body and closes linked issues through the gh argv seam after clearing', () => {
     const gh = vi.fn((args: string[]) => {
       if (args[0] === 'pr' && args[1] === 'diff') {
         return 'src/hooks/pr-kaizen-clear.ts';
@@ -1150,7 +1174,13 @@ describe('processHookInput auto-close PR metadata gh seam', () => {
         return 'MERGED';
       }
       if (args[0] === 'pr' && args[1] === 'view' && args.includes('body')) {
-        return 'No linked kaizen issues in this fixture';
+        return 'Closes Garsson-io/kaizen#1306';
+      }
+      if (args[0] === 'issue' && args[1] === 'view') {
+        return 'OPEN';
+      }
+      if (args[0] === 'issue' && args[1] === 'close') {
+        return '';
       }
       return '';
     });
@@ -1184,6 +1214,26 @@ describe('processHookInput auto-close PR metadata gh seam', () => {
       'body',
       '--jq',
       '.body',
+    ]);
+    expect(gh).toHaveBeenCalledWith([
+      'issue',
+      'view',
+      '1306',
+      '--repo',
+      'Garsson-io/kaizen',
+      '--json',
+      'state',
+      '--jq',
+      '.state',
+    ]);
+    expect(gh).toHaveBeenCalledWith([
+      'issue',
+      'close',
+      '1306',
+      '--repo',
+      'Garsson-io/kaizen',
+      '--comment',
+      'Auto-closed: PR merged (https://github.com/Garsson-io/kaizen/pull/42)',
     ]);
   });
 });

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -18,7 +18,7 @@
 import { execSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { gh } from '../lib/gh-exec.js';
+import { gh, type GhExecOptions } from '../lib/gh-exec.js';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import { verifyIssueRef, type RefStatus } from './lib/issue-ref-verifier.js';
@@ -51,7 +51,7 @@ interface Impediment {
   impact_minutes?: number;
 }
 
-type GhRunner = (args: string[]) => string;
+type GhRunner = (args: string[], options?: number | GhExecOptions) => string;
 
 // ── Audit logging ────────────────────────────────────────────────────
 
@@ -422,14 +422,17 @@ export function formatReflectionComment(
 }
 
 /** Post reflection as a PR comment (best-effort). */
-function defaultPostComment(prUrl: string, comment: string): void {
+export function defaultPostComment(
+  prUrl: string,
+  comment: string,
+  ghRun: GhRunner = gh,
+): void {
   const prNum = prUrl.match(/(\d+)$/)?.[1];
   const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
   if (!prNum || !repo) return;
-  execSync(`gh pr comment ${prNum} --repo "${repo}" --body-file -`, {
+  ghRun(['pr', 'comment', prNum, '--repo', repo, '--body-file', '-'], {
     input: comment,
-    stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 15000,
+    timeoutMs: 15_000,
   });
 }
 
@@ -713,7 +716,10 @@ export function processHookInput(
     markReflectionDone(gatePrUrl, currentBranch(), stateDir);
 
     // Post reflection as PR comment for audit trail (kaizen #388, best-effort)
-    const postComment = options.postComment ?? defaultPostComment;
+    const postComment =
+      options.postComment ??
+      ((prUrl: string, comment: string) =>
+        defaultPostComment(prUrl, comment, ghRun));
     try {
       const comment = formatReflectionComment(
         validatedItems,
@@ -807,20 +813,27 @@ function autoCloseKaizenIssues(prUrl: string, ghRun: GhRunner = gh): void {
 
   for (const num of issueNums) {
     try {
-      const state = execSync(
-        `gh issue view ${num} --repo Garsson-io/kaizen --json state --jq .state`,
-        {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-        },
-      ).trim();
+      const state = ghRun([
+        'issue',
+        'view',
+        num,
+        '--repo',
+        'Garsson-io/kaizen',
+        '--json',
+        'state',
+        '--jq',
+        '.state',
+      ]).trim();
       if (state === 'OPEN') {
-        execSync(
-          `gh issue close ${num} --repo Garsson-io/kaizen --comment "Auto-closed: PR merged (${prUrl})"`,
-          {
-            stdio: ['pipe', 'pipe', 'pipe'],
-          },
-        );
+        ghRun([
+          'issue',
+          'close',
+          num,
+          '--repo',
+          'Garsson-io/kaizen',
+          '--comment',
+          `Auto-closed: PR merged (${prUrl})`,
+        ]);
       }
     } catch {}
   }

--- a/src/lib/gh-exec-invariant.test.ts
+++ b/src/lib/gh-exec-invariant.test.ts
@@ -17,10 +17,7 @@ const REPO_ROOT = join(__dirname, '..', '..');
 const SRC_DIR = join(REPO_ROOT, 'src');
 const CANONICAL_HELPER = 'src/lib/gh-exec.ts';
 
-const OPT_OUT = new Set<string>([
-  // stdin-based PR comment posting; migrate after gh-exec grows stdin support.
-  'src/hooks/pr-kaizen-clear.ts',
-]);
+const OPT_OUT = new Set<string>();
 
 function repoRelative(path: string): string {
   return relative(REPO_ROOT, path).replace(/\\/g, '/');

--- a/src/lib/gh-exec.test.ts
+++ b/src/lib/gh-exec.test.ts
@@ -79,6 +79,28 @@ describe('ghResult — non-throwing shared GitHub CLI helper', () => {
       expect.objectContaining({ timeout: 15_000 }),
     );
   });
+
+  it('passes stdin input to spawnSync', () => {
+    mockSpawn.mockReturnValueOnce({
+      status: 0,
+      stdout: 'ok',
+      stderr: '',
+      signal: null,
+      pid: 0,
+      output: [],
+    } as any);
+
+    ghResult(['pr', 'comment', '42', '--body-file', '-'], {
+      input: 'comment body',
+      timeoutMs: 15_000,
+    });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gh',
+      ['pr', 'comment', '42', '--body-file', '-'],
+      expect.objectContaining({ input: 'comment body', timeout: 15_000 }),
+    );
+  });
 });
 
 describe('gh — shared GitHub CLI helper', () => {

--- a/src/lib/gh-exec.ts
+++ b/src/lib/gh-exec.ts
@@ -13,10 +13,24 @@ export interface GhResult {
   stderr: string;
 }
 
+export interface GhExecOptions {
+  timeoutMs?: number;
+  input?: string;
+}
+
+function normalizeOptions(
+  options: number | GhExecOptions = 30_000,
+): Required<Pick<GhExecOptions, 'timeoutMs'>> & Pick<GhExecOptions, 'input'> {
+  if (typeof options === 'number') return { timeoutMs: options };
+  return { timeoutMs: options.timeoutMs ?? 30_000, input: options.input };
+}
+
 /** Run a gh CLI command and return status/stdout/stderr without throwing. */
-export function ghResult(args: string[], timeoutMs: number = 30_000): GhResult {
+export function ghResult(args: string[], options: number | GhExecOptions = 30_000): GhResult {
+  const { timeoutMs, input } = normalizeOptions(options);
   const result = spawnSync('gh', args, {
     encoding: 'utf8',
+    input,
     timeout: timeoutMs,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
@@ -28,8 +42,8 @@ export function ghResult(args: string[], timeoutMs: number = 30_000): GhResult {
 }
 
 /** Run a gh CLI command and return trimmed stdout. Throws on non-zero exit. */
-export function gh(args: string[], timeoutMs: number = 30_000): string {
-  const result = ghResult(args, timeoutMs);
+export function gh(args: string[], options: number | GhExecOptions = 30_000): string {
+  const result = ghResult(args, options);
   if (result.status !== 0) {
     throw new Error(`gh ${args.slice(0, 3).join(' ')} failed: ${result.stderr}`);
   }


### PR DESCRIPTION
## Story

Once upon a time, the `gh-exec` ratchet started with several production hooks invoking the GitHub CLI through hand-built shell strings.

Every day, the invariant allowlist kept shrinking as each hook moved to the shared argv helper.

One day, after #1305, `src/hooks/pr-kaizen-clear.ts` was the final production opt-out. Its blocker was real: the reflection comment path used `gh pr comment --body-file -`, and `gh-exec` had no stdin passthrough.

Because of that, this PR extends `ghResult`/`gh` with a backward-compatible options object that can carry `input` while preserving numeric timeout callers.

Because of that, `pr-kaizen-clear` now posts reflection comments through `gh(['pr','comment',...], { input })` and routes linked issue view/close calls through its existing injected `ghRun` seam.

Until finally, the `gh-exec` production direct-subprocess allowlist is empty.

Closes #1306
Parent: #1164
Follows: #1294, #1296, #1299, #1303, #1304, #1305

## Architecture

```text
gh(args, options?)
  └─ ghResult(args, options?)
       └─ spawnSync('gh', args, { input?, timeout, stdio: pipes })

processHookInput(...)
  ├─ defaultPostComment(prUrl, comment, ghRun)
  │    └─ ghRun(['pr','comment',pr,'--repo',repo,'--body-file','-'], { input })
  └─ autoCloseKaizenIssues(prUrl, ghRun)
       ├─ ghRun(['issue','view',num,'--repo','Garsson-io/kaizen','--json','state','--jq','.state'])
       └─ ghRun(['issue','close',num,'--repo','Garsson-io/kaizen','--comment',comment])
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add an options object to `ghResult`/`gh` | Supports stdin for `--body-file -` at the canonical helper boundary | Slightly expands the helper API |
| Preserve numeric timeout arguments | Existing callers use `gh(args, timeoutMs)` and should remain untouched | `normalizeOptions` handles two input shapes |
| Reuse `ghRun` in `pr-kaizen-clear` | The hook already has this injection seam for PR metadata | `GhRunner` type now accepts optional helper options |
| Empty the invariant allowlist | Makes the ratchet terminal for direct production `gh` subprocess calls | Future exceptions must be explicit test changes |

## What's In This PR

| File | Purpose |
|---|---|
| `src/lib/gh-exec.ts` | Adds `GhExecOptions` with `input` and `timeoutMs`, preserving old numeric timeout behavior |
| `src/lib/gh-exec.test.ts` | Proves stdin reaches `spawnSync` through the shared helper |
| `src/hooks/pr-kaizen-clear.ts` | Migrates reflection comments and linked issue auto-close paths to argv-style `ghRun` calls |
| `src/hooks/pr-kaizen-clear.test.ts` | Proves comment stdin, issue state lookup, and issue close calls use argv seams |
| `src/lib/gh-exec-invariant.test.ts` | Removes the final production opt-out |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|----------|-------------|-------|--------|----------|
| 1 | `ghResult` accepts stdin input while preserving timeout behavior. | code | Unit | Tested | `src/lib/gh-exec.test.ts` asserts `spawnSync` receives `{ input, timeout }`. |
| 2 | Reflection comments use argv-style `gh pr comment` with stdin body. | code | Unit | Tested | `src/hooks/pr-kaizen-clear.test.ts` asserts args plus `{ input, timeoutMs }`. |
| 3 | Linked issue state lookup uses injected argv-style `ghRun`. | code | Unit | Tested | Hook test asserts `['issue','view',num,...]`. |
| 4 | Linked issue close uses injected argv-style `ghRun`. | code | Unit | Tested | Hook test asserts `['issue','close',num,'--comment',comment]`. |
| 5 | The direct-gh production allowlist is empty. | code | Unit | Tested | `src/lib/gh-exec-invariant.test.ts` passes with `OPT_OUT = new Set<string>()`. |
| 6 | Existing hook behavior remains intact. | code | Unit | Tested | Focused hook suite passes. |

## Validation

- [x] RED: `npm test -- --run src/lib/gh-exec.test.ts src/hooks/pr-kaizen-clear.test.ts` failed on the new stdin/comment/issue-close expectations before production changes.
- [x] GREEN: `npm test -- --run src/lib/gh-exec.test.ts src/hooks/pr-kaizen-clear.test.ts src/lib/gh-exec-invariant.test.ts` -> 119 passed.
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `rg -n "execSync\\s*\\(.*gh|execFileSync\\s*\\(.*gh|spawnSync\\s*\\(.*gh" src --glob '!**/*.test.ts'` -> only `src/lib/gh-exec.ts` canonical helper.

## Notes

This PR is scoped to direct production GitHub CLI subprocess calls. Generic git shell calls and parser utilities that inspect typed shell commands are unchanged.
