### PR TITLE
fix(hooks): reconcile status labels when a PR closes its kaizen issue (#1229)

### DIFF
--- a/src/hooks/hook-io.ts
+++ b/src/hooks/hook-io.ts
@@ -52,22 +52,26 @@ export async function readHookInput(): Promise<HookInput | null> {
 }
 
 /**
- * Write a null-input trace entry to the hook trace log.
- * Call before `process.exit(0)` in hooks that have no local trace infrastructure.
+ * Append a structured event to the hook trace log (best-effort, never throws).
+ * The shared primitive behind hook observability — use it to leave a durable
+ * signal when a hook takes (or skips) an action that would otherwise be silent.
  */
-export function traceNullInput(hookName: string): void {
+export function traceHookEvent(hook: string, fields: Record<string, unknown>): void {
   if (!isTraceEnabled()) return;
   try {
     appendFileSync(
       getTraceFile(),
-      JSON.stringify({
-        ts: new Date().toISOString(),
-        hook: hookName,
-        action: 'ignore',
-        reason: 'null_input',
-      }) + '\n',
+      JSON.stringify({ ts: new Date().toISOString(), hook, ...fields }) + '\n',
     );
   } catch { /* never fail on trace */ }
+}
+
+/**
+ * Write a null-input trace entry to the hook trace log.
+ * Call before `process.exit(0)` in hooks that have no local trace infrastructure.
+ */
+export function traceNullInput(hookName: string): void {
+  traceHookEvent(hookName, { action: 'ignore', reason: 'null_input' });
 }
 
 /** Write advisory output to stdout (shown to the agent in PostToolUse). */

--- a/src/hooks/pr-kaizen-clear-ghexec.test.ts
+++ b/src/hooks/pr-kaizen-clear-ghexec.test.ts
@@ -141,73 +141,143 @@ describe('extractClosingIssues — #1229', () => {
       'Closes #1215',
       'Fixes Garsson-io/kaizen#42',
       'resolved #7',
+      'Closes: #55', // GitHub also honors the colon form
       'Parent: #999', // mention, not a closing keyword
       'Refs: Garsson-io/kaizen#888',
     ].join('\n');
-    expect(extractClosingIssues(body).sort()).toEqual(['1215', '42', '7']);
+    expect(extractClosingIssues(body).sort()).toEqual(['1215', '42', '55', '7']);
   });
 
   it('returns no numbers for a body with only mentions', () => {
     expect(extractClosingIssues('Parent: #1\nRefs: #2')).toEqual([]);
   });
+
+  it('does not false-match keyword substrings (word boundary)', () => {
+    // "disclosed"/"prefixed"/"hotfixes"/"unresolved" embed close/fix/resolve.
+    const body = 'disclosed #5\nprefixed #9\nhotfixes #11\nunresolved #13';
+    expect(extractClosingIssues(body)).toEqual([]);
+  });
 });
 
 describe('reconcileClosedIssueStatusLabels — #1229', () => {
   // Mock ghRun: closing-keyword issue is CLOSED and carries `labels` (passed in).
-  function makeLabelGhRun(state: string, labels: string[]) {
+  // `labelsByIssue` lets a test give different label sets per issue number.
+  function makeLabelGhRun(
+    state: string,
+    labels: string[],
+    labelsByIssue?: Record<string, string[]>,
+  ) {
     return vi.fn((args: string[]) => {
       if (args[0] === 'issue' && args[1] === 'view' && args.includes('state'))
         return state;
-      if (args[0] === 'issue' && args[1] === 'view' && args.includes('labels'))
-        return JSON.stringify(labels);
+      if (args[0] === 'issue' && args[1] === 'view' && args.includes('labels')) {
+        const num = args[2];
+        return JSON.stringify(labelsByIssue?.[num] ?? labels);
+      }
       return '';
     });
   }
 
-  it('removes the in-progress status label and adds status:done on a closed issue', () => {
+  // Helper: collect the argv of every `issue edit` call.
+  const editCalls = (ghRun: ReturnType<typeof vi.fn>) =>
+    ghRun.mock.calls.map(c => c[0]).filter((a: string[]) => a[1] === 'edit');
+
+  it('removes the in-progress label and stamps status:done in SEPARATE calls', () => {
     const ghRun = makeLabelGhRun('CLOSED', ['kaizen', 'status:has-pr']);
     reconcileClosedIssueStatusLabels('Closes #1215', ghRun);
 
-    const edit = ghRun.mock.calls.map(c => c[0]).find(a => a[1] === 'edit');
-    expect(edit).toEqual([
-      'issue',
-      'edit',
-      '1215',
-      '--repo',
-      'Garsson-io/kaizen',
-      '--remove-label',
-      'status:has-pr',
-      '--add-label',
-      'status:done',
+    const edits = editCalls(ghRun);
+    // remove and add are independent calls — a missing status:done can't abort the removal
+    expect(edits).toContainEqual([
+      'issue', 'edit', '1215', '--repo', 'Garsson-io/kaizen',
+      '--remove-label', 'status:has-pr',
+    ]);
+    expect(edits).toContainEqual([
+      'issue', 'edit', '1215', '--repo', 'Garsson-io/kaizen',
+      '--add-label', 'status:done',
     ]);
   });
 
-  it('removes every in-progress label present in one edit call', () => {
+  it('removes every in-progress label present in a single remove call', () => {
     const ghRun = makeLabelGhRun('CLOSED', ['status:has-pr', 'status:active']);
     reconcileClosedIssueStatusLabels('Fixes #42', ghRun);
 
-    const edit = ghRun.mock.calls.map(c => c[0]).find(a => a[1] === 'edit')!;
-    const removed = edit
-      .map((v, i) => (v === '--remove-label' ? edit[i + 1] : null))
+    const removeEdit = editCalls(ghRun).find((a: string[]) =>
+      a.includes('--remove-label'),
+    )!;
+    const removed = removeEdit
+      .map((v: string, i: number) => (v === '--remove-label' ? removeEdit[i + 1] : null))
       .filter(Boolean);
     expect(removed.sort()).toEqual(['status:active', 'status:has-pr']);
-    expect(edit).toContain('--add-label');
+  });
+
+  it('a failing status:done add does NOT block the in-progress removal', () => {
+    // Simulate a host repo where status:done is undefined: --add-label throws.
+    const ghRun = vi.fn((args: string[]) => {
+      if (args[0] === 'issue' && args[1] === 'view' && args.includes('state'))
+        return 'CLOSED';
+      if (args[0] === 'issue' && args[1] === 'view' && args.includes('labels'))
+        return JSON.stringify(['status:has-pr']);
+      if (args[1] === 'edit' && args.includes('--add-label'))
+        throw new Error("'status:done' not found");
+      return '';
+    });
+    reconcileClosedIssueStatusLabels('Closes #42', ghRun);
+
+    // The removal still happened despite the add throwing.
+    expect(editCalls(ghRun)).toContainEqual([
+      'issue', 'edit', '42', '--repo', 'Garsson-io/kaizen',
+      '--remove-label', 'status:has-pr',
+    ]);
+  });
+
+  it('does not re-add status:done when it is already present', () => {
+    const ghRun = makeLabelGhRun('CLOSED', ['status:has-pr', 'status:done']);
+    reconcileClosedIssueStatusLabels('Closes #42', ghRun);
+
+    const addEdits = editCalls(ghRun).filter((a: string[]) =>
+      a.includes('--add-label'),
+    );
+    expect(addEdits).toHaveLength(0);
+  });
+
+  it('reconciles every closing-keyword issue in a multi-issue body', () => {
+    const ghRun = makeLabelGhRun('CLOSED', [], {
+      '42': ['status:has-pr'],
+      '43': ['status:active'],
+    });
+    reconcileClosedIssueStatusLabels('Closes #42\nFixes #43', ghRun);
+
+    const removed = editCalls(ghRun)
+      .filter((a: string[]) => a.includes('--remove-label'))
+      .map((a: string[]) => a[2]);
+    expect(removed.sort()).toEqual(['42', '43']);
   });
 
   it('does NOT stamp status:done when no in-progress label is present', () => {
     const ghRun = makeLabelGhRun('CLOSED', ['kaizen', 'bug']);
     reconcileClosedIssueStatusLabels('Closes #42', ghRun);
-
-    const editCalls = ghRun.mock.calls.map(c => c[0]).filter(a => a[1] === 'edit');
-    expect(editCalls).toHaveLength(0);
+    expect(editCalls(ghRun)).toHaveLength(0);
   });
 
   it('skips issues that are still OPEN', () => {
     const ghRun = makeLabelGhRun('OPEN', ['status:has-pr']);
     reconcileClosedIssueStatusLabels('Closes #42', ghRun);
+    expect(editCalls(ghRun)).toHaveLength(0);
+  });
 
-    const editCalls = ghRun.mock.calls.map(c => c[0]).filter(a => a[1] === 'edit');
-    expect(editCalls).toHaveLength(0);
+  it('tolerates malformed labels output without throwing or editing', () => {
+    const ghRun = vi.fn((args: string[]) => {
+      if (args[0] === 'issue' && args[1] === 'view' && args.includes('state'))
+        return 'CLOSED';
+      if (args[0] === 'issue' && args[1] === 'view' && args.includes('labels'))
+        return 'not-json';
+      return '';
+    });
+    expect(() =>
+      reconcileClosedIssueStatusLabels('Closes #42', ghRun),
+    ).not.toThrow();
+    expect(editCalls(ghRun)).toHaveLength(0);
   });
 
   it('does not reconcile mentioned-but-not-closed issues', () => {

--- a/src/hooks/pr-kaizen-clear-ghexec.test.ts
+++ b/src/hooks/pr-kaizen-clear-ghexec.test.ts
@@ -9,7 +9,12 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { gh } from '../lib/gh-exec.js';
-import { defaultPostComment, autoCloseKaizenIssues } from './pr-kaizen-clear.js';
+import {
+  defaultPostComment,
+  autoCloseKaizenIssues,
+  extractClosingIssues,
+  reconcileClosedIssueStatusLabels,
+} from './pr-kaizen-clear.js';
 
 vi.mock('../lib/gh-exec.js', () => ({
   gh: vi.fn(() => ''),
@@ -127,5 +132,100 @@ describe('autoCloseKaizenIssues — gh-exec argv migration', () => {
     autoCloseKaizenIssues(PR_URL, ghRun);
 
     expect(ghRun.mock.calls.every(c => c[0][0] === 'pr')).toBe(true);
+  });
+});
+
+describe('extractClosingIssues — #1229', () => {
+  it('parses close/fix/resolve keywords with and without repo prefix', () => {
+    const body = [
+      'Closes #1215',
+      'Fixes Garsson-io/kaizen#42',
+      'resolved #7',
+      'Parent: #999', // mention, not a closing keyword
+      'Refs: Garsson-io/kaizen#888',
+    ].join('\n');
+    expect(extractClosingIssues(body).sort()).toEqual(['1215', '42', '7']);
+  });
+
+  it('returns no numbers for a body with only mentions', () => {
+    expect(extractClosingIssues('Parent: #1\nRefs: #2')).toEqual([]);
+  });
+});
+
+describe('reconcileClosedIssueStatusLabels — #1229', () => {
+  // Mock ghRun: closing-keyword issue is CLOSED and carries `labels` (passed in).
+  function makeLabelGhRun(state: string, labels: string[]) {
+    return vi.fn((args: string[]) => {
+      if (args[0] === 'issue' && args[1] === 'view' && args.includes('state'))
+        return state;
+      if (args[0] === 'issue' && args[1] === 'view' && args.includes('labels'))
+        return JSON.stringify(labels);
+      return '';
+    });
+  }
+
+  it('removes the in-progress status label and adds status:done on a closed issue', () => {
+    const ghRun = makeLabelGhRun('CLOSED', ['kaizen', 'status:has-pr']);
+    reconcileClosedIssueStatusLabels('Closes #1215', ghRun);
+
+    const edit = ghRun.mock.calls.map(c => c[0]).find(a => a[1] === 'edit');
+    expect(edit).toEqual([
+      'issue',
+      'edit',
+      '1215',
+      '--repo',
+      'Garsson-io/kaizen',
+      '--remove-label',
+      'status:has-pr',
+      '--add-label',
+      'status:done',
+    ]);
+  });
+
+  it('removes every in-progress label present in one edit call', () => {
+    const ghRun = makeLabelGhRun('CLOSED', ['status:has-pr', 'status:active']);
+    reconcileClosedIssueStatusLabels('Fixes #42', ghRun);
+
+    const edit = ghRun.mock.calls.map(c => c[0]).find(a => a[1] === 'edit')!;
+    const removed = edit
+      .map((v, i) => (v === '--remove-label' ? edit[i + 1] : null))
+      .filter(Boolean);
+    expect(removed.sort()).toEqual(['status:active', 'status:has-pr']);
+    expect(edit).toContain('--add-label');
+  });
+
+  it('does NOT stamp status:done when no in-progress label is present', () => {
+    const ghRun = makeLabelGhRun('CLOSED', ['kaizen', 'bug']);
+    reconcileClosedIssueStatusLabels('Closes #42', ghRun);
+
+    const editCalls = ghRun.mock.calls.map(c => c[0]).filter(a => a[1] === 'edit');
+    expect(editCalls).toHaveLength(0);
+  });
+
+  it('skips issues that are still OPEN', () => {
+    const ghRun = makeLabelGhRun('OPEN', ['status:has-pr']);
+    reconcileClosedIssueStatusLabels('Closes #42', ghRun);
+
+    const editCalls = ghRun.mock.calls.map(c => c[0]).filter(a => a[1] === 'edit');
+    expect(editCalls).toHaveLength(0);
+  });
+
+  it('does not reconcile mentioned-but-not-closed issues', () => {
+    const ghRun = makeLabelGhRun('CLOSED', ['status:has-pr']);
+    reconcileClosedIssueStatusLabels('Parent: #999\nRefs: #888', ghRun);
+    expect(ghRun).not.toHaveBeenCalled();
+  });
+
+  it('pins all label calls to the kaizen repo even for a host-repo PR body', () => {
+    const ghRun = makeLabelGhRun('CLOSED', ['status:active']);
+    reconcileClosedIssueStatusLabels('Closes Garsson-io/kaizen#42', ghRun);
+
+    const issueCalls = ghRun.mock.calls.map(c => c[0]).filter(a => a[0] === 'issue');
+    expect(issueCalls.length).toBeGreaterThan(0);
+    for (const a of issueCalls) {
+      expect(a[a.indexOf('--repo') + 1]).toBe('Garsson-io/kaizen');
+    }
+    // every argv element is a discrete token — no fused shell string
+    for (const a of issueCalls) expect(a.some(t => t.includes(' '))).toBe(false);
   });
 });

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -870,11 +870,12 @@ export function extractClosingIssues(prBody: string): string[] {
 
 /**
  * For each issue the PR closes, if it is now CLOSED and still carries an
- * in-progress status label, remove those labels and add `status:done` in a
- * single argv `gh issue edit` call (routed through the injected ghRun boundary,
- * pinned to the kaizen repo). Conservative: acts ONLY when an in-progress label
- * is actually present — issues closed as not-planned/duplicate with no status
- * label are left untouched (never blindly stamped `status:done`).
+ * in-progress status label, remove those labels (one `gh issue edit`) and then
+ * add `status:done` (a separate best-effort edit), both routed through the
+ * injected ghRun boundary and pinned to the kaizen repo. Conservative: acts ONLY
+ * when an in-progress label is actually present — issues closed as
+ * not-planned/duplicate with no status label are left untouched (never blindly
+ * stamped `status:done`).
  */
 export function reconcileClosedIssueStatusLabels(
   prBody: string,

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -831,6 +831,90 @@ export function autoCloseKaizenIssues(prUrl: string, ghRun: GhRunner = gh): void
       }
     } catch {}
   }
+
+  // Reconcile workflow status labels for issues this PR actually CLOSES (#1229).
+  // GitHub auto-closes the linked issue on squash-merge before this hook runs, so
+  // the close loop above may find it already CLOSED and leave its in-progress
+  // status label (status:has-pr/active/...) stale. Strip those and stamp
+  // status:done so a PR-closed issue can't retain an in-progress status.
+  try {
+    reconcileClosedIssueStatusLabels(prBody, ghRun);
+  } catch {}
+}
+
+/** In-progress kaizen workflow status labels that must not survive issue closure. */
+export const IN_PROGRESS_STATUS_LABELS = [
+  'status:has-pr',
+  'status:active',
+  'status:backlog',
+  'status:blocked',
+] as const;
+
+/**
+ * Issue numbers a PR body CLOSES via a GitHub closing keyword
+ * (close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved), with or
+ * without the `Garsson-io/kaizen` repo prefix. Narrower than the mention-regex
+ * used for auto-close: `Parent:`/`Refs:` mentions are intentionally excluded so
+ * only genuinely-closed issues get their status labels reconciled.
+ */
+export function extractClosingIssues(prBody: string): string[] {
+  const nums = new Set<string>();
+  const re =
+    /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+(?:Garsson-io\/kaizen)?#(\d+)/gi;
+  for (const m of prBody.matchAll(re)) nums.add(m[1]);
+  return [...nums];
+}
+
+/**
+ * For each issue the PR closes, if it is now CLOSED and still carries an
+ * in-progress status label, remove those labels and add `status:done` in a
+ * single argv `gh issue edit` call (routed through the injected ghRun boundary,
+ * pinned to the kaizen repo). Conservative: acts ONLY when an in-progress label
+ * is actually present — issues closed as not-planned/duplicate with no status
+ * label are left untouched (never blindly stamped `status:done`).
+ */
+export function reconcileClosedIssueStatusLabels(
+  prBody: string,
+  ghRun: GhRunner = gh,
+): void {
+  for (const num of extractClosingIssues(prBody)) {
+    try {
+      const state = ghRun([
+        'issue',
+        'view',
+        num,
+        '--repo',
+        'Garsson-io/kaizen',
+        '--json',
+        'state',
+        '--jq',
+        '.state',
+      ]).trim();
+      if (state !== 'CLOSED') continue;
+
+      const labelsRaw = ghRun([
+        'issue',
+        'view',
+        num,
+        '--repo',
+        'Garsson-io/kaizen',
+        '--json',
+        'labels',
+        '--jq',
+        '[.labels[].name]',
+      ]).trim();
+      const labels: string[] = JSON.parse(labelsRaw);
+      const toRemove = IN_PROGRESS_STATUS_LABELS.filter(l =>
+        labels.includes(l),
+      );
+      if (toRemove.length === 0) continue; // no divergence → nothing to do
+
+      const args = ['issue', 'edit', num, '--repo', 'Garsson-io/kaizen'];
+      for (const l of toRemove) args.push('--remove-label', l);
+      if (!labels.includes('status:done')) args.push('--add-label', 'status:done');
+      ghRun(args);
+    } catch {}
+  }
 }
 
 // ── Main entry point ─────────────────────────────────────────────────

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -19,7 +19,7 @@ import { execSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { gh } from '../lib/gh-exec.js';
-import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
+import { type HookInput, readHookInput, writeHookOutput, traceNullInput, traceHookEvent } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import { verifyIssueRef, type RefStatus } from './lib/issue-ref-verifier.js';
 import { parseGithubPrUrl } from '../lib/github-pr.js';
@@ -859,8 +859,11 @@ export const IN_PROGRESS_STATUS_LABELS = [
  */
 export function extractClosingIssues(prBody: string): string[] {
   const nums = new Set<string>();
+  // Leading \b anchors the keyword to a word start so substrings like
+  // "disclosed"/"prefixed"/"hotfixes" don't false-match; optional `:` accepts
+  // the "Closes: #N" form GitHub also honors.
   const re =
-    /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+(?:Garsson-io\/kaizen)?#(\d+)/gi;
+    /\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+(?:Garsson-io\/kaizen)?#(\d+)/gi;
   for (const m of prBody.matchAll(re)) nums.add(m[1]);
   return [...nums];
 }
@@ -909,11 +912,44 @@ export function reconcileClosedIssueStatusLabels(
       );
       if (toRemove.length === 0) continue; // no divergence → nothing to do
 
-      const args = ['issue', 'edit', num, '--repo', 'Garsson-io/kaizen'];
-      for (const l of toRemove) args.push('--remove-label', l);
-      if (!labels.includes('status:done')) args.push('--add-label', 'status:done');
-      ghRun(args);
-    } catch {}
+      // Remove the stale in-progress label(s) FIRST, in their own call. This is
+      // the #1229 invariant ("a PR-closed issue can't stay in-progress") and the
+      // labels are known-present on the issue, so it can't fail on a missing one.
+      const removeArgs = ['issue', 'edit', num, '--repo', 'Garsson-io/kaizen'];
+      for (const l of toRemove) removeArgs.push('--remove-label', l);
+      ghRun(removeArgs);
+
+      // Stamp status:done in a SEPARATE best-effort call. `gh issue edit` applies
+      // a label set atomically, so fusing --add-label into the removal above would
+      // abort the whole edit (and the removal) if status:done is absent — which
+      // can happen in a host repo that never defined it.
+      if (!labels.includes('status:done')) {
+        try {
+          ghRun([
+            'issue',
+            'edit',
+            num,
+            '--repo',
+            'Garsson-io/kaizen',
+            '--add-label',
+            'status:done',
+          ]);
+        } catch {}
+      }
+      traceHookEvent('pr-kaizen-clear', {
+        action: 'reconcile-status',
+        issue: num,
+        removed: toRemove,
+      });
+    } catch (err) {
+      // Best-effort, but leave a durable signal so a failed reconcile isn't
+      // silent (the #1229 symptom would otherwise recur invisibly).
+      traceHookEvent('pr-kaizen-clear', {
+        action: 'reconcile-status',
+        issue: num,
+        error: String(err),
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

When a PR is squash-merged, GitHub auto-closes the linked kaizen issue via the `Closes #N` keyword. The `pr-kaizen-clear` post-merge hook (`autoCloseKaizenIssues`) then closes any *still-open* referenced issue — but it never touches the kaizen **workflow status labels**. So a PR-closed issue keeps `status:has-pr` (or `status:active`/`status:backlog`/`status:blocked`).

That stale label misleads issue hygiene, `/kaizen-pick`, and audit tooling — a closed issue still *looks* in-progress. The incident: after PR #1219 merged and closed #1215, the `status:has-pr` label had to be removed and `status:done` added **by hand**.

## Discovery

Issue **closure** and issue **status-label** state are managed by two different paths. GitHub (or the hook) closes the issue; nothing reconciles the labels. Crucially, on squash-merge GitHub auto-closes the issue *before* the hook runs, so the close loop finds it already `CLOSED` and does nothing — the divergence is structural, not a one-off.

## Solution

A reconciliation pass at the **same post-merge choke point** that already closes issues, in `src/hooks/pr-kaizen-clear.ts`:

- `extractClosingIssues(body)` — issues referenced by a genuine closing keyword (`close[sd]`/`fix(es|ed)`/`resolve[sd]`), with or without the `Garsson-io/kaizen` prefix. Narrower than the existing mention-regex, so `Parent:`/`Refs:` mentions are **excluded** — only issues the PR really closes get reconciled.
- `reconcileClosedIssueStatusLabels(body, ghRun)` — for each such issue that is now `CLOSED` and still carries an in-progress status label, removes those labels and adds `status:done` in one argv `gh issue edit` call, routed through the injected `ghRun` boundary and pinned to the kaizen repo.

**Conservative guard:** acts only when an in-progress label is actually present. Issues closed as not-planned/duplicate with no status label are left untouched — `status:done` is never stamped blindly.

Covers both "hook closes it" and "GitHub already auto-closed it" cases.

## Evidence

- 8 new unit tests in `pr-kaizen-clear-ghexec.test.ts`: keyword parsing (with/without prefix; mentions excluded), single + multiple in-progress labels removed in one edit, no-label → no edit, still-open → skip, mentions → no reconcile, repo-pinning + no fused shell strings.
- Full hooks suite green: **798 passed (37 files)**. `tsc --noEmit` clean.

## Impact

A PR-closed kaizen issue can no longer retain an in-progress status — the L3 lifecycle-sync gap from #1229 is closed at the merge boundary, removing recurring manual label cleanup.

## Behaviors × Levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Closing-keyword parsing (prefix variants, mentions excluded) | ✅ | | | | |
| Strip in-progress label(s) + add status:done on closed issue | ✅ | | | | |
| No blind status:done when no in-progress label present | ✅ | | | | |
| Skip still-open / mentioned-only issues | ✅ | | | | |
| Repo-pinning + argv boundary (no shell string) | ✅ | | | | |

Closes #1229
Run tag: handsome-lynx/run-18
