### PR TITLE
refactor(structured-data): share plan section extraction

### DIFF
--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -378,6 +378,23 @@ describe('storePlan + retrievePlan — round-trip', () => {
     expect(plan).toContain('Fix it');
     expect(plan).not.toContain('Test Plan');
   });
+
+  it('falls back to issue body ## Plan section with CRLF section boundaries', () => {
+    ghReturns(''); // readAttachment: no attachment
+    ghReturns('## Problem\r\n\r\nBug.\r\n\r\n## Plan\r\n\r\n1. Fix it.\r\n\r\n## Test Plan\r\n\r\n- Verify it.'); // fetchBody
+
+    const plan = retrievePlan(issue);
+
+    expect(plan).toContain('Fix it');
+    expect(plan).not.toContain('Test Plan');
+    expect(plan).not.toContain('Verify it');
+  });
+
+  it('keeps retrievePlan delegated to the shared plan-section extractor', () => {
+    const source = readFileSync(new URL('./structured-data.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toMatch(/const\s+planRe\s*=/);
+  });
 });
 
 describe('storePlan + retrieveTestPlan — round-trip via plan-section fallback (B15)', () => {

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -91,7 +91,7 @@ export function storeQuickPass(
 
 // ── Plan text extraction ────────────────────────────────────────────
 
-const PLAN_SECTION_RE = /## (?:Implementation )?Plan\b[\s\S]*?(?=\n## |\n```yaml|$)/i;
+const PLAN_SECTION_RE = /## (?:Implementation )?Plan\b[\s\S]*?(?=\r?\n## |\r?\n```yaml|$)/i;
 
 /** Extract the first plan section from markdown text. */
 export function extractPlanText(text: string): string | undefined {
@@ -383,9 +383,7 @@ export function retrievePlan(target: AttachmentTarget & SectionTarget): string |
 
   try {
     const body = fetchBody(target);
-    const planRe = /## (?:Implementation )?Plan\b[\s\S]*?(?=\n## |\n```yaml|$)/i;
-    const match = body.match(planRe);
-    return match ? match[0] : null;
+    return extractPlanText(body) ?? null;
   } catch { return null; }
 }
 


### PR DESCRIPTION
## Summary

- route `retrievePlan()` issue-body fallback through the existing `extractPlanText()` helper
- make the shared plan-section boundary explicitly CRLF-aware
- add regression coverage for CRLF issue-body fallback and a source invariant against reintroducing a local `planRe`

## Branch provenance

- Fresh worktree: `.claude/worktrees/260628-k1381-plan-section-helper`
- Fresh branch from `origin/main`: `case/260628-k1381-plan-section-helper`
- Pre-branch checks found no local branch, no remote branch, no all-state PR for this branch, no PR/commit history for #1381, and no existing worktree path.

## Validation

- RED: `npm test -- --run src/structured-data.test.ts` failed on the new source invariant before implementation
- GREEN: `npm test -- --run src/structured-data.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`

Closes #1381
