### PR TITLE
refactor(hooks): route plan gate git reads through argv runner

### DIFF
--- a/src/hooks/enforce-plan-stored.test.ts
+++ b/src/hooks/enforce-plan-stored.test.ts
@@ -5,6 +5,7 @@
  * No GitHub or git calls are made.
  */
 
+import { readFileSync } from 'node:fs';
 import { describe, expect, it, afterEach } from 'vitest';
 import {
   checkPlanBeforePr,
@@ -98,6 +99,21 @@ describe('extractCaseIssueFromBranch', () => {
     expect(extractCaseIssueFromBranch('worktree-2606261134-38ae')).toBeNull());
   it('returns null for a bare k<N> branch (not the canonical case shape)', () =>
     expect(extractCaseIssueFromBranch('k40-something')).toBeNull());
+});
+
+describe('git runner invariant', () => {
+  it('routes default git reads through argv-style gitStdout', () => {
+    const source = readFileSync(
+      new URL('./enforce-plan-stored.ts', import.meta.url),
+      'utf-8',
+    );
+
+    expect(source).not.toMatch(/execSync\(cmd/);
+    expect(source).not.toContain('git diff --name-only main...HEAD');
+    expect(source).not.toContain('git rev-parse --abbrev-ref HEAD');
+    expect(source).not.toContain('git remote get-url origin');
+    expect(source).toContain('gitStdout([');
+  });
 });
 
 

--- a/src/hooks/enforce-plan-stored.ts
+++ b/src/hooks/enforce-plan-stored.ts
@@ -15,9 +15,9 @@
  * Part of kaizen #1055.
  */
 
-import { execSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 import { readHookInput, traceNullInput } from './hook-io.js';
+import { gitStdout } from './lib/git-state.js';
 import { isGhPrCommand, stripHeredocBody, extractRepoFlag } from './parse-command.js';
 import { CaseSystem } from '../case-system.js';
 import { extractCaseIssueFromBranch } from './lib/case-branch.js';
@@ -46,36 +46,36 @@ export interface PlanCheckDeps {
 
 // ── Defaults ────────────────────────────────────────────────────────
 
-function exec(cmd: string): string {
-  try {
-    return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-  } catch {
-    return '';
-  }
+function currentGitBranch(): string {
+  return gitStdout(['rev-parse', '--abbrev-ref', 'HEAD']);
+}
+
+function gitCommonDir(): string {
+  return gitStdout(['rev-parse', '--git-common-dir']);
 }
 
 const DEFAULT_DEPS: PlanCheckDeps = {
   caseSystem: new CaseSystem(),
   getChangedFiles: () => {
-    const r = exec('git diff --name-only main...HEAD 2>/dev/null');
+    const r = gitStdout(['diff', '--name-only', 'main...HEAD']);
     return r ? r.split('\n').filter(Boolean) : [];
   },
-  getCurrentBranch: () => exec('git rev-parse --abbrev-ref HEAD 2>/dev/null'),
-  detectRepo: () => exec('git remote get-url origin 2>/dev/null').replace(/.*github\.com[:/]/, '').replace(/\.git$/, ''),
+  getCurrentBranch: currentGitBranch,
+  detectRepo: () => gitStdout(['remote', 'get-url', 'origin']).replace(/.*github\.com[:/]/, '').replace(/\.git$/, ''),
   isInWorktree: () => {
-    const gitDir = exec('git rev-parse --git-dir 2>/dev/null');
-    const gitCommon = exec('git rev-parse --git-common-dir 2>/dev/null');
+    const gitDir = gitStdout(['rev-parse', '--git-dir']);
+    const gitCommon = gitCommonDir();
     return !!gitDir && !!gitCommon && gitDir !== gitCommon;
   },
-  getWorktreeRoot: () => exec('git rev-parse --show-toplevel 2>/dev/null'),
+  getWorktreeRoot: () => gitStdout(['rev-parse', '--show-toplevel']),
   getMainCheckout: () => {
-    const gitCommon = exec('git rev-parse --git-common-dir 2>/dev/null');
+    const gitCommon = gitCommonDir();
     if (!gitCommon) return '';
     // git-common-dir is typically <main>/.git, so parent is main checkout
     return gitCommon.replace(/\/\.git$/, '').replace(/\/\.git\/.*$/, '');
   },
   getDeclaredIssue: () => {
-    const v = exec('git config --get kaizen.issue 2>/dev/null');
+    const v = gitStdout(['config', '--get', 'kaizen.issue']);
     return v && /^\d+$/.test(v) ? v : null;
   },
 };
@@ -406,7 +406,7 @@ function logEscapeHatchUse(context: string): void {
       ts: new Date().toISOString(),
       hook: 'enforce-plan-stored',
       context,
-      branch: (() => { try { return exec('git rev-parse --abbrev-ref HEAD 2>/dev/null'); } catch { return ''; } })(),
+      branch: currentGitBranch(),
       cwd: process.cwd(),
     }) + '\n';
     // Append-only; never throw

--- a/src/hooks/lib/git-state-invariant.test.ts
+++ b/src/hooks/lib/git-state-invariant.test.ts
@@ -23,8 +23,6 @@ const HOOKS_DIR = join(__dirname, '..');
 const OPT_OUT = new Set<string>([
   // bump-plugin-version.ts — migrated to git-state.ts (#1074)
   // hook-io.ts — migrated to git-state.ts (#1074)
-  'prehook-no-verify.ts',
-  'enforce-plan-stored.ts',
   'pr-quality-checks.ts',
 ]);
 


### PR DESCRIPTION
## Summary

Route `enforce-plan-stored.ts` default Git reads through the shared argv-style `gitStdout(...)` runner and remove stale git-state invariant opt-outs.

Fixes #1323

## Changes

- Replace the local generic `exec(cmd)`/`execSync(cmd)` Git wrapper with explicit `gitStdout([...])` calls.
- Preserve existing fallback behavior: failed Git reads return empty strings, and invalid/missing `kaizen.issue` still returns `null`.
- Reuse the same branch-read helper for escape-hatch audit logging.
- Remove `enforce-plan-stored.ts` and stale `prehook-no-verify.ts` opt-outs from `git-state-invariant.test.ts`.
- Add a focused source invariant for the default plan-gate Git reads.

## Validation

- RED: `npm test -- --run src/hooks/enforce-plan-stored.test.ts src/hooks/lib/git-state-invariant.test.ts` failed on the new source invariant before migration.
- GREEN: `npm test -- --run src/hooks/enforce-plan-stored.test.ts src/hooks/lib/git-state-invariant.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep found no old plan-gate Git shell strings in `src/hooks/enforce-plan-stored.ts`
