### PR TITLE
refactor(auto-dent): share codex jsonl row parsing

### DIFF
--- a/scripts/auto-dent-codex.test.ts
+++ b/scripts/auto-dent-codex.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import {
   buildCodexExecArgs,
@@ -45,6 +46,17 @@ describe('parseCodexJsonl (#1144)', () => {
 
     expect(parsed.events).toHaveLength(1);
     expect(parsed.malformedLines).toEqual(['{not json']);
+  });
+
+  it('delegates JSONL row parsing and malformed-row accounting to the shared helper', () => {
+    const source = readFileSync('scripts/auto-dent-codex.ts', 'utf8');
+    const parserSource = source.slice(
+      source.indexOf('export function parseCodexJsonl'),
+      source.indexOf('export function extractCodexPhaseMarkers'),
+    );
+
+    expect(parserSource).not.toMatch(/JSON\.parse\(line\)/);
+    expect(parserSource).not.toMatch(/jsonl\.split/);
   });
 
   it('extracts current Codex item payloads from supervised provider runs (#1197)', () => {

--- a/scripts/auto-dent-codex.ts
+++ b/scripts/auto-dent-codex.ts
@@ -6,6 +6,8 @@
  * that the existing auto-dent lifecycle validator can consume.
  */
 
+import { parseJsonLinesWithMalformedRows } from '../src/lib/json-lines.js';
+
 export interface ParsedCodexJsonl {
   events: unknown[];
   text: string;
@@ -51,39 +53,31 @@ function isFinalEvent(event: unknown): boolean {
 }
 
 export function parseCodexJsonl(jsonl: string): ParsedCodexJsonl {
-  const events: unknown[] = [];
   const textChunks: string[] = [];
   const finalChunks: string[] = [];
   const agentMessages: string[] = [];
-  const malformedLines: string[] = [];
+  const parsed = parseJsonLinesWithMalformedRows<unknown>(jsonl);
 
-  for (const raw of jsonl.split(/\r?\n/)) {
-    const line = raw.trim();
-    if (!line) continue;
-    try {
-      const event = JSON.parse(line) as unknown;
-      events.push(event);
-      const chunks: string[] = [];
-      collectText(event, chunks);
-      textChunks.push(...chunks);
-      if (isFinalEvent(event)) finalChunks.push(...chunks);
-      const item = (event as Record<string, unknown>).item;
-      if (item && typeof item === 'object') {
-        const itemObj = item as Record<string, unknown>;
-        if (itemObj.type === 'agent_message' && typeof itemObj.text === 'string') {
-          agentMessages.push(itemObj.text);
-        }
+  for (const event of parsed.rows) {
+    const chunks: string[] = [];
+    collectText(event, chunks);
+    textChunks.push(...chunks);
+    if (isFinalEvent(event)) finalChunks.push(...chunks);
+    if (!event || typeof event !== 'object') continue;
+    const item = (event as Record<string, unknown>).item;
+    if (item && typeof item === 'object') {
+      const itemObj = item as Record<string, unknown>;
+      if (itemObj.type === 'agent_message' && typeof itemObj.text === 'string') {
+        agentMessages.push(itemObj.text);
       }
-    } catch {
-      malformedLines.push(raw);
     }
   }
 
   return {
-    events,
+    events: parsed.rows,
     text: textChunks.join('\n'),
     finalText: finalChunks.length > 0 ? finalChunks.join('\n') : (agentMessages.at(-1) ?? ''),
-    malformedLines,
+    malformedLines: parsed.malformedRows,
   };
 }
 

--- a/src/lib/json-lines.test.ts
+++ b/src/lib/json-lines.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseJsonLines } from './json-lines.js';
+import { parseJsonLines, parseJsonLinesWithMalformedRows } from './json-lines.js';
 
 describe('parseJsonLines', () => {
   it('parses valid JSON lines while skipping blanks and malformed rows', () => {
@@ -12,5 +12,12 @@ describe('parseJsonLines', () => {
     const rows = parseJsonLines('{"a":1}\r\n{"b":2}\r\n');
 
     expect(rows).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('returns parsed rows and malformed raw rows when callers need diagnostics', () => {
+    const result = parseJsonLinesWithMalformedRows('{"a":1}\r\n\r\nnot-json\r\n  {"b":2}  \r\n{bad');
+
+    expect(result.rows).toEqual([{ a: 1 }, { b: 2 }]);
+    expect(result.malformedRows).toEqual(['not-json', '{bad']);
   });
 });

--- a/src/lib/json-lines.ts
+++ b/src/lib/json-lines.ts
@@ -1,13 +1,23 @@
-export function parseJsonLines<T = unknown>(text: string): T[] {
+export interface ParsedJsonLines<T = unknown> {
+  rows: T[];
+  malformedRows: string[];
+}
+
+export function parseJsonLinesWithMalformedRows<T = unknown>(text: string): ParsedJsonLines<T> {
   const rows: T[] = [];
-  for (const line of text.split(/\r?\n/)) {
-    const trimmed = line.trim();
+  const malformedRows: string[] = [];
+  for (const raw of text.split(/\r?\n/)) {
+    const trimmed = raw.trim();
     if (!trimmed) continue;
     try {
       rows.push(JSON.parse(trimmed) as T);
     } catch {
-      // Ignore malformed JSONL rows; callers consume best-effort streams.
+      malformedRows.push(raw);
     }
   }
-  return rows;
+  return { rows, malformedRows };
+}
+
+export function parseJsonLines<T = unknown>(text: string): T[] {
+  return parseJsonLinesWithMalformedRows<T>(text).rows;
 }


### PR DESCRIPTION
## Summary

`parseCodexJsonl()` needed the same JSONL row mechanics as the shared parser, but with malformed-row diagnostics. It was still carrying its own split/trim/parse loop to preserve `malformedLines`.

This PR adds `parseJsonLinesWithMalformedRows()` to `src/lib/json-lines.ts`, keeps `parseJsonLines()` as the simple parsed-row wrapper, and routes Codex JSONL parsing through the shared row decoder while leaving Codex-specific text extraction local.

Fixes Garsson-io/kaizen#1403

## Validation

- `npm test -- --run src/lib/json-lines.test.ts scripts/auto-dent-codex.test.ts`
- `npm run typecheck`
- `git diff --check`