### PR TITLE
test(experiments): consolidate Git invariant ownership

### DIFF
--- a/src/cli-experiment-git-invariant.test.ts
+++ b/src/cli-experiment-git-invariant.test.ts
@@ -13,6 +13,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const CLI_SOURCE = join(__dirname, 'cli-experiment.ts');
+const CLI_LIFECYCLE_TEST = join(__dirname, 'cli-experiment.test.ts');
 
 function stripComments(content: string): string {
   return content
@@ -77,5 +78,12 @@ describe('cli-experiment git-subprocess invariant', () => {
     const content = readFileSync(CLI_SOURCE, 'utf-8');
     expect(content).toMatch(/resolveProjectRoot/);
     expect(content).toMatch(/resolve-project-root/);
+  });
+
+  it('cli-experiment lifecycle tests do not duplicate this Git invariant', () => {
+    const content = readFileSync(CLI_LIFECYCLE_TEST, 'utf-8');
+    expect(content).not.toContain('git rev-parse --show-toplevel');
+    expect(content).not.toContain('direct git execSync');
+    expect(content).not.toContain('resolveProjectRoot(process.cwd())');
   });
 });

--- a/src/cli-experiment.test.ts
+++ b/src/cli-experiment.test.ts
@@ -27,17 +27,7 @@ const CLI_SOURCE = path.resolve(__dirname, 'cli-experiment.ts');
 // INVARIANT: Experiment CLI manages markdown files with YAML frontmatter lifecycle.
 // SUT: cli-experiment.ts
 // VERIFICATION: DI for file operations, subprocess for argument parsing.
-
-describe('cli-experiment source invariants', () => {
-  test('uses the shared project-root resolver instead of direct git execSync', () => {
-    const source = fs.readFileSync(CLI_SOURCE, 'utf-8');
-
-    expect(source).not.toContain('execSync');
-    expect(source).not.toContain('git rev-parse --show-toplevel');
-    expect(source).toContain("import { resolveProjectRoot } from './lib/resolve-project-root.js';");
-    expect(source).toContain('resolveProjectRoot(process.cwd())');
-  });
-});
+// Git-root subprocess invariants live in cli-experiment-git-invariant.test.ts.
 
 function makeTmpDeps(): { deps: ExperimentDeps; dir: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exp-test-'));


### PR DESCRIPTION
Fixes #1339

## Summary

Consolidates the experiment CLI Git-root invariant after both #1335 and #1336 landed overlapping checks for #1334.

## Changes

- Removes the narrower inline source invariant from `cli-experiment.test.ts`.
- Keeps `cli-experiment-git-invariant.test.ts` as the single owner of Git-subprocess category prevention.
- Adds an ownership guard so lifecycle tests do not reintroduce the same Git-root invariant strings.

## Validation

- RED: `npm test -- --run src/cli-experiment-git-invariant.test.ts` failed before duplicate removal on the new ownership guard.
- GREEN: `npm test -- --run src/cli-experiment.test.ts src/cli-experiment-git-invariant.test.ts`
- `npm run typecheck`
- `git diff --check`
- Static grep: duplicate Git-root invariant strings are absent from `src/cli-experiment.test.ts`.