### PR TITLE
refactor(hook-gym): share replay jsonl parsing

### DIFF
--- a/scripts/hook-gym-replay.test.ts
+++ b/scripts/hook-gym-replay.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -207,6 +207,16 @@ describe('extractToolActions', () => {
     expect(actions[0].result).toBeDefined();
     expect(actions[1].result).toBeDefined();
     expect(actions[2].result).toBeUndefined(); // no result yet
+  });
+
+  it('delegates tolerant stream-json decoding to the shared JSONL parser', () => {
+    const source = readFileSync('scripts/hook-gym-replay.ts', 'utf8');
+    const extractorSource = source.slice(
+      source.indexOf('export function extractToolActions'),
+      source.indexOf('/** Extract text content from a tool_result block. */'),
+    );
+
+    expect(extractorSource).not.toMatch(/JSON\.parse\(line\)/);
   });
 });
 

--- a/scripts/hook-gym-replay.ts
+++ b/scripts/hook-gym-replay.ts
@@ -21,6 +21,7 @@ import type { HookTimeline, ParsedHookEvent, Scenario } from './hook-gym-schema.
 import { parseHookGymFixtureContent } from './hook-gym-schema.js';
 import { validateAgainstScenario, type ValidationReport } from './hook-gym-validate.js';
 import { parseHookDecision } from './hook-gym-stream.js';
+import { parseJsonLines } from '../src/lib/json-lines.js';
 
 const __replay_dirname = dirname(fileURLToPath(import.meta.url));
 const KAIZEN_ROOT = resolve(__replay_dirname, '..');
@@ -81,14 +82,7 @@ export function extractToolActions(streamLines: string[]): ToolAction[] {
   const pending = new Map<string, ToolAction>();
   let index = 0;
 
-  for (const line of streamLines) {
-    let msg: Record<string, unknown>;
-    try {
-      msg = JSON.parse(line);
-    } catch {
-      continue;
-    }
-
+  for (const msg of parseJsonLines<Record<string, unknown>>(streamLines.join('\n'))) {
     // Assistant message → tool_use blocks
     if (msg.type === 'assistant') {
       const content = (msg as any).message?.content;


### PR DESCRIPTION
## Summary

`extractToolActions()` was carrying a private tolerant stream-json row parser: parse each row, skip malformed lines, and continue extracting tool actions.

This PR routes that generic JSONL decoding through `parseJsonLines()` while keeping hook-gym replay behavior local. Strict fixture validation remains in `parseHookGymFixtureContent()` and is intentionally unchanged.

Fixes Garsson-io/kaizen#1401

## Validation

- `npm test -- --run scripts/hook-gym-replay.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`