### PR TITLE
refactor(review): share prompt frontmatter stripping

### DIFF
--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseYamlFrontmatter, readYamlFrontmatter } from './frontmatter.js';
+import { parseYamlFrontmatter, readYamlFrontmatter, stripYamlFrontmatter } from './frontmatter.js';
 
 describe('parseYamlFrontmatter', () => {
   it('returns null when markdown has no leading YAML frontmatter', () => {
@@ -29,5 +29,15 @@ describe('parseYamlFrontmatter', () => {
     const parsed = readYamlFrontmatter('---\r\nname: sentinel\r\napplies_to: both\r\n---\r\nBody');
 
     expect(parsed).toEqual({ name: 'sentinel', applies_to: 'both' });
+  });
+
+  it('strips YAML frontmatter and returns the markdown body', () => {
+    const body = stripYamlFrontmatter('---\r\nname: prompt\r\n---\r\nBody\r\n');
+
+    expect(body).toBe('Body\r\n');
+  });
+
+  it('leaves markdown without frontmatter unchanged', () => {
+    expect(stripYamlFrontmatter('# Heading\n\nBody')).toBe('# Heading\n\nBody');
   });
 });

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -17,3 +17,7 @@ export function readYamlFrontmatter<T extends Record<string, unknown> = Record<s
 ): T | null {
   return parseYamlFrontmatter<T>(content)?.data ?? null;
 }
+
+export function stripYamlFrontmatter(content: string): string {
+  return parseYamlFrontmatter(content)?.body ?? content;
+}

--- a/src/review-battery.test.ts
+++ b/src/review-battery.test.ts
@@ -406,6 +406,37 @@ describe('loadReviewPrompt', () => {
     expect(prompt).not.toMatch(/^applies_to:\s+/m);
   });
 
+  it('uses shared YAML frontmatter stripping for rendered prompts', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/review-battery.ts'), 'utf8');
+
+    expect(source).not.toContain('content.replace(/^---\\n');
+  });
+
+  it('strips CRLF YAML frontmatter from rendered prompt', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'kaizen-prompt-crlf-'));
+    try {
+      writeFileSync(
+        join(tmpDir, 'review-crlf.md'),
+        [
+          '---',
+          'name: crlf',
+          'description: CRLF prompt',
+          'applies_to: pr',
+          '---',
+          'Review {{thing}}.',
+          '',
+        ].join('\r\n'),
+      );
+
+      const prompt = loadReviewPrompt('crlf', { thing: 'the diff' }, tmpDir);
+
+      expect(prompt).toBe('Review the diff.');
+      expect(prompt.startsWith('---'), 'Prompt must not start with YAML frontmatter').toBe(false);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('throws for nonexistent template', () => {
     const dir = resolvePromptsDir();
     const path = resolve(dir, 'review-plan-coverage.md');

--- a/src/review-battery.ts
+++ b/src/review-battery.ts
@@ -14,7 +14,7 @@
 import { spawn } from 'node:child_process';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve, dirname, basename } from 'node:path';
-import { readYamlFrontmatter } from './lib/frontmatter.js';
+import { readYamlFrontmatter, stripYamlFrontmatter } from './lib/frontmatter.js';
 import { resolveProjectRoot, type GitRunner } from './lib/resolve-project-root.js';
 import { retrievePlan, issueTarget } from './structured-data.js';
 import {
@@ -407,23 +407,23 @@ export function resolvePromptsDir(git?: GitRunner): string {
 export function loadReviewPrompt(
   dimension: ReviewDimension,
   vars: Record<string, string>,
+  promptsDir?: string,
 ): string {
-  const promptsDir = resolvePromptsDir();
-  const dims = discoverDimensions(promptsDir);
+  const dir = promptsDir ?? resolvePromptsDir();
+  const dims = discoverDimensions(dir);
   const templateFile = dims[dimension];
   if (!templateFile) {
     const available = Object.keys(dims).join(', ');
     throw new Error(`Unknown review dimension: "${dimension}". Available: ${available}`);
   }
-  const templatePath = resolve(promptsDir, templateFile);
+  const templatePath = resolve(dir, templateFile);
 
   if (!existsSync(templatePath)) {
     throw new Error(`Review prompt template not found: ${templatePath}`);
   }
 
   const content = readFileSync(templatePath, 'utf8');
-  // Strip YAML frontmatter (--- ... ---) — it's for the tool loader, not the LLM
-  const body = content.replace(/^---\n[\s\S]*?\n---\n?/, '');
+  const body = stripYamlFrontmatter(content);
   return renderTemplate(body, vars);
 }
 


### PR DESCRIPTION
## Summary

This PR removes the last local review-prompt frontmatter stripper from `loadReviewPrompt()`:

- Adds `stripYamlFrontmatter()` beside the shared frontmatter reader.
- Routes `loadReviewPrompt()` through the shared strip helper instead of an LF-only regex.
- Adds optional prompt-dir injection for deterministic prompt rendering tests.
- Covers CRLF-delimited prompt frontmatter so metadata parsing and prompt rendering cannot drift.

Fixes #1375
Related: #1373
Related: #1366
Related: #1164

## Validation

- RED first: `npm test -- --run src/review-battery.test.ts` failed before implementation on the local-stripper source invariant and CRLF prompt-rendering path.
- `npm test -- --run src/lib/frontmatter.test.ts src/review-battery.test.ts`
- `npm run typecheck`
- `git diff --check`
- `rg -n 'content\\.replace\\(/\\^---|replace\\(/\\^---' src/review-battery.ts src/lib/frontmatter.ts` returned no matches.

## Branch Hygiene

Started from a fresh worktree and fresh branch off `origin/main`:

- Worktree: `.claude/worktrees/260628-k1375-prompt-frontmatter-strip`
- Branch: `case/260628-k1375-prompt-frontmatter-strip`
- Verified before creation: no local branch, no remote branch, no PR history for the head branch, and no commits/PRs for `#1375`.
