### PR TITLE
fix(hooks): require all allowlist segments to be safe

### DIFF
--- a/.claude/hooks/lib/allowlist.sh
+++ b/.claude/hooks/lib/allowlist.sh
@@ -23,27 +23,69 @@
 #
 # Usage:
 #   if is_readonly_monitoring_command "$cmd"; then return 0; fi
-is_readonly_monitoring_command() {
-  local cmd="$1"
+is_neutral_setup_segment() {
+  local seg="$1"
+  if echo "$seg" | grep -qE '^([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+)([[:space:]]+[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+)*$'; then
+    return 0
+  fi
+  if echo "$seg" | grep -qE '^export[[:space:]]+[A-Za-z_][A-Za-z0-9_]*(=[^[:space:]]+)?([[:space:]]+[A-Za-z_][A-Za-z0-9_]*(=[^[:space:]]+)?)*$'; then
+    return 0
+  fi
+  if echo "$seg" | grep -qE '^cd([[:space:]]+("[^"]+"|'\''[^'\'']+'\''|[^[:space:]]+))?$'; then
+    return 0
+  fi
+  return 1
+}
+
+is_readonly_monitoring_segment() {
+  local seg="$1"
   # gh api — read-only API calls (CI monitoring, PR status checks)
-  if split_command_segments "$cmd" | grep -qE '^gh[[:space:]]+api[[:space:]]'; then
+  if echo "$seg" | grep -qE '^gh[[:space:]]+api[[:space:]]'; then
     return 0
   fi
   # gh run view/list/watch — CI run monitoring
-  if split_command_segments "$cmd" | grep -qE '^gh[[:space:]]+run[[:space:]]+(view|list|watch)'; then
+  if echo "$seg" | grep -qE '^gh[[:space:]]+run[[:space:]]+(view|list|watch)'; then
     return 0
   fi
   # git diff/log/show/status/branch/fetch — read-only git commands
-  if is_git_command "$cmd" "diff|log|show|status|branch|fetch"; then
+  if is_git_command "$seg" "diff|log|show|status|branch|fetch"; then
     return 0
   fi
   # Read-only filesystem commands
   local first_word
-  first_word=$(echo "$cmd" | awk '{print $1}')
+  first_word=$(echo "$seg" | awk '{print $1}')
   case "$first_word" in
     ls|cat|stat|find|head|tail|wc|file) return 0 ;;
+    grep|rg|awk|sed) return 0 ;;
   esac
+  if echo "$seg" | grep -qE '^npm[[:space:]]+test'; then
+    return 0
+  fi
+  if echo "$seg" | grep -qE '^npx[[:space:]]'; then
+    return 0
+  fi
   return 1
+}
+
+is_readonly_or_setup_segment() {
+  local seg="$1"
+  if is_neutral_setup_segment "$seg"; then
+    return 0
+  fi
+  is_readonly_monitoring_segment "$seg"
+}
+
+is_readonly_monitoring_command() {
+  local cmd="$1"
+  local saw_segment=0
+  local seg
+  while IFS= read -r seg; do
+    saw_segment=1
+    if ! is_readonly_or_setup_segment "$seg"; then
+      return 1
+    fi
+  done < <(split_command_segments "$cmd")
+  [ "$saw_segment" -eq 1 ]
 }
 
 # Check if a relative path is in an allowed runtime directory (non-source code).

--- a/.claude/hooks/tests/test-allowlist.sh
+++ b/.claude/hooks/tests/test-allowlist.sh
@@ -13,7 +13,7 @@ echo "=== is_readonly_monitoring_command: gh api allowed ==="
 
 assert_ok "gh api repos check" is_readonly_monitoring_command "gh api repos/Garsson-io/kaizen/pulls/42"
 assert_ok "gh api with --jq" is_readonly_monitoring_command "gh api repos/foo/bar --jq '.state'"
-assert_ok "piped gh api" is_readonly_monitoring_command "something | gh api repos/foo/bar"
+assert_ok "cat pipe gh api" is_readonly_monitoring_command "cat payload.json | gh api repos/foo/bar"
 
 echo ""
 echo "=== is_readonly_monitoring_command: gh run allowed ==="
@@ -70,10 +70,31 @@ assert_fails "mkdir blocked" is_readonly_monitoring_command "mkdir -p newdir"
 echo ""
 echo "=== is_readonly_monitoring_command: pipe bypass prevention ==="
 
-# The first segment is what matters — gh api after a pipe is still a readonly segment
-assert_ok "pipe into gh api" is_readonly_monitoring_command "echo foo | gh api repos/bar"
-# But npm before a pipe should fail (npm is the first word)
+# Every segment must be readonly or neutral. A blocked segment cannot be
+# laundered through a readonly segment.
+assert_fails "echo into gh api blocked" is_readonly_monitoring_command "echo foo | gh api repos/bar"
 assert_fails "npm before pipe" is_readonly_monitoring_command "npm run build | grep error"
