### PR TITLE
refactor(hooks): route post-merge checkout lookup through argv runner

### DIFF
--- a/src/hooks/lib/git-state-invariant.test.ts
+++ b/src/hooks/lib/git-state-invariant.test.ts
@@ -28,7 +28,6 @@ const OPT_OUT = new Set<string>([
   'pr-review-loop.ts',
   'pre-push.ts',
   'prehook-no-verify.ts',
-  'post-merge-clear.ts',
   'enforce-plan-stored.ts',
   'pr-quality-checks.ts',
 ]);

--- a/src/hooks/post-merge-clear.test.ts
+++ b/src/hooks/post-merge-clear.test.ts
@@ -243,3 +243,12 @@ describe('cross-session isolation (kaizen #786)', () => {
     expect(existsSync(join(TEST_STATE_DIR, 'post-merge-org_repo_99'))).toBe(true);
   });
 });
+
+describe('git runner invariant', () => {
+  it('routes post-merge checkout lookup through argv-style gitStdout', () => {
+    const source = readFileSync(new URL('./post-merge-clear.ts', import.meta.url), 'utf-8');
+
+    expect(source).not.toMatch(/execSync\(['"`]git\b/);
+    expect(source).toContain("gitStdout(['worktree', 'list', '--porcelain'])");
+  });
+});

--- a/src/hooks/post-merge-clear.ts
+++ b/src/hooks/post-merge-clear.ts
@@ -15,9 +15,9 @@
  * Bash predecessor deleted in #790.
  */
 
-import { execSync } from 'node:child_process';
 import { getCurrentBranch, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
+import { gitStdout } from './lib/git-state.js';
 import { isGhPrCommand, stripHeredocBody } from './parse-command.js';
 import {
   DEFAULT_STATE_DIR,
@@ -29,16 +29,9 @@ import {
 } from './state-utils.js';
 
 function resolveMainCheckout(): string {
-  try {
-    const output = execSync('git worktree list --porcelain', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const match = output.match(/^worktree (.+)/m);
-    return match?.[1] ?? '.';
-  } catch {
-    return '.';
-  }
+  const output = gitStdout(['worktree', 'list', '--porcelain']);
+  const match = output.match(/^worktree (.+)/m);
+  return match?.[1] ?? '.';
 }
 
 export function processPostMergeClear(


### PR DESCRIPTION
## Summary

Route the `post-merge-clear.ts` main checkout lookup through the shared argv-style Git runner and remove the hook from the git-state invariant opt-out list.

Closes #1319

## Changes

- Replace direct `execSync('git worktree list --porcelain')` with `gitStdout(['worktree', 'list', '--porcelain'])`.
- Preserve `.` fallback when the worktree lookup fails or does not contain a `worktree` line.
- Remove `post-merge-clear.ts` from `git-state-invariant.test.ts` opt-outs.
- Add a focused source invariant in `post-merge-clear.test.ts`.

## Validation

- RED: `npm test -- --run src/hooks/lib/git-state-invariant.test.ts` failed while `post-merge-clear.ts` was removed from opt-outs but still used raw Git exec.
- GREEN: `npm test -- --run src/hooks/post-merge-clear.test.ts src/hooks/lib/git-state-invariant.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep found no raw Git exec command strings in `src/hooks/post-merge-clear.ts`
