### PR TITLE
refactor(hooks): share wrapper root resolver

### DIFF
--- a/.claude/hooks/kaizen-bump-plugin-version-ts.sh
+++ b/.claude/hooks/kaizen-bump-plugin-version-ts.sh
@@ -3,5 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/bump-plugin-version.ts"

--- a/.claude/hooks/kaizen-check-dirty-files-ts.sh
+++ b/.claude/hooks/kaizen-check-dirty-files-ts.sh
@@ -3,5 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/check-dirty-files.ts"

--- a/.claude/hooks/kaizen-enforce-plan-stored-ts.sh
+++ b/.claude/hooks/kaizen-enforce-plan-stored-ts.sh
@@ -5,5 +5,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/enforce-plan-stored.ts"

--- a/.claude/hooks/kaizen-enforce-pr-reflect-ts.sh
+++ b/.claude/hooks/kaizen-enforce-pr-reflect-ts.sh
@@ -3,5 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/enforce-pr-reflect.ts"

--- a/.claude/hooks/kaizen-enforce-pr-review-ts.sh
+++ b/.claude/hooks/kaizen-enforce-pr-review-ts.sh
@@ -3,5 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/enforce-pr-review.ts"

--- a/.claude/hooks/kaizen-post-merge-clear-ts.sh
+++ b/.claude/hooks/kaizen-post-merge-clear-ts.sh
@@ -3,5 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/post-merge-clear.ts"

--- a/.claude/hooks/kaizen-pr-kaizen-clear-fallback.sh
+++ b/.claude/hooks/kaizen-pr-kaizen-clear-fallback.sh
@@ -13,7 +13,7 @@
 # compilation overhead), which uses TS state functions (listStateFilesAnyBranch, etc.)
 # from state-utils.ts. See kaizen #790 gap fix.
 
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || exit 0
 
 # Use pre-compiled TS version if available (no tsx overhead)
 JS_PATH="$KAIZEN_DIR/dist/hooks/pr-kaizen-clear-fallback.js"

--- a/.claude/hooks/kaizen-pr-quality-checks-ts.sh
+++ b/.claude/hooks/kaizen-pr-quality-checks-ts.sh
@@ -5,5 +5,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/pr-quality-checks.ts"

--- a/.claude/hooks/kaizen-prehook-no-verify.sh
+++ b/.claude/hooks/kaizen-prehook-no-verify.sh
@@ -4,5 +4,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/prehook-no-verify.ts"

--- a/.claude/hooks/kaizen-session-cleanup-ts.sh
+++ b/.claude/hooks/kaizen-session-cleanup-ts.sh
@@ -3,5 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/session-cleanup.ts"

--- a/.claude/hooks/kaizen-session-snapshot.sh
+++ b/.claude/hooks/kaizen-session-snapshot.sh
@@ -12,7 +12,7 @@
 # Non-blocking. Silent on success. Exits 0 even on write failure.
 
 set -u
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || exit 0
 
 # Resolve tsx from the kaizen repo's node_modules, then fall back to npx.
 # Stay silent if neither is available — this hook must never break startup.

--- a/.claude/hooks/kaizen-stop-gate.sh
+++ b/.claude/hooks/kaizen-stop-gate.sh
@@ -4,5 +4,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/stop-gate.ts"

--- a/.claude/hooks/lib/resolve-kaizen-dir.sh
+++ b/.claude/hooks/lib/resolve-kaizen-dir.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Part of kAIzen Agent Control Flow
+# resolve-kaizen-dir.sh - shared root resolver for hook wrappers.
+
+if [ -z "${KAIZEN_DIR:-}" ]; then
+  KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  export KAIZEN_DIR
+fi

--- a/.claude/hooks/lib/run-tsx.sh
+++ b/.claude/hooks/lib/run-tsx.sh
@@ -10,6 +10,8 @@
 #   source "$(dirname "$0")/lib/run-tsx.sh"
 #   run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/my-hook.ts"
 