+
+echo ""
+echo "=== is_readonly_monitoring_command: mixed compound bypass prevention ==="
+
+assert_fails "merge then status blocked" is_readonly_monitoring_command "gh pr merge 5 && git status"
+assert_fails "status then merge blocked" is_readonly_monitoring_command "git status; gh pr merge 5"
+assert_fails "status pipe merge blocked" is_readonly_monitoring_command "git status | gh pr merge 5"
+assert_fails "newline merge blocked" is_readonly_monitoring_command "git log
+gh pr merge 5"
+assert_fails "status then push blocked" is_readonly_monitoring_command "git status && git push"
+assert_fails "inline assignment push blocked" is_readonly_monitoring_command "FOO=1 git push"
+assert_fails "inline assignment install blocked" is_readonly_monitoring_command "PATH=/x npm install"
+
+echo ""
+echo "=== is_readonly_monitoring_command: pure readonly compounds ==="
+
+assert_ok "status and log allowed" is_readonly_monitoring_command "git status && git log --oneline"
+assert_ok "status and run list allowed" is_readonly_monitoring_command "git status; gh run list --limit 5"
+assert_ok "status pipe cat allowed" is_readonly_monitoring_command "git status | cat"
+assert_ok "cd then status allowed" is_readonly_monitoring_command "cd .
+git status"
 
 echo ""
 echo "=== is_allowed_runtime_dir: allowed directories ==="

--- a/src/hooks/lib/allowlist.test.ts
+++ b/src/hooks/lib/allowlist.test.ts
@@ -64,6 +64,23 @@ describe('isReadonlyMonitoringCommand', () => {
     // And a pure write command on its own line stays blocked.
     expect(isReadonlyMonitoringCommand('export PATH=/x\ngit push')).toBe(false);
   });
