### PR TITLE
refactor(dimensions): share validation parsers

### DIFF
--- a/src/cli-dimensions.test.ts
+++ b/src/cli-dimensions.test.ts
@@ -246,6 +246,13 @@ describe('cli-dimensions with temp fixtures', () => {
     expect(v.results[0].errors).toContain('Missing ```json output format section');
   });
 
+  it('validate accepts JSON output fences through the shared markdown fence parser', () => {
+    writeFileSync(resolve(tmpDir, 'review-json.md'), '---\nname: json\ndescription: test\napplies_to: pr\n---\n``` JSON \n{}\n```\n');
+    const v = cmdValidate(tmpDir);
+    expect(v.ok).toBe(true);
+    expect(v.results[0].errors).toEqual([]);
+  });
+
   it('validate catches frontmatter name/filename mismatch', () => {
     writeFileSync(resolve(tmpDir, 'review-correct-name.md'), '---\nname: wrong-name\ndescription: test\napplies_to: pr\n---\n```json\n{}\n```\n');
     const v = cmdValidate(tmpDir);
@@ -265,6 +272,22 @@ describe('cli-dimensions with temp fixtures', () => {
     const entry = v.results.find(r => r.file === 'review-badyaml.md');
     expect(entry?.errors[0]).toContain('invalid');
     expect(entry?.errors[0]).not.toContain('Missing YAML frontmatter');
+  });
+
+  it('validate distinguishes malformed CRLF YAML frontmatter from missing frontmatter', () => {
+    writeFileSync(resolve(tmpDir, 'review-badcrlf.md'), '---\r\nname: bad: yaml\r\ndescription: test\r\n---\r\nBody\r\n```json\r\n{}\r\n```\r\n');
+    const v = cmdValidate(tmpDir);
+    expect(v.ok).toBe(false);
+    const entry = v.results.find(r => r.file === 'review-badcrlf.md');
+    expect(entry?.errors[0]).toContain('invalid');
+    expect(entry?.errors[0]).not.toContain('Missing YAML frontmatter');
+  });
+
+  it('keeps validate on shared frontmatter and markdown fence parsers', () => {
+    const source = readFileSync(new URL('./cli-dimensions.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toContain("content.includes('```json')");
+    expect(source).not.toMatch(/\/\^---\\n/);
   });
 
   it('formatValidation shows FAIL for invalid dimensions', () => {

--- a/src/cli-dimensions.ts
+++ b/src/cli-dimensions.ts
@@ -20,6 +20,8 @@ import {
   parseFrontmatter,
   reviewBriefing,
 } from './review-battery.js';
+import { hasYamlFrontmatterBlock } from './lib/frontmatter.js';
+import { firstMarkdownFence } from './lib/markdown-fence.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -161,8 +163,7 @@ export function cmdValidate(promptsDir?: string): { results: ValidationResult[];
     // Check frontmatter exists and has required fields
     const fm = parseFrontmatter(content);
     if (!fm) {
-      const hasFrontmatterBlock = /^---\n[\s\S]*?\n---/.test(content);
-      errors.push(hasFrontmatterBlock ? 'Frontmatter YAML is invalid (cannot parse)' : 'Missing YAML frontmatter');
+      errors.push(hasYamlFrontmatterBlock(content) ? 'Frontmatter YAML is invalid (cannot parse)' : 'Missing YAML frontmatter');
     } else {
       if (!fm.name) errors.push('Frontmatter missing "name" field');
       if (!fm.description) errors.push('Frontmatter missing "description" field');
@@ -173,7 +174,7 @@ export function cmdValidate(promptsDir?: string): { results: ValidationResult[];
     }
 
     // Check for ```json output format section
-    if (!content.includes('```json')) {
+    if (!firstMarkdownFence(content, 'json')) {
       errors.push('Missing ```json output format section');
     }
 

--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseYamlFrontmatter, readYamlFrontmatter, stripYamlFrontmatter } from './frontmatter.js';
+import { hasYamlFrontmatterBlock, parseYamlFrontmatter, readYamlFrontmatter, stripYamlFrontmatter } from './frontmatter.js';
 
 describe('parseYamlFrontmatter', () => {
   it('returns null when markdown has no leading YAML frontmatter', () => {
@@ -8,6 +8,13 @@ describe('parseYamlFrontmatter', () => {
 
   it('returns null for malformed YAML without throwing', () => {
     const content = '---\nname: foo: bar\ndescription: nope\n---\nBody';
+    expect(parseYamlFrontmatter(content)).toBeNull();
+  });
+
+  it('detects a CRLF frontmatter block even when its YAML is malformed', () => {
+    const content = '---\r\nname: foo: bar\r\ndescription: nope\r\n---\r\nBody';
+
+    expect(hasYamlFrontmatterBlock(content)).toBe(true);
     expect(parseYamlFrontmatter(content)).toBeNull();
   });
 

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,4 +1,4 @@
-import { parseLeadingDelimitedYamlBlock } from './yaml-block.js';
+import { hasLeadingDelimitedYamlBlock, parseLeadingDelimitedYamlBlock } from './yaml-block.js';
 
 export interface YamlFrontmatter<T extends Record<string, unknown> = Record<string, unknown>> {
   data: T;
@@ -16,6 +16,10 @@ export function readYamlFrontmatter<T extends Record<string, unknown> = Record<s
   content: string,
 ): T | null {
   return parseYamlFrontmatter<T>(content)?.data ?? null;
+}
+
+export function hasYamlFrontmatterBlock(content: string): boolean {
+  return hasLeadingDelimitedYamlBlock(content);
 }
 
 export function stripYamlFrontmatter(content: string): string {

--- a/src/lib/yaml-block.test.ts
+++ b/src/lib/yaml-block.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseDelimitedYamlBlocks, parseLeadingDelimitedYamlBlock } from './yaml-block.js';
+import { hasLeadingDelimitedYamlBlock, parseDelimitedYamlBlocks, parseLeadingDelimitedYamlBlock } from './yaml-block.js';
 
 describe('parseLeadingDelimitedYamlBlock', () => {
   it('parses a leading YAML block and preserves trailing body', () => {
@@ -14,6 +14,11 @@ describe('parseLeadingDelimitedYamlBlock', () => {
 
   it('returns null when the leading YAML block is invalid', () => {
     expect(parseLeadingDelimitedYamlBlock('---\nname: nope: invalid\n---\nBody')).toBeNull();
+  });
+
+  it('detects a leading block with CRLF delimiters without parsing it', () => {
+    expect(hasLeadingDelimitedYamlBlock('---\r\nname: nope: invalid\r\n---\r\nBody')).toBe(true);
+    expect(hasLeadingDelimitedYamlBlock('# Heading\r\n---\r\nname: later\r\n---')).toBe(false);
   });
 });
 

--- a/src/lib/yaml-block.ts
+++ b/src/lib/yaml-block.ts
@@ -38,6 +38,10 @@ export function parseLeadingDelimitedYamlBlock<
   return { data, raw: match[1], body: match[3] ?? '' };
 }
 
+export function hasLeadingDelimitedYamlBlock(content: string): boolean {
+  return LEADING_DELIMITED_YAML_BLOCK_RE.test(content);
+}
+
 export function parseFirstDelimitedYamlBlock<
   T extends Record<string, unknown> = Record<string, unknown>,
 >(text: string): DelimitedYamlBlock<T> | null {


### PR DESCRIPTION
## Summary

- add shared frontmatter-block presence helpers beside the YAML frontmatter parser
- route dimension validation malformed-vs-missing frontmatter classification through the shared helper
- route dimension validation JSON output checks through the shared markdown fence parser

## Branch provenance

- Fresh worktree: `.claude/worktrees/260628-k1386-dimension-validation-parsers`
- Fresh branch from `origin/main`: `case/260628-k1386-dimension-validation-parsers`
- Pre-branch checks found #1386 open, no linked commit/PR history, no local branch, no remote branch, no all-state PR for this branch, and no existing worktree path.
- Note: existing issue/branch #1385 was detected and intentionally left untouched.

## Validation

- RED: `npm test -- --run src/cli-dimensions.test.ts` failed before implementation on spaced JSON fences, CRLF malformed frontmatter classification, and direct-parser source invariants
- GREEN: `npm test -- --run src/cli-dimensions.test.ts src/lib/yaml-block.test.ts src/lib/frontmatter.test.ts src/lib/markdown-fence.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`

Fixes Garsson-io/kaizen#1386
