### PR TITLE
refactor(review): share meta comment parsing

### DIFF
--- a/src/lib/meta-comment.test.ts
+++ b/src/lib/meta-comment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { parseJsonMetaComment } from './meta-comment.js';
+
+describe('parseJsonMetaComment', () => {
+  it('parses nested JSON from a meta HTML comment', () => {
+    expect(parseJsonMetaComment('<!-- meta:{"round":2,"counts":{"done":1}} -->\nBody')).toEqual({
+      round: 2,
+      counts: { done: 1 },
+    });
+  });
+
+  it('allows CRLF and spacing around the meta payload', () => {
+    expect(parseJsonMetaComment('<!-- meta:  {"verdict":"pass"}  -->\r\n## Review')).toEqual({
+      verdict: 'pass',
+    });
+  });
+
+  it('returns null when the first meta comment is malformed', () => {
+    expect(parseJsonMetaComment('<!-- meta:not-json -->')).toBeNull();
+  });
+});

--- a/src/lib/meta-comment.ts
+++ b/src/lib/meta-comment.ts
@@ -1,0 +1,15 @@
+const META_COMMENT_RE = /<!--\s*meta:([\s\S]*?)-->/;
+
+/**
+ * Parse the JSON payload from the first `<!-- meta:... -->` HTML comment.
+ */
+export function parseJsonMetaComment(text: string): unknown | null {
+  const match = text.match(META_COMMENT_RE);
+  if (!match) return null;
+
+  try {
+    return JSON.parse(match[1].trim());
+  } catch {
+    return null;
+  }
+}

--- a/src/review-finding-contract.test.ts
+++ b/src/review-finding-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
   normalizeFindingStatus,
   deriveVerdictFromFindings,
@@ -48,6 +49,12 @@ describe('review-finding-contract', () => {
     });
     const content = `<!-- meta:${JSON.stringify(meta)} -->\n### correctness — FAIL`;
     expect(extractReviewFindingMeta(content)).toEqual(meta);
+  });
+
+  it('keeps review finding metadata on the shared meta-comment parser', () => {
+    const source = readFileSync(new URL('./review-finding-contract.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toMatch(/\.match\(\s*\/<!--\s*meta:/);
   });
 });
 

--- a/src/review-finding-contract.ts
+++ b/src/review-finding-contract.ts
@@ -8,6 +8,8 @@
  * - review finding metadata shape
  */
 
+import { parseJsonMetaComment } from './lib/meta-comment.js';
+
 export type FindingStatus = 'DONE' | 'PARTIAL' | 'MISSING';
 
 export interface ReviewFinding {
@@ -302,11 +304,5 @@ export function parseReviewFindingMeta(value: unknown): ReviewFindingMeta | null
 }
 
 export function extractReviewFindingMeta(content: string): ReviewFindingMeta | null {
-  const match = content.match(/<!-- meta:(\{.*?\}) -->/);
-  if (!match) return null;
-  try {
-    return parseReviewFindingMeta(JSON.parse(match[1]));
-  } catch {
-    return null;
-  }
+  return parseReviewFindingMeta(parseJsonMetaComment(content));
 }

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -357,6 +357,12 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     // Pre-revert this threw via `if (target.kind !== 'pr') throw`; now it stores like any target.
     expect(() => storeReviewSummary(issue, 3)).not.toThrow();
   });
+
+  it('keeps review summary verdict metadata on the shared meta-comment parser', () => {
+    const source = readFileSync(new URL('./structured-data.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toMatch(/\.match\(\s*\/\^<!--\s*meta:/);
+  });
 });
 
 describe('storePlan + retrievePlan — round-trip', () => {

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -38,6 +38,7 @@ import {
   type RoundVerdict,
 } from './review-finding-contract.js';
 import { firstMarkdownFence } from './lib/markdown-fence.js';
+import { parseJsonMetaComment } from './lib/meta-comment.js';
 
 // ── Target helpers ──────────────────────────────────────────────────
 
@@ -106,19 +107,15 @@ export type { ReviewFinding, ReviewFindingData } from './review-finding-contract
 const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MISSING: '❌' };
 
 function extractSummaryRoundVerdict(summary: string): RoundVerdict | null {
-  const match = summary.match(/^<!-- meta:(\{.*\}) -->/);
-  if (!match) return null;
-  try {
-    const meta = JSON.parse(match[1]) as { round_verdict?: RoundVerdict; verdict?: string };
-    if (meta.round_verdict === 'PASS' || meta.round_verdict === 'PASS_WITH_PARTIALS' || meta.round_verdict === 'FAIL') {
-      return meta.round_verdict;
-    }
-    if (meta.verdict === 'fail') return 'FAIL';
-    if (meta.verdict === 'pass') return 'PASS';
-    return null;
-  } catch {
-    return null;
+  const meta = parseJsonMetaComment(summary);
+  if (!meta || typeof meta !== 'object') return null;
+  const verdictMeta = meta as { round_verdict?: RoundVerdict; verdict?: string };
+  if (verdictMeta.round_verdict === 'PASS' || verdictMeta.round_verdict === 'PASS_WITH_PARTIALS' || verdictMeta.round_verdict === 'FAIL') {
+    return verdictMeta.round_verdict;
   }
+  if (verdictMeta.verdict === 'fail') return 'FAIL';
+  if (verdictMeta.verdict === 'pass') return 'PASS';
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- add `parseJsonMetaComment()` for `<!-- meta:... -->` JSON comment extraction
- route review finding metadata and review summary verdict parsing through the shared helper
- add helper coverage for nested JSON plus CRLF/spaced payloads, and source invariants against direct review-path meta regex parsing

## Branch provenance

- Fresh worktree: `.claude/worktrees/260628-k1383-meta-comment-helper`
- Fresh branch from `origin/main`: `case/260628-k1383-meta-comment-helper`
- Pre-branch checks found no local branch, no remote branch, no all-state PR for this branch, no PR/commit history for #1383, and no existing worktree path.

## Validation

- RED: `npm test -- --run src/lib/meta-comment.test.ts src/review-finding-contract.test.ts src/structured-data.test.ts` failed before implementation on the missing helper and direct-parser invariants
- GREEN: `npm test -- --run src/lib/meta-comment.test.ts src/review-finding-contract.test.ts src/structured-data.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`

Closes #1383