+
+  it('blocks mixed readonly and write compounds (#1344)', () => {
+    expect(isReadonlyMonitoringCommand('gh pr merge 5 && git status')).toBe(false);
+    expect(isReadonlyMonitoringCommand('git status; gh pr merge 5')).toBe(false);
+    expect(isReadonlyMonitoringCommand('git status | gh pr merge 5')).toBe(false);
+    expect(isReadonlyMonitoringCommand('git log\ngh pr merge 5')).toBe(false);
+    expect(isReadonlyMonitoringCommand('git status && git push')).toBe(false);
+    expect(isReadonlyMonitoringCommand('FOO=1 git push')).toBe(false);
+    expect(isReadonlyMonitoringCommand('PATH=/x npm install')).toBe(false);
+  });
+
+  it('allows pure readonly compounds (#1344)', () => {
+    expect(isReadonlyMonitoringCommand('git status && git log --oneline')).toBe(true);
+    expect(isReadonlyMonitoringCommand('git status; gh run list --limit 5')).toBe(true);
+    expect(isReadonlyMonitoringCommand('git status | grep main')).toBe(true);
+    expect(isReadonlyMonitoringCommand('cd .\ngit status')).toBe(true);
+  });
 });
 
 describe('isReviewCommand', () => {
@@ -90,6 +107,12 @@ describe('isReviewCommand', () => {
   it('allows the universal KAIZEN_UNFINISHED escape (no deadlock — #1068)', () => {
     expect(isReviewCommand("echo 'KAIZEN_UNFINISHED: review blocked, deferring'")).toBe(true);
   });
+
+  it('blocks mixed review-allowed and write compounds (#1344)', () => {
+    expect(isReviewCommand('gh pr view 42 && git push')).toBe(false);
+    expect(isReviewCommand('git push && gh pr diff 42')).toBe(false);
+    expect(isReviewCommand('git status && gh pr view 42')).toBe(true);
+  });
 });
 
 describe('isEscapeHatch', () => {
@@ -110,6 +133,10 @@ describe('isEscapeHatch', () => {
     expect(isEscapeHatch('git push')).toBe(false);
     expect(isEscapeHatch('echo hello')).toBe(false);
     expect(isEscapeHatch('npm install')).toBe(false);
+  });
+
+  it('does not allow blocked work beside an escape declaration (#1344)', () => {
+    expect(isEscapeHatch("echo 'KAIZEN_UNFINISHED: later' && git push")).toBe(false);
   });
 });
 
@@ -169,9 +196,11 @@ describe('isKaizenCommand', () => {
     expect(isKaizenCommand('git push')).toBe(false);
   });
 
-  it('prevents bypass via pipe chains', () => {
-    // "npm build && echo KAIZEN_IMPEDIMENTS:" — the first segment is blocked
+  it('prevents bypass via compound commands (#1344)', () => {
     expect(isKaizenCommand('npm build')).toBe(false);
+    expect(isKaizenCommand('gh issue view 42 && git push')).toBe(false);
+    expect(isKaizenCommand('git push && gh pr merge 42')).toBe(false);
+    expect(isKaizenCommand('gh issue view 42 && git status')).toBe(true);
   });
 });
 

--- a/src/hooks/lib/allowlist.ts
+++ b/src/hooks/lib/allowlist.ts
@@ -24,6 +24,48 @@ function splitSegments(cmdLine: string): string[] {
   return splitCommandSegments(cmdLine);
 }
 
+function isNeutralSetupSegment(seg: string): boolean {
+  return /^cd(?:\s+(?:"[^"]+"|'[^']+'|\S+))?$/.test(seg)
+    || /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+)(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S+)*$/.test(seg)
+    || /^export\s+[A-Za-z_][A-Za-z0-9_]*(?:=\S+)?(?:\s+[A-Za-z_][A-Za-z0-9_]*(?:=\S+)?)*$/.test(seg);
+}
+
+function isReadonlyMonitoringSegment(seg: string): boolean {
+  const firstWord = seg.split(/\s+/)[0];
+
+  // gh api
+  if (/^gh\s+api\s/.test(seg)) return true;
+
+  // gh run view/list/watch
+  if (/^gh\s+run\s+(view|list|watch)/.test(seg)) return true;
+
+  // git read-only
+  if (isGitCommand(seg, 'diff|log|show|status|branch|fetch')) return true;
+
+  // Read-only filesystem commands
+  if (['ls', 'cat', 'stat', 'find', 'head', 'tail', 'wc', 'file'].includes(firstWord)) return true;
+
+  // Diagnostic commands (kaizen #775 — expand allowlist)
+  if (['grep', 'rg', 'awk', 'sed'].includes(firstWord)) return true;
+
+  // npm test / npx (diagnostic — kaizen #775)
+  if (/^npm\s+test/.test(seg) || /^npx\s/.test(seg)) return true;
+
+  return false;
+}
+
+function isReadonlyOrSetupSegment(seg: string): boolean {
+  return isNeutralSetupSegment(seg) || isReadonlyMonitoringSegment(seg);
+}
+
+function allSegmentsAllowed(
+  cmdLine: string,
+  allowsSegment: (seg: string) => boolean,
+): boolean {
+  const segments = splitSegments(cmdLine);
+  return segments.length > 0 && segments.every(allowsSegment);
+}
+
 /**
  * Check if a command is a readonly monitoring command allowed through any gate.
  * These commands can't "do work" (build, deploy, edit) so they don't violate
@@ -37,29 +79,7 @@ function splitSegments(cmdLine: string): string[] {
  *   grep, rg, awk, sed (read-only search — kaizen #775)
  */
 export function isReadonlyMonitoringCommand(cmdLine: string): boolean {
-  const segments = splitSegments(cmdLine);
-  for (const seg of segments) {
-    const firstWord = seg.split(/\s+/)[0];
-
-    // gh api
-    if (/^gh\s+api\s/.test(seg)) return true;
-
-    // gh run view/list/watch
-    if (/^gh\s+run\s+(view|list|watch)/.test(seg)) return true;
-
-    // git read-only
-    if (isGitCommand(seg, 'diff|log|show|status|branch|fetch')) return true;
-
-    // Read-only filesystem commands
-    if (['ls', 'cat', 'stat', 'find', 'head', 'tail', 'wc', 'file'].includes(firstWord)) return true;
-
-    // Diagnostic commands (kaizen #775 — expand allowlist)
-    if (['grep', 'rg', 'awk', 'sed'].includes(firstWord)) return true;
-
-    // npm test / npx (diagnostic — kaizen #775)
-    if (/^npm\s+test/.test(seg) || /^npx\s/.test(seg)) return true;
-  }
-  return false;
+  return allSegmentsAllowed(cmdLine, isReadonlyOrSetupSegment);
 }
 
 /**
@@ -74,16 +94,22 @@ export function isReadonlyMonitoringCommand(cmdLine: string): boolean {
  * accepts the same escape — see the escape-hatch invariant in allowlist.test.ts.
  */
 export function isEscapeHatch(cmdLine: string): boolean {
-  const segments = splitSegments(cmdLine);
-  for (const seg of segments) {
+  return allSegmentsAllowed(cmdLine, (seg) => {
+    if (isNeutralSetupSegment(seg)) return true;
     // KAIZEN_UNFINISHED: <reason> — universal "stopping with unfinished work" escape
     if (/^echo.*KAIZEN_UNFINISHED:/.test(seg) || /^KAIZEN_UNFINISHED:/.test(seg)) return true;
     // KAIZEN_NO_ACTION — "nothing to do here" declaration
     if (/^echo.*KAIZEN_NO_ACTION/.test(seg) || /^KAIZEN_NO_ACTION/.test(seg)) return true;
     // KAIZEN_IMPEDIMENTS: — reflection escape (also used to satisfy I16)
     if (/^echo.*KAIZEN_IMPEDIMENTS:/.test(seg) || /^KAIZEN_IMPEDIMENTS:/.test(seg)) return true;
-  }
-  return false;
+    return false;
+  });
+}
+
+function isReviewSegment(seg: string): boolean {
+  return isGhPrCommand(seg, 'diff|view|comment|edit')
+    || isEscapeHatch(seg)
+    || isReadonlyOrSetupSegment(seg);
 }
 
 /**
@@ -92,16 +118,20 @@ export function isEscapeHatch(cmdLine: string): boolean {
  * monitoring.
  */
 export function isReviewCommand(cmdLine: string): boolean {
-  // gh pr diff/view/comment/edit
-  if (isGhPrCommand(cmdLine, 'diff|view|comment|edit')) return true;
+  return allSegmentsAllowed(cmdLine, isReviewSegment);
+}
 
-  // Universal stop-gate escape — must work from any gate-blocked state (#1068)
-  if (isEscapeHatch(cmdLine)) return true;
+function isKaizenSegment(seg: string): boolean {
+  // gh issue create/list/search/comment/view
+  if (/^gh\s+issue\s+(create|list|search|comment|view)/.test(seg)) return true;
 
-  // Shared readonly monitoring
-  if (isReadonlyMonitoringCommand(cmdLine)) return true;
+  // `cat` heredoc bodies for issue/reflection payloads
+  if (/^cat/.test(seg)) return true;
 
-  return false;
+  // gh pr diff/view/comment/edit/checks/merge
+  if (isGhPrCommand(seg, 'diff|view|comment|edit|checks|merge')) return true;
+
+  return isEscapeHatch(seg) || isReadonlyOrSetupSegment(seg);
 }
 
 /**
@@ -109,28 +139,7 @@ export function isReviewCommand(cmdLine: string): boolean {
  * Includes kaizen-related commands + shared readonly monitoring.
  */
 export function isKaizenCommand(cmdLine: string): boolean {
-  const segments = splitSegments(cmdLine);
-
-  for (const seg of segments) {
-    // gh issue create/list/search/comment/view
-    if (/^gh\s+issue\s+(create|list|search|comment|view)/.test(seg)) return true;
-
-    // `cat` heredoc bodies for issue/reflection payloads
-    if (/^cat/.test(seg)) return true;
-  }
-
-  // Universal stop-gate escape declarations (KAIZEN_UNFINISHED/NO_ACTION/IMPEDIMENTS).
-  // Single source of truth — shared with isReviewCommand so the documented escape
-  // works from every gate-blocked state (#1068, kaizen #775).
-  if (isEscapeHatch(cmdLine)) return true;
-
-  // gh pr diff/view/comment/edit/checks/merge
-  if (isGhPrCommand(cmdLine, 'diff|view|comment|edit|checks|merge')) return true;
-
-  // Shared readonly monitoring
-  if (isReadonlyMonitoringCommand(cmdLine)) return true;
-
-  return false;
+  return allSegmentsAllowed(cmdLine, isKaizenSegment);
 }
 
 /**


### PR DESCRIPTION
## Problem

Gate allowlists treated compound commands as allowed when any segment matched an allowed readonly/review/kaizen pattern. That let a blocked action be smuggled beside a harmless command, for example `gh pr merge 5 && git status` or `gh pr view 5 && git push`.

Fixes #1344
Related: #1272

## Solution

- Centralized TypeScript allow decisions through `allSegmentsAllowed`, so every segment must be either allowed for that gate or a neutral setup segment.
- Split readonly matching into a segment predicate and reused it from review/kaizen allowlists.
- Matched the bash readonly allowlist to the same segment-level rule instead of `grep -q` OR-over-segments.
- Kept pure readonly compounds working, including setup-only `cd`/standalone assignment lines followed by monitoring commands.

## Validation

- RED confirmed before implementation:
  - `npm test -- --run src/hooks/lib/allowlist.test.ts` failed on mixed compounds.
  - `bash .claude/hooks/tests/test-allowlist.sh` failed on mixed compounds.
- GREEN:
  - `npm test -- --run src/hooks/lib/allowlist.test.ts src/hooks/enforce-pr-review.test.ts src/hooks/enforce-pr-reflect.test.ts src/hooks/bash-ts-parity.test.ts`
  - `bash .claude/hooks/tests/test-allowlist.sh`
  - `npm run typecheck`
  - `git diff --check`
  - `npm test -- --run src/hooks` (39 files, 844 tests)
- Direct reproduction now returns false for the mixed examples and true for `git status && git log`.
