### PR TITLE
refactor(hooks): share transcript jsonl parsing

### DIFF
--- a/src/hooks/transcript-analysis.test.ts
+++ b/src/hooks/transcript-analysis.test.ts
@@ -50,6 +50,33 @@ describe('parseTranscript', () => {
     const entries = parseTranscript(jsonl);
     expect(entries).toHaveLength(2);
   });
+
+  it('parses CRLF JSONL while skipping blank and malformed rows', () => {
+    const jsonl = [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: [] } }),
+      '',
+      'not-json',
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [] },
+      }),
+    ].join('\r\n');
+
+    const entries = parseTranscript(jsonl);
+
+    expect(entries.map((entry) => entry.type)).toEqual(['user', 'assistant']);
+  });
+
+  it('delegates tolerant JSONL decoding to the shared parser', () => {
+    const source = readFileSync('src/hooks/transcript-analysis.ts', 'utf8');
+    const parserSource = source.slice(
+      source.indexOf('export function parseTranscript'),
+      source.indexOf('/** Read and parse a transcript file. */'),
+    );
+
+    expect(parserSource).not.toMatch(/\.split\(['"]\\n['"]\)/);
+    expect(parserSource).not.toMatch(/JSON\.parse\(line\)/);
+  });
 });
 
 describe('truncation ownership (#1351)', () => {

--- a/src/hooks/transcript-analysis.ts
+++ b/src/hooks/transcript-analysis.ts
@@ -14,6 +14,7 @@
 
 import { readFileSync } from 'node:fs';
 import { truncateAfterPrefix } from '../analysis/util.js';
+import { parseJsonLines } from '../lib/json-lines.js';
 
 // ── Types ──
 
@@ -159,18 +160,7 @@ function detectRepeatedRequests(userMessages: string[]): Signal[] {
 
 /** Parse a JSONL transcript into entries. */
 export function parseTranscript(content: string): TranscriptEntry[] {
-  return content
-    .trim()
-    .split('\n')
-    .filter((line) => line.trim())
-    .map((line) => {
-      try {
-        return JSON.parse(line) as TranscriptEntry;
-      } catch {
-        return null;
-      }
-    })
-    .filter((e): e is TranscriptEntry => e !== null);
+  return parseJsonLines<TranscriptEntry>(content);
 }
 
 /** Read and parse a transcript file. */


### PR DESCRIPTION
## Summary

`parseTranscript()` was still carrying a private tolerant JSONL parser: trim the transcript, split rows, skip blanks, parse each line, and discard malformed JSON.

This PR routes that generic decoding through `parseJsonLines()` and keeps transcript analysis behavior local to `src/hooks/transcript-analysis.ts`.

Fixes Garsson-io/kaizen#1395

## Validation

- `npm test -- --run src/hooks/transcript-analysis.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`