### PR TITLE
refactor(core): route project root Git lookup through argv runner

### DIFF
--- a/src/lib/resolve-project-root.test.ts
+++ b/src/lib/resolve-project-root.test.ts
@@ -1,28 +1,42 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { resolveProjectRoot, resolveProjectPaths } from "./resolve-project-root.js";
 
 describe("resolveProjectRoot", () => {
+  it("routes default git lookup through an argv runner", () => {
+    const source = readFileSync(fileURLToPath(new URL("./resolve-project-root.ts", import.meta.url)), "utf-8");
+
+    expect(source).not.toContain("execSync");
+    expect(source).not.toContain('git -C "${dir}" rev-parse --show-toplevel');
+    expect(source).toContain("spawnSync('git', args");
+    expect(source).toContain("['-C', dir, 'rev-parse', '--show-toplevel']");
+  });
+
   it("returns git toplevel when in a repo", () => {
-    const exec = () => "/home/user/project";
-    expect(resolveProjectRoot("/home/user/project/src", exec)).toBe("/home/user/project");
+    const git = (args: readonly string[]) => {
+      expect(args).toEqual(["-C", "/home/user/project/src", "rev-parse", "--show-toplevel"]);
+      return "/home/user/project";
+    };
+    expect(resolveProjectRoot("/home/user/project/src", git)).toBe("/home/user/project");
   });
 
   it("falls back to parent dir when git fails", () => {
-    const exec = () => { throw new Error("not a git repo"); };
-    expect(resolveProjectRoot("/some/dir", exec)).toMatch(/\/some$/);
+    const git = () => { throw new Error("not a git repo"); };
+    expect(resolveProjectRoot("/some/dir", git)).toMatch(/\/some$/);
   });
 
   it("falls back when exec returns empty", () => {
-    const exec = () => "";
-    const result = resolveProjectRoot("/some/dir", exec);
+    const git = () => "";
+    const result = resolveProjectRoot("/some/dir", git);
     expect(result).toMatch(/\/some$/);
   });
 });
 
 describe("resolveProjectPaths", () => {
   it("derives all paths from project root", () => {
-    const exec = () => "/repo";
-    const paths = resolveProjectPaths("/repo/src", exec);
+    const git = () => "/repo";
+    const paths = resolveProjectPaths("/repo/src", git);
     expect(paths.projectRoot).toBe("/repo");
     expect(paths.scriptDir).toBe("/repo/scripts");
     expect(paths.worktreesDir).toBe("/repo/.claude/worktrees");

--- a/src/lib/resolve-project-root.ts
+++ b/src/lib/resolve-project-root.ts
@@ -1,10 +1,10 @@
 /**
  * resolve-project-root.ts — Resolve PROJECT_ROOT and SCRIPT_DIR from a directory.
  *
- * Pure functions with injectable exec for testability.
+ * Pure functions with injectable git runner for testability.
  */
 
-import { execSync } from "child_process";
+import { spawnSync } from "node:child_process";
 import { join } from "path";
 
 export interface ProjectPaths {
@@ -13,17 +13,29 @@ export interface ProjectPaths {
   worktreesDir: string;
 }
 
+export type GitRunner = (args: readonly string[]) => string;
+
+function defaultGit(args: readonly string[]): string {
+  const result = spawnSync('git', args, {
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || "git command failed");
+  }
+  return (result.stdout || "").trim();
+}
+
 /**
  * Resolve the git toplevel from a directory.
  * Falls back to parent dir if not in a git repo.
  */
 export function resolveProjectRoot(
   dir: string,
-  exec: (cmd: string) => string = (cmd) =>
-    execSync(cmd, { encoding: "utf8" }).trim(),
+  git: GitRunner = defaultGit,
 ): string {
   try {
-    const root = exec(`git -C "${dir}" rev-parse --show-toplevel`);
+    const root = git(['-C', dir, 'rev-parse', '--show-toplevel']);
     if (root) return root;
   } catch {
     // not a git repo
@@ -36,9 +48,9 @@ export function resolveProjectRoot(
  */
 export function resolveProjectPaths(
   dir: string,
-  exec?: (cmd: string) => string,
+  git?: GitRunner,
 ): ProjectPaths {
-  const projectRoot = resolveProjectRoot(dir, exec);
+  const projectRoot = resolveProjectRoot(dir, git);
   return {
     projectRoot,
     scriptDir: join(projectRoot, "scripts"),

--- a/src/review-battery.ts
+++ b/src/review-battery.ts
@@ -15,7 +15,7 @@ import { spawn } from 'node:child_process';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve, dirname, basename } from 'node:path';
 import YAML from 'yaml';
-import { resolveProjectRoot } from './lib/resolve-project-root.js';
+import { resolveProjectRoot, type GitRunner } from './lib/resolve-project-root.js';
 import { retrievePlan, issueTarget } from './structured-data.js';
 import {
   normalizeFindingStatus,
@@ -397,9 +397,9 @@ export function renderTemplate(template: string, vars: Record<string, string>): 
  * Resolve the prompts directory. Checks repo-root/prompts first,
  * then falls back to the directory relative to this file.
  */
-export function resolvePromptsDir(exec?: (cmd: string) => string): string {
+export function resolvePromptsDir(git?: GitRunner): string {
   const thisDir = dirname(new URL(import.meta.url).pathname);
-  const root = resolveProjectRoot(thisDir, exec);
+  const root = resolveProjectRoot(thisDir, git);
   const dir = resolve(root, 'prompts');
   if (existsSync(dir)) return dir;
   return resolve(thisDir, '..', 'prompts');


### PR DESCRIPTION
Fixes #1329

## Summary

Routes `resolveProjectRoot` through a fixed `git` binary plus argv array instead of interpolating `dir` into a shell command string.

## Changes

- Replaces the default `execSync(`git -C ...`)` path with `spawnSync('git', args, ...)`.
- Exports a `GitRunner` argv seam so tests and callers can still inject deterministic Git behavior.
- Updates `review-battery`'s optional prompt-dir resolver seam to the same argv runner type.
- Adds a source invariant covering the no-shell project-root lookup pattern.

## Validation

- RED: `npm test -- --run src/lib/resolve-project-root.test.ts` failed before migration on the new invariant.
- GREEN: `npm test -- --run src/lib/resolve-project-root.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep: no `execSync` / fused `git -C ... rev-parse --show-toplevel` remains in touched production files.