### PR TITLE
refactor(auto-dent): share markdown table cell escaping

### DIFF
--- a/scripts/auto-dent-provider-capabilities.ts
+++ b/scripts/auto-dent-provider-capabilities.ts
@@ -6,6 +6,8 @@
  * runtime behavior; later provider-aware phases can consume the same inventory.
  */
 
+import { escapeMarkdownTableCell } from './markdown-table.js';
+
 export const AUTO_DENT_PHASES = [
   'planning',
   'implementation',
@@ -197,7 +199,7 @@ export function renderProviderCapabilityMatrix(matrix: ProviderCapabilityMatrix)
       row.phaseFit.reflection,
       row.phaseFit.validation,
       row.notes,
-    ].map(escapeCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+    ].map(escapeMarkdownTableCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
   }
 
   return lines.join('\n');
@@ -212,13 +214,6 @@ function providerLabel(provider: AgentProvider): string {
     case 'provider-independent':
       return 'Provider-independent';
   }
-}
-
-function escapeCell(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/\|/g, '\\|')
-    .replace(/\n/g, ' ');
 }
 
 const isDirectRun = process.argv[1]?.endsWith('auto-dent-provider-capabilities.ts') ||

--- a/scripts/auto-dent-provider-matrix.test.ts
+++ b/scripts/auto-dent-provider-matrix.test.ts
@@ -19,6 +19,14 @@ import {
 } from './auto-dent-provider-matrix.js';
 
 describe('provider comparison matrix (#1152)', () => {
+  it('uses the shared Markdown table cell escaping helper for provider tables (#1356)', () => {
+    const capabilitySource = readFileSync('scripts/auto-dent-provider-capabilities.ts', 'utf8');
+    const matrixSource = readFileSync('scripts/auto-dent-provider-matrix.ts', 'utf8');
+
+    expect(capabilitySource).not.toMatch(/function\s+escapeCell\s*\(/);
+    expect(matrixSource).not.toMatch(/function\s+escapeMarkdownCell\s*\(/);
+  });
+
   it('dry-run renders all required provider strategies with phase-level provider records', () => {
     const scenarios = providerComparisonScenarios();
 

--- a/scripts/auto-dent-provider-matrix.ts
+++ b/scripts/auto-dent-provider-matrix.ts
@@ -21,6 +21,7 @@ import {
   validateProviderPlan,
 } from './auto-dent-provider.js';
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
+import { escapeMarkdownTableCell } from './markdown-table.js';
 
 export type ReviewQuality = 'strong' | 'adequate' | 'weak' | 'missing';
 export type CostSignal = 'available' | 'partial' | 'missing';
@@ -422,13 +423,6 @@ function formatRate(value: number): string {
   return `${Math.round(value * 100)}%`;
 }
 
-function escapeMarkdownCell(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/\|/g, '\\|')
-    .replace(/\n/g, ' ');
-}
-
 export function formatProviderComparisonReport(artifact: ProviderComparisonArtifact): string {
   const lines: string[] = [];
   lines.push(`## Provider Comparison Matrix: ${artifact.batchId}`);
@@ -448,7 +442,7 @@ export function formatProviderComparisonReport(artifact: ProviderComparisonArtif
       phaseCell(result.phaseProviders, 'validation'),
       result.processVerdict,
       result.failureClass ?? 'none',
-    ].map(escapeMarkdownCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+    ].map(escapeMarkdownTableCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
   }
 
   lines.push('');
@@ -465,7 +459,7 @@ export function formatProviderComparisonReport(artifact: ProviderComparisonArtif
       result.metrics.costSignal,
       String(result.metrics.hookRejections),
       result.metrics.operatorInspectability,
-    ].map(escapeMarkdownCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+    ].map(escapeMarkdownTableCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
   }
 
   lines.push('');

--- a/scripts/markdown-table.test.ts
+++ b/scripts/markdown-table.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { escapeMarkdownTableCell } from './markdown-table.js';
+
+describe('escapeMarkdownTableCell', () => {
+  it('escapes backslashes, pipes, and newlines for Markdown table cells (#1356)', () => {
+    expect(escapeMarkdownTableCell('Pipe | Backslash \\')).toBe('Pipe \\| Backslash \\\\');
+    expect(escapeMarkdownTableCell('line one\nline | two \\')).toBe('line one line \\| two \\\\');
+  });
+
+  it('leaves ordinary cell text unchanged', () => {
+    expect(escapeMarkdownTableCell('provider-independent')).toBe('provider-independent');
+  });
+});

--- a/scripts/markdown-table.ts
+++ b/scripts/markdown-table.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared Markdown table formatting helpers for generated runtime reports.
+ */
+
+export function escapeMarkdownTableCell(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ');
+}


### PR DESCRIPTION
## Summary

Fixes #1356.
Related #1164.
Related #1348.
Related #1155.
Related #1190.

This extracts the duplicated Markdown table cell escaping contract from the provider capability and provider comparison renderers into `scripts/markdown-table.ts`. Both provider table renderers now share the same backslash, pipe, and newline escaping helper while preserving their existing output.

Hook Gym has a related but slightly different table-row helper that also handles carriage returns; this PR keeps that behavior separate instead of silently changing it.

## Validation

- RED: `npm test -- --run scripts/markdown-table.test.ts scripts/auto-dent-provider-capabilities.test.ts scripts/auto-dent-provider-matrix.test.ts` failed before implementation because the shared helper module was missing and private provider helper ownership still existed.
- GREEN: `npm test -- --run scripts/markdown-table.test.ts scripts/auto-dent-provider-capabilities.test.ts scripts/auto-dent-provider-matrix.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`
- GREEN: `rg -n "function escapeCell|function escapeMarkdownCell|escapeCell\(|escapeMarkdownCell\(" scripts/auto-dent-provider-capabilities.ts scripts/auto-dent-provider-matrix.ts` returned no matches.

## Branch provenance

- Created in a fresh worktree from `origin/main`.
- Pre-push check found no remote branch and no existing PR for `case/260628-k1356-markdown-cell-escape`.
- Branch merge-base before push was `origin/main` (`3abc8b8640c1d73835740aa688bd15c2a3f90335`).
- Stored plan and test plan are attached to #1356.