### PR TITLE
refactor(hooks): reuse bash output helper

### DIFF
--- a/.claude/hooks/kaizen-enforce-case-exists.sh
+++ b/.claude/hooks/kaizen-enforce-case-exists.sh
@@ -20,6 +20,7 @@
 source "$(dirname "$0")/lib/allowlist.sh" 2>/dev/null || { exit 0; }
 source "$(dirname "$0")/lib/read-config.sh" 2>/dev/null || { exit 0; }
 source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
 
 read_hook_input
 get_file_path
@@ -91,11 +92,7 @@ fi
 
 # No case found — block the edit with helpful guidance (kaizen #146)
 WORKTREE_PATH="$WORKTREE_ROOT"
-jq -n \
-  --arg branch "$BRANCH" \
-  --arg file "$FILE_PATH" \
-  --arg cli "$KAIZEN_CASE_CLI" \
-  --arg reason "No case record found for branch '$BRANCH'. All dev work must have a case before writing code.
+REASON="No case record found for branch '$BRANCH'. All dev work must have a case before writing code.
 
 Create a case first:
   $KAIZEN_CASE_CLI case-create --description \"your description\" --type dev --github-issue N
@@ -106,12 +103,5 @@ This ensures:
   - /kaizen-pick filters out this work (prevents duplicate effort)
   - Kaizen reflection fires on completion
 
-If this is exploratory work (not implementation), use the main checkout with .claude/ paths instead." \
-  '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $reason
-    }
-  }'
-exit 0
+If this is exploratory work (not implementation), use the main checkout with .claude/ paths instead."
+emit_deny "$REASON"

--- a/.claude/hooks/kaizen-enforce-worktree-writes.sh
+++ b/.claude/hooks/kaizen-enforce-worktree-writes.sh
@@ -22,6 +22,7 @@
 
 source "$(dirname "$0")/lib/allowlist.sh" 2>/dev/null || { exit 0; }
 source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
 
 read_hook_input
 get_file_path
@@ -71,15 +72,5 @@ if [ "$MAIN_BRANCH" != "main" ]; then
 fi
 
 # Block the write — source code on main branch
-jq -n \
-  --arg file "$FILE_PATH" \
-  --arg main_root "$MAIN_ROOT" \
-  --arg reason "Cannot write to '$FILE_PATH' — it's source code in the main checkout ($MAIN_ROOT) on main branch. Use a worktree for code changes. Runtime dirs (groups/, data/, store/, logs/) and .claude/ are allowed." \
-  '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $reason
-    }
-  }'
-exit 0
+REASON="Cannot write to '$FILE_PATH' — it's source code in the main checkout ($MAIN_ROOT) on main branch. Use a worktree for code changes. Runtime dirs (groups/, data/, store/, logs/) and .claude/ are allowed."
+emit_deny "$REASON"

--- a/src/hooks/bash-hook-invariants.test.ts
+++ b/src/hooks/bash-hook-invariants.test.ts
@@ -21,4 +21,21 @@ describe('bash hook source invariants', () => {
 
     expect(offenders).toEqual([]);
   });
+
+  it('keeps deny JSON emission behind hook-output (#828)', () => {
+    const offenders = readdirSync(HOOKS_DIR)
+      .filter((name) => name.endsWith('.sh'))
+      .flatMap((name) => {
+        const content = readFileSync(join(HOOKS_DIR, name), 'utf-8');
+        const emitsDenyJson =
+          content.includes('hookSpecificOutput') &&
+          content.includes('permissionDecision');
+        const usesSharedOutput = content.includes('lib/hook-output.sh');
+
+        return emitsDenyJson && !usesSharedOutput ? [name] : [];
+      })
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Refs #828.

Routes the remaining pure-bash deny JSON emitters through `.claude/hooks/lib/hook-output.sh` instead of hand-rolling `hookSpecificOutput.permissionDecision=deny` blocks.

## Plan

Plan stored on issue: https://github.com/Garsson-io/kaizen/issues/828#issuecomment-4823860103

## Changes

- Migrates `kaizen-enforce-case-exists.sh` to `emit_deny` while preserving the existing case guidance text.
- Migrates `kaizen-enforce-worktree-writes.sh` to `emit_deny` while preserving the existing main-checkout source-edit block text.
- Extends `src/hooks/bash-hook-invariants.test.ts` so top-level bash hooks cannot reintroduce inline deny JSON without sourcing `hook-output.sh`.

## Validation

- RED: `npm test -- --run src/hooks/bash-hook-invariants.test.ts -t 'deny JSON emission'` failed before migration, listing the two hand-rolled deny emitters.
- GREEN: `npm test -- --run src/hooks/bash-hook-invariants.test.ts`
- GREEN: `bash .claude/hooks/tests/test-enforce-case-exists.sh`
- GREEN: `bash .claude/hooks/tests/test-enforce-worktree-writes.sh`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`
- GREEN: source scan found no top-level `hookSpecificOutput` / `permissionDecision` shell emitters outside the shared helper.
