### PR TITLE
refactor(experiment): route frontmatter parsing through shared helper (#1368)

### DIFF
--- a/src/cli-experiment-frontmatter-invariant.test.ts
+++ b/src/cli-experiment-frontmatter-invariant.test.ts
@@ -23,15 +23,26 @@ function stripComments(content: string): string {
 }
 
 /**
- * True when source (comments stripped) contains a local YAML-frontmatter
- * delimiter regex — an anchored `/^---\n` or `/^---\r` regex literal.
+ * True when source (comments stripped) contains local YAML-frontmatter
+ * delimiter split/parse logic. Two shapes are caught:
+ *   (a) a regex literal frontmatter delimiter — `/^---\n`, `/---\n`,
+ *       `/^---\r`, `/---\r` (the `^` anchor is optional);
+ *   (b) a `.split`/`.match`/`.exec`/`.replace` call whose first argument
+ *       opens with `---` (string or regex) — e.g. `content.split('---\n')`.
+ * The shared template-string serializer (`` `---\n${yaml}\n---` ``) is NOT a
+ * regex literal and is NOT a split/match/exec/replace argument, so it stays
+ * clean. Broader than the canonical #1368 shape so a non-anchored or
+ * string-split reintroduction can't slip past (tooling-fitness, PR #1371).
  */
 export function hasLocalFrontmatterRegex(content: string): boolean {
   const code = stripComments(content);
-  // `/` `^` `---` then an escaped \r or \n — the shape every local
-  // frontmatter splitter shares. The shared template-string serializer
-  // (`---\n${yaml}\n---`) has no leading `/`, so it is not matched.
-  return /\/\^-{3}\\[rn]/.test(code);
+  // (a) frontmatter regex literal: `/` then optional `^`, `---`, escaped \r|\n.
+  if (/\/\^?-{3}\\[rn]/.test(code)) return true;
+  // (b) split/match/exec/replace on a `---`-leading string or regex arg.
+  if (/\.(?:split|match|exec|replace)\s*\(\s*[/'"`]\^?-{3}/.test(code)) {
+    return true;
+  }
+  return false;
 }
 
 /** True when source imports the shared frontmatter helper. */
@@ -54,8 +65,23 @@ describe('cli-experiment frontmatter-parsing invariant', () => {
     ).toBe(true);
   });
 
+  it('detects non-anchored and string-split frontmatter forms', () => {
+    // Non-anchored regex literal (no `^`).
+    expect(
+      hasLocalFrontmatterRegex('const RE = /---\\n([\\s\\S]*?)\\n---/;'),
+    ).toBe(true);
+    // String-split on the `---` delimiter.
+    expect(
+      hasLocalFrontmatterRegex("const parts = content.split('---\\n');"),
+    ).toBe(true);
+    expect(
+      hasLocalFrontmatterRegex('const parts = content.split(/^---$/m);'),
+    ).toBe(true);
+  });
+
   it('does not flag the shared template-string serializer', () => {
-    // serializeFrontmatter builds `---\n${yaml}\n---` — no leading `/`.
+    // serializeFrontmatter builds `---\n${yaml}\n---` — not a regex literal
+    // and not a split/match/exec/replace argument.
     expect(
       hasLocalFrontmatterRegex('return `---\\n${yaml}\\n---`;'),
     ).toBe(false);

--- a/src/cli-experiment-frontmatter-invariant.test.ts
+++ b/src/cli-experiment-frontmatter-invariant.test.ts
@@ -1,0 +1,83 @@
+/**
+ * cli-experiment-frontmatter-invariant.test.ts — focused category-prevention
+ * lint for #1368.
+ *
+ * The experiment CLI must parse markdown YAML frontmatter through the shared
+ * src/lib/frontmatter.ts helper (`parseYamlFrontmatter`), never via its own
+ * local split regex. This is a source-text ratchet: it fails the moment a
+ * future edit re-introduces a local `^---\n...---` frontmatter-delimiter
+ * regex. Mirrors cli-experiment-git-invariant.test.ts (#1334) and the
+ * gh-exec-invariant.test.ts (#1294) pattern.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CLI_SOURCE = join(__dirname, 'cli-experiment.ts');
+
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+}
+
+/**
+ * True when source (comments stripped) contains a local YAML-frontmatter
+ * delimiter regex — an anchored `/^---\n` or `/^---\r` regex literal.
+ */
+export function hasLocalFrontmatterRegex(content: string): boolean {
+  const code = stripComments(content);
+  // `/` `^` `---` then an escaped \r or \n — the shape every local
+  // frontmatter splitter shares. The shared template-string serializer
+  // (`---\n${yaml}\n---`) has no leading `/`, so it is not matched.
+  return /\/\^-{3}\\[rn]/.test(code);
+}
+
+/** True when source imports the shared frontmatter helper. */
+export function importsSharedFrontmatter(content: string): boolean {
+  const code = stripComments(content);
+  return /import\s*\{[^}]*\bparseYamlFrontmatter\b[^}]*\}\s*from\s*['"][^'"]*frontmatter(?:\.js)?['"]/.test(
+    code,
+  );
+}
+
+describe('cli-experiment frontmatter-parsing invariant', () => {
+  it('detects a local frontmatter regex in a synthetic fixture', () => {
+    expect(
+      hasLocalFrontmatterRegex(
+        'const m = content.match(/^---\\n([\\s\\S]*?)\\n---\\n([\\s\\S]*)$/);',
+      ),
+    ).toBe(true);
+    expect(
+      hasLocalFrontmatterRegex('const RE = /^---\\r?\\n([\\s\\S]*?)\\r?\\n---/;'),
+    ).toBe(true);
+  });
+
+  it('does not flag the shared template-string serializer', () => {
+    // serializeFrontmatter builds `---\n${yaml}\n---` — no leading `/`.
+    expect(
+      hasLocalFrontmatterRegex('return `---\\n${yaml}\\n---`;'),
+    ).toBe(false);
+  });
+
+  it('detects the shared frontmatter import in a synthetic fixture', () => {
+    expect(
+      importsSharedFrontmatter(
+        "import { parseYamlFrontmatter } from './lib/frontmatter.js';",
+      ),
+    ).toBe(true);
+    expect(importsSharedFrontmatter("import path from 'path';")).toBe(false);
+  });
+
+  it('cli-experiment.ts has no local frontmatter delimiter regex', () => {
+    const content = readFileSync(CLI_SOURCE, 'utf-8');
+    expect(hasLocalFrontmatterRegex(content)).toBe(false);
+  });
+
+  it('cli-experiment.ts routes through the shared frontmatter helper', () => {
+    const content = readFileSync(CLI_SOURCE, 'utf-8');
+    expect(importsSharedFrontmatter(content)).toBe(true);
+    expect(content).toMatch(/parseYamlFrontmatter/);
+  });
+});

--- a/src/cli-experiment.test.ts
+++ b/src/cli-experiment.test.ts
@@ -135,6 +135,21 @@ Some body text.
     );
   });
 
