### PR TITLE
refactor(auto-dent): share aggregate jsonl parsing

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -989,6 +989,34 @@ describe('readAggregate', () => {
     const records = readAggregate(tmpDir);
     expect(records).toHaveLength(2);
   });
+
+  it('parses CRLF aggregate JSONL while skipping blank and malformed rows', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'agg-test-'));
+    writeFileSync(
+      join(tmpDir, 'aggregate.jsonl'),
+      [
+        '{"batch_id":"b1","total_runs":1}',
+        '',
+        'not json',
+        '{"batch_id":"b2","total_runs":2}',
+      ].join('\r\n'),
+    );
+
+    const records = readAggregate(tmpDir);
+
+    expect(records.map((record) => record.batch_id)).toEqual(['b1', 'b2']);
+  });
+
+  it('delegates tolerant aggregate JSONL decoding to the shared parser', () => {
+    const source = readFileSync('scripts/auto-dent-ctl.ts', 'utf8');
+    const aggregateSource = source.slice(
+      source.indexOf('export function appendBatchToAggregate'),
+      source.indexOf('export interface AggregateStats'),
+    );
+
+    expect(aggregateSource).not.toMatch(/JSON\.parse\(line\)/);
+    expect(aggregateSource).not.toMatch(/\.split\(['"]\\n['"]\)/);
+  });
 });
 
 describe('computeAggregateStats', () => {

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -41,6 +41,7 @@ import {
   type ReadOutcomesDeps,
 } from './batch-outcome.js';
 import { truncateDisplay } from './auto-dent-display.js';
+import { parseJsonLines } from '../src/lib/json-lines.js';
 
 function getRepoRoot(): string {
   try {
@@ -839,17 +840,9 @@ export function appendBatchToAggregate(
 ): { action: 'appended' | 'already_exists' | 'error'; path: string } {
   const aggregatePath = join(logsDir, 'aggregate.jsonl');
 
-  // Check for duplicate
-  if (existsSync(aggregatePath)) {
-    const existing = readFileSync(aggregatePath, 'utf8');
-    const lines = existing.split('\n').filter(Boolean);
-    for (const line of lines) {
-      try {
-        const record = JSON.parse(line);
-        if (record.batch_id === batch.batchId) {
-          return { action: 'already_exists', path: aggregatePath };
-        }
-      } catch { /* skip malformed lines */ }
+  for (const record of readAggregate(logsDir)) {
+    if (record.batch_id === batch.batchId) {
+      return { action: 'already_exists', path: aggregatePath };
     }
   }
 
@@ -866,13 +859,7 @@ export function readAggregate(logsDir: string): AggregateBatchRecord[] {
   if (!existsSync(aggregatePath)) return [];
 
   const content = readFileSync(aggregatePath, 'utf8');
-  const records: AggregateBatchRecord[] = [];
-  for (const line of content.split('\n').filter(Boolean)) {
-    try {
-      records.push(JSON.parse(line));
-    } catch { /* skip malformed lines */ }
-  }
-  return records;
+  return parseJsonLines<AggregateBatchRecord>(content);
 }
 
 export interface AggregateStats {


### PR DESCRIPTION
## Summary

`auto-dent-ctl` was carrying two private tolerant JSONL readers for `aggregate.jsonl`: one for duplicate detection during append and one for history reads.

This PR routes aggregate reads through the shared `parseJsonLines()` helper and makes duplicate detection reuse `readAggregate()`, so blank rows, malformed rows, and CRLF handling stay owned by one JSONL parser.

Fixes Garsson-io/kaizen#1397

## Validation

- `npm test -- --run scripts/auto-dent-ctl.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`