### PR TITLE
fix(hooks): split command segments on newlines so gate detectors fire (#1013)

### DIFF
--- a/src/hooks/lib/allowlist.test.ts
+++ b/src/hooks/lib/allowlist.test.ts
@@ -54,6 +54,16 @@ describe('isReadonlyMonitoringCommand', () => {
     expect(isReadonlyMonitoringCommand('gh pr create --title "test"')).toBe(false);
     expect(isReadonlyMonitoringCommand('gh pr merge 42')).toBe(false);
   });
+
+  it('splits on bare newlines like the canonical splitter (#1013)', () => {
+    // A readonly command on its own line after env assignments must still be
+    // recognized — same newline-split parity the gate detectors rely on.
+    expect(
+      isReadonlyMonitoringCommand('export PATH=/x\ngit status'),
+    ).toBe(true);
+    // And a pure write command on its own line stays blocked.
+    expect(isReadonlyMonitoringCommand('export PATH=/x\ngit push')).toBe(false);
+  });
 });
 
 describe('isReviewCommand', () => {

--- a/src/hooks/lib/allowlist.ts
+++ b/src/hooks/lib/allowlist.ts
@@ -6,16 +6,22 @@
  * enforce-pr-reflect to ensure consistent command allowlists.
  */
 
-import { isGhPrCommand, isGitCommand } from '../parse-command.js';
+import {
+  isGhPrCommand,
+  isGitCommand,
+  splitCommandSegments,
+} from '../parse-command.js';
 
 /**
- * Split a command line by pipe/chain operators and return segments.
+ * Split a command line into statements. Delegates to the canonical
+ * `splitCommandSegments` so the allowlist splits identically to every gate
+ * detector — previously this was a private copy that split on `|;&` but NOT
+ * bare newlines, diverging from the canonical splitter after #1013. The
+ * divergence let a multi-line command whose readonly statement sits on a
+ * separate line classify inconsistently across hooks.
  */
 function splitSegments(cmdLine: string): string[] {
-  return cmdLine
-    .split(/[|;&]{1,2}/)
-    .map((s) => s.trim())
-    .filter(Boolean);
+  return splitCommandSegments(cmdLine);
 }
 
 /**

--- a/src/hooks/parse-command.test.ts
+++ b/src/hooks/parse-command.test.ts
@@ -10,6 +10,7 @@ import {
   isGhPrCommand,
   isGitCommand,
   reconstructPrUrl,
+  splitCommandSegments,
   stripHeredocBody,
 } from './parse-command.js';
 
@@ -57,6 +58,32 @@ describe('stripHeredocBody', () => {
   });
 });
 
+describe('splitCommandSegments', () => {
+  it('splits on bare newlines (#1013)', () => {
+    expect(splitCommandSegments('a\nb\nc')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('still collapses operator chains', () => {
+    expect(splitCommandSegments('npm run build && gh pr create')).toEqual([
+      'npm run build',
+      'gh pr create',
+    ]);
+    expect(splitCommandSegments('a || b ; c | d')).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+    ]);
+  });
+
+  it('collapses an operator+newline run into a single delimiter', () => {
+    expect(splitCommandSegments('a &&\ngh pr create')).toEqual([
+      'a',
+      'gh pr create',
+    ]);
+  });
+});
+
 describe('isGhPrCommand', () => {
   it('detects gh pr create', () => {
     expect(isGhPrCommand('gh pr create --title "test"', 'create')).toBe(true);
@@ -89,6 +116,21 @@ describe('isGhPrCommand', () => {
       isGhPrCommand('npm run build && gh pr create --title x', 'create'),
     ).toBe(true);
   });
+
+  it('detects gh pr create after newline-separated assignments (#1013)', () => {
+    const cmd = `KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)\nHOST_REPO=$(jq -r '.host.repo' kaizen.config.json)\ngh pr create --repo "$HOST_REPO" --title x`;
+    expect(isGhPrCommand(cmd, 'create')).toBe(true);
+  });
+
+  it('detects gh pr create when backslash-continued across lines (#1013)', () => {
+    const cmd = `export PATH="/x"\ngh pr create \\\n  --repo R \\\n  --title x`;
+    expect(isGhPrCommand(cmd, 'create')).toBe(true);
+  });
+
+  it('does not resurrect heredoc false-positive after stripHeredocBody (#1013)', () => {
+    const cmd = `git commit -m "$(cat <<'EOF'\ngh pr create --title sneaky\nEOF\n)"`;
+    expect(isGhPrCommand(stripHeredocBody(cmd), 'create')).toBe(false);
+  });
 });
 
 describe('isGitCommand', () => {
@@ -104,6 +146,12 @@ describe('isGitCommand', () => {
 
   it('rejects non-git commands', () => {
     expect(isGitCommand('npm run build', 'push')).toBe(false);
+  });
+
+  it('detects git push after newline-separated assignments (#1013)', () => {
+    expect(
+      isGitCommand('export PATH=/x\ngit push -u origin main', 'push'),
+    ).toBe(true);
   });
 });
 

--- a/src/hooks/parse-command.ts
+++ b/src/hooks/parse-command.ts
@@ -36,12 +36,23 @@ export function stripHeredocBody(command: string): string {
 }
 
 /**
- * Split a command line by pipe/chain operators (|, &&, ||, ;)
- * and return individual segments trimmed.
+ * Split a command line by pipe/chain operators (|, &&, ||, ;) AND bare newlines,
+ * returning individual segments trimmed.
+ *
+ * Newlines are delimiters because a multi-statement Bash block separates
+ * statements with bare `\n` (e.g. variable assignments on their own lines
+ * before `gh pr create`). Without splitting on `\n` the whole block is one
+ * segment beginning with the first assignment, so anchored detectors like
+ * `isGhPrCommand` (`^gh\s+pr\s+create`) never match and the review/plan/dirty
+ * gates silently no-op (#1013). The bash original
+ * (`.claude/hooks/lib/parse-command.sh`) already splits on newlines via its
+ * line-based sed pipeline; this restores that parity. Callers strip heredoc
+ * bodies first, so an embedded `gh pr create` in a commit message is not
+ * resurrected as a false segment.
  */
 export function splitCommandSegments(cmdLine: string): string[] {
   return cmdLine
-    .split(/[|;&]{1,2}/)
+    .split(/[\n|;&]{1,2}/)
     .map((s) => s.trim())
     .filter(Boolean);
 }


### PR DESCRIPTION
## Problem

The review-loop gate is supposed to fire on every `gh pr create`. PR #1012 was created **without it firing at all** — the gate ran (PostToolUse always runs) but classified the command as "not a trigger." The same silent miss applies to the plan gate, the dirty-files gate, and the allowlist: all are built on the same command parser.

## Discovery

The miss traces to one function. `splitCommandSegments` (`src/hooks/parse-command.ts`) breaks a command line into statements so anchored detectors like `isGhPrCommand` (`^gh\s+pr\s+create`) can test each one. It split on `|`, `&&`, `||`, `;` — but **not on bare newlines**. A normal multi-statement Bash block looks like:

```bash
KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
gh pr create --repo "$HOST_REPO" ...
```

With no newline split, the whole block is **one** segment beginning with `KAIZEN_REPO=`, so the `^gh\s+pr\s+create` anchor never matches and the gate no-ops.

Notably, the bash original (`.claude/hooks/lib/parse-command.sh`) already handles this: it rewrites operators to newlines via `sed` and then processes line-by-line, so literal newlines were always delimiters there. The TS port dropped that behavior — this is a parity regression, not new design.

## Solution

Add `\n` to the split character class: `/[\n|;&]{1,2}/`. The `{1,2}` quantifier keeps `&&`, `||`, `;;`, and operator+newline runs collapsing to a single delimiter. Every caller already strips heredoc bodies (`stripHeredocBody`) before splitting, so an embedded `gh pr create` inside a commit-message heredoc is removed first and cannot resurface as a false segment.

## Evidence

`src/hooks/parse-command.test.ts` — new tests:
- `splitCommandSegments` splits on bare `\n`; still collapses `&&`/`||`/`;`; collapses operator+newline runs.
- `isGhPrCommand` detects `gh pr create` after newline-separated assignments (the exact #1012 incident shape) and when backslash-continued across lines.
- `isGitCommand` detects `git push` after newline-separated assignments.
- Heredoc regression guard: a commit-message heredoc containing `gh pr create`, post-`stripHeredocBody`, is **not** detected.

Tests were written red (4 failed against pre-fix code), then green after the one-line change. Full hook suite: **835 passed**. `tsc --noEmit` clean.

## Behaviors × Levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Newline-separated `gh pr create` is detected | ✅ | — | — | — | — |
| Newline-separated `git push` is detected | ✅ | — | — | — | — |
| Operator chains still collapse (regression) | ✅ | — | — | — | — |
| Heredoc body not falsely detected | ✅ | — | — | — | — |

## Impact

The review, plan, and dirty-files gates now fire on the most common real-world command shape agents produce. Closes a false-negative class affecting every detector built on `splitCommandSegments`.

Closes #1013

Run tag: handsome-lynx/run-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