+  test('throws the missing-frontmatter error when delimiters wrap invalid YAML', () => {
+    // Behavior pinned after #1368: the shared helper catches a YAML parse
+    // failure (or a non-object scalar/array body) and returns null, so
+    // parseFrontmatter surfaces the same missing-frontmatter error rather
+    // than leaking a raw YAMLParseError or spreading a junk scalar.
+    const malformed = '---\nfoo: [unclosed\n---\n\n## Body\n';
+    expect(() => parseFrontmatter(malformed)).toThrow(
+      'Invalid experiment file: no YAML frontmatter found',
+    );
+    const scalarOnly = '---\njust-a-scalar\n---\n\n## Body\n';
+    expect(() => parseFrontmatter(scalarOnly)).toThrow(
+      'Invalid experiment file: no YAML frontmatter found',
+    );
+  });
+
   test('roundtrips through serialize → parse', () => {
     const fm: ExperimentFrontmatter = {
       id: 'EXP-042',

--- a/src/cli-experiment.test.ts
+++ b/src/cli-experiment.test.ts
@@ -101,6 +101,40 @@ Some body text.
     expect(body).toContain('## Context');
   });
 
+  test('parses CRLF (\\r\\n) frontmatter delimiters through the shared helper', () => {
+    // The old local regex was `\n`-only and could not parse Windows-authored
+    // experiment files. Routing through the shared frontmatter helper (#1368)
+    // makes CRLF delimiters first-class.
+    const content =
+      '---\r\n' +
+      'id: EXP-009\r\n' +
+      'title: "crlf title"\r\n' +
+      'hypothesis: "crlf hypothesis"\r\n' +
+      'falsification: "crlf falsification"\r\n' +
+      'pattern: probe-and-observe\r\n' +
+      'status: pending\r\n' +
+      'issue: 1368\r\n' +
+      'created: 2026-06-28\r\n' +
+      'completed: null\r\n' +
+      'result: null\r\n' +
+      '---\r\n' +
+      '\r\n' +
+      '## Context\r\n';
+    const { frontmatter, body } = parseFrontmatter(content);
+    expect(frontmatter.id).toBe('EXP-009');
+    expect(frontmatter.title).toBe('crlf title');
+    expect(frontmatter.issue).toBe(1368);
+    // measurements omitted from the YAML → defaults to []
+    expect(frontmatter.measurements).toEqual([]);
+    expect(body).toContain('## Context');
+  });
+
+  test('throws the missing-frontmatter error when no frontmatter is present', () => {
+    expect(() => parseFrontmatter('just a body, no frontmatter\n')).toThrow(
+      'Invalid experiment file: no YAML frontmatter found',
+    );
+  });
+
   test('roundtrips through serialize → parse', () => {
     const fm: ExperimentFrontmatter = {
       id: 'EXP-042',

--- a/src/cli-experiment.ts
+++ b/src/cli-experiment.ts
@@ -19,6 +19,7 @@ import path from 'path';
 import YAML from 'yaml';
 
 import { parseExperimentSpec } from './experiment-spec-parser.js';
+import { parseYamlFrontmatter } from './lib/frontmatter.js';
 import { resolveProjectRoot } from './lib/resolve-project-root.js';
 
 // --- Types ---
@@ -76,20 +77,19 @@ export function parseFrontmatter(content: string): {
   frontmatter: ExperimentFrontmatter;
   body: string;
 } {
-  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-  if (!match) {
+  // Route through the shared body-preserving, CRLF-aware frontmatter helper
+  // (src/lib/frontmatter.ts, #1367) instead of a local split regex (#1368).
+  const parsed = parseYamlFrontmatter<Partial<ExperimentFrontmatter>>(content);
+  if (!parsed) {
     throw new Error('Invalid experiment file: no YAML frontmatter found');
   }
 
-  const parsed = YAML.parse(match[1]);
-  const body = match[2];
-
   return {
     frontmatter: {
-      ...parsed,
-      measurements: parsed.measurements ?? [],
+      ...parsed.data,
+      measurements: parsed.data.measurements ?? [],
     } as ExperimentFrontmatter,
-    body,
+    body: parsed.body,
   };
 }
 


### PR DESCRIPTION
## Problem

#1368 asked for two things: (1) route `cli-experiment.ts` frontmatter parsing through the shared `parseYamlFrontmatter` helper (#1367), and (2) **"a source invariant prevents reintroducing local split/parse logic."**

While this work was in flight, sibling PR **#1369 merged the swap** (the #1273/#1274 same-issue race — two runs picked the same consolidation). #1369 shipped the helper migration and a CRLF test, but it satisfied criterion (2) only *superficially*: an inline two-substring check in the lifecycle test —

```ts
expect(source).not.toContain('content.match(/^---\n');
expect(source).not.toContain('YAML.parse(match[1])');
```

That catches only the two **exact** old substrings. A reintroduction using a non-anchored regex (`/---\n/`), a different capture group, or `content.split('---\n')` sails straight past it — so it does not prevent the *category*. #1369 also introduced a real **behavior change** (malformed YAML / a bare scalar inside delimiters now throw the generic "no frontmatter" error instead of leaking a `YAMLParseError` or spreading a junk scalar) and shipped **no test** for it.

## Solution

This PR completes #1368's unmet acceptance criterion as the quality remainder on top of #1369 (run-23 partial-acceptance pattern — `git merge origin/main`, never rebase, per I12):

1. **Categorical source-invariant ratchet** — `cli-experiment-frontmatter-invariant.test.ts`, mirroring the sibling `cli-experiment-git-invariant.test.ts` (#1334) / `gh-exec-invariant.test.ts` (#1294). `hasLocalFrontmatterRegex` catches anchored **and** non-anchored frontmatter regex literals **and** `.split`/`.match`/`.exec`/`.replace` calls on a `---`-leading arg, while keeping the template-string serializer clean.
2. **Consolidate** — remove #1369's weak inline `not.toContain` check; the dedicated ratchet is the single, stronger owner (DRY).
3. **Pin #1369's untested behavior** — a test asserting malformed YAML and a bare-scalar frontmatter both surface the same `Invalid experiment file: no YAML frontmatter found` error.

The production swap itself is already on main (#1369); this PR's net diff is **test-only**.

## Evidence

- `npx vitest run` on the three experiment test files: **31 passed**.
- New malformed-YAML / bare-scalar test: would have **failed under pre-#1369 code** (old code leaked `YAMLParseError` / spread a junk scalar without throwing) — a true behavior pin.
- **Red-bar proof**: reintroducing a local `^---\n...` regex into `cli-experiment.ts` makes the ratchet fail; the broadened detector also trips on non-anchored and `.split('---')` forms (covered by fixtures).
- `npm run build` (tsc) clean.

## Impact

#1368's source-invariant criterion is now genuinely met — categorical, not two-substring — and #1369's silent behavior change is locked by a test. The consolidation advances "make DRYness a more core part of kaizen" as an enforced CI ratchet rather than reviewer vigilance.

## Test Plan

| Behavior | Unit |
|----------|:----:|
| malformed YAML within delimiters throws clean error | ✅ (new) |
| bare-scalar frontmatter throws clean error | ✅ (new) |
| missing frontmatter throws same error | ✅ (new) |
| source invariant: no local frontmatter regex (anchored, non-anchored, split forms) | ✅ (new ratchet) |
| shared-helper import present | ✅ (new ratchet) |
| CRLF frontmatter parses (from #1369) | ✅ (existing) |

Closes #1368
Refs: #1369, #1367, #1164

Run tag: handsome-lynx/run-36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
