### PR TITLE
refactor(issues): run custom backend CLI with argv

### DIFF
--- a/src/issue-backend.test.ts
+++ b/src/issue-backend.test.ts
@@ -139,3 +139,58 @@ describe("GitHubBackend gh execution", () => {
     }
   });
 });
+
+describe("CustomCliBackend execution", () => {
+  it("passes custom CLI create arguments as argv without shell flattening", async () => {
+    vi.resetModules();
+    const spawnSync = vi.fn(() => ({
+      status: 0,
+      stdout: JSON.stringify({
+        number: 77,
+        url: "https://issues.example/custom/77",
+      }),
+      stderr: "",
+    }));
+    const execSync = vi.fn(() => JSON.stringify({
+      number: 77,
+      url: "https://issues.example/custom/77",
+    }));
+    vi.doMock("node:child_process", () => ({ spawnSync, execSync }));
+
+    try {
+      const { CustomCliBackend: MockedCustomCliBackend } = await import("./issue-backend.js");
+
+      const result = new MockedCustomCliBackend("/opt/bin/custom-issues").create({
+        repo: "Garsson-io/kaizen",
+        title: "Title with spaces; $(touch nope)",
+        body: "Body with `backticks` and \"quotes\"",
+        labels: ["kaizen", "needs review"],
+      });
+
+      expect(result).toEqual({
+        number: 77,
+        url: "https://issues.example/custom/77",
+      });
+      expect(spawnSync).toHaveBeenCalledWith("/opt/bin/custom-issues", [
+        "create",
+        "--title",
+        "Title with spaces; $(touch nope)",
+        "--body",
+        "Body with `backticks` and \"quotes\"",
+        "--label",
+        "kaizen",
+        "--label",
+        "needs review",
+        "--repo",
+        "Garsson-io/kaizen",
+      ], {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      expect(execSync).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
+  });
+});

--- a/src/issue-backend.ts
+++ b/src/issue-backend.ts
@@ -26,7 +26,7 @@
  *   npx tsx src/issue-backend.ts comment 42 --body "Working on this"
  */
 
-import { execSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
@@ -112,10 +112,16 @@ function parseRawIssue(r: Record<string, any>): Issue {
   };
 }
 
-/** Shell-safe exec: quotes args containing spaces. */
-function shellExec(bin: string, args: string[]): string {
-  const cmd = `${bin} ${args.map(a => a.includes(" ") ? `"${a}"` : a).join(" ")}`;
-  return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+/** Run a custom CLI with a fixed binary and explicit argv. */
+function runCli(bin: string, args: string[]): string {
+  const result = spawnSync(bin, args, {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `${bin} failed`);
+  }
+  return (result.stdout || "").trim();
 }
 
 // ── GitHub Backend (default) ──
@@ -214,7 +220,7 @@ export class CustomCliBackend implements IssueBackend {
   }
 
   private run(args: string[]): string {
-    return shellExec(this.cli, args);
+    return runCli(this.cli, args);
   }
 
   create(opts: CreateIssueOpts): CreateResult {


### PR DESCRIPTION
Fixes #1332

## Summary

Routes `CustomCliBackend` through `spawnSync(bin, args, ...)` instead of flattening structured issue args into a shell command string.

## Changes

- Replaces `shellExec` / `execSync(cmd)` with a no-shell custom CLI runner.
- Preserves trimmed stdout and non-zero failure behavior for custom backends.
- Adds a focused test proving title/body/label/repo values with spaces and shell metacharacters remain separate argv elements.
- Leaves GitHubBackend behavior unchanged.

## Validation

- RED: `npm test -- --run src/issue-backend.test.ts` failed before migration because `spawnSync` was never called.
- GREEN: `npm test -- --run src/issue-backend.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep: only intended `spawnSync(bin, args)` remains in `src/issue-backend.ts`.