+source "$(dirname "${BASH_SOURCE[0]}")/resolve-kaizen-dir.sh" || exit 0
+
 run_tsx() {
   local kaizen_dir="$1"
   local ts_file="$2"

--- a/.claude/hooks/pr-review-loop-ts.sh
+++ b/.claude/hooks/pr-review-loop-ts.sh
@@ -3,5 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/$(basename "${BASH_SOURCE[0]}" .sh | sed 's/-ts$//' ).ts"

--- a/src/hooks/wrapper-smoke.test.ts
+++ b/src/hooks/wrapper-smoke.test.ts
@@ -89,6 +89,32 @@ const NOOP_INPUT = {
   tool_response: { stdout: 'hello', stderr: '', exit_code: '0' },
 };
 
+describe('wrapper smoke: root-resolution boilerplate', () => {
+  it('keeps hook wrappers from duplicating root resolution (#365)', () => {
+    const wrappers = fs
+      .readdirSync(HOOKS_DIR)
+      .filter((name) => name.endsWith('.sh'))
+      .sort();
+    const forbidden = [
+      { name: 'SCRIPT_DIR=', pattern: /^\s*SCRIPT_DIR=/m },
+      { name: 'PROJECT_ROOT=', pattern: /^\s*PROJECT_ROOT=/m },
+      {
+        name: 'inline KAIZEN_DIR dirname resolution',
+        pattern: /^\s*KAIZEN_DIR=.*dirname/m,
+      },
+    ];
+
+    const offenders = wrappers.flatMap((wrapper) => {
+      const content = fs.readFileSync(path.join(HOOKS_DIR, wrapper), 'utf-8');
+      return forbidden
+        .filter(({ pattern }) => pattern.test(content))
+        .map(({ name }) => `${wrapper}: ${name}`);
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe('wrapper smoke: bash wrappers exist and are executable', () => {
   for (const wrapper of [
     'pr-review-loop-ts.sh',


### PR DESCRIPTION
## Summary

Closes #365.

Moves hook-wrapper root resolution into a shared shell library so top-level wrappers no longer duplicate inline `SCRIPT_DIR` / `PROJECT_ROOT` / `KAIZEN_DIR` path boilerplate.

## Plan

Plan stored on issue: https://github.com/Garsson-io/kaizen/issues/365#issuecomment-4823771287

## Changes

- Adds `.claude/hooks/lib/resolve-kaizen-dir.sh` as the single `KAIZEN_DIR` resolver for hook wrappers.
- Makes `lib/run-tsx.sh` source that resolver, so TS shims keep using the existing `run_tsx "$KAIZEN_DIR" ...` contract without per-wrapper root math.
- Updates the compiled fallback and session snapshot wrappers to source the shared resolver while preserving their existing silent/non-blocking behavior.
- Adds a wrapper smoke invariant that scans top-level `.claude/hooks/*.sh` files and fails on reintroduced inline root-resolution boilerplate.

## Validation

- RED: `npm test -- --run src/hooks/wrapper-smoke.test.ts -t 'root-resolution boilerplate'` failed before the refactor, listing 11 wrappers with inline `KAIZEN_DIR` dirname resolution.
- GREEN: `npm test -- --run src/hooks/wrapper-smoke.test.ts -t 'root-resolution boilerplate'`
- GREEN: `npm test -- --run src/hooks/wrapper-smoke.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`
- GREEN: direct source scan over `.claude/hooks/*.sh` found no top-level inline `SCRIPT_DIR=`, `PROJECT_ROOT=`, or `KAIZEN_DIR=.*dirname` matches.
- GREEN: `source .claude/hooks/lib/resolve-kaizen-dir.sh` resolves `KAIZEN_DIR` to the worktree root.
- GREEN: direct silent invocations of `kaizen-pr-kaizen-clear-fallback.sh` and `kaizen-session-snapshot.sh` exit 0.
