### PR TITLE
refactor(worktree): route worktree-du Git calls through argv runner

### DIFF
--- a/src/worktree-du.test.ts
+++ b/src/worktree-du.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   classifyLock,
   lockAge,
@@ -16,9 +18,25 @@ import type { ProjectPaths } from "./lib/resolve-project-root.js";
 
 // ── Test helpers ──
 
+function formatGitCommand(args: readonly string[]): string {
+  const parts = ["git"];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-C" && i + 1 < args.length) {
+      parts.push("-C", `"${args[i + 1]}"`);
+      i++;
+      continue;
+    }
+    parts.push(args[i]);
+  }
+  return parts.join(" ");
+}
+
 function makeDeps(overrides: Partial<Deps> = {}): Deps {
+  const exec = overrides.exec ?? (() => "");
+  const git = overrides.git ?? ((args: readonly string[]) => exec(formatGitCommand(args)));
   return {
-    exec: () => "",
+    exec,
+    git,
     gh: () => "",
     pidAlive: () => false,
     now: () => Date.now(),
@@ -98,6 +116,32 @@ function makePaths(root = "/project"): ProjectPaths {
 function lockJson(lock: LockFile): string {
   return JSON.stringify(lock);
 }
+
+describe("worktree-du Git execution invariants", () => {
+  it("routes Git operations through argv-shaped deps.git, not shell exec strings", () => {
+    const source = readFileSync(fileURLToPath(new URL("./worktree-du.ts", import.meta.url)), "utf8");
+
+    expect(source).not.toContain("deps.exec(`git ");
+    expect(source).not.toContain("git -C");
+    expect(source).toContain("git: (args: readonly string[]) => string");
+    expect(source).toContain("deps.git([");
+  });
+
+  it("passes project root Git arguments as argv elements", () => {
+    const calls: string[][] = [];
+    const deps = makeDeps({
+      git: (args) => {
+        calls.push([...args]);
+        return "* main\n  feature-a";
+      },
+    });
+
+    expect(getMergedBranches("/repo with spaces", deps)).toEqual(new Set(["main", "feature-a"]));
+    expect(calls).toEqual([
+      ["-C", "/repo with spaces", "branch", "--merged", "main"],
+    ]);
+  });
+});
 
 // ── Lock classification ──
 
@@ -275,7 +319,7 @@ describe("analyzeBranches", () => {
   it("counts branches correctly", () => {
     const deps = makeDeps({
       exec: (cmd) => {
-        if (cmd.includes("config \"branch.")) throw new Error("no remote");
+        if (cmd.includes("config branch.")) throw new Error("no remote");
         if (cmd.includes("--merged")) return "* main\n  feat-a\n  feat-b";
         if (cmd.includes("--no-merged")) return "  feat-c";
         if (cmd.includes("branch")) return "* main\n  feat-a\n  feat-b\n  feat-c";

--- a/src/worktree-du.ts
+++ b/src/worktree-du.ts
@@ -6,7 +6,7 @@
  *   npx tsx src/worktree-du.ts [analyze|cleanup] [--fast] [--dry-run]
  */
 
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 import { gh as runGh } from "./lib/gh-exec.js";
@@ -56,6 +56,7 @@ interface BranchSummary {
 
 export interface Deps {
   exec: (cmd: string) => string;
+  git: (args: readonly string[]) => string;
   gh: (args: string[], timeoutMs?: number) => string;
   pidAlive: (pid: number) => boolean;
   now: () => number;
@@ -71,6 +72,16 @@ export interface Deps {
 export function defaultDeps(): Deps {
   return {
     exec: (cmd) => execSync(cmd, { encoding: "utf8" }).trim(),
+    git: (args) => {
+      const result = spawnSync("git", [...args], {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      if (result.status !== 0) {
+        throw new Error(result.stderr || "git command failed");
+      }
+      return (result.stdout || "").trim();
+    },
     gh: (args, timeoutMs) => runGh(args, timeoutMs),
     pidAlive: (pid) => {
       try { process.kill(pid, 0); return true; } catch { return false; }
@@ -154,7 +165,7 @@ function safeBranch(branch: string): string {
 
 export function getMergedBranches(projectRoot: string, deps: Deps): Set<string> {
   try {
-    const raw = deps.exec(`git -C "${projectRoot}" branch --merged main`);
+    const raw = deps.git(["-C", projectRoot, "branch", "--merged", "main"]);
     return new Set(
       raw.split("\n").map((b) => b.replace(/^[* +]*/, "").trim()).filter(Boolean),
     );
@@ -173,7 +184,7 @@ export function branchMergeStatus(
   if (mergedBranches.has(branch)) {
     try {
       const ahead = parseInt(
-        deps.exec(`git -C "${projectRoot}" rev-list --count "main..${safe}"`),
+        deps.git(["-C", projectRoot, "rev-list", "--count", `main..${safe}`]),
         10,
       );
       return ahead === 0 ? "at-main" : "merged";
@@ -184,7 +195,7 @@ export function branchMergeStatus(
 
   // Squash-merge detection
   try {
-    const diffStat = deps.exec(`git -C "${projectRoot}" diff --stat "main..${safe}"`);
+    const diffStat = deps.git(["-C", projectRoot, "diff", "--stat", `main..${safe}`]);
     if (!diffStat) return "squash-merged";
   } catch {
     // diff failed — treat as unmerged
@@ -197,7 +208,7 @@ export function branchMergeStatus(
 
 function getWorktreeBranch(wtPath: string, deps: Deps): string {
   try {
-    return deps.exec(`git -C "${wtPath}" rev-parse --abbrev-ref HEAD`);
+    return deps.git(["-C", wtPath, "rev-parse", "--abbrev-ref", "HEAD"]);
   } catch {
     return "?";
   }
@@ -205,7 +216,7 @@ function getWorktreeBranch(wtPath: string, deps: Deps): string {
 
 function getDirtyFileCount(wtPath: string, deps: Deps): number {
   try {
-    const lines = deps.exec(`git -C "${wtPath}" status --porcelain`);
+    const lines = deps.git(["-C", wtPath, "status", "--porcelain"]);
     if (!lines) return 0;
     return lines.split("\n").filter((l) => !l.includes(".worktree-lock.json")).length;
   } catch {
@@ -215,7 +226,7 @@ function getDirtyFileCount(wtPath: string, deps: Deps): number {
 
 function getUnpushedCount(wtPath: string, deps: Deps): number {
   try {
-    const lines = deps.exec(`git -C "${wtPath}" log --oneline @{u}..HEAD`);
+    const lines = deps.git(["-C", wtPath, "log", "--oneline", "@{u}..HEAD"]);
     return lines ? lines.split("\n").length : 0;
   } catch {
     return 0;
@@ -296,7 +307,7 @@ export function analyzeBranches(
 
   let unmerged = 0;
   try {
-    const raw = deps.exec(`git -C "${projectRoot}" branch --no-merged main`);
+    const raw = deps.git(["-C", projectRoot, "branch", "--no-merged", "main"]);
     unmerged = raw ? raw.split("\n").filter(Boolean).length : 0;
   } catch {
     // no unmerged branches
@@ -304,12 +315,12 @@ export function analyzeBranches(
 
   let localOnly = 0;
   try {
-    const allBranches = deps.exec(`git -C "${projectRoot}" branch`);
+    const allBranches = deps.git(["-C", projectRoot, "branch"]);
     for (const line of allBranches.split("\n")) {
       const branch = line.replace(/^[* +]*/, "").trim();
       if (!branch || branch === "main") continue;
       try {
-        deps.exec(`git -C "${projectRoot}" config "branch.${branch}.remote"`);
+        deps.git(["-C", projectRoot, "config", `branch.${branch}.remote`]);
       } catch {
         localOnly++;
       }
@@ -420,7 +431,7 @@ export function cleanupWorktrees(
       // worktree a chance to detect imminent deletion (Fix B for #934, #939).
       try { deps.writeFile(join(wtPath, ".worktree-will-delete"), new Date().toISOString()); } catch { /* ignore */ }
       try {
-        deps.exec(`git -C "${paths.projectRoot}" worktree remove "${wtPath}" --force`);
+        deps.git(["-C", paths.projectRoot, "worktree", "remove", wtPath, "--force"]);
         result.actions.push({ type: "remove", target: name, reason: ms });
       } catch {
         result.actions.push({ type: "fail", target: name, reason: ms });
@@ -433,10 +444,10 @@ export function cleanupWorktrees(
 
   // Phase 2: Merged branches with no worktree
   try {
-    const allBranches = deps.exec(`git -C "${paths.projectRoot}" branch`);
+    const allBranches = deps.git(["-C", paths.projectRoot, "branch"]);
     let wtList: string;
     try {
-      wtList = deps.exec(`git -C "${paths.projectRoot}" worktree list`);
+      wtList = deps.git(["-C", paths.projectRoot, "worktree", "list"]);
     } catch {
       wtList = "";
     }
@@ -455,7 +466,7 @@ export function cleanupWorktrees(
       if (ms === "merged" || ms === "at-main" || ms === "squash-merged") {
         if (!dryRun) {
           try {
-            deps.exec(`git -C "${paths.projectRoot}" branch ${deleteFlag} "${safe}"`);
+            deps.git(["-C", paths.projectRoot, "branch", deleteFlag, safe]);
             result.actions.push({ type: "remove", target: branch, reason: ms });
           } catch { /* skip */ }
         } else {
@@ -663,8 +674,10 @@ Flags:
     console.log("");
     console.log(`  ${BOLD}Git worktree prune${NC}`);
     try {
-      const flag = opts.dryRun ? "--dry-run -v" : "-v";
-      const out = deps.exec(`git -C "${paths.projectRoot}" worktree prune ${flag}`);
+      const pruneArgs = opts.dryRun
+        ? ["-C", paths.projectRoot, "worktree", "prune", "--dry-run", "-v"]
+        : ["-C", paths.projectRoot, "worktree", "prune", "-v"];
+      const out = deps.git(pruneArgs);
       if (out) console.log("    " + out.split("\n").join("\n    "));
     } catch { /* nothing to prune */ }
   }
@@ -686,7 +699,7 @@ export function listOpenPullRequests(paths: ProjectPaths, deps: Deps): string {
   try {
     repo = JSON.parse(deps.readFile(join(paths.projectRoot, "kaizen.config.json"))).host?.repo ?? "";
   } catch {
-    repo = deps.exec(`git -C "${paths.projectRoot}" remote get-url origin`)
+    repo = deps.git(["-C", paths.projectRoot, "remote", "get-url", "origin"])
       .replace(/.*github\.com[:/]/, "").replace(/\.git$/, "");
   }
 


### PR DESCRIPTION
Fixes #1337

## Summary

Splits `worktree-du` subprocess execution into explicit Git and non-Git boundaries. Git worktree/branch operations now use `deps.git([...])` argv calls instead of shell-string `deps.exec(`git ...`)` calls.

## Changes

- Adds a dedicated `Deps.git(args)` runner backed by `spawnSync("git", args, ...)`.
- Routes worktree branch reads, dirty/unpushed checks, branch analysis, worktree remove, branch delete, worktree prune, and remote URL fallback through `deps.git`.
- Keeps `Deps.exec(cmd)` for non-Git shell commands such as Docker and `du`, so this PR does not mix subprocess domains.
- Adds source and behavior invariants proving Git commands use argv elements, including paths with spaces.
- Preserves the deletion sentinel ordering before `git worktree remove`.

## Related issues

Related but not fixed: #958 and #1010 cover deletion timing/lifecycle behavior. This PR only removes duplicated Git subprocess mechanics.

## Validation

- RED: `npm test -- --run src/worktree-du.test.ts` failed before migration on the new Git-runner invariants.
- GREEN: `npm test -- --run src/worktree-du.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep: no forbidden `deps.exec(`git ...`)`, `execSync(`git ...`)`, or `git -C` shell strings remain in `src/worktree-du.ts`.
- Dogfood: `npx tsx src/worktree-du.ts analyze --fast` completed successfully.