### PR TITLE
refactor(markdown): share fenced code parsing

### DIFF
--- a/src/lib/markdown-fence.test.ts
+++ b/src/lib/markdown-fence.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { firstMarkdownFence, markdownFences } from './markdown-fence.js';
+
+describe('markdownFences', () => {
+  it('extracts every matching fenced code block by language', () => {
+    const blocks = markdownFences(
+      [
+        'before',
+        '```json',
+        '{"one":1}',
+        '```',
+        'middle',
+        '```yaml',
+        'two: 2',
+        '```',
+        'after',
+      ].join('\n'),
+      'json',
+    );
+
+    expect(blocks).toEqual([{ language: 'json', code: '{"one":1}' }]);
+  });
+
+  it('accepts CRLF fences and language labels with whitespace/case differences', () => {
+    const block = firstMarkdownFence('prefix\r\n``` JSON \r\n{"ok":true}\r\n```\r\nsuffix', 'json');
+
+    expect(block).toEqual({ language: 'JSON', code: '{"ok":true}' });
+  });
+});

--- a/src/lib/markdown-fence.ts
+++ b/src/lib/markdown-fence.ts
@@ -1,0 +1,31 @@
+export interface MarkdownFence {
+  language: string;
+  code: string;
+}
+
+const FENCE_RE = /^```([^\r\n`]*)\r?\n([\s\S]*?)\r?\n```(?=\r?\n|$)/gm;
+
+function normalizeLanguage(language: string): string {
+  return language.trim().toLowerCase();
+}
+
+function languageMatches(actual: string, expected?: string | string[]): boolean {
+  if (expected == null) return true;
+  const accepted = Array.isArray(expected) ? expected : [expected];
+  const normalized = normalizeLanguage(actual);
+  return accepted.some(language => normalizeLanguage(language) === normalized);
+}
+
+export function markdownFences(text: string, language?: string | string[]): MarkdownFence[] {
+  const blocks: MarkdownFence[] = [];
+  for (const match of text.matchAll(FENCE_RE)) {
+    const rawLanguage = match[1].trim();
+    if (!languageMatches(rawLanguage, language)) continue;
+    blocks.push({ language: rawLanguage, code: match[2].trim() });
+  }
+  return blocks;
+}
+
+export function firstMarkdownFence(text: string, language?: string | string[]): MarkdownFence | null {
+  return markdownFences(text, language)[0] ?? null;
+}

--- a/src/review-battery.test.ts
+++ b/src/review-battery.test.ts
@@ -71,6 +71,15 @@ function makeMeta(name: string, needs: string[] = ['diff']): DimensionMeta {
 // Tier 1: Schema and parser tests
 
 describe('parseReviewOutput', () => {
+  it('uses shared markdown fence parsing', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/review-battery.ts'), 'utf8');
+
+    expect(source).not.toContain('fenceMatch');
+    expect(source).not.toContain('fenceRe');
+    expect(source).not.toContain('raw.match(/```');
+    expect(source).not.toContain('raw.matchAll(fenceRe)');
+  });
+
   it('parses valid JSON with findings', () => {
     const raw = `Here is my review:
 \`\`\`json
@@ -99,6 +108,14 @@ describe('parseReviewOutput', () => {
     const result = parseReviewOutput(raw, 'plan-coverage');
     expect(result).not.toBeNull();
     expect(result!.verdict).toBe('pass');
+  });
+
+  it('parses fenced JSON with CRLF and spaced language label', () => {
+    const raw = 'result\r\n``` JSON \r\n{"dimension":"requirements","summary":"ok","findings":[]}\r\n```\r\n';
+    const result = parseReviewOutput(raw, 'requirements');
+
+    expect(result).not.toBeNull();
+    expect(result!.dimension).toBe('requirements');
   });
 
   it('normalizes status variants', () => {
@@ -849,6 +866,22 @@ Second dimension:
     const results = parseAllReviewOutputs(raw, ['requirements']);
     expect(results).toHaveLength(1);
     expect(results[0].dimension).toBe('requirements');
+  });
+
+  it('parses multiple CRLF fenced JSON blocks with spaced language labels', () => {
+    const raw = [
+      '``` JSON ',
+      '{"dimension":"requirements","summary":"ok","findings":[]}',
+      '```',
+      '``` json ',
+      '{"dimension":"test-quality","summary":"ok","findings":[]}',
+      '```',
+      '',
+    ].join('\r\n');
+
+    const results = parseAllReviewOutputs(raw, ['requirements', 'test-quality']);
+
+    expect(results.map(r => r.dimension)).toEqual(['requirements', 'test-quality']);
   });
 });
 

--- a/src/review-battery.ts
+++ b/src/review-battery.ts
@@ -15,6 +15,7 @@ import { spawn } from 'node:child_process';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve, dirname, basename } from 'node:path';
 import { readYamlFrontmatter, stripYamlFrontmatter } from './lib/frontmatter.js';
