### PR TITLE
refactor(experiment): share markdown frontmatter parsing

### DIFF
--- a/src/cli-experiment.test.ts
+++ b/src/cli-experiment.test.ts
@@ -63,6 +63,13 @@ describe('cli-experiment argument parsing', () => {
 });
 
 describe('parseFrontmatter', () => {
+  test('uses the shared YAML frontmatter parser', () => {
+    const source = fs.readFileSync(CLI_SOURCE, 'utf8');
+
+    expect(source).not.toContain('content.match(/^---\\n');
+    expect(source).not.toContain('YAML.parse(match[1])');
+  });
+
   test('parses experiment file with measurements', () => {
     const content = `---
 id: EXP-001
@@ -99,6 +106,31 @@ Some body text.
     expect(frontmatter.measurements[0].name).toBe('count');
     expect(frontmatter.measurements[0].actual).toBeNull();
     expect(body).toContain('## Context');
+  });
+
+  test('parses CRLF experiment frontmatter and preserves body', () => {
+    const content = [
+      '---',
+      'id: EXP-002',
+      'title: crlf test',
+      'hypothesis: handles CRLF',
+      'falsification: CRLF parse fails',
+      'pattern: probe-and-observe',
+      'status: pending',
+      'issue: 388',
+      'created: 2026-03-21',
+      'completed: null',
+      'result: null',
+      '---',
+      '## Body',
+      '',
+    ].join('\r\n');
+
+    const { frontmatter, body } = parseFrontmatter(content);
+
+    expect(frontmatter.id).toBe('EXP-002');
+    expect(frontmatter.measurements).toEqual([]);
+    expect(body).toBe('## Body\r\n');
   });
 
   test('roundtrips through serialize → parse', () => {

--- a/src/cli-experiment.ts
+++ b/src/cli-experiment.ts
@@ -19,6 +19,7 @@ import path from 'path';
 import YAML from 'yaml';
 
 import { parseExperimentSpec } from './experiment-spec-parser.js';
+import { parseYamlFrontmatter } from './lib/frontmatter.js';
 import { resolveProjectRoot } from './lib/resolve-project-root.js';
 
 // --- Types ---
@@ -76,20 +77,17 @@ export function parseFrontmatter(content: string): {
   frontmatter: ExperimentFrontmatter;
   body: string;
 } {
-  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-  if (!match) {
+  const parsed = parseYamlFrontmatter<Partial<ExperimentFrontmatter>>(content);
+  if (!parsed) {
     throw new Error('Invalid experiment file: no YAML frontmatter found');
   }
 
-  const parsed = YAML.parse(match[1]);
-  const body = match[2];
-
   return {
     frontmatter: {
-      ...parsed,
-      measurements: parsed.measurements ?? [],
+      ...parsed.data,
+      measurements: parsed.data.measurements ?? [],
     } as ExperimentFrontmatter,
-    body,
+    body: parsed.body,
   };
 }
 


### PR DESCRIPTION
## Summary

This PR routes experiment markdown frontmatter parsing through the shared helper added in #1367:

- `cli-experiment.parseFrontmatter()` now delegates to `parseYamlFrontmatter()`.
- The public `{ frontmatter, body }` return shape is preserved.
- Missing-frontmatter failures still throw the existing experiment-specific error.
- `measurements` still defaults to `[]` for older experiment files.
- Added CRLF coverage and a source invariant to keep local split/parse logic from returning.

Fixes #1368
Related: #1366
Related: #1164

## Validation

- RED first: `npm test -- --run src/cli-experiment.test.ts` failed before implementation on the duplicate parser invariant and CRLF frontmatter case.
- `npm test -- --run src/cli-experiment.test.ts src/lib/frontmatter.test.ts`
- `npm run typecheck`
- `git diff --check`
- `rg -n "content\\.match\\(/\\^---|YAML\\.parse\\(match\\[1\\]\\)" src/cli-experiment.ts` returned no matches.

## Branch Hygiene

Started from a fresh worktree and fresh branch off `origin/main`:

- Worktree: `.claude/worktrees/260628-k1368-experiment-frontmatter-helper`
- Branch: `case/260628-k1368-experiment-frontmatter-helper`
- Verified before creation: no local branch, no remote branch, no PR history for the head branch, and no commits/PRs for `#1368`.
