### PR TITLE
fix(hooks): anchor isGitCommand/isGhPrCommand alternation — close substring gate bypass (#1350)

### DIFF
--- a/src/hooks/lib/allowlist.test.ts
+++ b/src/hooks/lib/allowlist.test.ts
@@ -81,6 +81,19 @@ describe('isReadonlyMonitoringCommand', () => {
     expect(isReadonlyMonitoringCommand('git status | grep main')).toBe(true);
     expect(isReadonlyMonitoringCommand('cd .\ngit status')).toBe(true);
   });
+
+  // #1350: isGitCommand's alternation was unanchored, so a blocking command that
+  // merely CONTAINS a readonly subcommand substring (branch/log/show/status/...)
+  // was classified as a readonly git command and sailed through every gate.
+  it('does not allow a blocking command that merely contains a git subcommand substring (#1350)', () => {
+    expect(isReadonlyMonitoringCommand('rm -rf branch-backups')).toBe(false);
+    expect(isReadonlyMonitoringCommand('git push origin show')).toBe(false);
+    expect(isReadonlyMonitoringCommand('docker rm show')).toBe(false);
+    expect(isReadonlyMonitoringCommand('make deploy-log')).toBe(false);
+    // ...and the same blocking commands are rejected by the review/kaizen gates.
+    expect(isReviewCommand('rm -rf branch-backups')).toBe(false);
+    expect(isKaizenCommand('git push origin show')).toBe(false);
+  });
 });
 
 describe('isReviewCommand', () => {

--- a/src/hooks/parse-command.test.ts
+++ b/src/hooks/parse-command.test.ts
@@ -173,7 +173,8 @@ describe('isGitCommand', () => {
       expect(isGitCommand('git push origin show', READONLY)).toBe(false);
       expect(isGitCommand('docker rm show', READONLY)).toBe(false);
       expect(isGitCommand('make deploy-log', READONLY)).toBe(false);
-      expect(isGitCommand('kubectl delete statefulset', READONLY)).toBe(false);
+      // contains the literal substring "status" — flips OLD true -> NEW false
+      expect(isGitCommand('echo status', READONLY)).toBe(false);
     });
 
     it('still matches every real git read-only subcommand', () => {

--- a/src/hooks/parse-command.test.ts
+++ b/src/hooks/parse-command.test.ts
@@ -122,6 +122,13 @@ describe('isGhPrCommand', () => {
     expect(isGhPrCommand(cmd, 'create')).toBe(true);
   });
 
+  it('word-bounds the subcommand so a longer one is not a prefix match (#1350)', () => {
+    // `gh pr difftool` must not match the `diff` subcommand.
+    expect(isGhPrCommand('gh pr difftool 42', 'diff')).toBe(false);
+    expect(isGhPrCommand('gh pr diff 42', 'diff')).toBe(true);
+    expect(isGhPrCommand('gh pr view 42', 'diff|view|comment|edit')).toBe(true);
+  });
+
   it('detects gh pr create when backslash-continued across lines (#1013)', () => {
     const cmd = `export PATH="/x"\ngh pr create \\\n  --repo R \\\n  --title x`;
     expect(isGhPrCommand(cmd, 'create')).toBe(true);
@@ -152,6 +159,38 @@ describe('isGitCommand', () => {
     expect(
       isGitCommand('export PATH=/x\ngit push -u origin main', 'push'),
     ).toBe(true);
+  });
+
+  // #1350: the alternation was unanchored, so every alternative after the first
+  // matched as a bare substring anywhere in the segment. Any command merely
+  // CONTAINING `log`/`show`/`status`/`branch`/`fetch` was treated as a readonly
+  // git command — a gate bypass.
+  describe('grouped + word-bounded alternation (#1350)', () => {
+    const READONLY = 'diff|log|show|status|branch|fetch';
+
+    it('does not match a non-git command that contains a subcommand substring', () => {
+      expect(isGitCommand('rm -rf branch-backups', READONLY)).toBe(false);
+      expect(isGitCommand('git push origin show', READONLY)).toBe(false);
+      expect(isGitCommand('docker rm show', READONLY)).toBe(false);
+      expect(isGitCommand('make deploy-log', READONLY)).toBe(false);
+      expect(isGitCommand('kubectl delete statefulset', READONLY)).toBe(false);
+    });
+
+    it('still matches every real git read-only subcommand', () => {
+      expect(isGitCommand('git diff', READONLY)).toBe(true);
+      expect(isGitCommand('git log --oneline', READONLY)).toBe(true);
+      expect(isGitCommand('git show HEAD', READONLY)).toBe(true);
+      expect(isGitCommand('git status', READONLY)).toBe(true);
+      expect(isGitCommand('git branch -a', READONLY)).toBe(true);
+      expect(isGitCommand('git fetch origin', READONLY)).toBe(true);
+      expect(isGitCommand('git -C /some/path show HEAD', READONLY)).toBe(true);
+    });
+
+    it('word-bounds so a longer subcommand is not matched as a prefix', () => {
+      // `git difftool` is interactive, not the readonly `diff`.
+      expect(isGitCommand('git difftool', 'diff')).toBe(false);
+      expect(isGitCommand('git diff', 'diff')).toBe(true);
+    });
   });
 });
 

--- a/src/hooks/parse-command.ts
+++ b/src/hooks/parse-command.ts
@@ -63,7 +63,11 @@ export function splitCommandSegments(cmdLine: string): string[] {
  */
 export function isGhPrCommand(cmdLine: string, subcommand: string): boolean {
   const segments = splitCommandSegments(cmdLine);
-  const pattern = new RegExp(`^gh\\s+pr\\s+(${subcommand})`);
+  // The alternation MUST be grouped and word-bounded: a bare `${subcommand}`
+  // would (a) bind the `^gh\s+pr\s+` anchor only to the first alternative and
+  // (b) match a longer subcommand by prefix (e.g. `gh pr difftool` as `diff`).
+  // See isGitCommand for the full failure mode (#1350).
+  const pattern = new RegExp(`^gh\\s+pr\\s+(${subcommand})\\b`);
   return segments.some((seg) => pattern.test(seg));
 }
 
@@ -73,7 +77,15 @@ export function isGhPrCommand(cmdLine: string, subcommand: string): boolean {
  */
 export function isGitCommand(cmdLine: string, subcommand: string): boolean {
   const segments = splitCommandSegments(cmdLine);
-  const pattern = new RegExp(`^git\\s+(-C\\s+\\S+\\s+)?${subcommand}`);
+  // The alternation MUST be wrapped in a group, or `|` (lowest precedence)
+  // makes the `^git\s+(-C…)?` anchor bind only to the FIRST alternative and
+  // every later alternative becomes a bare, unanchored substring match. With
+  // subcommand='diff|log|show|status|branch|fetch' that classified
+  // `rm -rf branch-backups`, `git push origin show`, `docker rm show`, and
+  // `make deploy-log` as a readonly git command — a gate bypass (#1350). The
+  // trailing `\b` also stops a longer command (`git difftool`) from matching a
+  // bare subcommand (`diff`).
+  const pattern = new RegExp(`^git\\s+(-C\\s+\\S+\\s+)?(${subcommand})\\b`);
   return segments.some((seg) => pattern.test(seg));
 }
 


### PR DESCRIPTION
## Problem

PR #1347 correctly made the PR-review/reflect gate decision **AND-over-segments** (a compound command passes only if *every* statement is benign). But that combinator is only as strong as the per-segment predicates it calls — and one of them was quietly defeating the whole gate.

## Discovery

While reviewing the #1344/#1347 fix, an adversarial check found that `isGitCommand` in `src/hooks/parse-command.ts` built its matcher like this:

```ts
new RegExp(`^git\\s+(-C\\s+\\S+\\s+)?${subcommand}`)   // subcommand = 'diff|log|show|status|branch|fetch'
```

`|` has the lowest precedence in a regex, and the alternation was **not wrapped in a group**. So the pattern actually parsed as:

```
(^git\s+(-C…)?diff)  OR  log  OR  show  OR  status  OR  branch  OR  fetch
```

Every alternative after `diff` became a **bare, unanchored substring** matching anywhere in the segment. Reproduced empirically against current `main` (post-#1347):

```
isReadonlyMonitoringCommand('rm -rf branch-backups')  === true   // contains "branch"
isReadonlyMonitoringCommand('git push origin show')   === true   // contains "show"
isReadonlyMonitoringCommand('docker rm show')         === true   // contains "show"
isReadonlyMonitoringCommand('make deploy-log')        === true   // contains "log"
```

All three gate classifiers (`isReadonlyMonitoringCommand` / `isReviewCommand` / `isKaizenCommand`) returned ALLOW for these. During an active `needs_review` / `needs_pr_kaizen` gate, an agent could run an arbitrary blocking command whose text merely *contained* `branch`/`log`/`show`/`status`/`fetch` and the gate's fast-path would wave it through.

## Solution

Group the alternation and add a trailing word boundary in the shared `parse-command` primitive:

```ts
new RegExp(`^git\\s+(-C\\s+\\S+\\s+)?(${subcommand})\\b`)
```

- The **group** makes the `^git\s+…` anchor bind to *every* alternative, not just the first.
- The **`\b`** stops a longer command (`git difftool`) from matching a bare subcommand (`diff`).

The same `\b` is applied to `isGhPrCommand` for parity. Fixing the primitive repairs the predicate for **every** gate caller (allowlist classifiers + all gate detectors), so this is complementary to #1347's combinator — it hardens the predicate that combinator depends on.

## Evidence

| Behavior | Level | Test |
|----------|-------|------|
| Non-git command containing a subcommand substring is NOT a git command | Unit | `parse-command.test.ts` — `rm -rf branch-backups`, `git push origin show`, `docker rm show`, `make deploy-log`, `echo status` → false |
| Real git read-only subcommands still match | Unit | `parse-command.test.ts` — `git diff/log/show/status/branch/fetch`, `git -C /p show HEAD` → true |
| Word boundary: `git difftool` ≠ `diff`; `gh pr difftool` ≠ `diff` | Unit | `parse-command.test.ts` |
| Gate classifiers block the bypass commands end-to-end | Unit | `allowlist.test.ts` — `isReadonlyMonitoringCommand`/`isReviewCommand`/`isKaizenCommand` of the bypass examples → false |
| No regression for any existing caller | Unit | full hooks suite: **849 tests pass** (callers pass single-word subcommands; the change only adds a safe `\b`) |

`npx tsc --noEmit` clean. `npx vitest run src/hooks/` → 849 passing.

## Impact

Closes a real gate bypass that survived #1344/#1347: blocking commands can no longer slip past a review/reflect gate by containing a readonly git subcommand as a substring. Directly in service of "correct gate handling" — the gate's per-segment classifier is now as strict as its AND-over-segments combinator.

Closes #1350
Refs #1344, #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)
