### PR TITLE
refactor(hooks): share hook gym table escaping

### DIFF
--- a/scripts/hook-gym-format.test.ts
+++ b/scripts/hook-gym-format.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
 import type { HookTimeline } from './hook-gym-schema.js';
 import { formatTimeline, summarizeTimeline } from './hook-gym-format.js';
 import { evt } from './hook-gym-test-utils.js';
@@ -63,22 +64,27 @@ describe('formatTimeline', () => {
     expect(formatTimeline(timeline)).toContain('| 0 | SessionStart | SessionStart:s | none | 3 | — |');
   });
 
-  it('escapes pipe characters in hook names and reasons so the table does not break', () => {
+  it('escapes table-breaking characters in hook names and reasons so the table does not break', () => {
     const timeline: HookTimeline = {
       events: [
         evt({
           timestamp: 1,
-          hookName: 'weird|hook',
+          hookName: 'weird|hook\\name',
           decision: 'deny',
-          reason: 'contains | pipes | everywhere',
+          reason: 'contains | pipes\nand carriage\rreturns \\ everywhere',
         }),
       ],
       gatesActivated: {},
       gatesCleared: {},
     };
     const out = formatTimeline(timeline);
-    expect(out).toContain('weird\\|hook');
-    expect(out).toContain('contains \\| pipes \\| everywhere');
+    expect(out).toContain('weird\\|hook\\\\name');
+    expect(out).toContain('contains \\| pipes and carriagereturns \\\\ everywhere');
+  });
+
+  it('uses the shared Markdown table helper instead of a private escape helper (#1360)', () => {
+    const source = readFileSync('scripts/hook-gym-format.ts', 'utf8');
+    expect(source).not.toMatch(/function\s+escape\s*\(/);
   });
 
   it('truncates very long reasons', () => {

--- a/scripts/hook-gym-format.ts
+++ b/scripts/hook-gym-format.ts
@@ -9,6 +9,7 @@
  * Pure function — no I/O, no clock. Deterministic output for a given input.
  */
 
+import { escapeMarkdownTableCell } from './markdown-table.js';
 import type { HookTimeline, ParsedHookEvent } from './hook-gym-schema.js';
 
 /**
@@ -69,7 +70,9 @@ function renderEventRow(e: ParsedHookEvent): string {
   const decision = e.decision ?? 'none';
   const reason = e.reason ? truncate(e.reason, 60) : '—';
   const hook = e.hookName || e.eventType;
-  return `| ${e.timestamp} | ${e.eventType} | ${escape(hook)} | ${decision} | ${e.durationMs} | ${escape(reason)} |`;
+  const escapedHook = escapeMarkdownTableCell(hook, { carriageReturn: 'drop' });
+  const escapedReason = escapeMarkdownTableCell(reason, { carriageReturn: 'drop' });
+  return `| ${e.timestamp} | ${e.eventType} | ${escapedHook} | ${decision} | ${e.durationMs} | ${escapedReason} |`;
 }
 
 function formatGateLine(name: string, t: HookTimeline): string {
@@ -87,21 +90,6 @@ function formatGateLine(name: string, t: HookTimeline): string {
     return `**${name}**: cleared @${cleared}ms (no activation observed this run)`;
   }
   return `**${name}**: (unknown)`;
-}
-
-function escape(s: string): string {
-  // Replace all characters that could break a Markdown table row in one pass.
-  // CodeQL js/regex/incomplete-sanitization flags chained .replace() calls
-  // that don't cover all members of a meta-character group.
-  return s.replace(/[\|\n\r\\]/g, (ch) => {
-    switch (ch) {
-      case '|': return '\\|';
-      case '\\': return '\\\\';
-      case '\n': return ' ';
-      case '\r': return '';
-      default: return ch;
-    }
-  });
 }
 
 function truncate(s: string, max: number): string {

--- a/scripts/markdown-table.test.ts
+++ b/scripts/markdown-table.test.ts
@@ -10,4 +10,9 @@ describe('escapeMarkdownTableCell', () => {
   it('leaves ordinary cell text unchanged', () => {
     expect(escapeMarkdownTableCell('provider-independent')).toBe('provider-independent');
   });
+
+  it('can drop carriage returns for timeline table cells without changing the default (#1360)', () => {
+    expect(escapeMarkdownTableCell('a\rb')).toBe('a\rb');
+    expect(escapeMarkdownTableCell('a\rb', { carriageReturn: 'drop' })).toBe('ab');
+  });
 });

--- a/scripts/markdown-table.ts
+++ b/scripts/markdown-table.ts
@@ -2,9 +2,22 @@
  * Shared Markdown table formatting helpers for generated runtime reports.
  */
 
-export function escapeMarkdownTableCell(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/\|/g, '\\|')
-    .replace(/\n/g, ' ');
+export interface MarkdownTableCellOptions {
+  carriageReturn?: 'preserve' | 'drop';
+}
+
+export function escapeMarkdownTableCell(
+  value: string,
+  options: MarkdownTableCellOptions = {},
+): string {
+  const carriageReturn = options.carriageReturn ?? 'preserve';
+  return value.replace(/[\|\n\r\\]/g, (ch) => {
+    switch (ch) {
+      case '|': return '\\|';
+      case '\\': return '\\\\';
+      case '\n': return ' ';
+      case '\r': return carriageReturn === 'drop' ? '' : '\r';
+      default: return ch;
+    }
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #1360.
Related #1356.
Related #1164.
Related #1348.

This moves Hook Gym timeline table-cell escaping onto the shared `escapeMarkdownTableCell()` helper introduced in #1356/#1359. The helper now has an explicit `carriageReturn` policy: provider tables keep the default behavior, while Hook Gym asks to drop carriage returns to preserve its prior timeline output contract.

This does not change Hook Gym reason truncation.

## Validation

- RED: `npm test -- --run scripts/markdown-table.test.ts scripts/hook-gym-format.test.ts` failed before implementation because the shared helper lacked the carriage-return option and Hook Gym still had a private `escape()` helper.
- GREEN: `npm test -- --run scripts/markdown-table.test.ts scripts/hook-gym-format.test.ts scripts/auto-dent-provider-capabilities.test.ts scripts/auto-dent-provider-matrix.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`
- GREEN: `rg -n "function escape\s*\(" scripts/hook-gym-format.ts` returned no matches.

## Branch provenance

- Created in a fresh worktree from `origin/main`.
- Pre-push check found no remote branch and no existing PR for `case/260628-k1360-hook-gym-table-escape`.
- Branch merge-base before push was `origin/main` (`74f5feb22b80f1c8c0cd280da1a7f4359a751c43`).
- Stored plan and test plan are attached to #1360.