+import { firstMarkdownFence, markdownFences } from './lib/markdown-fence.js';
 import { resolveProjectRoot, type GitRunner } from './lib/resolve-project-root.js';
 import { retrievePlan, issueTarget } from './structured-data.js';
 import {
@@ -338,9 +339,7 @@ export function validateReviewCoverage(
  *   - Malformed JSON (returns null)
  */
 export function parseReviewOutput(raw: string, dimension: string): DimensionReview | null {
-  // Try to extract JSON from markdown code fences first
-  const fenceMatch = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
-  const jsonStr = fenceMatch ? fenceMatch[1].trim() : raw.trim();
+  const jsonStr = firstMarkdownFence(raw, ['json', ''])?.code ?? raw.trim();
 
   // Try to find a JSON object in the text
   const jsonMatch = jsonStr.match(/\{[\s\S]*\}/);
@@ -593,9 +592,8 @@ export interface SpawnBatchReviewOptions extends Omit<SpawnReviewOptions, 'dimen
  */
 export function parseAllReviewOutputs(raw: string, expectedDimensions: string[]): DimensionReview[] {
   const results: DimensionReview[] = [];
-  const fenceRe = /```(?:json)?\s*\n?([\s\S]*?)\n?```/g;
-  for (const match of raw.matchAll(fenceRe)) {
-    const review = parseReviewOutput(match[0], '');
+  for (const block of markdownFences(raw, ['json', ''])) {
+    const review = parseReviewOutput(block.code, '');
     if (review && review.dimension) results.push(review);
   }
   return results;

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { clearCommentCache } from './section-editor.js';
 import {
   prTarget,
@@ -462,7 +463,25 @@ describe('retrieveTestPlan — lookup order', () => {
   });
 });
 
+describe('retrieveMetadata', () => {
+  it('parses YAML metadata fallback from CRLF fence with spaced language label', () => {
+    ghReturns(''); // no metadata attachment
+    ghReturns('Body\r\n``` YAML \r\ndeep_dive:\r\n  pr: 1377\r\n```\r\n');
+
+    const metadata = retrieveMetadata(issue);
+
+    expect(metadata).toEqual({ deep_dive: { pr: 1377 } });
+  });
+});
+
 describe('storeIterationState + retrieveIterationState', () => {
+  it('uses shared markdown fence parsing for structured data attachments', () => {
+    const source = readFileSync(new URL('./structured-data.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toContain('text.match(/```yaml');
+    expect(source).not.toContain('attachment.content.match(/```json');
+  });
+
   it('round-trips JSON state', () => {
     ghReturns(''); ghReturns('https://...');
     storeIterationState(pr, { round: 3, phase: 'fix_running', cost: 1.5 });
@@ -470,6 +489,12 @@ describe('storeIterationState + retrieveIterationState', () => {
     ghReturns(JSON.stringify({ url: 'u', body: '<!-- kaizen:iteration/state -->\n```json\n{"round":3,"phase":"fix_running","cost":1.5}\n```' }));
     const state = retrieveIterationState(pr);
     expect(state).toEqual({ round: 3, phase: 'fix_running', cost: 1.5 });
+  });
+
+  it('round-trips JSON state from CRLF fence with spaced language label', () => {
+    ghReturns(JSON.stringify({ url: 'u', body: '<!-- kaizen:iteration/state -->\r\n``` JSON \r\n{"round":4,"phase":"fix_done"}\r\n```' }));
+    const state = retrieveIterationState(pr);
+    expect(state).toEqual({ round: 4, phase: 'fix_done' });
   });
 });
 

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -37,6 +37,7 @@ import {
   type RoundRow,
   type RoundVerdict,
 } from './review-finding-contract.js';
+import { firstMarkdownFence } from './lib/markdown-fence.js';
 
 // ── Target helpers ──────────────────────────────────────────────────
 
@@ -450,10 +451,9 @@ export function retrieveMetadata(target: AttachmentTarget & SectionTarget): Reco
   for (const src of sources) {
     const text = src();
     if (!text) continue;
-    const match = text.match(/```yaml\n([\s\S]*?)```/);
-    if (match) {
-      try { return YAML.parse(match[1]) as Record<string, unknown>; } catch { continue; }
-    }
+    const block = firstMarkdownFence(text, 'yaml');
+    if (!block) continue;
+    try { return YAML.parse(block.code) as Record<string, unknown>; } catch { continue; }
   }
   return null;
 }
@@ -527,7 +527,7 @@ export function storeIterationState(target: AttachmentTarget, state: Record<stri
 export function retrieveIterationState(target: AttachmentTarget): Record<string, unknown> | null {
   const attachment = readAttachment(target, 'iteration/state');
   if (!attachment) return null;
-  const match = attachment.content.match(/```json\n([\s\S]*?)```/);
-  if (!match) return null;
-  try { return JSON.parse(match[1]); } catch { return null; }
+  const block = firstMarkdownFence(attachment.content, 'json');
+  if (!block) return null;
+  try { return JSON.parse(block.code); } catch { return null; }
 }


### PR DESCRIPTION
## Summary

This PR consolidates markdown fenced-code extraction across review and structured-data runtime paths:

- Adds `src/lib/markdown-fence.ts` with first/all fence extraction by language.
- Rewires review JSON parsing in `parseReviewOutput()` and `parseAllReviewOutputs()` through the helper.
- Rewires YAML metadata and JSON iteration-state retrieval through the helper.
- Adds CRLF and language-label spacing/case coverage for the drift cases the local regexes missed.

Fixes #1377
Related: #1373
Related: #1164

## Validation

- RED first: `npm test -- --run src/lib/markdown-fence.test.ts src/review-battery.test.ts src/structured-data.test.ts` failed before implementation because the helper did not exist, local regex source invariants failed, and CRLF/spaced-language iteration parsing returned `null`.
- `npm test -- --run src/lib/markdown-fence.test.ts src/review-battery.test.ts src/structured-data.test.ts`
- `npm run typecheck`
- `git diff --check`
- `rg -n 'fenceMatch|fenceRe|matchAll\\(fenceRe|\\.match\\(/```|\\.matchAll\\(/```' src/review-battery.ts src/structured-data.ts` returned no matches.

## Branch Hygiene

Started from a fresh worktree and fresh branch off `origin/main`:

- Worktree: `.claude/worktrees/260628-k1377-markdown-fence-helper`
- Branch: `case/260628-k1377-markdown-fence-helper`
- Verified before creation: no local branch, no remote branch, no PR history for the head branch, and no commits/PRs for `#1377`.
