### PR TITLE
refactor(skills): share metadata frontmatter parsing

### DIFF
--- a/src/skill-metadata.test.ts
+++ b/src/skill-metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
@@ -11,6 +11,14 @@ import {
 import type { SkillMetadata } from "./skill-metadata.js";
 
 describe("parseSkillFrontmatter", () => {
+  it("uses the shared YAML frontmatter parser", () => {
+    const source = readFileSync(join(__dirname, "skill-metadata.ts"), "utf8");
+
+    expect(source).not.toContain("content.match(/^---\\r?\\n");
+    expect(source).not.toContain("for (const line of yaml.split");
+    expect(source).not.toContain("colonIdx");
+  });
+
   it("parses minimal frontmatter with name and description", () => {
     const content = `---
 name: kaizen-zen
@@ -54,6 +62,25 @@ user_invocable: true
       min_version: "1.0.40",
       user_invocable: true,
     });
+  });
+
+  it("parses block-style YAML arrays", () => {
+    const content = `---
+name: block-arrays
+description: Block array metadata
+triggers:
+  - implement spec
+  - go ahead
+depends_on:
+  - kaizen-evaluate
+  - kaizen-write-plan
+---
+
+# Block Arrays`;
+
+    const meta = parseSkillFrontmatter(content);
+    expect(meta?.triggers).toEqual(["implement spec", "go ahead"]);
+    expect(meta?.depends_on).toEqual(["kaizen-evaluate", "kaizen-write-plan"]);
   });
 
   it("handles user_invocable boolean correctly", () => {

--- a/src/skill-metadata.ts
+++ b/src/skill-metadata.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync, readdirSync, existsSync } from "fs";
 import { join } from "path";
+import { readYamlFrontmatter } from "./lib/frontmatter.js";
 
 export interface SkillMetadata {
   name: string;
@@ -23,38 +24,8 @@ export interface SkillMetadata {
  * Returns null if no valid frontmatter is found.
  */
 export function parseSkillFrontmatter(content: string): SkillMetadata | null {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
-
-  const yaml = match[1];
-  const meta: Record<string, unknown> = {};
-
-  for (const line of yaml.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-
-    const colonIdx = trimmed.indexOf(":");
-    if (colonIdx === -1) continue;
-
-    const key = trimmed.slice(0, colonIdx).trim();
-    const rawValue = trimmed.slice(colonIdx + 1).trim();
-
-    if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
-      // Inline YAML array: [a, b, c] or ["a", "b", "c"]
-      const inner = rawValue.slice(1, -1);
-      meta[key] = inner
-        .split(",")
-        .map((s) => s.trim().replace(/^["']|["']$/g, ""))
-        .filter((s) => s.length > 0);
-    } else if (rawValue === "true") {
-      meta[key] = true;
-    } else if (rawValue === "false") {
-      meta[key] = false;
-    } else {
-      meta[key] = rawValue.replace(/^["']|["']$/g, "");
-    }
-  }
-
+  const meta = readYamlFrontmatter(content);
+  if (!meta) return null;
   if (!meta.name || typeof meta.name !== "string") return null;
 
   return {


### PR DESCRIPTION
## Summary

This PR routes SKILL.md metadata parsing through the shared markdown frontmatter helper:

- `parseSkillFrontmatter()` now uses `readYamlFrontmatter()` instead of a hand-rolled line parser.
- Existing `SkillMetadata` normalization/filtering is preserved.
- Block-style YAML arrays now parse correctly for `triggers` and `depends_on`.
- Added a source invariant to prevent local frontmatter regex/tokenization from returning.

Fixes #1370
Related: #666
Related: #1366
Related: #1164

## Validation

- RED first: `npm test -- --run src/skill-metadata.test.ts` failed before implementation on the source invariant and block-style YAML array case.
- `npm test -- --run src/skill-metadata.test.ts src/lib/frontmatter.test.ts`
- `npm run typecheck`
- `git diff --check`
- `rg -n "content\\.match\\(/\\^---|yaml\\.split|colonIdx|rawValue" src/skill-metadata.ts` returned no matches.

## Branch Hygiene

Started from a fresh worktree and fresh branch off `origin/main`:

- Worktree: `.claude/worktrees/260628-k1370-skill-frontmatter-helper`
- Branch: `case/260628-k1370-skill-frontmatter-helper`
- Verified before creation: no local branch, no remote branch, no PR history for the head branch, and no commits/PRs for `#1370`.
