### PR TITLE
refactor(auto-dent): share display truncation helpers

### DIFF
--- a/scripts/auto-dent-analyze.ts
+++ b/scripts/auto-dent-analyze.ts
@@ -19,6 +19,7 @@ import { readdirSync, readFileSync, existsSync } from 'fs';
 import { join, basename, resolve } from 'path';
 import { execSync } from 'child_process';
 import { readState, type BatchState } from './auto-dent-run.js';
+import { truncateDisplay } from './auto-dent-display.js';
 
 // Types
 
@@ -148,7 +149,7 @@ const CODING_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit']);
 const DISCOVERY_TOOLS = new Set(['Read', 'Grep', 'Glob', 'Agent', 'ToolSearch']);
 const SHIPPING_TOOLS = new Set(['Bash']); // git/gh commands
 
-function truncateInput(name: string, input: Record<string, any>): string {
+function formatToolInputSummary(name: string, input: Record<string, any>): string {
   switch (name) {
     case 'Read':
     case 'Edit':
@@ -156,16 +157,16 @@ function truncateInput(name: string, input: Record<string, any>): string {
       return basename(input?.file_path || '?');
     case 'Bash': {
       const cmd = input?.command || input?.description || '?';
-      return cmd.slice(0, 60);
+      return truncateDisplay(cmd, 60, { ellipsis: '' });
     }
     case 'Grep':
-      return `"${(input?.pattern || '?').slice(0, 30)}"`;
+      return `"${truncateDisplay(input?.pattern || '?', 30, { ellipsis: '' })}"`;
     case 'Glob':
-      return (input?.pattern || '?').slice(0, 40);
+      return truncateDisplay(input?.pattern || '?', 40, { ellipsis: '' });
     case 'Skill':
       return `/${input?.skill_name || input?.skill || '?'}`;
     case 'Agent':
-      return (input?.description || '?').slice(0, 40);
+      return truncateDisplay(input?.description || '?', 40, { ellipsis: '' });
     default:
       return '';
   }
@@ -553,7 +554,7 @@ export function analyzeRunLog(logPath: string): RunAnalysis {
         if (block.type === 'tool_use') {
           const name = block.name;
           const input = block.input || {};
-          const summary = `${name} ${truncateInput(name, input)}`.trim();
+          const summary = `${name} ${formatToolInputSummary(name, input)}`.trim();
           toolEvents.push({ offsetSec, name, summary });
           toolInputs.push({ name, input });
         }

--- a/scripts/auto-dent-display.test.ts
+++ b/scripts/auto-dent-display.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+import {
+  collapseWhitespace,
+  truncateAtWordBoundary,
+  truncateDisplay,
+} from './auto-dent-display.js';
+
+describe('auto-dent display text helpers (#1348)', () => {
+  it('collapses arbitrary free text to one display line', () => {
+    expect(collapseWhitespace(' line one\n\tline two   line three ')).toBe(
+      'line one line two line three',
+    );
+  });
+
+  it('truncates after whitespace collapse with a visible one-character ellipsis', () => {
+    expect(truncateDisplay('abc\n  def ghi', 8)).toBe('abc def…');
+  });
+
+  it('leaves already short display text unchanged', () => {
+    expect(truncateDisplay('short text', 20)).toBe('short text');
+  });
+
+  it('supports the existing word-boundary title contract', () => {
+    expect(truncateAtWordBoundary('improve hooks, testing, and more stuff here', 25)).toBe(
+      'improve hooks, testing...',
+    );
+    expect(truncateAtWordBoundary('abcdefghijklmnopqrstuvwxyz', 10)).toBe(
+      'abcdefghij...',
+    );
+  });
+});
+
+describe('auto-dent display ownership invariant (#1348)', () => {
+  it('keeps migrated Auto-dent files from reintroducing private generic truncators', () => {
+    const migratedFiles = [
+      'scripts/auto-dent-stream.ts',
+      'scripts/auto-dent-analyze.ts',
+      'scripts/auto-dent-run.ts',
+    ];
+
+    for (const file of migratedFiles) {
+      const source = readFileSync(file, 'utf8');
+      expect(source, `${file} should use scripts/auto-dent-display.ts`).not.toMatch(
+        /function\s+truncate(?:Input|AtWord)?\s*\(/,
+      );
+    }
+  });
+});

--- a/scripts/auto-dent-display.ts
+++ b/scripts/auto-dent-display.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared display-text helpers for Auto-dent runtime output.
+ *
+ * These helpers own the small but drift-prone contract for rendering arbitrary
+ * command/path/tool text as bounded human-readable summaries (#1348).
+ */
+
+export interface TruncateDisplayOptions {
+  ellipsis?: string;
+  collapse?: boolean;
+}
+
+/**
+ * Collapse internal whitespace - newlines, tabs, runs of spaces - to a single
+ * space and trim (#1170). Display-only: machine-readable logs keep original
+ * command/input text.
+ */
+export function collapseWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+export function truncateDisplay(
+  text: string,
+  max: number,
+  options: TruncateDisplayOptions = {},
+): string {
+  const ellipsis = options.ellipsis ?? '\u2026';
+  const displayText = options.collapse === false ? text : collapseWhitespace(text);
+
+  if (max <= 0) return '';
+  if (displayText.length <= max) return displayText;
+  if (ellipsis.length >= max) return ellipsis.slice(0, max);
+  return displayText.slice(0, max - ellipsis.length) + ellipsis;
+}
+
+/**
+ * Truncate text at a word boundary, max `max` characters before the ellipsis.
+ * Falls back to an exact cut when no useful word boundary exists.
+ */
+export function truncateAtWordBoundary(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const truncated = text.slice(0, max);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cut = lastSpace > max * 0.5 ? lastSpace : max;
+  return truncated.slice(0, cut).replace(/[,\s]+$/, '') + '...';
+}

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -56,6 +56,7 @@ import {
   upsertProgressStep,
   type RunProgressStep,
 } from './auto-dent-progress.js';
+import { truncateAtWordBoundary } from './auto-dent-display.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -1268,17 +1269,7 @@ Emit these naturally as you complete each phase. Missing keys are fine — emit 
 
 // Text utilities
 
-/**
- * Truncate text at a word boundary, max `max` characters.
- * Appends ellipsis if truncated.
- */
-export function truncateAtWord(text: string, max: number): string {
-  if (text.length <= max) return text;
-  const truncated = text.slice(0, max);
-  const lastSpace = truncated.lastIndexOf(' ');
-  const cut = lastSpace > max * 0.5 ? lastSpace : max;
-  return truncated.slice(0, cut).replace(/[,\s]+$/, '') + '...';
-}
+export const truncateAtWord = truncateAtWordBoundary;
 
 /**
  * Clean raw guidance into a readable title.

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -18,6 +18,10 @@ import {
   upsertProgressStep,
   type RunProgressStep,
 } from './auto-dent-progress.js';
+import {
+  collapseWhitespace,
+  truncateDisplay,
+} from './auto-dent-display.js';
 import { parseHookOutputs, type HookOutput } from '../src/hooks/lib/gate-signal.js';
 
 // ANSI color helpers (graceful degradation when NO_COLOR is set or not a TTY)
@@ -60,25 +64,7 @@ function formatElapsed(startMs: number): string {
   return `${m}m${s.toString().padStart(2, '0')}s`;
 }
 
-function truncate(s: string, max: number): string {
-  // Collapse first so the one-event-one-line stream contract holds for ANY
-  // free-text field (#1170), not just Bash commands, and so the length budget
-  // is spent on visible content rather than on whitespace we'd drop anyway.
-  const oneLine = collapseWhitespace(s);
-  return oneLine.length > max ? oneLine.slice(0, max - 1) + '\u2026' : oneLine;
-}
-
-/**
- * Collapse internal whitespace \u2014 newlines, tabs, runs of spaces \u2014 to a single
- * space and trim (#1170). The live terminal stream's contract is one tool event
- * per readable line; a multiline command (heredoc, script body) otherwise spills
- * its body onto following lines with no timestamp/tool prefix, so the body looks
- * like separate auto-dent events. Display-only: the machine-readable logs keep
- * the original command verbatim.
- */
-export function collapseWhitespace(s: string): string {
-  return s.replace(/\s+/g, ' ').trim();
-}
+export { collapseWhitespace } from './auto-dent-display.js';
 
 // Semantic line budget (#1157)
 //
@@ -127,23 +113,23 @@ export function formatToolUse(
 ): string {
   switch (name) {
     case 'Read':
-      return `Read ${truncate(prettifyPath(input?.file_path || '?'), 60)}`;
+      return `Read ${truncateDisplay(prettifyPath(input?.file_path || '?'), 60)}`;
     case 'Edit':
-      return `Edit ${truncate(prettifyPath(input?.file_path || '?'), 60)}`;
+      return `Edit ${truncateDisplay(prettifyPath(input?.file_path || '?'), 60)}`;
     case 'Write':
-      return `Write ${truncate(prettifyPath(input?.file_path || '?'), 60)}`;
+      return `Write ${truncateDisplay(prettifyPath(input?.file_path || '?'), 60)}`;
     case 'Bash':
-      return `$ ${truncate(prettifyPath(stripCdPrefix(collapseWhitespace(input?.command || input?.description || '?'))), 90)}`;
+      return `$ ${truncateDisplay(prettifyPath(stripCdPrefix(collapseWhitespace(input?.command || input?.description || '?'))), 90)}`;
     case 'Grep':
-      return `Grep "${truncate(input?.pattern || '?', 30)}" ${prettifyPath(input?.path || '')}`;
+      return `Grep "${truncateDisplay(input?.pattern || '?', 30)}" ${prettifyPath(input?.path || '')}`;
     case 'Glob':
-      return `Glob ${truncate(input?.pattern || '?', 50)}`;
+      return `Glob ${truncateDisplay(input?.pattern || '?', 50)}`;
     case 'Skill':
       return `Skill /${input?.skill_name || input?.skill || '?'}`;
     case 'Agent':
-      return `Agent: ${truncate(input?.description || '?', 50)}`;
+      return `Agent: ${truncateDisplay(input?.description || '?', 50)}`;
     case 'TaskCreate':
-      return `Task+ ${truncate(input?.subject || '?', 50)}`;
+      return `Task+ ${truncateDisplay(input?.subject || '?', 50)}`;
     case 'TaskUpdate':
       return `Task~ #${input?.taskId || '?'} -> ${input?.status || '?'}`;
     case 'EnterWorktree':
@@ -211,7 +197,7 @@ export function formatPhaseMarker(marker: PhaseMarker): string {
   if (fields.issues_filed) parts.push(`${fields.issues_filed} issues filed`);
   if (fields.lessons) parts.push(fields.lessons);
 
-  return truncate(parts.join(' '), 120);
+  return truncateDisplay(parts.join(' '), 120);
 }
 
 // Artifact extraction from agent output


### PR DESCRIPTION
## Problem

Auto-dent display text had several small local truncation mechanisms: stream formatting owned `truncate()`/`collapseWhitespace()`, run title generation owned `truncateAtWord()`, and analyze summaries used inline `slice()` truncation. These are the same runtime concern - bounded, single-line human-readable summaries - but they could drift independently.

Fixes #1348
Related: #1164
Related: #1208

## Solution

- Added `scripts/auto-dent-display.ts` as the shared owner for Auto-dent display text helpers:
  - `collapseWhitespace`
  - `truncateDisplay`
  - `truncateAtWordBoundary`
- Routed `auto-dent-stream` through the shared helpers while preserving its exported `collapseWhitespace` name.
- Kept `auto-dent-run`'s exported `truncateAtWord` API as a compatibility alias over the shared word-boundary helper.
- Routed compatible `auto-dent-analyze` summary truncation through `truncateDisplay`.
- Added an invariant test so migrated files do not reintroduce private generic truncators.

## Validation

- RED: `npm test -- --run scripts/auto-dent-display.test.ts` initially failed because `auto-dent-display` did not exist.
- GREEN:
  - `npm test -- --run scripts/auto-dent-display.test.ts scripts/auto-dent-stream.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-analyze.test.ts`
  - `npm test -- --run scripts/auto-dent-*.test.ts` (20 files, 963 passed, 2 skipped)
  - `npm run typecheck`
  - `git diff --check`
