### PR TITLE
refactor(review): share finding metadata extraction

### DIFF
--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -7,6 +7,7 @@ import {
   storeMetadata,
   storeReviewFinding,
   storeReviewSummary,
+  readReviewFinding,
 } from './structured-data.js';
 
 vi.mock('node:fs', () => ({
@@ -228,6 +229,37 @@ describe('store-review-batch — review sentinel', () => {
       dimensionCount: 2,
     });
     expect(payload.integrity).toMatch(/^sha256:/);
+  });
+
+  it('derives sentinel totals through the shared review finding metadata contract (#1362)', async () => {
+    vi.mocked(readReviewFinding).mockImplementation((_target, _round, dim) =>
+      `leading text\n<!-- meta:{"round":1,"dimension":"${dim}","verdict":"pass","done":2,"partial":1,"missing":0} -->\n### ${dim}`,
+    );
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await handlers['store-review-batch']({
+      ...baseArgs,
+      text: JSON.stringify([{ dimension: 'dry', verdict: 'pass', summary: 'ok', findings: [] }]),
+    });
+    log.mockRestore();
+
+    const sentinelCall = vi.mocked(writeFileSync).mock.calls.find(
+      ([path]) => typeof path === 'string' && path.includes('.reviewed-r1'),
+    );
+    expect(sentinelCall).toBeDefined();
+    const payload = JSON.parse(String(sentinelCall![1]));
+    expect(payload).toMatchObject({
+      findingCount: 6,
+      totalDone: 4,
+      totalPartial: 2,
+      totalMissing: 0,
+    });
+  });
+
+  it('does not keep a private review finding metadata parser in the CLI (#1362)', async () => {
+    const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const source = fs.readFileSync(new URL('./cli-structured-data.ts', import.meta.url), 'utf8');
+    expect(source).not.toMatch(/function\s+parseFindingMeta\s*\(/);
   });
 
   it('sentinel path encodes PR number and repo', async () => {

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -64,7 +64,12 @@ import {
   buildReviewSentinelRecord,
   serializeReviewSentinel,
 } from './review-sentinel.js';
-import { normalizeReviewFindingData, validateReviewFindingPayload, summarizeFindingStatuses } from './review-finding-contract.js';
+import {
+  normalizeReviewFindingData,
+  validateReviewFindingPayload,
+  summarizeFindingStatuses,
+  extractReviewFindingMeta,
+} from './review-finding-contract.js';
 
 export type CliArgs = Record<string, string> & { command: string };
 type Handler = (a: CliArgs) => Promise<void>;
@@ -128,21 +133,6 @@ export function resolveRound(a: CliArgs): number {
   return 1;
 }
 
-function parseFindingMeta(content: string): { done: number; partial: number; missing: number } | null {
-  const match = content.match(/^<!-- meta:(\{.*\}) -->/);
-  if (!match) return null;
-  try {
-    const meta = JSON.parse(match[1]) as { done?: number; partial?: number; missing?: number };
-    return {
-      done: Number.isInteger(meta.done) ? meta.done! : 0,
-      partial: Number.isInteger(meta.partial) ? meta.partial! : 0,
-      missing: Number.isInteger(meta.missing) ? meta.missing! : 0,
-    };
-  } catch {
-    return null;
-  }
-}
-
 function writeReviewSentinel(repo: string, pr: string | undefined, round: number): void {
   if (!pr) return;
   try {
@@ -153,7 +143,7 @@ function writeReviewSentinel(repo: string, pr: string | undefined, round: number
     const totals = dimensionsReviewed.reduce(
       (acc, dim) => {
         const content = readReviewFinding(target, round, dim);
-        const meta = content ? parseFindingMeta(content) : null;
+        const meta = content ? extractReviewFindingMeta(content) : null;
         if (!meta) return acc;
         acc.totalDone += meta.done;
         acc.totalPartial += meta.partial;


### PR DESCRIPTION
## Summary

Fixes #1362.
Related #1039.
Related #966.
Related #1164.

This removes the private review-finding metadata parser from `cli-structured-data.ts` and routes review sentinel totals through `extractReviewFindingMeta()` from `review-finding-contract.ts`. `structured-data.ts` already used that contract; now the CLI sentinel path consumes the same schema owner too.

## Validation

- RED: `npm test -- --run src/cli-structured-data.test.ts` failed before implementation because the CLI parser ignored metadata after a leading line and still defined private `parseFindingMeta()`.
- GREEN: `npm test -- --run src/cli-structured-data.test.ts src/structured-data.test.ts src/review-finding-contract.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`
- GREEN: `rg -n "function parseFindingMeta" src/cli-structured-data.ts` returned no matches.

## Branch provenance

- Created in a fresh worktree from `origin/main`.
- Pre-push check found no remote branch and no existing PR for `case/260628-k1362-review-meta-contract`.
- Branch merge-base before push was `origin/main` (`a1d28d17cc52cc6342a870e8f4e9993a4860d53b`).
- Stored plan and test plan are attached to #1362.