### PR TITLE
test(hook-gym): dedup repeated push fixtures in push-review test (#1246)

### DIFF
--- a/scripts/hook-gym-push-review.test.ts
+++ b/scripts/hook-gym-push-review.test.ts
@@ -50,38 +50,47 @@ function createState(filename: string, fields: Record<string, string>): void {
 const PR_URL = 'https://github.com/Garsson-io/kaizen/pull/999';
 const STATE_KEY = 'Garsson-io_kaizen_999';
 const BRANCH = 'worktree-feat+test';
+const REVIEWED_SHA = 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111';
+
+// Seed the review-loop state file for round 1 with a valid reviewed SHA.
+// Only STATUS differs across scenarios ('passed' = review happened,
+// 'needs_review' = PR just created, no review yet).
+function seedReviewState(status: string): void {
+  createState(STATE_KEY, {
+    PR_URL,
+    ROUND: '1',
+    STATUS: status,
+    BRANCH,
+    LAST_REVIEWED_SHA: REVIEWED_SHA,
+    LAST_FULL_REVIEW_SHA: REVIEWED_SHA,
+  });
+}
+
+// Simulate a successful `git push`. The SHA always exists; only the diff
+// size varies (under SMALL_PUSH_THRESHOLD of 15 = small, above = large).
+function simulatePush(diffLines: number) {
+  return processHookInput(
+    {
+      tool_input: { command: 'git push' },
+      tool_response: { stdout: 'To github.com:...', stderr: '', exit_code: '0' },
+    },
+    {
+      stateDir,
+      branch: BRANCH,
+      checkShaExists: () => true,
+      computeDiffLines: () => diffLines,
+    },
+  );
+}
 
 describe('push after review should trigger new review round', () => {
 
   it('small push after round 1 PASSED should still require review (not auto-pass)', () => {
-    // Setup: Round 1 review has passed, state file has a valid LAST_REVIEWED_SHA.
-    createState(STATE_KEY, {
-      PR_URL,
-      ROUND: '1',
-      STATUS: 'passed',
-      BRANCH,
-      LAST_REVIEWED_SHA: 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111',
-      LAST_FULL_REVIEW_SHA: 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111',
-    });
+    // Round 1 review has passed; a small push (5 lines, under SMALL_PUSH_THRESHOLD)
+    // should still require review because it lands AFTER a review round.
+    seedReviewState('passed');
+    const decision = simulatePush(5);
 
-    // Simulate: git push with a small diff (5 lines — under SMALL_PUSH_THRESHOLD of 15)
-    const decision = processHookInput(
-      {
-        tool_input: { command: 'git push' },
-        tool_response: { stdout: 'To github.com:...', stderr: '', exit_code: '0' },
-      },
-      {
-        stateDir,
-        branch: BRANCH,
-        // Mock: SHA exists but diff is small (5 lines)
-        checkShaExists: () => true,
-        computeDiffLines: () => 5,
-      },
-    );
-
-    // Expectation: Even though the push is small, it should require review
-    // because this is a push AFTER a review round, not a trivial push
-    // before any review has happened.
     expect(decision.action).toBe('needs_review');
     expect(decision.reason).toBe('push_exceeds_threshold');
 
@@ -92,57 +101,17 @@ describe('push after review should trigger new review round', () => {
   });
 
   it('auto-pass SHOULD be allowed for first push (no prior review)', () => {
-    // Setup: PR was just created, round 1 is needs_review (no review happened yet).
-    // A git push happens (e.g., hook auto-fixed formatting).
-    // This is NOT a review fix — auto-pass is appropriate.
-    createState(STATE_KEY, {
-      PR_URL,
-      ROUND: '1',
-      STATUS: 'needs_review',
-      BRANCH,
-      LAST_REVIEWED_SHA: 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111',
-      LAST_FULL_REVIEW_SHA: 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111',
-    });
+    // PR was just created, round 1 is needs_review (no review happened yet).
+    // A small supplementary push (e.g., hook auto-fixed formatting) may auto-pass.
+    seedReviewState('needs_review');
+    const decision = simulatePush(5);
 
-    const decision = processHookInput(
-      {
-        tool_input: { command: 'git push' },
-        tool_response: { stdout: 'To github.com:...', stderr: '', exit_code: '0' },
-      },
-      {
-        stateDir,
-        branch: BRANCH,
-        checkShaExists: () => true,
-        computeDiffLines: () => 5,
-      },
-    );
-
-    // Auto-pass is OK here — no prior review, just a small supplementary push
     expect(decision.action).toBe('auto_pass');
   });
 
   it('large push after review should also require review', () => {
-    createState(STATE_KEY, {
-      PR_URL,
-      ROUND: '1',
-      STATUS: 'passed',
-      BRANCH,
-      LAST_REVIEWED_SHA: 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111',
-      LAST_FULL_REVIEW_SHA: 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111',
-    });
-
-    const decision = processHookInput(
-      {
-        tool_input: { command: 'git push' },
-        tool_response: { stdout: 'To github.com:...', stderr: '', exit_code: '0' },
-      },
-      {
-        stateDir,
-        branch: BRANCH,
-        checkShaExists: () => true,
-        computeDiffLines: () => 50,
-      },
-    );
+    seedReviewState('passed');
+    const decision = simulatePush(50);
 
     // Large push always requires review
     expect(decision.action).toBe('needs_review');


### PR DESCRIPTION
## Problem

The jscpd duplicate scan on `origin/main` flags large copy-paste blocks in `scripts/hook-gym-push-review.test.ts`. Three of its four `it()` cases each re-encode the **same two fixtures**: the full review-loop state file (`createState(STATE_KEY, {PR_URL, ROUND, STATUS, BRANCH, LAST_REVIEWED_SHA, LAST_FULL_REVIEW_SHA})`) and the `git push` simulation (`processHookInput({...}, {stateDir, branch, checkShaExists, computeDiffLines})`). Across the copies, only two values actually change — `STATUS` (`passed` vs `needs_review`) and `computeDiffLines` (5 vs 50).

## Why it matters

The fixtures were longer than the behavior they prove, and copy-paste fixtures rot asymmetrically: a future change to the push contract updates one scenario and silently misses the cloned siblings — the exact class of drift #1246 (and its merged sibling #1239) calls out.

## Solution

Extract two local, behavior-preserving helpers:

- **`seedReviewState(status)`** — seeds the round-1 state file with the shared defaults, varying only `STATUS`.
- **`simulatePush(diffLines)`** — invokes `processHookInput` with the shared `git push` hook-input fixture and deps (`checkShaExists: () => true`), varying only the diff size.

The 40-char reviewed SHA is hoisted to a `REVIEWED_SHA` const. Each affected case collapses to a two-line `seed → push → assert`. No change to `src/hooks/pr-review-loop.ts` or any hook behavior.

## Evidence

- `npx vitest run scripts/hook-gym-push-review.test.ts` → **4/4 pass**, same names, same assertions.
- `npx vitest run scripts/hook-gym` → **147/147 pass** (no shared-helper collision).
- File shrank **155 → 124 lines**; the three duplicated fixture blocks are gone.

### Behaviors × levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Small push after a passed review ⇒ needs_review round 2 | ✅ (unchanged) | — | — | — | — |
| First push (no prior review) ⇒ auto_pass | ✅ (unchanged) | — | — | — | — |
| Large push after review ⇒ needs_review | ✅ (unchanged) | — | — | — | — |
| SMALL_PUSH_THRESHOLD = 15 documented | ✅ (unchanged) | — | — | — | — |

This is a DRY reduction of a test file, so coverage is unchanged-by-design: the refactor neither adds nor removes a behavior, and a bug in either helper would flip one of the existing assertions.

## Impact

Behavior-preserving cleanup that removes the flagged duplication and makes the push→review decision scenarios read as `seed → push → assert`. Continues the DRY-as-core-practice thread of this batch.

Closes #1246
Refs: #1239
