### PR TITLE
refactor(runtime): centralize GitHub PR URL parsing

### DIFF
--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -16,6 +16,7 @@ import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { gh } from '../lib/gh-exec.js';
+import { parseGithubPrUrl } from '../lib/github-pr.js';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import {
@@ -142,17 +143,16 @@ function sendTelegramIpc(text: string, projectDir?: string): void {
 
 /** Get PR title via gh CLI. */
 function getPrTitle(prUrl: string, ghRun: GhRunner = gh): string {
-  const prNum = prUrl.match(/(\d+)$/)?.[1];
-  const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
-  if (!prNum || !repo) return 'unknown';
+  const parsed = parseGithubPrUrl(prUrl);
+  if (!parsed) return 'unknown';
   try {
     return (
       ghRun([
         'pr',
         'view',
-        prNum,
+        String(parsed.number),
         '--repo',
-        repo,
+        parsed.repo,
         '--json',
         'title',
         '--jq',

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -22,6 +22,7 @@ import { gh } from '../lib/gh-exec.js';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import { verifyIssueRef, type RefStatus } from './lib/issue-ref-verifier.js';
+import { parseGithubPrUrl } from '../lib/github-pr.js';
 import { resolveProjectRoot } from '../lib/resolve-project-root.js';
 import { stripHeredocBody } from './parse-command.js';
 import {
@@ -114,8 +115,8 @@ const STANDARD_DISPOSITIONS = new Set(['filed', 'incident', 'fixed-in-pr']);
 
 function getCandidateRepos(gatePrUrl: string): string[] {
   const repos: string[] = [];
-  const prRepo = gatePrUrl?.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
-  if (prRepo) repos.push(prRepo);
+  const parsedPrUrl = parseGithubPrUrl(gatePrUrl);
+  if (parsedPrUrl) repos.push(parsedPrUrl.repo);
   try {
     const root = resolveProjectRoot(process.cwd());
     const cfg = JSON.parse(
@@ -423,23 +424,21 @@ export function formatReflectionComment(
 
 /** Post reflection as a PR comment (best-effort). */
 export function defaultPostComment(prUrl: string, comment: string): void {
-  const prNum = prUrl.match(/(\d+)$/)?.[1];
-  const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
-  if (!prNum || !repo) return;
+  const parsed = parseGithubPrUrl(prUrl);
+  if (!parsed) return;
   // Route through the shared gh-exec argv boundary (no shell-string interpolation
   // of prNum/repo); the comment body is fed on stdin via `--body-file -`.
-  gh(['pr', 'comment', prNum, '--repo', repo, '--body-file', '-'], 15000, comment);
+  gh(['pr', 'comment', String(parsed.number), '--repo', parsed.repo, '--body-file', '-'], 15000, comment);
 }
 
 // ── PRD detection (kaizen #694) ───────────────────────────────────────
 
 /** List changed files in a PR (best-effort). */
 function defaultGetPrFiles(prUrl: string, ghRun: GhRunner = gh): string[] {
-  const prNum = prUrl.match(/(\d+)$/)?.[1];
-  const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
-  if (!prNum || !repo) return [];
+  const parsed = parseGithubPrUrl(prUrl);
+  if (!parsed) return [];
   try {
-    const out = ghRun(['pr', 'diff', prNum, '--repo', repo, '--name-only']).trim();
+    const out = ghRun(['pr', 'diff', String(parsed.number), '--repo', parsed.repo, '--name-only']).trim();
     return out ? out.split('\n').map(f => f.trim()).filter(Boolean) : [];
   } catch {
     return [];
@@ -756,18 +755,17 @@ export function processHookInput(
 
 /** Auto-close kaizen issues referenced in a merged PR body. */
 export function autoCloseKaizenIssues(prUrl: string, ghRun: GhRunner = gh): void {
-  const prNum = prUrl.match(/(\d+)$/)?.[1];
-  const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/)?.[1];
-  if (!prNum || !repo) return;
+  const parsed = parseGithubPrUrl(prUrl);
+  if (!parsed) return;
 
   let prState: string;
   try {
     prState = ghRun([
       'pr',
       'view',
-      prNum,
+      String(parsed.number),
       '--repo',
-      repo,
+      parsed.repo,
       '--json',
       'state',
       '--jq',
@@ -783,9 +781,9 @@ export function autoCloseKaizenIssues(prUrl: string, ghRun: GhRunner = gh): void
     prBody = ghRun([
       'pr',
       'view',
-      prNum,
+      String(parsed.number),
       '--repo',
-      repo,
+      parsed.repo,
       '--json',
       'body',
       '--jq',

--- a/src/lib/github-pr.test.ts
+++ b/src/lib/github-pr.test.ts
@@ -3,11 +3,28 @@ import {
   findOpenPrUrlForBranch,
   parseBranchPrQueryResult,
   parseFirstPrUrl,
+  parseGithubPrUrl,
   parseIssueNumber,
   parseIssueState,
   queryBranchPrState,
   queryIssueState,
 } from './github-pr.js';
+
+describe('parseGithubPrUrl', () => {
+  it('returns repo and PR number for a full GitHub PR URL', () => {
+    expect(parseGithubPrUrl('https://github.com/Garsson-io/kaizen/pull/997')).toEqual({
+      repo: 'Garsson-io/kaizen',
+      number: 997,
+    });
+  });
+
+  it('returns null for non-PR, non-GitHub, and malformed numeric URLs', () => {
+    expect(parseGithubPrUrl('https://github.com/Garsson-io/kaizen/issues/997')).toBeNull();
+    expect(parseGithubPrUrl('https://gitlab.com/Garsson-io/kaizen/pull/997')).toBeNull();
+    expect(parseGithubPrUrl('https://github.com/Garsson-io/kaizen/pull/not-a-number')).toBeNull();
+    expect(parseGithubPrUrl('')).toBeNull();
+  });
+});
 
 describe('parseFirstPrUrl', () => {
   it('returns the first PR URL from gh JSON output', () => {

--- a/src/lib/github-pr.ts
+++ b/src/lib/github-pr.ts
@@ -24,6 +24,11 @@ export interface BranchPrQueryResult {
   openUrl?: string;
 }
 
+export interface GithubPrUrl {
+  repo: string;
+  number: number;
+}
+
 export interface QueryBranchPrStateOptions {
   repo: string;
   branch: string;
@@ -33,6 +38,15 @@ export interface QueryBranchPrStateOptions {
 
 export function emptyBranchPrQueryResult(): BranchPrQueryResult {
   return { mostRecent: null, hasOpen: false };
+}
+
+export function parseGithubPrUrl(prUrl: string | undefined | null): GithubPrUrl | null {
+  if (!prUrl) return null;
+  const match = prUrl.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)$/);
+  if (!match) return null;
+  const number = Number(match[2]);
+  if (!Number.isInteger(number) || number <= 0) return null;
+  return { repo: match[1], number };
 }
 
 export function parseFirstPrUrl(output: string): string | undefined {

--- a/src/review-sentinel.test.ts
+++ b/src/review-sentinel.test.ts
@@ -83,4 +83,13 @@ describe('review sentinel contract', () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('invalid_findingCount');
   });
+
+  it('throws for malformed PR URLs before building a sentinel', () => {
+    expect(() =>
+      buildReviewSentinelRecord({
+        prUrl: 'https://github.com/Garsson-io/kaizen/pull/not-a-number',
+        round: 1,
+      }),
+    ).toThrow('invalid PR URL');
+  });
 });

--- a/src/review-sentinel.ts
+++ b/src/review-sentinel.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import { resolve } from 'node:path';
 import YAML from 'yaml';
+import { parseGithubPrUrl } from './lib/github-pr.js';
 import { resolveProjectRoot } from './lib/resolve-project-root.js';
 
 export const REVIEW_SENTINEL_SCHEMA_VERSION = 1;
@@ -56,12 +57,6 @@ export interface ReviewSentinelValidation {
 
 type ReviewSentinelUnsigned = Omit<ReviewSentinelRecord, 'integrity'>;
 
-function parsePrUrl(prUrl: string): { repo: string; prNumber: number } | null {
-  const match = prUrl.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)$/);
-  if (!match) return null;
-  return { repo: match[1], prNumber: Number(match[2]) };
-}
-
 function stableStringify(value: unknown): string {
   if (Array.isArray(value)) {
     return `[${value.map(stableStringify).join(',')}]`;
@@ -104,7 +99,7 @@ export function expectedPrReviewDimensions(): string[] {
 }
 
 export function buildReviewSentinelRecord(input: ReviewSentinelInput): ReviewSentinelRecord {
-  const parsed = parsePrUrl(input.prUrl);
+  const parsed = parseGithubPrUrl(input.prUrl);
   if (!parsed) {
     throw new Error(`invalid PR URL for review sentinel: ${input.prUrl}`);
   }
@@ -114,7 +109,7 @@ export function buildReviewSentinelRecord(input: ReviewSentinelInput): ReviewSen
     schemaVersion: REVIEW_SENTINEL_SCHEMA_VERSION,
     prUrl: input.prUrl,
     repo: parsed.repo,
-    prNumber: parsed.prNumber,
+    prNumber: parsed.number,
     round: Number(input.round),
     reviewedAt: input.reviewedAt ?? new Date().toISOString(),
     dimensionsReviewed,


### PR DESCRIPTION
## Story

Once upon a time, hook/runtime code parsed GitHub PR URLs in place wherever it needed a repo and PR number.

Every day, those snippets worked independently: `pr-kaizen-clear` parsed PR URLs for comments, changed-file lookup, candidate repos, and auto-close; `kaizen-reflect` parsed them for merge notification titles; `review-sentinel` had its own private parser for sentinel records.

One day, the direct `gh` execution ratchet reached its terminal state in #1307, leaving a smaller but similar drift point: one URL contract represented by multiple regexes.

Because of that, this PR adds `parseGithubPrUrl` to the existing `src/lib/github-pr.ts` PR utility boundary.

Because of that, the hook/runtime callers now share the same full-PR-url parser while preserving their existing best-effort invalid-url behavior.

Until finally, the migrated files have one canonical regex for `https://github.com/{owner}/{repo}/pull/{number}`: the parser in `github-pr.ts`.

Closes #1310
Parent: #1164
Follows: #1307

## Architecture

```text
parseGithubPrUrl(url)
  ├─ valid full PR URL -> { repo: owner/name, number }
  └─ invalid/non-PR URL -> null

Runtime callers
  ├─ pr-kaizen-clear
  │    ├─ candidate repos
  │    ├─ defaultPostComment
  │    ├─ defaultGetPrFiles
  │    └─ autoCloseKaizenIssues
  ├─ kaizen-reflect getPrTitle
  └─ review-sentinel buildReviewSentinelRecord
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Put the helper in `src/lib/github-pr.ts` | Existing shared boundary for PR-related GitHub helpers | Keeps GitHub PR identity helpers together rather than creating a broader URL module |
| Return `null` for invalid input | Matches best-effort hook behavior and keeps callers explicit | Callers that need hard failure must throw after `null` |
| Keep command-token parsing out of scope | `gh pr merge 42` parsing is a different contract from full URL parsing | Some other parsers remain intentionally local |
| Preserve review-sentinel hard failure | Sentinel integrity still requires a valid full PR URL | `review-sentinel` converts `null` into the same invalid-URL throw |

## What's In This PR

| File | Purpose |
|---|---|
| `src/lib/github-pr.ts` | Adds `parseGithubPrUrl` shared parser |
| `src/lib/github-pr.test.ts` | Covers valid, non-PR, non-GitHub, and malformed numeric URL inputs |
| `src/hooks/pr-kaizen-clear.ts` | Reuses shared parser for candidate repos, comments, changed-file lookup, and auto-close |
| `src/hooks/kaizen-reflect.ts` | Reuses shared parser for PR title lookup |
| `src/review-sentinel.ts` | Reuses shared parser for sentinel repo/number extraction |
| `src/review-sentinel.test.ts` | Covers malformed PR URL rejection |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Evidence |
|---|----------|-------------|-------|--------|----------|
| 1 | Shared parser returns repo and numeric PR number for `https://github.com/{owner}/{repo}/pull/{number}`. | code | Unit | Tested | `src/lib/github-pr.test.ts` |
| 2 | Shared parser rejects non-PR, non-GitHub, and malformed numeric URLs. | code | Unit | Tested | `src/lib/github-pr.test.ts` |
| 3 | `pr-kaizen-clear` comment/PRD/auto-close paths preserve argv construction through shared parsed repo/number. | code | Unit | Tested | `src/hooks/pr-kaizen-clear-ghexec.test.ts`, `src/hooks/pr-kaizen-clear.test.ts`, `src/hooks/pr-kaizen-clear-outcome.test.ts` |
| 4 | `kaizen-reflect` PR title lookup preserves `gh pr view` args through shared parsed repo/number. | code | Unit | Tested | `src/hooks/kaizen-reflect.test.ts` |
| 5 | Review sentinel records preserve repo and PR number from valid URLs and still reject invalid URLs. | code | Unit | Tested | `src/review-sentinel.test.ts` |
| 6 | Runtime source no longer carries duplicated full GitHub PR URL repo/number regexes in migrated files. | code | Static | Tested | grep guard reports only `src/lib/github-pr.ts` |

## Validation

- [x] RED: `npm test -- --run src/lib/github-pr.test.ts src/review-sentinel.test.ts` failed because `parseGithubPrUrl` was not yet exported.
- [x] GREEN: `npm test -- --run src/lib/github-pr.test.ts src/review-sentinel.test.ts src/hooks/pr-kaizen-clear-ghexec.test.ts src/hooks/pr-kaizen-clear.test.ts src/hooks/pr-kaizen-clear-outcome.test.ts src/hooks/kaizen-reflect.test.ts` -> 154 passed.
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] grep guard for old migrated regex shape -> only `src/lib/github-pr.ts` canonical parser remains.

## Notes

This PR intentionally does not touch loose issue-ref parsing or command-line PR token parsing. Those are different contracts from full GitHub PR URLs.
