### PR TITLE
refactor(hooks): route pr-kaizen branch reads through argv runner

### DIFF
--- a/src/hooks/lib/git-state-invariant.test.ts
+++ b/src/hooks/lib/git-state-invariant.test.ts
@@ -23,10 +23,6 @@ const HOOKS_DIR = join(__dirname, '..');
 const OPT_OUT = new Set<string>([
   // bump-plugin-version.ts — migrated to git-state.ts (#1074)
   // hook-io.ts — migrated to git-state.ts (#1074)
-  'pr-kaizen-clear.ts',
-  'pr-kaizen-clear-fallback.ts',
-  'pr-review-loop.ts',
-  'pre-push.ts',
   'prehook-no-verify.ts',
   'enforce-plan-stored.ts',
   'pr-quality-checks.ts',

--- a/src/hooks/pr-kaizen-clear-fallback.test.ts
+++ b/src/hooks/pr-kaizen-clear-fallback.test.ts
@@ -191,3 +191,15 @@ describe('pr-kaizen-clear-fallback: does not touch other gate types', () => {
     expect(gateStatus('pr-review-Garsson-io_kaizen_55')).toBe('needs_review');
   });
 });
+
+describe('git runner invariant', () => {
+  it('routes fallback branch reads through argv-style gitStdout', () => {
+    const source = fs.readFileSync(
+      new URL('./pr-kaizen-clear-fallback.ts', import.meta.url),
+      'utf-8',
+    );
+
+    expect(source).not.toMatch(/execSync\(['"`]git\b/);
+    expect(source).toContain("gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown')");
+  });
+});

--- a/src/hooks/pr-kaizen-clear-fallback.ts
+++ b/src/hooks/pr-kaizen-clear-fallback.ts
@@ -19,10 +19,10 @@
  * Migrated to TS state functions in #790 gap fix.
  */
 
-import { execSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { readHookInput, traceNullInput } from './hook-io.js';
+import { gitStdout } from './lib/git-state.js';
 import {
   DEFAULT_AUDIT_DIR,
   DEFAULT_STATE_DIR,
@@ -32,14 +32,7 @@ import {
 } from './state-utils.js';
 
 function currentBranch(): string {
-  try {
-    return execSync('git rev-parse --abbrev-ref HEAD', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return 'unknown';
-  }
+  return gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown');
 }
 
 async function main(): Promise<void> {

--- a/src/hooks/pr-kaizen-clear-seams.test.ts
+++ b/src/hooks/pr-kaizen-clear-seams.test.ts
@@ -113,6 +113,18 @@ describe('KAIZEN_UNFINISHED seam: grep pattern false-positive prevention', () =>
   });
 });
 
+describe('git runner invariant', () => {
+  it('routes pr-kaizen-clear branch reads through argv-style gitStdout', () => {
+    const source = fs.readFileSync(
+      new URL('./pr-kaizen-clear.ts', import.meta.url),
+      'utf-8',
+    );
+
+    expect(source).not.toMatch(/execSync\(['"`]git\b/);
+    expect(source).toContain("gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown')");
+  });
+});
+
 // ── Piped KAIZEN_IMPEDIMENTS seam ────────────────────────────────────
 
 describe('KAIZEN_IMPEDIMENTS seam: piped command extraction', () => {

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -15,12 +15,12 @@
  * Migration: kaizen #320 (Phase 3 of #223)
  */
 
-import { execSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { gh } from '../lib/gh-exec.js';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
+import { gitStdout } from './lib/git-state.js';
 import { verifyIssueRef, type RefStatus } from './lib/issue-ref-verifier.js';
 import { parseGithubPrUrl } from '../lib/github-pr.js';
 import { resolveProjectRoot } from '../lib/resolve-project-root.js';
@@ -62,14 +62,7 @@ function getAuditDir(): string {
 }
 
 function currentBranch(): string {
-  try {
-    return execSync('git rev-parse --abbrev-ref HEAD', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return 'unknown';
-  }
+  return gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown');
 }
 
 function logAudit(file: string, line: string): void {


### PR DESCRIPTION
## Summary

Route the duplicated `currentBranch()` Git reads in `pr-kaizen-clear.ts` and `pr-kaizen-clear-fallback.ts` through the shared argv-style `gitStdout(...)` runner. This also retires stale git-state invariant opt-outs for hooks that now pass the invariant.

Fixes #1321

## Changes

- Replace direct `execSync('git rev-parse --abbrev-ref HEAD')` branch reads with `gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown')`.
- Preserve the existing `unknown` fallback behavior.
- Remove stale opt-outs for `pr-kaizen-clear.ts`, `pr-kaizen-clear-fallback.ts`, `pre-push.ts`, and `pr-review-loop.ts` from `git-state-invariant.test.ts`.
- Add focused source invariants for the two pr-kaizen-clear branch readers.

## Validation

- RED: `npm test -- --run src/hooks/lib/git-state-invariant.test.ts` failed on `pr-kaizen-clear.ts` and `pr-kaizen-clear-fallback.ts` after removing the opt-outs.
- GREEN: `npm test -- --run src/hooks/pr-kaizen-clear-seams.test.ts src/hooks/pr-kaizen-clear-fallback.test.ts src/hooks/pr-kaizen-clear-ghexec.test.ts src/hooks/pr-kaizen-clear-outcome.test.ts src/hooks/lib/git-state-invariant.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep found no raw `git rev-parse --abbrev-ref HEAD` shell reads in the migrated production files
