### PR TITLE
refactor(jsonl): share tolerant line parsing

### DIFF
--- a/scripts/batch-summary.test.ts
+++ b/scripts/batch-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import type { EventEnvelope } from './auto-dent-events.js';
@@ -69,6 +69,24 @@ describe('parseEventsFile', () => {
 
     const result = parseEventsFile(join(tmpDir, 'events.jsonl'));
     expect(result).toHaveLength(2);
+  });
+
+  it('parses CRLF JSONL while skipping blank and malformed lines', () => {
+    const first = JSON.stringify(makeCompleteEvent({ run_num: 1 }));
+    const second = JSON.stringify(makeCompleteEvent({ run_num: 2 }));
+    const content = `${first}\r\n\r\nnot-json\r\n${second}\r\n`;
+    writeFileSync(join(tmpDir, 'events.jsonl'), content);
+
+    const result = parseEventsFile(join(tmpDir, 'events.jsonl'));
+
+    expect(result.map(e => e.event.type)).toEqual(['run.complete', 'run.complete']);
+    expect(result).toHaveLength(2);
+  });
+
+  it('keeps JSONL parsing on the shared helper', () => {
+    const source = readFileSync(new URL('./batch-summary.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toContain('JSON.parse(line)');
   });
 });
 

--- a/scripts/batch-summary.ts
+++ b/scripts/batch-summary.ts
@@ -15,6 +15,7 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
+import { parseJsonLines } from '../src/lib/json-lines.js';
 import type { EventEnvelope, RunCompleteEvent, RunIssuePickedEvent, RunPrCreatedEvent } from './auto-dent-events.js';
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
 
@@ -80,14 +81,7 @@ export function parseEventsFile(eventsPath: string): EventEnvelope[] {
   const content = readFileSync(eventsPath, 'utf8').trim();
   if (!content) return [];
 
-  return content.split('\n').reduce<EventEnvelope[]>((acc, line) => {
-    try {
-      acc.push(JSON.parse(line));
-    } catch {
-      // Skip malformed lines
-    }
-    return acc;
-  }, []);
+  return parseJsonLines<EventEnvelope>(content);
 }
 
 /**

--- a/src/lib/json-lines.test.ts
+++ b/src/lib/json-lines.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { parseJsonLines } from './json-lines.js';
+
+describe('parseJsonLines', () => {
+  it('parses valid JSON lines while skipping blanks and malformed rows', () => {
+    const rows = parseJsonLines('{"a":1}\n\nnot-json\n{"b":2}\n');
+
+    expect(rows).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('splits CRLF JSON lines', () => {
+    const rows = parseJsonLines('{"a":1}\r\n{"b":2}\r\n');
+
+    expect(rows).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+});

--- a/src/lib/json-lines.ts
+++ b/src/lib/json-lines.ts
@@ -1,0 +1,13 @@
+export function parseJsonLines<T = unknown>(text: string): T[] {
+  const rows: T[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      rows.push(JSON.parse(trimmed) as T);
+    } catch {
+      // Ignore malformed JSONL rows; callers consume best-effort streams.
+    }
+  }
+  return rows;
+}

--- a/src/section-editor.test.ts
+++ b/src/section-editor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { parseSections, listSections, readSection, addSection, replaceSection, removeSection, listAttachments, readAttachment, writeAttachment, removeAttachment, listAttachmentSections, readAttachmentSection, addAttachmentSection, removeAttachmentSection, clearCommentCache, type AttachmentTarget } from './section-editor.js';
 
 vi.mock('node:child_process', () => ({
@@ -273,6 +274,12 @@ describe('listAttachments', () => {
   it('returns empty for no attachments', () => {
     ghReturns('');
     expect(listAttachments(issueAttach)).toEqual([]);
+  });
+
+  it('keeps comment JSONL parsing on the shared helper', () => {
+    const source = readFileSync(new URL('./section-editor.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toContain('JSON.parse(line)');
   });
 });
 

--- a/src/section-editor.ts
+++ b/src/section-editor.ts
@@ -12,6 +12,7 @@
  */
 
 import { gh } from './lib/gh-exec.js';
+import { parseJsonLines } from './lib/json-lines.js';
 
 export type TargetKind = 'pr' | 'issue';
 
@@ -261,11 +262,12 @@ function fetchComments(target: AttachmentTarget): Array<{ url: string; body: str
       '--jq', '.[] | {url: .html_url, body: .body} | @json',
     ]);
     if (!raw) return [];
-    const results: Array<{ url: string; body: string }> = [];
-    for (const line of raw.split('\n')) {
-      if (!line.trim()) continue;
-      try { results.push(JSON.parse(line)); } catch { continue; }
-    }
+    const results = parseJsonLines<Record<string, unknown>>(raw)
+      .filter(row => typeof row.body === 'string')
+      .map(row => ({
+        url: typeof row.url === 'string' ? row.url : '',
+        body: row.body as string,
+      }));
     // Only cache non-empty results — empty results may be from a new PR
     // with no comments yet, and the next call might be after a write.
     if (results.length > 0) {


### PR DESCRIPTION
## Summary

- add `parseJsonLines()` for tolerant newline-delimited JSON parsing
- route batch event parsing through the shared helper
- route GitHub comment JSONL parsing through the shared helper while preserving old-gh null-url behavior

## Branch provenance

- Fresh worktree: `.claude/worktrees/260628-k1389-json-lines-helper`
- Fresh branch from `origin/main`: `case/260628-k1389-json-lines-helper`
- Pre-branch checks found #1389 open, no linked commit/PR history, no local branch, no remote branch, no all-state PR for this branch, and no existing worktree path.

## Validation

- RED: `npm test -- --run src/lib/json-lines.test.ts scripts/batch-summary.test.ts src/section-editor.test.ts` failed before implementation on the missing helper and direct-parser source invariants
- GREEN: `npm test -- --run src/lib/json-lines.test.ts scripts/batch-summary.test.ts src/section-editor.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`

Fixes Garsson-io/kaizen#1389
