### PR TITLE
refactor(github): share tolerant json decoding

### DIFF
--- a/src/lib/github-pr.test.ts
+++ b/src/lib/github-pr.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
   findOpenPrUrlForBranch,
   parseBranchPrQueryResult,
@@ -189,6 +190,14 @@ describe('parseIssueState', () => {
     expect(parseIssueState('{not json')).toBeNull();
     expect(parseIssueState(JSON.stringify({ state: 'MERGED' }))).toBeNull();
     expect(parseIssueState(JSON.stringify({}))).toBeNull();
+  });
+});
+
+describe('github-pr JSON parsing internals', () => {
+  it('keeps gh JSON decoding on shared helpers', () => {
+    const source = readFileSync(new URL('./github-pr.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toMatch(/JSON\.parse\(output\s*\|\|/);
   });
 });
 

--- a/src/lib/github-pr.ts
+++ b/src/lib/github-pr.ts
@@ -1,4 +1,5 @@
 import { gh as defaultGh } from './gh-exec.js';
+import { parseJsonArray, parseJsonObject } from './json-value.js';
 
 export type GhRunner = (args: string[]) => string;
 
@@ -50,14 +51,9 @@ export function parseGithubPrUrl(prUrl: string | undefined | null): GithubPrUrl 
 }
 
 export function parseFirstPrUrl(output: string): string | undefined {
-  try {
-    const parsed = JSON.parse(output || '[]') as unknown;
-    if (!Array.isArray(parsed)) return undefined;
-    const url = (parsed[0] as { url?: unknown } | undefined)?.url;
-    return typeof url === 'string' && url.length > 0 ? url : undefined;
-  } catch {
-    return undefined;
-  }
+  const parsed = parseJsonArray(output);
+  const url = (parsed[0] as { url?: unknown } | undefined)?.url;
+  return typeof url === 'string' && url.length > 0 ? url : undefined;
 }
 
 function normalizeBranchPrSummary(input: unknown): BranchPrSummary | undefined {
@@ -71,23 +67,17 @@ function normalizeBranchPrSummary(input: unknown): BranchPrSummary | undefined {
 }
 
 export function parseBranchPrQueryResult(output: string): BranchPrQueryResult {
-  try {
-    const parsed = JSON.parse(output || '[]') as unknown;
-    if (!Array.isArray(parsed)) return emptyBranchPrQueryResult();
-    const prs = parsed
-      .map((item) => normalizeBranchPrSummary(item))
-      .filter((item): item is BranchPrSummary => item != null);
-    if (prs.length === 0) return emptyBranchPrQueryResult();
+  const prs = parseJsonArray(output)
+    .map((item) => normalizeBranchPrSummary(item))
+    .filter((item): item is BranchPrSummary => item != null);
+  if (prs.length === 0) return emptyBranchPrQueryResult();
 
-    const open = prs.find((pr) => pr.state === 'OPEN');
-    return {
-      mostRecent: prs[0],
-      hasOpen: open != null,
-      ...(open ? { openUrl: open.url } : {}),
-    };
-  } catch {
-    return emptyBranchPrQueryResult();
-  }
+  const open = prs.find((pr) => pr.state === 'OPEN');
+  return {
+    mostRecent: prs[0],
+    hasOpen: open != null,
+    ...(open ? { openUrl: open.url } : {}),
+  };
 }
 
 export function findOpenPrUrlForBranch(options: FindOpenPrUrlForBranchOptions): string | undefined {
@@ -145,13 +135,9 @@ export function parseIssueNumber(token: string | undefined | null): number | nul
  * "do not block" — never as "closed".
  */
 export function parseIssueState(output: string): IssueState | null {
-  try {
-    const parsed = JSON.parse(output || '{}') as { state?: unknown };
-    const raw = typeof parsed.state === 'string' ? parsed.state.toUpperCase() : null;
-    return raw === 'OPEN' || raw === 'CLOSED' ? raw : null;
-  } catch {
-    return null;
-  }
+  const parsed = parseJsonObject(output);
+  const raw = typeof parsed?.state === 'string' ? parsed.state.toUpperCase() : null;
+  return raw === 'OPEN' || raw === 'CLOSED' ? raw : null;
 }
 
 export interface QueryIssueStateOptions {

--- a/src/lib/json-value.test.ts
+++ b/src/lib/json-value.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { parseJsonArray, parseJsonObject, parseJsonValue } from './json-value.js';
+
+describe('parseJsonValue', () => {
+  it('returns parsed JSON values', () => {
+    expect(parseJsonValue('{"ok":true}')).toEqual({ ok: true });
+    expect(parseJsonValue('[1,2]')).toEqual([1, 2]);
+    expect(parseJsonValue('"text"')).toBe('text');
+  });
+
+  it('returns null for blank or malformed JSON', () => {
+    expect(parseJsonValue('')).toBeNull();
+    expect(parseJsonValue('  ')).toBeNull();
+    expect(parseJsonValue('{not json')).toBeNull();
+  });
+});
+
+describe('parseJsonArray', () => {
+  it('returns arrays and rejects non-arrays', () => {
+    expect(parseJsonArray('[{"url":"u"}]')).toEqual([{ url: 'u' }]);
+    expect(parseJsonArray('{"url":"u"}')).toEqual([]);
+    expect(parseJsonArray('{not json')).toEqual([]);
+  });
+});
+
+describe('parseJsonObject', () => {
+  it('returns plain JSON objects and rejects arrays/primitives', () => {
+    expect(parseJsonObject('{"state":"OPEN"}')).toEqual({ state: 'OPEN' });
+    expect(parseJsonObject('[{"state":"OPEN"}]')).toBeNull();
+    expect(parseJsonObject('"OPEN"')).toBeNull();
+    expect(parseJsonObject('{not json')).toBeNull();
+  });
+});

--- a/src/lib/json-value.ts
+++ b/src/lib/json-value.ts
@@ -1,0 +1,20 @@
+export function parseJsonValue(text: string): unknown | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+export function parseJsonArray(text: string): unknown[] {
+  const parsed = parseJsonValue(text);
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+export function parseJsonObject(text: string): Record<string, unknown> | null {
+  const parsed = parseJsonValue(text);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return parsed as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary

- add shared JSON value helpers for tolerant value/array/object parsing
- route `github-pr.ts` gh-output parsers through the shared helpers
- keep PR URL, branch PR summary, and issue-state validation local to `github-pr.ts`

## Branch provenance

- Fresh worktree: `.claude/worktrees/260628-k1391-github-json-parser`
- Fresh branch from `origin/main`: `case/260628-k1391-github-json-parser`
- Pre-branch checks found #1391 open, no linked commit/PR history, no local branch, no remote branch, no all-state PR for this branch, and no existing worktree path.

## Validation

- RED: `npm test -- --run src/lib/json-value.test.ts src/lib/github-pr.test.ts` failed before implementation on the missing helper and direct-parser source invariant
- GREEN: `npm test -- --run src/lib/json-value.test.ts src/lib/github-pr.test.ts`
- GREEN: `npm run typecheck`
- GREEN: `git diff --check`

Fixes Garsson-io/kaizen#1391
