### PR TITLE
refactor(hooks): share delimited YAML block parsing

### DIFF
--- a/src/hooks/lib/gate-signal.test.ts
+++ b/src/hooks/lib/gate-signal.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { formatHookOutput, parseHookOutput, parseHookOutputs, formatGateSignal, parseGateSignal, type HookOutput } from './gate-signal.js';
 
 describe('formatHookOutput', () => {
@@ -59,6 +61,14 @@ describe('formatHookOutput', () => {
 });
 
 describe('parseHookOutput', () => {
+  it('uses shared delimited YAML block parsing', () => {
+    const source = readFileSync(join(__dirname, 'gate-signal.ts'), 'utf8');
+
+    expect(source).not.toContain("text.match(/^---\\n");
+    expect(source).not.toContain('text.matchAll(/^---\\n');
+    expect(source).not.toContain('YAML.parse(match[1])');
+  });
+
   it('extracts from a YAML block at the start of text', () => {
     const text = `---\nhook: pr-review-loop\ntype: gate-set\ngate: needs_review\nreason: PR created\n---\n`;
     const parsed = parseHookOutput(text);
@@ -67,6 +77,13 @@ describe('parseHookOutput', () => {
 
   it('extracts from the middle of text (trailing content after ---)', () => {
     const text = `Some preamble\n---\nhook: pr-kaizen-clear\ntype: gate-clear\nreason: impediments filed\n---\nDone.\n`;
+    const parsed = parseHookOutput(text);
+    expect(parsed?.type).toBe('gate-clear');
+    expect(parsed?.reason).toBe('impediments filed');
+  });
+
+  it('extracts CRLF-delimited YAML blocks from mixed text', () => {
+    const text = `Some preamble\r\n---\r\nhook: pr-kaizen-clear\r\ntype: gate-clear\r\nreason: impediments filed\r\n---\r\nDone.\r\n`;
     const parsed = parseHookOutput(text);
     expect(parsed?.type).toBe('gate-clear');
     expect(parsed?.reason).toBe('impediments filed');

--- a/src/hooks/lib/gate-signal.ts
+++ b/src/hooks/lib/gate-signal.ts
@@ -26,7 +26,11 @@
  */
 
 import { z } from 'zod';
-import YAML from 'yaml';
+import {
+  formatDelimitedYamlBlock,
+  parseDelimitedYamlBlocks,
+  parseFirstDelimitedYamlBlock,
+} from '../../lib/yaml-block.js';
 
 export const GateNameSchema = z.enum(['needs_review', 'needs_pr_kaizen', 'needs_post_merge']);
 export type GateName = z.infer<typeof GateNameSchema>;
@@ -61,7 +65,7 @@ export function formatHookOutput(output: HookOutput): string {
   if (validated.pr) obj.pr = validated.pr;
   if (validated.round != null) obj.round = validated.round;
   obj.reason = validated.reason;
-  return `---\n${YAML.stringify(obj).trimEnd()}\n---\n`;
+  return formatDelimitedYamlBlock(obj);
 }
 
 // Convenience alias for gate signals
@@ -72,15 +76,10 @@ export const formatGateSignal = formatHookOutput;
  * Returns the parsed output if found, null otherwise.
  */
 export function parseHookOutput(text: string): HookOutput | null {
-  const match = text.match(/^---\n([\s\S]*?\n)---/m);
-  if (!match) return null;
-  try {
-    const parsed = YAML.parse(match[1]);
-    const result = HookOutputSchema.safeParse(parsed);
-    return result.success ? result.data : null;
-  } catch {
-    return null;
-  }
+  const parsed = parseFirstDelimitedYamlBlock(text);
+  if (!parsed) return null;
+  const result = HookOutputSchema.safeParse(parsed.data);
+  return result.success ? result.data : null;
 }
 
 /**
@@ -88,9 +87,9 @@ export function parseHookOutput(text: string): HookOutput | null {
  */
 export function parseHookOutputs(text: string): HookOutput[] {
   const outputs: HookOutput[] = [];
-  for (const match of text.matchAll(/^---\n[\s\S]*?\n---/gm)) {
-    const parsed = parseHookOutput(match[0]);
-    if (parsed) outputs.push(parsed);
+  for (const block of parseDelimitedYamlBlocks(text)) {
+    const result = HookOutputSchema.safeParse(block.data);
+    if (result.success) outputs.push(result.data);
   }
   return outputs;
 }

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,25 +1,15 @@
-import YAML from 'yaml';
+import { parseLeadingDelimitedYamlBlock } from './yaml-block.js';
 
 export interface YamlFrontmatter<T extends Record<string, unknown> = Record<string, unknown>> {
   data: T;
   body: string;
 }
 
-const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/;
-
 export function parseYamlFrontmatter<T extends Record<string, unknown> = Record<string, unknown>>(
   content: string,
 ): YamlFrontmatter<T> | null {
-  const match = content.match(FRONTMATTER_RE);
-  if (!match) return null;
-
-  try {
-    const parsed = YAML.parse(match[1]);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
-    return { data: parsed as T, body: match[2] ?? '' };
-  } catch {
-    return null;
-  }
+  const parsed = parseLeadingDelimitedYamlBlock<T>(content);
+  return parsed ? { data: parsed.data, body: parsed.body } : null;
 }
 
 export function readYamlFrontmatter<T extends Record<string, unknown> = Record<string, unknown>>(

--- a/src/lib/yaml-block.test.ts
+++ b/src/lib/yaml-block.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parseDelimitedYamlBlocks, parseLeadingDelimitedYamlBlock } from './yaml-block.js';
+
+describe('parseLeadingDelimitedYamlBlock', () => {
+  it('parses a leading YAML block and preserves trailing body', () => {
+    const parsed = parseLeadingDelimitedYamlBlock('---\nname: review\n---\nBody\n');
+
+    expect(parsed).toEqual({
+      data: { name: 'review' },
+      body: 'Body\n',
+      raw: '---\nname: review\n---\n',
+    });
+  });
+
+  it('returns null when the leading YAML block is invalid', () => {
+    expect(parseLeadingDelimitedYamlBlock('---\nname: nope: invalid\n---\nBody')).toBeNull();
+  });
+});
+
+describe('parseDelimitedYamlBlocks', () => {
+  it('parses every valid delimited YAML block from mixed text', () => {
+    const blocks = parseDelimitedYamlBlocks([
+      'prefix',
+      '---',
+      'hook: one',
+      '---',
+      'middle',
+      '---',
+      'hook: two',
+      '---',
+      'suffix',
+    ].join('\n'));
+
+    expect(blocks.map(block => block.data)).toEqual([{ hook: 'one' }, { hook: 'two' }]);
+  });
+
+  it('accepts CRLF delimiters in mixed output', () => {
+    const blocks = parseDelimitedYamlBlocks('prefix\r\n---\r\nhook: crlf\r\n---\r\nsuffix');
+
+    expect(blocks.map(block => block.data)).toEqual([{ hook: 'crlf' }]);
+  });
+});

--- a/src/lib/yaml-block.ts
+++ b/src/lib/yaml-block.ts
@@ -1,0 +1,65 @@
+import YAML from 'yaml';
+
+export interface DelimitedYamlBlock<T extends Record<string, unknown> = Record<string, unknown>> {
+  data: T;
+  raw: string;
+}
+
+export interface LeadingDelimitedYamlBlock<T extends Record<string, unknown> = Record<string, unknown>>
+  extends DelimitedYamlBlock<T> {
+  body: string;
+}
+
+const LEADING_DELIMITED_YAML_BLOCK_RE = /^(---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?)([\s\S]*)$/;
+const DELIMITED_YAML_BLOCK_RE = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/gm;
+
+function parseYamlObject<T extends Record<string, unknown>>(yaml: string): T | null {
+  try {
+    const parsed = YAML.parse(yaml);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as T;
+  } catch {
+    return null;
+  }
+}
+
+export function formatDelimitedYamlBlock(data: Record<string, unknown>): string {
+  return `---\n${YAML.stringify(data).trimEnd()}\n---\n`;
+}
+
+export function parseLeadingDelimitedYamlBlock<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(content: string): LeadingDelimitedYamlBlock<T> | null {
+  const match = content.match(LEADING_DELIMITED_YAML_BLOCK_RE);
+  if (!match) return null;
+
+  const data = parseYamlObject<T>(match[2]);
+  if (!data) return null;
+  return { data, raw: match[1], body: match[3] ?? '' };
+}
+
+export function parseFirstDelimitedYamlBlock<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(text: string): DelimitedYamlBlock<T> | null {
+  DELIMITED_YAML_BLOCK_RE.lastIndex = 0;
+  const match = DELIMITED_YAML_BLOCK_RE.exec(text);
+  DELIMITED_YAML_BLOCK_RE.lastIndex = 0;
+  if (!match) return null;
+
+  const data = parseYamlObject<T>(match[1]);
+  if (!data) return null;
+  return { data, raw: match[0] };
+}
+
+export function parseDelimitedYamlBlocks<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(text: string): Array<DelimitedYamlBlock<T>> {
+  const blocks: Array<DelimitedYamlBlock<T>> = [];
+  DELIMITED_YAML_BLOCK_RE.lastIndex = 0;
+  for (const match of text.matchAll(DELIMITED_YAML_BLOCK_RE)) {
+    const data = parseYamlObject<T>(match[1]);
+    if (data) blocks.push({ data, raw: match[0] });
+  }
+  DELIMITED_YAML_BLOCK_RE.lastIndex = 0;
+  return blocks;
+}


### PR DESCRIPTION
## Summary

This PR extracts shared `--- yaml ---` block parsing for the hook gate-signal path and the existing frontmatter helper:

- Adds `src/lib/yaml-block.ts` for formatting, leading-block parsing, first-block parsing, and multi-block scanning.
- Routes `src/lib/frontmatter.ts` through the shared leading-block parser while preserving its `{ data, body }` API.
- Routes `src/hooks/lib/gate-signal.ts` through the shared block parser while keeping hook-output schema validation local.
- Adds CRLF hook-output coverage and a source invariant preventing local gate-signal YAML block parsing from returning.

Fixes #1373
Related: #1366
Related: #1164

## Validation

- RED first: `npm test -- --run src/lib/yaml-block.test.ts src/hooks/lib/gate-signal.test.ts` failed before implementation because the helper did not exist, `gate-signal.ts` owned local parsing, and CRLF hook output did not parse.
- `npm test -- --run src/lib/yaml-block.test.ts src/lib/frontmatter.test.ts src/hooks/lib/gate-signal.test.ts`
- `npm run typecheck`
- `git diff --check`
- `rg -n "YAML\\.parse\\(match\\[1\\]\\)|matchAll\\(/\\^---|text\\.match\\(/\\^---" src/hooks/lib/gate-signal.ts src/lib/frontmatter.ts` returned no matches.

## Branch Hygiene

Started from a fresh worktree and fresh branch off `origin/main`:

- Worktree: `.claude/worktrees/260628-k1373-yaml-block-helper`
- Branch: `case/260628-k1373-yaml-block-helper`
- Verified before creation: no local branch, no remote branch, no PR history for the head branch, and no commits/PRs for `#1373`.
