### PR TITLE
refactor(hooks): share transcript evidence truncation

### DIFF
--- a/src/analysis/util.test.ts
+++ b/src/analysis/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { truncate, isTestFile } from './util.js';
+import { truncate, truncateAfterPrefix, isTestFile } from './util.js';
 
 describe('truncate', () => {
   it('returns string unchanged when under maxLen', () => {
@@ -16,6 +16,20 @@ describe('truncate', () => {
 
   it('handles empty string', () => {
     expect(truncate('', 5)).toBe('');
+  });
+});
+
+describe('truncateAfterPrefix', () => {
+  it('returns string unchanged when under prefix length', () => {
+    expect(truncateAfterPrefix('hello', 10)).toBe('hello');
+  });
+
+  it('returns string unchanged when exactly prefix length', () => {
+    expect(truncateAfterPrefix('12345', 5)).toBe('12345');
+  });
+
+  it('appends ellipsis after the visible prefix when over prefix length', () => {
+    expect(truncateAfterPrefix('123456', 5)).toBe('12345...');
   });
 });
 

--- a/src/analysis/util.ts
+++ b/src/analysis/util.ts
@@ -3,6 +3,16 @@ export function truncate(s: string, maxLen: number): string {
   return s.length > maxLen ? s.slice(0, maxLen - 3) + '...' : s;
 }
 
+/**
+ * Truncate after a visible prefix, then append "...".
+ *
+ * This preserves the transcript-analysis evidence contract (#1351): callers
+ * choose how many source characters remain visible before the ellipsis.
+ */
+export function truncateAfterPrefix(s: string, prefixLen: number): string {
+  return s.length > prefixLen ? s.slice(0, prefixLen) + '...' : s;
+}
+
 /** Check if a file path is a test file (path-segment aware, not substring). */
 export function isTestFile(path: string): boolean {
   return (

--- a/src/hooks/transcript-analysis.test.ts
+++ b/src/hooks/transcript-analysis.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
@@ -49,6 +49,13 @@ describe('parseTranscript', () => {
       '{"type":"user"}\nnot-json\n{"type":"assistant"}';
     const entries = parseTranscript(jsonl);
     expect(entries).toHaveLength(2);
+  });
+});
+
+describe('truncation ownership (#1351)', () => {
+  it('does not keep a private generic truncate helper in transcript analysis', () => {
+    const source = readFileSync('src/hooks/transcript-analysis.ts', 'utf8');
+    expect(source).not.toMatch(/function\s+truncate\s*\(/);
   });
 });
 

--- a/src/hooks/transcript-analysis.ts
+++ b/src/hooks/transcript-analysis.ts
@@ -13,6 +13,7 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { truncateAfterPrefix } from '../analysis/util.js';
 
 // ── Types ──
 
@@ -119,7 +120,7 @@ function detectRetries(
       signals.push({
         type: 'retry',
         description: `Retried ${curr.name} after failure`,
-        evidence: `Previous: ${truncate(prev.input, 100)} | Current: ${truncate(curr.input, 100)}`,
+        evidence: `Previous: ${truncateAfterPrefix(prev.input, 100)} | Current: ${truncateAfterPrefix(curr.input, 100)}`,
       });
     }
   }
@@ -131,10 +132,6 @@ function similarCommands(a: string, b: string): boolean {
   const baseA = a.split(/\s+/).slice(0, 2).join(' ');
   const baseB = b.split(/\s+/).slice(0, 2).join(' ');
   return baseA === baseB;
-}
-
-function truncate(s: string, max: number): string {
-  return s.length <= max ? s : s.slice(0, max) + '...';
 }
 
 // ── Repeated request detection ──
@@ -151,7 +148,7 @@ function detectRepeatedRequests(userMessages: string[]): Signal[] {
       signals.push({
         type: 'repeated_request',
         description: 'User referenced a previous request that was not addressed',
-        evidence: truncate(msg, 200),
+        evidence: truncateAfterPrefix(msg, 200),
       });
     }
   }
@@ -211,7 +208,7 @@ export function analyzeTranscript(entries: TranscriptEntry[]): TranscriptAnalysi
             signals.push({
               type: 'user_correction',
               description: 'User corrected or pushed back on agent approach',
-              evidence: truncate(block.text, 200),
+              evidence: truncateAfterPrefix(block.text, 200),
             });
           }
         }
@@ -224,7 +221,7 @@ export function analyzeTranscript(entries: TranscriptEntry[]): TranscriptAnalysi
             signals.push({
               type: 'failed_tool_call',
               description: 'Tool call failed',
-              evidence: truncate(resultContent, 200),
+              evidence: truncateAfterPrefix(resultContent, 200),
             });
 
             // Only check for hook denials on error results — successful tool
@@ -235,7 +232,7 @@ export function analyzeTranscript(entries: TranscriptEntry[]): TranscriptAnalysi
               signals.push({
                 type: 'hook_denial',
                 description: 'Hook blocked an action (near-miss caught by L2)',
-                evidence: truncate(resultContent, 200),
+                evidence: truncateAfterPrefix(resultContent, 200),
               });
             }
           }


### PR DESCRIPTION
## Summary

Fixes #1351.
Related #1164.
Related #1348.

This extracts the transcript-analysis evidence truncation contract into `src/analysis/util.ts` as `truncateAfterPrefix()`, then routes transcript-analysis call sites through that shared helper. The existing transcript evidence behavior is preserved: callers choose the visible prefix length and the helper appends `...` only when truncation happens.

## Validation

- RED: `npm test -- --run src/analysis/util.test.ts src/hooks/transcript-analysis.test.ts` failed before implementation because `truncateAfterPrefix` was missing and the private transcript helper still existed.
- GREEN: `npm test -- --run src/analysis/util.test.ts src/hooks/transcript-analysis.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`

## Branch provenance

- Created in a fresh worktree from `origin/main`.
- Pre-push check found no remote branch and no existing PR for `case/260628-k1351-transcript-truncate-util`.
- Branch merge-base before push was `origin/main` (`34cd01091116a97db0f1939429ea3e0d35217a46`).