### PR TITLE
refactor(hooks): route kaizen-reflect git reads through argv runner

### DIFF
--- a/src/hooks/kaizen-reflect.test.ts
+++ b/src/hooks/kaizen-reflect.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HookInput } from './hook-io.js';
@@ -276,6 +276,18 @@ describe('processHookInput', () => {
       const output2 = processHookInput(input, defaultOpts);
       expect(output2).toBeNull();
     });
+  });
+});
+
+describe('git runner invariant', () => {
+  it('routes kaizen-reflect git reads through argv-style gitStdout calls', () => {
+    const source = readFileSync(new URL('./kaizen-reflect.ts', import.meta.url), 'utf-8');
+
+    expect(source).not.toMatch(/execSync\(['"`]git\b/);
+    expect(source).toContain("gitStdout(['remote', 'get-url', 'origin'])");
+    expect(source).toContain("gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown')");
+    expect(source).toContain("gitStdout(['diff', '--name-only', 'main...HEAD'])");
+    expect(source).toContain("gitStdout(['worktree', 'list', '--porcelain'], '.')");
   });
 });
 

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -19,6 +19,7 @@ import { gh } from '../lib/gh-exec.js';
 import { parseGithubPrUrl } from '../lib/github-pr.js';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
+import { gitStdout } from './lib/git-state.js';
 import {
   extractRepoFlag,
   isGhPrCommand,
@@ -41,28 +42,14 @@ type GhRunner = (args: string[]) => string;
 
 /** Detect the GitHub repo from the origin remote URL. */
 function detectGhRepo(): string | undefined {
-  try {
-    const url = execSync('git remote get-url origin', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    const match = url.match(/github\.com[:/]([^/]+\/[^/.]+)/);
-    return match?.[1];
-  } catch {
-    return undefined;
-  }
+  const url = gitStdout(['remote', 'get-url', 'origin']);
+  const match = url.match(/github\.com[:/]([^/]+\/[^/.]+)/);
+  return match?.[1];
 }
 
 /** Get current git branch. */
 function getCurrentBranch(): string {
-  try {
-    return execSync('git rev-parse --abbrev-ref HEAD', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return 'unknown';
-  }
+  return gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown');
 }
 
 /** Get changed files for context. */
@@ -81,10 +68,7 @@ function getChangedFiles(cmdLine: string, isMerge: boolean, ghRun: GhRunner = gh
       }
       return ghRun(args).trim();
     }
-    return execSync('git diff --name-only main...HEAD', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    return gitStdout(['diff', '--name-only', 'main...HEAD']);
   } catch {
     return '';
   }
@@ -92,16 +76,9 @@ function getChangedFiles(cmdLine: string, isMerge: boolean, ghRun: GhRunner = gh
 
 /** Get main checkout path. */
 function getMainCheckout(): string {
-  try {
-    const output = execSync('git worktree list --porcelain', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const firstLine = output.split('\n')[0];
-    return firstLine.replace('worktree ', '');
-  } catch {
-    return '.';
-  }
+  const output = gitStdout(['worktree', 'list', '--porcelain'], '.');
+  const firstLine = output.split('\n')[0];
+  return firstLine.replace('worktree ', '');
 }
 
 /** Send a Telegram notification via IPC. */

--- a/src/hooks/lib/git-state-invariant.test.ts
+++ b/src/hooks/lib/git-state-invariant.test.ts
@@ -23,7 +23,6 @@ const HOOKS_DIR = join(__dirname, '..');
 const OPT_OUT = new Set<string>([
   // bump-plugin-version.ts — migrated to git-state.ts (#1074)
   // hook-io.ts — migrated to git-state.ts (#1074)
-  'kaizen-reflect.ts',
   'pr-kaizen-clear.ts',
   'pr-kaizen-clear-fallback.ts',
   'pr-review-loop.ts',


### PR DESCRIPTION
## Summary

Route `kaizen-reflect.ts` read-only Git state calls through `gitStdout(...)`, reusing the shared argv-style Git runner added for hook Git reads. This removes `kaizen-reflect.ts` from the git-state invariant opt-out list while preserving the existing fallbacks.

Closes #1316

## Changes

- Replace direct `execSync('git ...')` calls in `kaizen-reflect.ts` with explicit `gitStdout([...])` argv calls.
- Keep the bash hook timing sentinel out of scope; it intentionally invokes bash and is not a Git state read.
- Remove `kaizen-reflect.ts` from `git-state-invariant.test.ts` opt-outs.
- Add a focused source invariant in `kaizen-reflect.test.ts` for the expected argv-style calls.

## Validation

- RED: `npm test -- --run src/hooks/lib/git-state-invariant.test.ts` failed while `kaizen-reflect.ts` was removed from opt-outs but still used raw Git execs.
- GREEN: `npm test -- --run src/hooks/kaizen-reflect.test.ts src/hooks/lib/git-state-invariant.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep found no raw `execSync(...git ...)` / old Git command strings in `src/hooks/kaizen-reflect.ts`
