### PR TITLE
refactor(auto-dent): share history guidance truncation

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -1100,6 +1100,36 @@ describe('formatAggregateStats', () => {
     expect(output).toContain('Recent batches');
     expect(output).toContain('b1');
   });
+
+  it('formats recent-batch guidance through the shared display helper (#1354)', () => {
+    const stats = computeAggregateStats([{
+      batch_id: 'b1',
+      guidance: 'focus on hooks reliability and review evidence quality',
+      batch_start: 1742680800,
+      batch_end: 1742684400,
+      total_runs: 5,
+      successful_runs: 3,
+      success_rate: 0.6,
+      total_cost_usd: 10,
+      total_prs: 3,
+      total_issues_closed: 2,
+      total_issues_filed: 1,
+      total_duration_seconds: 1500,
+      stop_reason: 'completed',
+      mode_breakdown: { exploit: { runs: 5, successes: 3, prs: 3, cost: 10 } },
+      issues_attempted: [],
+      prs: [],
+      recorded_at: '2026-03-22T00:00:00.000Z',
+    }]);
+
+    const output = formatAggregateStats(stats);
+    expect(output).toContain('| b1 | focus on hooks reliability and review... |');
+  });
+
+  it('does not keep private guidance truncation logic in aggregate stats (#1354)', () => {
+    const source = readFileSync('scripts/auto-dent-ctl.ts', 'utf8');
+    expect(source).not.toMatch(/guidance\.slice\(0,\s*37\)\s*\+\s*['"]\.\.\.['"]/);
+  });
 });
 
 describe('buildSteerOutput — cloud-backed steer command (#940 Phase 2)', () => {

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -40,6 +40,7 @@ import {
   formatSteeringReport,
   type ReadOutcomesDeps,
 } from './batch-outcome.js';
+import { truncateDisplay } from './auto-dent-display.js';
 
 function getRepoRoot(): string {
   try {
@@ -988,7 +989,7 @@ export function formatAggregateStats(stats: AggregateStats): string {
     lines.push('| Batch | Guidance | Runs | PRs | Cost | Success |');
     lines.push('|-------|----------|------|-----|------|---------|');
     for (const b of stats.recentBatches) {
-      const guidance = b.guidance.length > 40 ? b.guidance.slice(0, 37) + '...' : b.guidance;
+      const guidance = truncateDisplay(b.guidance, 40, { ellipsis: '...' });
       lines.push(`| ${b.batch_id} | ${guidance} | ${b.runs} | ${b.prs} | $${b.cost.toFixed(2)} | ${(b.success_rate * 100).toFixed(0)}% |`);
     }
   }


### PR DESCRIPTION
## Summary

Fixes #1354.
Related #1164.
Related #1348.

`formatAggregateStats()` now routes recent-batch guidance cells through `truncateDisplay()` instead of keeping its own `guidance.slice(0, 37) + '...'` expression. The existing 40-character table budget and ASCII ellipsis output stay stable via `truncateDisplay(b.guidance, 40, { ellipsis: '...' })`.

## Validation

- RED: `npm test -- --run scripts/auto-dent-ctl.test.ts` failed before implementation on the new ownership test because the inline guidance truncation still existed.
- GREEN: `npm test -- --run scripts/auto-dent-ctl.test.ts scripts/auto-dent-display.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`
- GREEN: `rg -n "guidance\.slice|slice\(0, 37\) \+ '\.\.\.'" scripts/auto-dent-ctl.ts` returned no matches.

## Branch provenance

- Created in a fresh worktree from `origin/main`.
- Pre-push check found no remote branch and no existing PR for `case/260628-k1354-auto-dent-guidance-display`.
- Branch merge-base before push was `origin/main` (`d2a9f884502bd42802e619d6cfce07cb1de3096f`).