### PR TITLE
refactor(experiment): reuse shared project-root resolver in CLI (#1334)

### DIFF
--- a/src/cli-experiment-git-invariant.test.ts
+++ b/src/cli-experiment-git-invariant.test.ts
@@ -1,0 +1,81 @@
+/**
+ * cli-experiment-git-invariant.test.ts — focused category-prevention lint for #1334.
+ *
+ * The experiment CLI must resolve the worktree root through the shared
+ * src/lib/resolve-project-root.ts (no-shell argv runner), never via its own
+ * direct `git rev-parse --show-toplevel` subprocess. This is a source-text
+ * ratchet: it fails the moment a future edit re-introduces the duplicated
+ * Git-root path. Mirrors the gh-exec-invariant.test.ts (#1294) pattern.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CLI_SOURCE = join(__dirname, 'cli-experiment.ts');
+
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+}
+
+/** True when source (comments stripped) shells out to git directly. */
+export function hasDirectGitSubprocessCall(content: string): boolean {
+  const code = stripComments(content);
+
+  // Any exec/execFile/spawn family call whose first string arg is `git ...`
+  // or a literal that contains the toplevel lookup.
+  if (/\bexec(?:Sync)?\s*\(\s*[`'"][^`'"]*\bgit\b/.test(code)) return true;
+  if (/\b(?:execFile|spawn)(?:Sync)?\s*\(\s*[`'"]git[`'"]/.test(code)) return true;
+  if (/git\s+rev-parse\s+--show-toplevel/.test(code)) return true;
+
+  return false;
+}
+
+/** True when source imports execSync from child_process. */
+export function importsExecSync(content: string): boolean {
+  const code = stripComments(content);
+  return /import\s*\{[^}]*\bexecSync\b[^}]*\}\s*from\s*['"]child_process['"]/.test(
+    code,
+  );
+}
+
+describe('cli-experiment git-subprocess invariant', () => {
+  it('detects a direct git subprocess call in a synthetic fixture', () => {
+    expect(
+      hasDirectGitSubprocessCall("execSync('git rev-parse --show-toplevel')"),
+    ).toBe(true);
+    expect(
+      hasDirectGitSubprocessCall("spawnSync('git', ['rev-parse'])"),
+    ).toBe(true);
+  });
+
+  it('does not flag the shared resolver import', () => {
+    const clean = "import { resolveProjectRoot } from './lib/resolve-project-root.js';\nresolveProjectRoot(process.cwd());";
+    expect(hasDirectGitSubprocessCall(clean)).toBe(false);
+  });
+
+  it('detects an execSync import in a synthetic fixture', () => {
+    expect(importsExecSync("import { execSync } from 'child_process';")).toBe(
+      true,
+    );
+    expect(importsExecSync("import path from 'path';")).toBe(false);
+  });
+
+  it('cli-experiment.ts has no direct git subprocess call', () => {
+    const content = readFileSync(CLI_SOURCE, 'utf-8');
+    expect(hasDirectGitSubprocessCall(content)).toBe(false);
+  });
+
+  it('cli-experiment.ts does not import execSync', () => {
+    const content = readFileSync(CLI_SOURCE, 'utf-8');
+    expect(importsExecSync(content)).toBe(false);
+  });
+
+  it('cli-experiment.ts routes through the shared resolveProjectRoot', () => {
+    const content = readFileSync(CLI_SOURCE, 'utf-8');
+    expect(content).toMatch(/resolveProjectRoot/);
+    expect(content).toMatch(/resolve-project-root/);
+  });
+});

--- a/src/cli-experiment.ts
+++ b/src/cli-experiment.ts
@@ -16,10 +16,10 @@
 import fs from 'fs';
 import path from 'path';
 
-import { execSync } from 'child_process';
 import YAML from 'yaml';
 
 import { parseExperimentSpec } from './experiment-spec-parser.js';
+import { resolveProjectRoot } from './lib/resolve-project-root.js';
 
 // --- Types ---
 
@@ -62,20 +62,12 @@ export interface ExperimentDeps {
   resolveExperimentsDir: () => string;
 }
 
-/**
- * Resolve the current git repo root (worktree-aware).
- * Unlike resolveProjectRoot() which returns the main checkout,
- * this returns the working tree root — correct for git-tracked files.
- */
-function resolveCurrentRepoRoot(): string {
-  return execSync('git rev-parse --show-toplevel', {
-    encoding: 'utf-8',
-  }).trim();
-}
-
 const defaultDeps: ExperimentDeps = {
   resolveExperimentsDir: () => {
-    const root = resolveCurrentRepoRoot();
+    // Worktree-aware: resolveProjectRoot() runs `git -C <cwd> rev-parse
+    // --show-toplevel` through the shared no-shell argv runner, returning the
+    // current working tree's root — correct for git-tracked files (#1334).
+    const root = resolveProjectRoot(process.cwd());
     return path.join(root, '.claude', 'kaizen', 'experiments');
   },
 };


### PR DESCRIPTION
## Problem

`src/cli-experiment.ts` resolved the worktree root with a private helper that shelled out via `execSync('git rev-parse --show-toplevel')` — a duplicate of the no-shell argv lookup in `src/lib/resolve-project-root.ts` (#1330). Issue #1334 asked for two things: (1) swap to the shared resolver, **and** (2) "Add a focused source invariant covering this no-direct-Git-subprocess rule."

## Discovery

While this work was in flight, a sibling commit (`80e3d6e`, "Fixes #1334") landed the **swap** on main and closed the issue — but it shipped *only* the swap. The explicit acceptance criterion for a source invariant was never delivered. So main has the consolidation with **no ratchet**: nothing fails if a future edit re-introduces a direct `git` subprocess in this CLI. That is exactly the regression the issue wanted guarded.

## Solution

This PR completes #1334's unfinished half. After merging main (which already carries the swap), the net change here is:

- **`cli-experiment-git-invariant.test.ts`** — a source-text **ratchet**: it fails the moment `cli-experiment.ts` re-introduces a direct git subprocess (`exec*/spawn*('git'…)` or a `rev-parse --show-toplevel` literal) or re-imports `execSync`. Synthetic-fixture cases prove the scanner itself detects violations; real-source cases lock in the current clean state. Mirrors `gh-exec-invariant.test.ts` (#1294) and `hook-git-runner-invariant.test.ts`.
- A worktree-correctness comment on `resolveExperimentsDir` documenting *why* `resolveProjectRoot(process.cwd())` is correct (it uses `--show-toplevel`, returning the current worktree root — the prior code's "main checkout" comment was stale).

This is the DRY-as-ratchet pattern the batch reflection endorsed: don't just remove duplication, install the guard that keeps it gone. The bare swap was the cheap half; the ratchet is the compounding half.

## Evidence

| Behavior | Level | Result |
|----------|-------|--------|
| Ratchet detects a re-introduced git subprocess / execSync import | Unit (source invariant) | ✅ 6 tests (3 synthetic-fixture detection + 3 real-source) |
| cli-experiment.ts is currently clean (uses shared resolver) | Unit | ✅ asserted against real source |
| Existing experiment lifecycle intact | Unit/Integration | ✅ existing suite green |
| Typecheck / no conflict markers | Static | ✅ `tsc --noEmit`, `git diff --check` clean |

`npx vitest run src/cli-experiment.test.ts src/cli-experiment-git-invariant.test.ts` → 22 passed. Net diff vs main: +84 lines (invariant test + comment) only.

## Impact

The "reuse the shared resolver" rule becomes a checked property for the experiment CLI, not a convention a future edit can quietly undo — closing the gap the concurrent bare swap left open.

Closes #1334

Run tag: handsome-lynx/run-23
