### PR TITLE
refactor(hooks): route PR quality git reads through argv runner

### DIFF
--- a/src/hooks/lib/git-state-invariant.test.ts
+++ b/src/hooks/lib/git-state-invariant.test.ts
@@ -23,7 +23,6 @@ const HOOKS_DIR = join(__dirname, '..');
 const OPT_OUT = new Set<string>([
   // bump-plugin-version.ts — migrated to git-state.ts (#1074)
   // hook-io.ts — migrated to git-state.ts (#1074)
-  'pr-quality-checks.ts',
 ]);
 
 function isHookSource(name: string): boolean {

--- a/src/hooks/pr-quality-checks.test.ts
+++ b/src/hooks/pr-quality-checks.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   checkCodeQuality,
@@ -35,13 +36,30 @@ describe('detectCommandType', () => {
   });
 });
 
+describe('git runner invariant', () => {
+  it('routes default git reads through argv-style gitStdout', () => {
+    const source = readFileSync(
+      new URL('./pr-quality-checks.ts', import.meta.url),
+      'utf-8',
+    );
+
+    expect(source).not.toMatch(/execSync\(cmd/);
+    expect(source).not.toContain('git diff --name-only main...HEAD');
+    expect(source).not.toContain('git diff --cached --name-only');
+    expect(source).toContain("import { gitStdout } from './lib/git-state.js';");
+    expect(source).toContain('const defaultGit: GitRunner = (args) => gitStdout(args);');
+    expect(source).toContain("git(['diff', '--name-only', 'main...HEAD'])");
+    expect(source).toContain("git(['diff', '--cached', '--name-only'])");
+  });
+});
+
 describe('getChangedFiles', () => {
   it('uses git diff for create', () => {
-    const exec = (cmd: string) => {
-      if (cmd.includes('git diff')) return 'src/a.ts\nsrc/b.ts';
+    const git = (args: string[]) => {
+      if (args[0] === 'diff') return 'src/a.ts\nsrc/b.ts';
       return '';
     };
-    expect(getChangedFiles('gh pr create', false, exec)).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(getChangedFiles('gh pr create', false, git)).toEqual(['src/a.ts', 'src/b.ts']);
   });
 
   it('uses gh pr diff for merge', () => {
@@ -72,24 +90,23 @@ describe('getChangedFiles', () => {
   });
 
   it('falls back to git diff on merge if gh pr diff fails', () => {
-    const exec = (cmd: string) => {
-      if (cmd.includes('gh pr diff')) return '';
-      if (cmd.includes('git diff')) return 'src/e.ts';
+    const git = (args: string[]) => {
+      if (args[0] === 'diff') return 'src/e.ts';
       return '';
     };
-    expect(getChangedFiles('gh pr merge 42', true, exec)).toEqual(['src/e.ts']);
+    expect(getChangedFiles('gh pr merge 42', true, git)).toEqual(['src/e.ts']);
   });
 
   it('falls back to git diff when argv-style gh PR diff returns empty', () => {
-    const execCalls: string[] = [];
-    const exec = (cmd: string) => {
-      execCalls.push(cmd);
-      if (cmd.includes('git diff')) return 'src/e.ts';
+    const gitCalls: string[][] = [];
+    const git = (args: string[]) => {
+      gitCalls.push(args);
+      if (args[0] === 'diff') return 'src/e.ts';
       return '';
     };
 
-    expect(getChangedFiles('gh pr merge 42', true, exec, () => '')).toEqual(['src/e.ts']);
-    expect(execCalls).toEqual(['git diff --name-only main...HEAD']);
+    expect(getChangedFiles('gh pr merge 42', true, git, () => '')).toEqual(['src/e.ts']);
+    expect(gitCalls).toEqual([['diff', '--name-only', 'main...HEAD']]);
   });
 });
 
@@ -181,17 +198,17 @@ describe('formatTestCoverageWarning', () => {
 
 describe('checkVerification', () => {
   it('warns on missing verification in pr_create', () => {
-    const msg = checkVerification('gh pr create --title "test" --body "just a summary"', 'pr_create', () => '');
+    const msg = checkVerification('gh pr create --title "test" --body "just a summary"', 'pr_create');
     expect(msg).toContain('Missing Verification section');
   });
 
   it('passes when verification keyword present in command', () => {
-    const msg = checkVerification('gh pr create --body "## Verification\n- check this"', 'pr_create', () => '');
+    const msg = checkVerification('gh pr create --body "## Verification\n- check this"', 'pr_create');
     expect(msg).toBe('');
   });
 
   it('passes with Test plan header', () => {
-    const msg = checkVerification('gh pr create --body "## Test plan\n- tests pass"', 'pr_create', () => '');
+    const msg = checkVerification('gh pr create --body "## Test plan\n- tests pass"', 'pr_create');
     expect(msg).toBe('');
   });
 
@@ -200,7 +217,7 @@ describe('checkVerification', () => {
       if (args[0] === 'pr' && args[1] === 'view') return '## Verification\n- Run npm test\n- Check output';
       return '';
     };
-    const msg = checkVerification('gh pr merge 42', 'pr_merge', () => '', gh);
+    const msg = checkVerification('gh pr merge 42', 'pr_merge', gh);
     expect(msg).toContain('POST-MERGE VERIFICATION REQUIRED');
   });
 
@@ -211,7 +228,7 @@ describe('checkVerification', () => {
       return '## Verification\n- Run npm test';
     };
 
-    const msg = checkVerification('gh pr merge 42', 'pr_merge', () => '', gh);
+    const msg = checkVerification('gh pr merge 42', 'pr_merge', gh);
 
     expect(msg).toContain('POST-MERGE VERIFICATION REQUIRED');
     expect(ghCalls).toEqual([[
@@ -232,7 +249,7 @@ describe('checkVerification', () => {
       return '## Verification\n- Run npm test';
     };
 
-    const msg = checkVerification('gh pr merge --squash', 'pr_merge', () => '', gh);
+    const msg = checkVerification('gh pr merge --squash', 'pr_merge', gh);
 
     expect(msg).toContain('POST-MERGE VERIFICATION REQUIRED');
     expect(ghCalls).toEqual([[
@@ -250,12 +267,12 @@ describe('checkVerification', () => {
       if (args[0] === 'pr' && args[1] === 'view') return '## Summary\nSome changes';
       return '';
     };
-    const msg = checkVerification('gh pr merge 42', 'pr_merge', () => '', gh);
+    const msg = checkVerification('gh pr merge 42', 'pr_merge', gh);
     expect(msg).toContain('no Verification section');
   });
 
   it('returns empty for git_commit', () => {
-    expect(checkVerification('git commit -m "fix"', 'git_commit', () => '')).toBe('');
+    expect(checkVerification('git commit -m "fix"', 'git_commit')).toBe('');
   });
 });
 
@@ -302,19 +319,24 @@ describe('checkPractices', () => {
 
 describe('checkCodeQuality', () => {
   it('checks mock count on git_commit', () => {
+    const gitCalls: string[][] = [];
     const result = checkCodeQuality([], 'git_commit', {
-      exec: () => 'src/foo.test.ts',
+      git: (args) => {
+        gitCalls.push(args);
+        return 'src/foo.test.ts';
+      },
       fileExists: () => true,
       readFile: () => 'vi.mock("a");\nvi.mock("b");\nvi.mock("c");\nvi.mock("d");',
     });
     expect(result.warnings.length).toBe(1);
     expect(result.warnings[0]).toContain('4 mocks');
+    expect(gitCalls).toEqual([['diff', '--cached', '--name-only']]);
   });
 
   it('checks file length on git_commit', () => {
     const longFile = Array(501).fill('const x = 1;').join('\n');
     const result = checkCodeQuality([], 'git_commit', {
-      exec: () => 'src/big.ts',
+      git: () => 'src/big.ts',
       fileExists: () => true,
       readFile: () => longFile,
     });
@@ -324,7 +346,7 @@ describe('checkCodeQuality', () => {
 
   it('skips checks for non-commit commands', () => {
     const result = checkCodeQuality([], 'pr_create', {
-      exec: () => '',
+      git: () => '',
       fileExists: () => true,
       readFile: () => '',
     });
@@ -362,7 +384,7 @@ describe('runQualityChecks', () => {
 
   it('runs all PR checks for gh pr create', () => {
     const result = runQualityChecks('gh pr create --title "test" --body "## Verification\n- ok"', {
-      exec: () => 'src/a.ts\nsrc/a.test.ts',
+      git: () => 'src/a.ts\nsrc/a.test.ts',
     });
     // Should have test coverage success + practices checklist
     expect(result.messages.length).toBeGreaterThanOrEqual(1);
@@ -370,7 +392,7 @@ describe('runQualityChecks', () => {
 
   it('runs test coverage and verification for gh pr merge', () => {
     const result = runQualityChecks('gh pr merge 42', {
-      exec: (cmd) => {
+      git: () => {
         return '';
       },
       gh: (args) => {
@@ -384,7 +406,7 @@ describe('runQualityChecks', () => {
 
   it('runs code quality checks for git commit', () => {
     const result = runQualityChecks('git commit -m "fix"', {
-      exec: () => '',
+      git: () => '',
     });
     // No warnings if no files
     expect(result.messages).toEqual([]);

--- a/src/hooks/pr-quality-checks.ts
+++ b/src/hooks/pr-quality-checks.ts
@@ -18,10 +18,10 @@
  * Part of kAIzen Agent Control Flow — consolidation from #800
  */
 
-import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { readHookInput, traceNullInput } from './hook-io.js';
+import { gitStdout } from './lib/git-state.js';
 import {
   isGhPrCommand,
   isGitCommand,
@@ -30,6 +30,7 @@ import {
 import { gh as runGh } from '../lib/gh-exec.js';
 
 type CommandType = 'pr_create' | 'pr_merge' | 'git_commit' | 'none';
+type GitRunner = (args: string[]) => string;
 
 export function detectCommandType(cmdLine: string): CommandType {
   if (isGhPrCommand(cmdLine, 'create')) return 'pr_create';
@@ -39,20 +40,14 @@ export function detectCommandType(cmdLine: string): CommandType {
 }
 
 interface RunnerOptions {
-  exec?: (cmd: string) => string;
+  git?: GitRunner;
   gh?: (args: string[]) => string;
   fileExists?: (path: string) => boolean;
   readFile?: (path: string) => string;
   hookDir?: string;
 }
 
-const defaultExec = (cmd: string): string => {
-  try {
-    return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-  } catch {
-    return '';
-  }
-};
+const defaultGit: GitRunner = (args) => gitStdout(args);
 
 const defaultGh = (args: string[]): string => {
   try {
@@ -66,7 +61,7 @@ const defaultGh = (args: string[]): string => {
 export function getChangedFiles(
   cmdLine: string,
   isMerge: boolean,
-  exec: (cmd: string) => string,
+  git: GitRunner = defaultGit,
   gh: (args: string[]) => string = defaultGh,
 ): string[] {
   let raw: string;
@@ -80,10 +75,10 @@ export function getChangedFiles(
     if (repoMatch) args.push('--repo', repoMatch[1]);
     raw = gh(args);
     if (!raw) {
-      raw = exec('git diff --name-only main...HEAD');
+      raw = git(['diff', '--name-only', 'main...HEAD']);
     }
   } else {
-    raw = exec('git diff --name-only main...HEAD');
+    raw = git(['diff', '--name-only', 'main...HEAD']);
   }
   return raw.split('\n').map((l) => l.trim()).filter(Boolean);
 }
@@ -200,7 +195,6 @@ Replace <reason> with a specific justification (e.g., "constant change", "covere
 export function checkVerification(
   command: string,
   cmdType: CommandType,
-  exec: (cmd: string) => string,
   gh: (args: string[]) => string = defaultGh,
 ): string {
   if (cmdType === 'pr_create') {
@@ -338,8 +332,8 @@ export function checkCodeQuality(
     const LINE_THRESHOLD = 500;
 
     // Get staged files
-    const exec = opts.exec ?? defaultExec;
-    const stagedRaw = exec('git diff --cached --name-only');
+    const git = opts.git ?? defaultGit;
+    const stagedRaw = git(['diff', '--cached', '--name-only']);
     const stagedFiles = stagedRaw.split('\n').filter(Boolean);
 
     // Check 1: Mock count in test files
@@ -393,7 +387,7 @@ export function runQualityChecks(
   command: string,
   opts: RunnerOptions = {},
 ): QualityCheckOutput {
-  const exec = opts.exec ?? defaultExec;
+  const git = opts.git ?? defaultGit;
   const gh = opts.gh ?? defaultGh;
   const cmdLine = stripHeredocBody(command);
   const cmdType = detectCommandType(cmdLine);
@@ -406,7 +400,7 @@ export function runQualityChecks(
   const isPrCommand = cmdType === 'pr_create' || cmdType === 'pr_merge';
 
   if (isPrCommand) {
-    const changedFiles = getChangedFiles(cmdLine, isMerge, exec, gh);
+    const changedFiles = getChangedFiles(cmdLine, isMerge, git, gh);
 
     // Test coverage check (pr_create and pr_merge)
     const coverageResult = checkTestCoverage(changedFiles, opts);
@@ -414,7 +408,7 @@ export function runQualityChecks(
     if (coverageMsg) messages.push(coverageMsg);
 
     // Verification check
-    const verificationMsg = checkVerification(command, cmdType, exec, gh);
+    const verificationMsg = checkVerification(command, cmdType, gh);
     if (verificationMsg) messages.push(verificationMsg);
 
     // Practices checklist (pr_create only)


### PR DESCRIPTION
## Summary

Route the last git-state opt-out, `pr-quality-checks.ts`, through the shared argv-style `gitStdout(...)` runner. This removes the hook-local shell-string Git runner and leaves the git-state invariant with no production hook opt-outs.

Fixes #1327

## Changes

- Replace `defaultExec(cmd)` / `execSync(cmd)` with an argv-style `GitRunner` seam.
- Route PR changed-file reads through `git(['diff', '--name-only', 'main...HEAD'])`.
- Route staged-file reads through `git(['diff', '--cached', '--name-only'])`.
- Update tests to inject argv-style Git runners and assert the exact argv arrays.
- Remove `pr-quality-checks.ts` from the git-state invariant opt-out list.

## Validation

- RED: `npm test -- --run src/hooks/pr-quality-checks.test.ts src/hooks/lib/git-state-invariant.test.ts` failed on the new source invariant before migration.
- GREEN: `npm test -- --run src/hooks/pr-quality-checks.test.ts src/hooks/lib/git-state-invariant.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep found no old PR-quality Git shell strings in `src/hooks/pr-quality-checks.ts`
