### PR TITLE
refactor(auto-dent): share planning jsonl parsing

### DIFF
--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -181,6 +181,27 @@ describe('provider-aware planning (#1146)', () => {
     expect(validatePlan(extractPlanJson(codexText))).not.toBeNull();
   });
 
+  it('extracts Claude planning text from CRLF stream-json while skipping blank and malformed rows', () => {
+    const raw = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'prefix ' }] } }),
+      '',
+      'not-json',
+      JSON.stringify({ type: 'result', result: 'result text' }),
+    ].join('\r\n');
+
+    expect(extractPlanningText('claude', raw)).toBe('prefix \nresult text');
+  });
+
+  it('delegates Claude stream-json decoding to the shared JSONL parser', () => {
+    const source = readFileSync('scripts/auto-dent-plan.ts', 'utf8');
+    const extractorSource = source.slice(
+      source.indexOf('export function extractPlanningText'),
+      source.indexOf('export function extractPlanJson'),
+    );
+
+    expect(extractorSource).not.toMatch(/JSON\.parse\(line\)/);
+  });
+
   it('validates schema-constrained Codex JSONL into a Codex-attributed plan (#1215)', () => {
     const providerPlan = {
       created_at: '2026-06-27T22:20:00Z',

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -30,6 +30,7 @@ import {
 } from './auto-dent-run.js';
 import { buildCodexExecArgs, parseCodexJsonl } from './auto-dent-codex.js';
 import type { PhaseProvider } from './auto-dent-provider.js';
+import { parseJsonLines } from '../src/lib/json-lines.js';
 
 export interface PlanItem {
   issue: string;
@@ -234,22 +235,22 @@ export function extractPlanningText(provider: PlanningProviderName, raw: string)
   }
 
   let fullText = '';
-  for (const line of raw.split(/\r?\n/)) {
-    if (!line.trim()) continue;
-    try {
-      const msg = JSON.parse(line);
-      if (msg.type === 'assistant' && msg.message?.content) {
-        for (const block of msg.message.content) {
-          if (block.type === 'text') {
-            fullText += block.text;
+  for (const msg of parseJsonLines<Record<string, unknown>>(raw)) {
+    const message = msg.message;
+    if (msg.type === 'assistant' && message && typeof message === 'object') {
+      const content = (message as Record<string, unknown>).content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (!block || typeof block !== 'object') continue;
+          const record = block as Record<string, unknown>;
+          if (record.type === 'text' && typeof record.text === 'string') {
+            fullText += record.text;
           }
         }
       }
-      if (msg.type === 'result' && msg.result) {
-        fullText += '\n' + msg.result;
-      }
-    } catch {
-      // Non-JSON line
+    }
+    if (msg.type === 'result' && msg.result) {
+      fullText += '\n' + String(msg.result);
     }
   }
   return fullText;


### PR DESCRIPTION
## Summary

The Claude branch of `extractPlanningText()` was carrying a private tolerant stream-json parser: split rows, skip blanks, parse JSON, and ignore malformed lines.

This PR routes that generic row decoding through `parseJsonLines()` while keeping provider-specific planning text extraction in `scripts/auto-dent-plan.ts`. The Codex path remains on `parseCodexJsonl()` because it has different final-message behavior.

Fixes Garsson-io/kaizen#1399

## Validation

- `npm test -- --run scripts/auto-dent-plan.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`