### PR TITLE
refactor(hooks): reuse bash input parser

### DIFF
--- a/.claude/hooks/kaizen-capture-worktree-context.sh
+++ b/.claude/hooks/kaizen-capture-worktree-context.sh
@@ -11,17 +11,16 @@
 # Always exits 0 — advisory, not blocking.
 
 source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-STDOUT=$(echo "$INPUT" | jq -r '.tool_response.stdout // empty')
-STDERR=$(echo "$INPUT" | jq -r '.tool_response.stderr // empty')
-EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // "0"')
+read_hook_input
+get_command
+get_stdout
+get_stderr
+get_exit_code
 
 # Only trigger on successful commands
-if [ "$EXIT_CODE" != "0" ]; then
-  exit 0
-fi
+require_success
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true

--- a/.claude/hooks/kaizen-enforce-case-exists.sh
+++ b/.claude/hooks/kaizen-enforce-case-exists.sh
@@ -19,9 +19,10 @@
 
 source "$(dirname "$0")/lib/allowlist.sh" 2>/dev/null || { exit 0; }
 source "$(dirname "$0")/lib/read-config.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
 
-INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+read_hook_input
+get_file_path
 
 # If no file path, allow
 if [ -z "$FILE_PATH" ]; then

--- a/.claude/hooks/kaizen-enforce-case-worktree.sh
+++ b/.claude/hooks/kaizen-enforce-case-worktree.sh
@@ -7,8 +7,10 @@
 # Runs as PreToolUse hook on Bash tool calls.
 # Always exits 0 (advisory only — never blocks).
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
+
+read_hook_input
+get_command
 
 # Only check git commit and git push commands
 if ! echo "$COMMAND" | grep -qE '^\s*git\s+(commit|push)'; then

--- a/.claude/hooks/kaizen-enforce-worktree-writes.sh
+++ b/.claude/hooks/kaizen-enforce-worktree-writes.sh
@@ -21,9 +21,10 @@
 # Runs as PreToolUse hook on Edit and Write tool calls.
 
 source "$(dirname "$0")/lib/allowlist.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
 
-INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+read_hook_input
+get_file_path
 
 # If no file path, allow (shouldn't happen for Edit/Write)
 if [ -z "$FILE_PATH" ]; then

--- a/.claude/hooks/kaizen-pr-kaizen-clear-fallback.sh
+++ b/.claude/hooks/kaizen-pr-kaizen-clear-fallback.sh
@@ -14,6 +14,7 @@
 # from state-utils.ts. See kaizen #790 gap fix.
 
 source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || exit 0
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || exit 0
 
 # Use pre-compiled TS version if available (no tsx overhead)
 JS_PATH="$KAIZEN_DIR/dist/hooks/pr-kaizen-clear-fallback.js"
@@ -22,15 +23,12 @@ if [ -f "$JS_PATH" ]; then
 fi
 
 # Bash fallback when dist isn't built (CI, fresh checkout, pre-build)
-INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-[ "$TOOL_NAME" = "Bash" ] || exit 0
-
-EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // "0"' 2>/dev/null)
-[ "$EXIT_CODE" = "0" ] || exit 0
-
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-STDOUT=$(echo "$INPUT" | jq -r '.tool_response.stdout // empty' 2>/dev/null)
+read_hook_input
+require_tool_bash
+get_exit_code
+require_success
+get_command
+get_stdout
 
 if ! echo "$COMMAND$STDOUT" | grep -qE 'KAIZEN_IMPEDIMENTS:|KAIZEN_NO_ACTION'; then
   exit 0

--- a/.claude/hooks/kaizen-search-before-file.sh
+++ b/.claude/hooks/kaizen-search-before-file.sh
@@ -15,9 +15,10 @@
 # Advisory gives the agent information to make a good decision.
 
 source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+read_hook_input
+get_command
 
 if [ -z "$COMMAND" ]; then
   exit 0

--- a/src/hooks/bash-hook-invariants.test.ts
+++ b/src/hooks/bash-hook-invariants.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HOOKS_DIR = join(__dirname, '../../.claude/hooks');
+
+describe('bash hook source invariants', () => {
+  it('keeps stdin JSON parsing behind input-utils (#828)', () => {
+    const offenders = readdirSync(HOOKS_DIR)
+      .filter((name) => name.endsWith('.sh'))
+      .flatMap((name) => {
+        const content = readFileSync(join(HOOKS_DIR, name), 'utf-8');
+        const parsesHookInput =
+          content.includes('INPUT=$(cat)') ||
+          /\.tool_(input|response)\./.test(content);
+        const usesSharedParser = content.includes('lib/input-utils.sh');
+
+        return parsesHookInput && !usesSharedParser ? [name] : [];
+      })
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #828.

Routes the remaining top-level bash hooks that parse hook JSON input through `.claude/hooks/lib/input-utils.sh` instead of repeating `INPUT=$(cat)` and direct `.tool_input` / `.tool_response` jq extraction.

## Plan

Plan stored on issue: https://github.com/Garsson-io/kaizen/issues/828#issuecomment-4823842278

## Changes

- Migrates six bash hooks to shared parser helpers:
  - `kaizen-capture-worktree-context.sh`
  - `kaizen-enforce-case-exists.sh`
  - `kaizen-enforce-case-worktree.sh`
  - `kaizen-enforce-worktree-writes.sh`
  - `kaizen-pr-kaizen-clear-fallback.sh`
  - `kaizen-search-before-file.sh`
- Adds `src/hooks/bash-hook-invariants.test.ts` to prevent top-level hooks from reintroducing inline hook-input JSON parsing outside `input-utils.sh`.

## Validation

- RED: `npm test -- --run src/hooks/bash-hook-invariants.test.ts` failed before migration, listing the six inline parser offenders.
- GREEN: `npm test -- --run src/hooks/bash-hook-invariants.test.ts`
- GREEN: `bash .claude/hooks/tests/test-capture-worktree-context.sh`
- GREEN: `bash .claude/hooks/tests/test-capture-worktree-runtag.sh`
- GREEN: `bash .claude/hooks/tests/test-enforce-case-worktree.sh`
- GREEN: `bash .claude/hooks/tests/test-enforce-worktree-writes.sh`
- GREEN: `bash .claude/hooks/tests/test-search-before-file.sh`
- GREEN: `bash .claude/hooks/tests/test-pr-kaizen-clear-fallback.sh`
- GREEN: `bash .claude/hooks/tests/test-enforce-case-exists.sh`
- GREEN: `npm test -- --run src/hooks/wrapper-smoke.test.ts -t 'pr-kaizen-clear'`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`
- GREEN: source scan found no top-level `INPUT=$(cat)` or `.tool_input` / `.tool_response` jq extraction in `.claude/hooks/*.sh` outside the shared helper.
