### PR TITLE
refactor(hooks): ratchet bare truncate-helper drift, consolidate last dup (#1385)

### DIFF
--- a/scripts/hook-gym-format.ts
+++ b/scripts/hook-gym-format.ts
@@ -10,6 +10,7 @@
  */
 
 import { escapeMarkdownTableCell } from './markdown-table.js';
+import { truncateDisplay } from './auto-dent-display.js';
 import type { HookTimeline, ParsedHookEvent } from './hook-gym-schema.js';
 
 /**
@@ -68,7 +69,7 @@ export function formatTimeline(timeline: HookTimeline): string {
 
 function renderEventRow(e: ParsedHookEvent): string {
   const decision = e.decision ?? 'none';
-  const reason = e.reason ? truncate(e.reason, 60) : '—';
+  const reason = e.reason ? truncateDisplay(e.reason, 60, { collapse: false }) : '—';
   const hook = e.hookName || e.eventType;
   const escapedHook = escapeMarkdownTableCell(hook, { carriageReturn: 'drop' });
   const escapedReason = escapeMarkdownTableCell(reason, { carriageReturn: 'drop' });
@@ -90,11 +91,6 @@ function formatGateLine(name: string, t: HookTimeline): string {
     return `**${name}**: cleared @${cleared}ms (no activation observed this run)`;
   }
   return `**${name}**: (unknown)`;
-}
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return s.slice(0, max - 1) + '…';
 }
 
 /**

--- a/scripts/truncate-helper-invariant.test.ts
+++ b/scripts/truncate-helper-invariant.test.ts
@@ -1,0 +1,184 @@
+/**
+ * truncate-helper-invariant.test.ts — category-prevention lint for #1385 (slice of #1164).
+ *
+ * #1164 named the truncation/formatting family as the canonical cross-PR DRY
+ * drift: `auto-dent-stream.ts`, `auto-dent-run.ts`, `auto-dent-analyze.ts`, and
+ * `transcript-analysis.ts` each grew their own bare `truncate()`. Merged PRs
+ * (#1349, #1353, #1355) consolidated them into the canonical helpers in
+ * `src/analysis/util.ts` (`truncate`) and `scripts/auto-dent-display.ts`
+ * (`truncateDisplay`). This ratchet freezes that consolidation: it fails loudly
+ * if any production file outside the canonical home defines a *bare* `truncate`
+ * helper again.
+ *
+ * The bare generic name `truncate` is the copy-paste tell. Descriptive,
+ * genuinely-distinct variants — `truncateMiddle` (head+tail), `truncateAtWordBoundary`
+ * (word-aware), `truncateAfterPrefix` (prefix-preserving), `truncateDisplay`
+ * (display-aware) — carry their own names and are intentionally NOT matched.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+interface Violation {
+  file: string;
+}
+
+const REPO_ROOT = join(__dirname, '..');
+const SCAN_DIRS = [join(REPO_ROOT, 'src'), join(REPO_ROOT, 'scripts')];
+
+// Canonical home for the bare `truncate(s, maxLen)` ellipsis helper. Every other
+// truncation need routes through this or through `truncateDisplay` in
+// scripts/auto-dent-display.ts (descriptive name, not matched by this scanner).
+const CANONICAL_HOME = 'src/analysis/util.ts';
+
+// Terminal state of the truncation-helper consolidation. scripts/hook-gym-format.ts
+// was the last duplicate and was migrated to truncateDisplay in #1385 — the ratchet
+// is empty. Any new bare-`truncate` definition fails the invariant with no escape hatch.
+const OPT_OUT = new Set<string>([]);
+
+function repoRelative(path: string): string {
+  return relative(REPO_ROOT, path).replace(/\\/g, '/');
+}
+
+function isProductionTsFile(file: string): boolean {
+  if (!file.endsWith('.ts')) return false;
+  if (file.endsWith('.test.ts')) return false;
+  if (file.endsWith('.d.ts')) return false;
+  return true;
+}
+
+function collectProductionFiles(dirs: string[] = SCAN_DIRS): Map<string, string> {
+  const files = new Map<string, string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      const rel = repoRelative(fullPath);
+      if (!isProductionTsFile(rel)) continue;
+      if (rel === CANONICAL_HOME) continue;
+      files.set(rel, readFileSync(fullPath, 'utf-8'));
+    }
+  };
+  for (const dir of dirs) walk(dir);
+  return files;
+}
+
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+}
+
+/**
+ * True if the file defines a bare `truncate` helper:
+ *   - `function truncate(` (with or without `export`/`async`)
+ *   - `const|let|var truncate =` / `: ... =>`
+ *
+ * The `\btruncate\b` word boundary means descriptive variants like
+ * `truncateDisplay`/`truncateMiddle` do NOT match (no boundary between
+ * `truncate` and the following capital).
+ */
+function definesBareTruncate(content: string): boolean {
+  const src = stripComments(content);
+  if (/\bfunction\s+truncate\s*\(/.test(src)) return true;
+  if (/\b(?:const|let|var)\s+truncate\s*[:=]/.test(src)) return true;
+  return false;
+}
+
+function findBareTruncateDefinitions(files: Map<string, string>): Violation[] {
+  return Array.from(files.entries())
+    .filter(([, content]) => definesBareTruncate(content))
+    .map(([file]) => ({ file }));
+}
+
+function unallowlistedViolations(violations: Violation[], allowlist: Set<string>): Violation[] {
+  return violations.filter(v => !allowlist.has(v.file));
+}
+
+function staleAllowlistEntries(violations: Violation[], allowlist: Set<string>): string[] {
+  const violationFiles = new Set(violations.map(v => v.file));
+  return Array.from(allowlist).filter(f => !violationFiles.has(f));
+}
+
+describe('truncate-helper invariant scanner', () => {
+  it('detects bare truncate definitions in synthetic fixtures', () => {
+    const violations = findBareTruncateDefinitions(new Map([
+      ['scripts/bad-fn.ts', 'function truncate(s: string, max: number) { return s; }'],
+      ['scripts/bad-arrow.ts', 'const truncate = (s: string, max: number) => s.slice(0, max);'],
+      ['scripts/bad-typed.ts', 'const truncate: (s: string) => string = s => s;'],
+    ]));
+
+    expect(violations.map(v => v.file).sort()).toEqual([
+      'scripts/bad-arrow.ts',
+      'scripts/bad-fn.ts',
+      'scripts/bad-typed.ts',
+    ]);
+  });
+
+  it('ignores descriptive truncation variants (no false positives)', () => {
+    const violations = findBareTruncateDefinitions(new Map([
+      ['scripts/ok-display.ts', 'export function truncateDisplay(t: string, m: number) { return t; }'],
+      ['scripts/ok-middle.ts', 'function truncateMiddle(t: string, m: number) { return t; }'],
+      ['scripts/ok-word.ts', 'export function truncateAtWordBoundary(t: string, m: number) { return t; }'],
+      ['scripts/ok-prefix.ts', 'export function truncateAfterPrefix(s: string, p: number) { return s; }'],
+      ['scripts/ok-call.ts', 'const x = truncate(reason, 60);'],
+    ]));
+
+    expect(violations).toEqual([]);
+  });
+
+  it('ignores a bare truncate that only appears in a comment', () => {
+    const violations = findBareTruncateDefinitions(new Map([
+      ['scripts/commented.ts', '// function truncate(s, max) { ... } — removed, use truncateDisplay\nexport const y = 1;'],
+    ]));
+
+    expect(violations).toEqual([]);
+  });
+
+  it('fails when a new bare truncate caller is not allowlisted', () => {
+    const violations = findBareTruncateDefinitions(new Map([
+      ['scripts/new-dup.ts', 'function truncate(s: string, max: number) { return s.slice(0, max); }'],
+    ]));
+
+    expect(unallowlistedViolations(violations, OPT_OUT)).toEqual([
+      { file: 'scripts/new-dup.ts' },
+    ]);
+  });
+
+  it('reports stale allowlist entries after migration', () => {
+    const violations = findBareTruncateDefinitions(new Map([
+      ['scripts/still-bad.ts', 'function truncate(s: string) { return s; }'],
+    ]));
+    const allowlist = new Set([
+      'scripts/still-bad.ts',
+      'scripts/already-migrated.ts',
+    ]);
+
+    expect(staleAllowlistEntries(violations, allowlist)).toEqual([
+      'scripts/already-migrated.ts',
+    ]);
+  });
+
+  it('finds production source files and excludes the canonical home', () => {
+    const files = collectProductionFiles();
+
+    expect(files.size).toBeGreaterThan(50);
+    expect(files.has(CANONICAL_HOME)).toBe(false);
+  });
+
+  it('current production tree has no unallowlisted bare truncate definitions', () => {
+    const violations = findBareTruncateDefinitions(collectProductionFiles());
+
+    expect(unallowlistedViolations(violations, OPT_OUT)).toEqual([]);
+  });
+
+  it('OPT_OUT entries correspond to current bare truncate definitions', () => {
+    const violations = findBareTruncateDefinitions(collectProductionFiles());
+
+    expect(staleAllowlistEntries(violations, OPT_OUT)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The problem

#1164 asked for a mechanism that keeps DRYness across PR boundaries, and named the **truncation/formatting helper family** as the canonical recurring drift: `auto-dent-stream.ts`, `auto-dent-run.ts`, `auto-dent-analyze.ts`, and `transcript-analysis.ts` had each independently grown a bare `truncate()`. A run of merged PRs (#1349, #1353, #1355) consolidated most of those into the canonical helpers — `src/analysis/util.ts` (`truncate`) and `scripts/auto-dent-display.ts` (`truncateDisplay`).

## The discovery

Two gaps survived that cleanup:

1. **One live duplicate remained.** `scripts/hook-gym-format.ts` still defined a private `truncate(s, max)` whose body — `s.slice(0, max - 1) + '…'` — is an *exact* reimplementation of `truncateDisplay(s, max, { collapse: false })`.
2. **Nothing prevented regression.** The per-PR DRY dimension (`prompts/review-dry.md`, `applies_to: pr`) reviews one diff at a time; it structurally cannot see that a *new* bare `truncate()` in some file duplicates the canonical one. That is precisely the cross-PR blindness #1164 describes.

## The solution

A **CI-invariant ratchet**, the only DRY play that has survived this batch (the `gh-exec-invariant` for #1294, the source-invariant for #1336). One-off "migrate to shared helper" tickets get closed as duplicates; a ratchet that *prevents regression* is durable and makes DRYness **enforced (L2/L3) rather than advisory** — the literal meaning of "make DRYness a more core part of kaizen."

- **Subtraction:** `hook-gym-format.ts` now imports the shared `truncateDisplay` (byte-identical output at the one `truncate(e.reason, 60)` call site via `{ collapse: false }`); the private function is deleted.
- **Prevention:** `scripts/truncate-helper-invariant.test.ts` scans production `.ts` under `src/` and `scripts/` for definitions of a *bare* `truncate` helper, allows only the canonical home (`src/analysis/util.ts`), and freezes the rest with an empty `OPT_OUT`. The bare generic name is the copy-paste tell; descriptive variants (`truncateMiddle`, `truncateAtWordBoundary`, `truncateAfterPrefix`, `truncateDisplay`) carry their own names and are intentionally not matched.

## Evidence

- `scripts/truncate-helper-invariant.test.ts` — 8 cases: synthetic-fixture detection, no-false-positive on descriptive variants, comment-only ignore, unallowlisted-fail, stale-OPT_OUT report, canonical-home exclusion, and a live-tree assertion that the current tree is clean.
- All 23 tests in the two touched suites pass; full hook-gym suite (148 tests) green; `tsc --noEmit` clean.

## Behaviors × levels

| Behavior | Unit | Integration | System |
|----------|:----:|:-----------:|:------:|
| Bare-`truncate` definitions are detected (fixtures) | ✅ | | |
| Descriptive variants are not flagged (no false positive) | ✅ | | |
| Canonical home excluded; live tree clean; OPT_OUT not stale | ✅ | | |
| hook-gym-format output unchanged after consolidation | ✅ | | |

## Scope

- **In this PR:** consolidate the last truncation duplicate + add the truncation-drift ratchet.
- **Deferred (stays in #1164):** broader cross-PR sweep mode, comment-posting and telemetry-envelope families, LLM reflection dimension.

Run tag: handsome-lynx/run-39

Closes #1385
Refs #1164