### PR TITLE
refactor(structured-data): remove orphaned storeConnectedIssues

### DIFF
--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -459,18 +459,6 @@ export function retrieveMetadata(target: AttachmentTarget & SectionTarget): Reco
 }
 
 /**
- * Store connected issues in metadata.
- */
-export function storeConnectedIssues(target: AttachmentTarget & SectionTarget, issues: ConnectedIssue[], extra?: Record<string, unknown>): string {
-  const existing = retrieveMetadata(target) ?? {};
-  const deepDive = (existing.deep_dive as Record<string, unknown>) ?? {};
-  deepDive.connected_issues = issues;
-  if (extra) Object.assign(deepDive, extra);
-  existing.deep_dive = deepDive;
-  return storeMetadata(target, existing);
-}
-
-/**
  * Query connected issues from metadata.
  */
 export function queryConnectedIssues(target: AttachmentTarget & SectionTarget): ConnectedIssue[] {


### PR DESCRIPTION
## Problem

`storeConnectedIssues()` in `src/structured-data.ts` looked like half of a clean read/write pair with `queryConnectedIssues()`. It wasn't. It was dead weight — a function nobody ever called.

## Discovery

A subtraction-run sweep for dead code flagged it. Verification:

- **Repo-wide grep** for `storeConnectedIssues` (src, scripts, tests, cli, `.agents/**/SKILL.md`, json) → only the definition line. No caller, no `store-connected` CLI command, no test, no doc.
- **Full-history `-S` search** (`git log -S storeConnectedIssues --all`) → the symbol appears in exactly **one** commit: #903, the one that introduced it. It has been unreferenced since birth.
- The connected-issues **write** path the docs actually prescribe is the generic `store-metadata` (`storeMetadata()`); only the **read** side (`queryConnectedIssues`, exposed as `query-connected`) is live and consumed by the section / review-pr SKILLs.

## Solution

Delete `storeConnectedIssues()` and its doc comment. Keep:
- `ConnectedIssue` interface (consumed by the live `queryConnectedIssues`)
- `queryConnectedIssues()` and the `query-connected` CLI command

## Chesterton's Fence

Introduced in #903 as the symmetric write helper; the deep-dive write path it was meant to serve routes through `storeMetadata` instead, orphaning it. Confirmed via `-S` history that it was never wired.

Deliberately **left in place** (couldn't prove them safe to remove):
- `validateReviewCoverage` — tested but no prod caller; likely staged L2-escalation infrastructure for I28 (currently L1-only).
- attachment-section CRUD primitives (`listAttachmentSections` etc.) — a cohesive, fully-tested designed API.

## Evidence

| Behavior | Level | Evidence |
|----------|-------|----------|
| Removed symbol has no remaining importers | Static | post-removal `grep -rn storeConnectedIssues` returns nothing |
| Project still type-checks | Build | `npm run build` (tsc) passes — a dangling reference would be a compile error |
| Live read path unaffected | Unit | `src/structured-data.test.ts` green |
| CLI `query-connected` surface unaffected | Unit | `src/cli-structured-data.test.ts` green |
| Sibling section/attachment API unaffected | Unit | `src/section-editor.test.ts` green |

All three suites: **105 tests passed**. No new test added — the function had zero tests (it was dead); the regression guard is the compiler plus the existing suites exercising sibling live functions in the same module.

## Impact

One fewer dead export in the structured-data module — the "primary interface for skills." Removes the false impression of a read/write pair where only the read side is real, so future contributors don't wire against a function the documented write path bypasses.

Closes #1378