### PR TITLE
refactor(review): share prompt frontmatter parsing

### DIFF
--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { parseYamlFrontmatter, readYamlFrontmatter } from './frontmatter.js';
+
+describe('parseYamlFrontmatter', () => {
+  it('returns null when markdown has no leading YAML frontmatter', () => {
+    expect(parseYamlFrontmatter('# Heading\n\nBody')).toBeNull();
+  });
+
+  it('returns null for malformed YAML without throwing', () => {
+    const content = '---\nname: foo: bar\ndescription: nope\n---\nBody';
+    expect(parseYamlFrontmatter(content)).toBeNull();
+  });
+
+  it('parses frontmatter and preserves the markdown body', () => {
+    const content = '---\nname: correctness\napplies_to: pr\nneeds: [diff, issue]\n---\nPrompt body\n';
+
+    const parsed = parseYamlFrontmatter(content);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed!.data).toEqual({
+      name: 'correctness',
+      applies_to: 'pr',
+      needs: ['diff', 'issue'],
+    });
+    expect(parsed!.body).toBe('Prompt body\n');
+  });
+
+  it('accepts CRLF frontmatter delimiters', () => {
+    const parsed = readYamlFrontmatter('---\r\nname: sentinel\r\napplies_to: both\r\n---\r\nBody');
+
+    expect(parsed).toEqual({ name: 'sentinel', applies_to: 'both' });
+  });
+});

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,0 +1,29 @@
+import YAML from 'yaml';
+
+export interface YamlFrontmatter<T extends Record<string, unknown> = Record<string, unknown>> {
+  data: T;
+  body: string;
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/;
+
+export function parseYamlFrontmatter<T extends Record<string, unknown> = Record<string, unknown>>(
+  content: string,
+): YamlFrontmatter<T> | null {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return null;
+
+  try {
+    const parsed = YAML.parse(match[1]);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return { data: parsed as T, body: match[2] ?? '' };
+  } catch {
+    return null;
+  }
+}
+
+export function readYamlFrontmatter<T extends Record<string, unknown> = Record<string, unknown>>(
+  content: string,
+): T | null {
+  return parseYamlFrontmatter<T>(content)?.data ?? null;
+}

--- a/src/review-battery.ts
+++ b/src/review-battery.ts
@@ -14,7 +14,7 @@
 import { spawn } from 'node:child_process';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve, dirname, basename } from 'node:path';
-import YAML from 'yaml';
+import { readYamlFrontmatter } from './lib/frontmatter.js';
 import { resolveProjectRoot, type GitRunner } from './lib/resolve-project-root.js';
 import { retrievePlan, issueTarget } from './structured-data.js';
 import {
@@ -227,13 +227,7 @@ export function reviewBriefing(
  * Returns null if no frontmatter found or YAML is invalid.
  */
 export function parseFrontmatter(content: string): Record<string, unknown> | null {
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return null;
-  try {
-    return YAML.parse(match[1]) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
+  return readYamlFrontmatter(content);
 }
 
 /**

--- a/src/review-sentinel.test.ts
+++ b/src/review-sentinel.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   buildReviewSentinelRecord,
@@ -9,6 +10,13 @@ import {
 const PR_URL = 'https://github.com/Garsson-io/kaizen/pull/997';
 
 describe('review sentinel contract', () => {
+  it('uses the shared YAML frontmatter parser for expected review dimensions', () => {
+    const source = readFileSync('src/review-sentinel.ts', 'utf8');
+
+    expect(source).not.toContain('content.match(/^---\\n');
+    expect(source).not.toContain('YAML.parse(match[1])');
+  });
+
   it('validates a complete structured sentinel', () => {
     const record = buildReviewSentinelRecord({
       prUrl: PR_URL,

--- a/src/review-sentinel.ts
+++ b/src/review-sentinel.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import { resolve } from 'node:path';
-import YAML from 'yaml';
+import { readYamlFrontmatter } from './lib/frontmatter.js';
 import { parseGithubPrUrl } from './lib/github-pr.js';
 import { resolveProjectRoot } from './lib/resolve-project-root.js';
 
@@ -84,9 +84,7 @@ export function expectedPrReviewDimensions(): string[] {
     const files = fs.readdirSync(promptsDir).filter(f => /^review-.*\.md$/.test(f));
     const dimensions = files.flatMap(file => {
       const content = fs.readFileSync(resolve(promptsDir, file), 'utf8');
-      const match = content.match(/^---\n([\s\S]*?)\n---/);
-      if (!match) return [];
-      const frontmatter = YAML.parse(match[1]) as { name?: string; applies_to?: string } | null;
+      const frontmatter = readYamlFrontmatter<{ name?: string; applies_to?: string }>(content);
       if (!frontmatter?.name) return [];
       if (frontmatter.applies_to !== 'pr' && frontmatter.applies_to !== 'both') return [];
       return [frontmatter.name];


### PR DESCRIPTION
## Summary

This PR consolidates review prompt YAML frontmatter parsing behind a shared helper:

- Adds `src/lib/frontmatter.ts` with `parseYamlFrontmatter()` and `readYamlFrontmatter()`.
- Keeps `review-battery`'s public `parseFrontmatter()` wrapper while delegating to the helper.
- Rewires `review-sentinel` expected-dimension discovery away from its local regex/YAML parser.
- Adds focused helper coverage plus a sentinel invariant to prevent this duplicated parser from returning.

Fixes #1366
Related: #1164
Related: #1362

## Validation

- RED first: `npm test -- --run src/lib/frontmatter.test.ts src/review-sentinel.test.ts` failed before implementation due the missing helper and duplicated sentinel parser.
- `npm test -- --run src/lib/frontmatter.test.ts src/review-battery.test.ts src/review-sentinel.test.ts`
- `npm run typecheck`
- `git diff --check`
- `rg -n "content\\.match\\(/\\^---|YAML\\.parse\\(match\\[1\\]\\)" src/review-battery.ts src/review-sentinel.ts` returned no matches.

## Branch Hygiene

Started from a fresh worktree and fresh branch off `origin/main`:

- Worktree: `.claude/worktrees/260628-k1366-review-frontmatter-helper`
- Branch: `case/260628-k1366-review-frontmatter-helper`
- Verified before creation: no local branch, no remote branch, no PR history for the head branch, and no commits/PRs for `#1366`.
