### PR TITLE
refactor(hooks): share telemetry jsonl parsing

### DIFF
--- a/src/hooks/telemetry-analysis.test.ts
+++ b/src/hooks/telemetry-analysis.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
@@ -51,6 +51,37 @@ describe('parseHooksJsonl', () => {
     expect(records[1].hook).toBe('also-valid');
   });
 
+  it('parses CRLF JSONL while skipping blank, malformed, and invalid telemetry rows', () => {
+    const content = [
+      '{"hook":"valid","timestamp":"2026-03-23T08:00:00Z","duration_ms":50}',
+      '',
+      'not json',
+      '{"hook":"missing-duration","timestamp":"2026-03-23T08:00:01Z"}',
+      '{"hook":"also-valid","timestamp":"2026-03-23T08:00:02Z","duration_ms":20,"exit_code":1}',
+    ].join('\r\n');
+
+    const records = parseHooksJsonl(content);
+
+    expect(records).toEqual([
+      {
+        hook: 'valid',
+        timestamp: '2026-03-23T08:00:00Z',
+        duration_ms: 50,
+        exit_code: 0,
+        branch: '',
+        case_id: '',
+      },
+      {
+        hook: 'also-valid',
+        timestamp: '2026-03-23T08:00:02Z',
+        duration_ms: 20,
+        exit_code: 1,
+        branch: '',
+        case_id: '',
+      },
+    ]);
+  });
+
   it('handles empty content', () => {
     expect(parseHooksJsonl('')).toHaveLength(0);
     expect(parseHooksJsonl('\n\n\n')).toHaveLength(0);
@@ -60,6 +91,13 @@ describe('parseHooksJsonl', () => {
     const content = '{"hook":"test","timestamp":"2026-03-23T08:00:00Z","duration_ms":10}';
     const records = parseHooksJsonl(content);
     expect(records[0].exit_code).toBe(0);
+  });
+
+  it('delegates tolerant JSONL decoding to the shared parser', () => {
+    const source = readFileSync(new URL('./telemetry-analysis.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toMatch(/JSON\.parse\(trimmed\)/);
+    expect(source).not.toContain("content.split('\\n')");
   });
 });
 

--- a/src/hooks/telemetry-analysis.ts
+++ b/src/hooks/telemetry-analysis.ts
@@ -13,6 +13,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { parseJsonLines } from '../lib/json-lines.js';
 
 export interface HookTelemetryRecord {
   hook: string;
@@ -51,27 +52,20 @@ const HIGH_FAILURE_RATE = 0.05;
  */
 export function parseHooksJsonl(content: string): HookTelemetryRecord[] {
   const records: HookTelemetryRecord[] = [];
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-      if (
-        typeof parsed.hook === 'string' &&
-        typeof parsed.duration_ms === 'number' &&
-        typeof parsed.timestamp === 'string'
-      ) {
-        records.push({
-          hook: parsed.hook,
-          timestamp: parsed.timestamp,
-          duration_ms: parsed.duration_ms,
-          exit_code: typeof parsed.exit_code === 'number' ? parsed.exit_code : 0,
-          branch: typeof parsed.branch === 'string' ? parsed.branch : '',
-          case_id: typeof parsed.case_id === 'string' ? parsed.case_id : '',
-        });
-      }
-    } catch {
-      // Skip malformed lines
+  for (const parsed of parseJsonLines<Record<string, unknown>>(content)) {
+    if (
+      typeof parsed.hook === 'string' &&
+      typeof parsed.duration_ms === 'number' &&
+      typeof parsed.timestamp === 'string'
+    ) {
+      records.push({
+        hook: parsed.hook,
+        timestamp: parsed.timestamp,
+        duration_ms: parsed.duration_ms,
+        exit_code: typeof parsed.exit_code === 'number' ? parsed.exit_code : 0,
+        branch: typeof parsed.branch === 'string' ? parsed.branch : '',
+        case_id: typeof parsed.case_id === 'string' ? parsed.case_id : '',
+      });
     }
   }
   return records;


### PR DESCRIPTION
## Summary

`parseHooksJsonl()` was still carrying its own tolerant JSONL loop: split lines, trim blanks, catch malformed JSON, and continue.

This PR routes that generic JSONL decoding through `parseJsonLines()` while keeping the hook telemetry schema validation and projection local to `src/hooks/telemetry-analysis.ts`.

Fixes Garsson-io/kaizen#1393

## Validation

- `npm test -- --run src/hooks/telemetry-analysis.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`