### PR TITLE
refactor(hooks): route git helpers through argv runner

### DIFF
--- a/src/hooks/hook-git-runner-invariant.test.ts
+++ b/src/hooks/hook-git-runner-invariant.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const MIGRATED_FILES = [
+  'src/hooks/pre-push.ts',
+  'src/hooks/pr-review-loop.ts',
+];
+
+describe('hook git runner invariant', () => {
+  it('keeps migrated hooks off shell-string git wrappers', () => {
+    const offenders = MIGRATED_FILES.filter((file) => {
+      const content = readFileSync(file, 'utf-8');
+      return [
+        /execSync\(`git \$\{args\}`/,
+        /function git\(args: string/,
+        /\bgit\('/,
+      ].some((pattern) => pattern.test(content));
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/hooks/lib/git-state.test.ts
+++ b/src/hooks/lib/git-state.test.ts
@@ -16,10 +16,30 @@
 import { describe, expect, it } from 'vitest';
 import {
   formatDiagnostic,
+  gitStdout,
   isBypassRequested,
   readDirtyFiles,
   resolveTargetWorktree,
 } from './git-state.js';
+
+describe('gitStdout', () => {
+  it('returns trimmed stdout from an argv git runner', () => {
+    const calls: string[][] = [];
+    const runner = (args: readonly string[]) => {
+      calls.push([...args]);
+      return { stdout: '  main  \n', stderr: '', exitCode: 0 };
+    };
+
+    expect(gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], '', runner)).toBe('main');
+    expect(calls).toEqual([['rev-parse', '--abbrev-ref', 'HEAD']]);
+  });
+
+  it('returns fallback on non-zero exit', () => {
+    const runner = () => ({ stdout: '', stderr: 'fatal', exitCode: 128 });
+
+    expect(gitStdout(['remote', 'get-url', 'origin'], 'fallback', runner)).toBe('fallback');
+  });
+});
 
 describe('resolveTargetWorktree', () => {
   const CWD = '/agent/cwd';

--- a/src/hooks/lib/git-state.ts
+++ b/src/hooks/lib/git-state.ts
@@ -102,6 +102,16 @@ export function createDefaultGitExec(): GitExec {
   };
 }
 
+export function gitStdout(
+  args: readonly string[],
+  fallback = '',
+  exec: GitExec = createDefaultGitExec(),
+): string {
+  const result = exec(args);
+  if (result.exitCode !== 0) return fallback;
+  return result.stdout.trim();
+}
+
 /**
  * Parse porcelain v1 output into staged/modified/untracked buckets.
  * Exported so check-dirty-files.ts can reuse the single parser.

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -20,7 +20,6 @@
  * Migration: kaizen #320 (Phase 3 of #223)
  */
 
-import { execSync } from 'node:child_process';
 import { appendFileSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -33,6 +32,7 @@ import {
 import { findOpenPrUrlForBranch } from '../lib/github-pr.js';
 import { type HookInput, readHookInput, writeHookOutput } from './hook-io.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
+import { gitStdout } from './lib/git-state.js';
 import {
   isGhPrCommand,
   isGitCommand,
@@ -87,21 +87,10 @@ function trace(decision: HookDecision, trigger: string): void {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function git(args: string, fallback = ''): string {
-  try {
-    return execSync(`git ${args}`, {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return fallback;
-  }
-}
-
 /** Compute diff line count between two SHAs. Returns 0 if either SHA is invalid. */
 function diffLines(fromSha: string, toRef: string = 'HEAD'): number {
   if (!fromSha) return 0;
-  const statLine = git(`diff --stat ${fromSha}..${toRef}`).split('\n').pop() ?? '';
+  const statLine = gitStdout(['diff', '--stat', `${fromSha}..${toRef}`]).split('\n').pop() ?? '';
   const ins = parseInt(statLine.match(/(\d+) insertion/)?.[1] ?? '0', 10);
   const del = parseInt(statLine.match(/(\d+) deletion/)?.[1] ?? '0', 10);
   return ins + del;
@@ -110,11 +99,11 @@ function diffLines(fromSha: string, toRef: string = 'HEAD'): number {
 /** Check if a SHA exists in the git history. */
 function shaExists(sha: string): boolean {
   if (!sha) return false;
-  return git(`cat-file -t ${sha}`) === 'commit';
+  return gitStdout(['cat-file', '-t', sha]) === 'commit';
 }
 
 function detectGhRepo(): string | undefined {
-  const url = git('remote get-url origin');
+  const url = gitStdout(['remote', 'get-url', 'origin']);
   return url.match(/github\.com[:/]([^/]+\/[^/.]+)/)?.[1];
 }
 
@@ -260,7 +249,7 @@ export function processHookInput(
   const stateDir =
     options.stateDir ?? process.env.STATE_DIR ?? DEFAULT_STATE_DIR;
   const branch =
-    options.branch ?? git('rev-parse --abbrev-ref HEAD', 'unknown');
+    options.branch ?? gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown');
   const repoFromGit = options.repoFromGit ?? detectGhRepo();
   const getDiffLines = options.computeDiffLines ?? diffLines;
   const isShaValid = options.checkShaExists ?? shaExists;
@@ -297,7 +286,7 @@ export function processHookInput(
     const postMergeKey = prUrlToStateKey(mergeUrl);
     const mc =
       options.mainCheckout ??
-      git('worktree list --porcelain').match(/^worktree (.+)/m)?.[1] ??
+      gitStdout(['worktree', 'list', '--porcelain']).match(/^worktree (.+)/m)?.[1] ??
       '.';
 
     if (isAuto) {
@@ -340,7 +329,7 @@ export function processHookInput(
       STATUS: 'needs_review',
       BRANCH: branch,
     });
-    const sha = git('rev-parse HEAD');
+    const sha = gitStdout(['rev-parse', 'HEAD']);
     if (sha) {
       appendFileSync(fp, `LAST_REVIEWED_SHA=${sha}\n`);
       appendFileSync(fp, `LAST_FULL_REVIEW_SHA=${sha}\n`);
@@ -366,9 +355,9 @@ export function processHookInput(
     }
 
     // Skip merge-from-main pushes (kaizen #85)
-    const parents = git('log -1 --format=%P HEAD').split(/\s+/).filter(Boolean);
+    const parents = gitStdout(['log', '-1', '--format=%P', 'HEAD']).split(/\s+/).filter(Boolean);
     if (parents.length >= 2) {
-      const mainHead = git('rev-parse origin/main');
+      const mainHead = gitStdout(['rev-parse', 'origin/main']);
       if (mainHead && parents.includes(mainHead)) {
         return decide('ignore', 'merge_from_main', null, { parents });
       }
@@ -408,7 +397,7 @@ export function processHookInput(
         STATUS: 'passed',
         BRANCH: branch,
       });
-      const sha = git('rev-parse HEAD');
+      const sha = gitStdout(['rev-parse', 'HEAD']);
       if (sha) appendFileSync(fp, `LAST_REVIEWED_SHA=${sha}\n`);
       if (lastFullReviewSha) appendFileSync(fp, `LAST_FULL_REVIEW_SHA=${lastFullReviewSha}\n`);
       return decide('auto_pass', 'small_incremental_and_cumulative',
@@ -470,7 +459,7 @@ export function processHookInput(
       STATUS: 'passed',
       BRANCH: branch,
     });
-    const sha = git('rev-parse HEAD');
+    const sha = gitStdout(['rev-parse', 'HEAD']);
     if (sha) {
       appendFileSync(fp, `LAST_REVIEWED_SHA=${sha}\n`);
       appendFileSync(fp, `LAST_FULL_REVIEW_SHA=${sha}\n`);

--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -26,10 +26,10 @@
  */
 
 import { appendFileSync, existsSync, readFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { DEFAULT_STATE_DIR, ensureStateDir, parseStateFile, prUrlToStateKey, writeStateFile } from './state-utils.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
+import { gitStdout } from './lib/git-state.js';
 import { queryBranchPrState, type BranchPrQueryResult } from '../lib/github-pr.js';
 
 // ── Types ─────────────────────────────────────────────────────────────
@@ -222,19 +222,8 @@ function buildMergedBranchMessage(branch: string, pr: { number: number; url: str
 
 // ── Wiring helpers (I/O boundary) ─────────────────────────────────────
 
-function git(args: string, fallback = ''): string {
-  try {
-    return execSync(`git ${args}`, {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return fallback;
-  }
-}
-
 export function detectRepo(): string {
-  const url = git('remote get-url origin');
+  const url = gitStdout(['remote', 'get-url', 'origin']);
   // GitHub repo names may contain dots (owner/site.github.io, owner/foo.bar).
   // Match "owner/repo" stopping at whitespace, .git suffix, or slash.
   const match = url.match(/github\.com[:/]([\w.-]+\/[\w.-]+?)(?:\.git)?(?:\/|\s|$)/);
@@ -242,7 +231,7 @@ export function detectRepo(): string {
 }
 
 export function getCurrentBranch(): string {
-  return git('rev-parse --abbrev-ref HEAD', '');
+  return gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], '');
 }
 
 /**


### PR DESCRIPTION
## Summary

Route the remaining hook-local `git(args)` shell-string wrappers in `pre-push` and `pr-review-loop` through the shared hook git runner boundary. This keeps the hook Git I/O on argv-style execution while preserving the existing fallback behavior.

Closes #1314

## Changes

- Add `gitStdout(args, fallback, exec)` to `src/hooks/lib/git-state.ts` for callers that only need trimmed stdout.
- Replace local `execSync(`git ${args}`)` wrappers in `pre-push.ts` and `pr-review-loop.ts` with explicit argv calls.
- Add regression coverage proving the migrated hooks stay off shell-string Git wrappers.

## Validation

- `npm test -- --run src/hooks/hook-git-runner-invariant.test.ts src/hooks/lib/git-state.test.ts src/hooks/pre-push.test.ts src/hooks/pr-review-loop.test.ts src/hooks/pr-review-loop-scenarios.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static scan: no `execSync(`git ${args}`)`, `function git(args: string)`, or `git(...)` wrapper calls remain in migrated files
