### PR TITLE
refactor(hooks): share bash command segment splitter

### DIFF
--- a/.claude/hooks/kaizen-block-git-rebase.sh
+++ b/.claude/hooks/kaizen-block-git-rebase.sh
@@ -40,8 +40,6 @@ is_rebase_command() {
   local cmd="$1"
   # Split by pipe/chain operators and check each segment
   while IFS= read -r segment; do
-    # Trim leading whitespace
-    segment=$(echo "$segment" | sed 's/^[[:space:]]*//')
     # Skip empty segments, comments, and echo/printf commands
     [ -z "$segment" ] && continue
     echo "$segment" | grep -qE '^(#|echo |printf )' && continue
@@ -53,7 +51,7 @@ is_rebase_command() {
       fi
       return 0
     fi
-  done < <(echo "$cmd" | sed 's/[|;&]\{1,\}/\n/g')
+  done < <(split_command_segments "$cmd")
   return 1
 }
 

--- a/.claude/hooks/kaizen-block-self-plugin-enable.sh
+++ b/.claude/hooks/kaizen-block-self-plugin-enable.sh
@@ -24,8 +24,7 @@ read_hook_input
 get_command
 
 CMD_LINE=$(strip_heredoc_body "$COMMAND")
-if ! printf '%s\n' "$CMD_LINE" | sed 's/[|;&]\{1,\}/\n/g' | sed 's/^[[:space:]]*//' | \
-     grep -qE '^git[[:space:]]+(-[A-Za-z][^[:space:]]*[[:space:]]+)*commit([[:space:]]|$)'; then
+if ! split_command_segments "$CMD_LINE" | grep -qE '^git[[:space:]]+(-[A-Za-z][^[:space:]]*[[:space:]]+)*commit([[:space:]]|$)'; then
   exit 0
 fi
 

--- a/.claude/hooks/kaizen-search-before-file.sh
+++ b/.claude/hooks/kaizen-search-before-file.sh
@@ -32,8 +32,7 @@ CMD_LINE=$(strip_heredoc_body "$COMMAND")
 # Use segment splitting to avoid matching gh issue create inside strings
 is_issue_create() {
   local cmd="$1"
-  echo "$cmd" | sed 's/[|;&]\{1,\}/\n/g' | sed 's/^[[:space:]]*//' | \
-    grep -qE '^gh[[:space:]]+issue[[:space:]]+create'
+  split_command_segments "$cmd" | grep -qE '^gh[[:space:]]+issue[[:space:]]+create'
 }
 
 if ! is_issue_create "$CMD_LINE"; then

--- a/.claude/hooks/lib/allowlist.sh
+++ b/.claude/hooks/lib/allowlist.sh
@@ -26,13 +26,11 @@
 is_readonly_monitoring_command() {
   local cmd="$1"
   # gh api — read-only API calls (CI monitoring, PR status checks)
-  if echo "$cmd" | sed 's/[|;&]\{1,\}/\n/g' | sed 's/^[[:space:]]*//' | \
-    grep -qE '^gh[[:space:]]+api[[:space:]]'; then
+  if split_command_segments "$cmd" | grep -qE '^gh[[:space:]]+api[[:space:]]'; then
     return 0
   fi
   # gh run view/list/watch — CI run monitoring
-  if echo "$cmd" | sed 's/[|;&]\{1,\}/\n/g' | sed 's/^[[:space:]]*//' | \
-    grep -qE '^gh[[:space:]]+run[[:space:]]+(view|list|watch)'; then
+  if split_command_segments "$cmd" | grep -qE '^gh[[:space:]]+run[[:space:]]+(view|list|watch)'; then
     return 0
   fi
   # git diff/log/show/status/branch/fetch — read-only git commands

--- a/.claude/hooks/lib/parse-command.sh
+++ b/.claude/hooks/lib/parse-command.sh
@@ -25,6 +25,18 @@ strip_heredoc_body() {
   echo "$result"
 }
 
+# Split a command line by pipe/chain operators and bare newlines.
+# Keeps hook detectors consistent with the TypeScript splitCommandSegments()
+# helper while preserving the historical sed-based shell behavior.
+split_command_segments() {
+  local cmd_line="$1"
+  printf '%s\n' "$cmd_line" | \
+    sed 's/[|;&]\{1,\}/\n/g' | \
+    sed 's/^[[:space:]]*//' | \
+    sed 's/[[:space:]]*$//' | \
+    sed '/^$/d'
+}
+
 # Check if a command line contains an actual `gh pr <subcommand>` invocation,
 # not just the text inside a string argument (e.g., echo '...gh pr create...').
 # Splits by pipe/chain operators and checks if any segment starts with `gh pr`.
@@ -33,8 +45,7 @@ is_gh_pr_command() {
   local cmd_line="$1"
   local subcommands="$2"
   # Split by |, &&, ||, ; then check if any segment starts with gh pr <sub>
-  echo "$cmd_line" | sed 's/[|;&]\{1,\}/\n/g' | sed 's/^[[:space:]]*//' | \
-    grep -qE "^gh[[:space:]]+pr[[:space:]]+($subcommands)"
+  split_command_segments "$cmd_line" | grep -qE "^gh[[:space:]]+pr[[:space:]]+($subcommands)"
 }
 
 # Check if a command line contains an actual `git <subcommand>` invocation.
@@ -47,8 +58,7 @@ is_git_command() {
   # Match both `git push` and `git -C /some/path push`
   # Note: subcommand must be parenthesized to prevent regex alternation leak
   # (kaizen #323: `--delete-branch` matched bare `branch` without grouping)
-  echo "$cmd_line" | sed 's/[|;&]\{1,\}/\n/g' | sed 's/^[[:space:]]*//' | \
-    grep -qE "^git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?(${subcommand})"
+  split_command_segments "$cmd_line" | grep -qE "^git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?(${subcommand})"
 }
 
 # Extract the -C <path> argument from a git command, if present.
@@ -56,7 +66,7 @@ is_git_command() {
 # Usage: TARGET_DIR=$(extract_git_c_path "$CMD_LINE")
 extract_git_c_path() {
   local cmd_line="$1"
-  echo "$cmd_line" | sed 's/[|;&]\{1,\}/\n/g' | sed 's/^[[:space:]]*//' | \
+  split_command_segments "$cmd_line" | \
     grep -E '^git[[:space:]]+-C' | \
     sed -n 's/^git[[:space:]]\{1,\}-C[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*/\1/p' | head -1
 }

--- a/.claude/hooks/tests/test-parse-command.sh
+++ b/.claude/hooks/tests/test-parse-command.sh
@@ -70,6 +70,21 @@ EOF
 )"')"
 
 echo ""
+echo "=== split_command_segments ==="
+
+assert_eq "splits bare newlines" \
+  "a|b|c" \
+  "$(split_command_segments $'a\nb\nc' | paste -sd '|' -)"
+
+assert_eq "splits command operators" \
+  "npm run build|gh pr create|git push" \
+  "$(split_command_segments "npm run build && gh pr create ; git push" | paste -sd '|' -)"
+
+assert_eq "collapses operator plus newline run" \
+  "npm run build|gh pr create" \
+  "$(split_command_segments $'npm run build &&\ngh pr create' | paste -sd '|' -)"
+
+echo ""
 echo "=== is_gh_pr_command ==="
 
 # Direct commands — should match

--- a/src/hooks/bash-hook-invariants.test.ts
+++ b/src/hooks/bash-hook-invariants.test.ts
@@ -3,6 +3,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const HOOKS_DIR = join(__dirname, '../../.claude/hooks');
+const HOOK_LIB_DIR = join(HOOKS_DIR, 'lib');
 
 describe('bash hook source invariants', () => {
   it('keeps stdin JSON parsing behind input-utils (#828)', () => {
@@ -34,6 +35,24 @@ describe('bash hook source invariants', () => {
 
         return emitsDenyJson && !usesSharedOutput ? [name] : [];
       })
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps command segment splitting behind parse-command (#828)', () => {
+    const segmentSplitPattern = /sed 's\/\[\|;&\]\\\{1,\\\}\/\\n\/g'/;
+    const files = [
+      ...readdirSync(HOOKS_DIR)
+        .filter((name) => name.endsWith('.sh'))
+        .map((name) => join(HOOKS_DIR, name)),
+      ...readdirSync(HOOK_LIB_DIR)
+        .filter((name) => name.endsWith('.sh') && name !== 'parse-command.sh')
+        .map((name) => join(HOOK_LIB_DIR, name)),
+    ];
+    const offenders = files
+      .filter((file) => segmentSplitPattern.test(readFileSync(file, 'utf-8')))
+      .map((file) => file.replace(`${HOOKS_DIR}/`, ''))
       .sort();
 
     expect(offenders).toEqual([]);

--- a/src/hooks/bash-ts-parity.test.ts
+++ b/src/hooks/bash-ts-parity.test.ts
@@ -22,10 +22,6 @@ const HOOKS_TS_DIR = __dirname;
 // Functions intentionally present in only one version.
 // Each entry must have a comment explaining WHY it's excluded.
 const EXCLUSIONS: Record<string, string> = {
-  // TS internal utility for splitting compound commands; bash uses IFS/sed inline
-  splitCommandSegments:
-    'ts-only: internal helper, bash splits on operators inline',
-
   // TS splits extractPrUrl from reconstructPrUrl; bash inlines the grep
   extractPrUrl:
     'ts-only: extracted helper, bash inlines grep in reconstruct_pr_url',


### PR DESCRIPTION
## Summary

Refs #828.

Centralizes bash hook command segment splitting in `.claude/hooks/lib/parse-command.sh` so PR/git/issue detectors stop duplicating the same sed pipeline.

## Plan

Plan stored on issue: https://github.com/Garsson-io/kaizen/issues/828#issuecomment-4823891535

## Changes

- Adds `split_command_segments` to `parse-command.sh`, matching the existing TypeScript `splitCommandSegments` helper.
- Routes parser helpers, readonly allowlist checks, rebase blocking, self-plugin dual-load blocking, and issue-create duplicate search through the shared splitter.
- Removes the stale `splitCommandSegments` parity exclusion now that bash has the corresponding helper.
- Adds invariant coverage so raw segment-splitting sed pipelines cannot spread outside the shared parser.
- Adds direct shell tests for `split_command_segments`.

## Validation

- RED: `npm test -- --run src/hooks/bash-hook-invariants.test.ts -t 'command segment splitting'` failed before migration, listing `kaizen-block-git-rebase.sh`, `kaizen-block-self-plugin-enable.sh`, `kaizen-search-before-file.sh`, and `lib/allowlist.sh`.
- GREEN: `bash .claude/hooks/tests/test-parse-command.sh`
- GREEN: `bash .claude/hooks/tests/test-allowlist.sh`
- GREEN: `bash .claude/hooks/tests/test-block-git-rebase.sh`
- GREEN: `bash .claude/hooks/tests/test-search-before-file.sh`
- GREEN: `bash .claude/hooks/tests/test-block-self-plugin-enable.sh`
- GREEN: `npm test -- --run src/hooks/parse-command.test.ts src/hooks/bash-hook-invariants.test.ts src/hooks/bash-ts-parity.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`
- GREEN: source scan found the old raw segment splitter only inside `parse-command.sh`.
