### PR TITLE
refactor(review-fix): share stream jsonl parsing

### DIFF
--- a/scripts/review-fix.test.ts
+++ b/scripts/review-fix.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync as spawnRaw } from 'node:child_process';
@@ -116,6 +116,18 @@ describe('parseStreamJsonResult', () => {
     const r = parseStreamJsonResult(log);
     expect(r.found).toBe(true);
     expect(r.costUsd).toBeCloseTo(0.09);
+  });
+
+  it('delegates JSONL row parsing to the shared helper', () => {
+    const source = readFileSync(new URL('./review-fix.ts', import.meta.url), 'utf8');
+    const functionBody = source.slice(
+      source.indexOf('export function parseStreamJsonResult'),
+      source.indexOf('// ── Fix-running phase handler'),
+    );
+
+    expect(functionBody).toContain('parseJsonLines');
+    expect(functionBody).not.toContain('JSON.parse(line.trim())');
+    expect(functionBody).not.toContain(".split('\\n')");
   });
 });
 

--- a/scripts/review-fix.ts
+++ b/scripts/review-fix.ts
@@ -37,6 +37,7 @@ import {
   type ReviewProvider,
 } from '../src/review-battery.js';
 import { addSection, writeAttachment } from '../src/section-editor.js';
+import { parseJsonLines } from '../src/lib/json-lines.js';
 import { ghExec } from './auto-dent-github.js';
 import { buildCodexExecArgs, parseCodexJsonl } from './auto-dent-codex.js';
 import {
@@ -59,6 +60,13 @@ export interface StreamJsonResult {
   output: string;
 }
 
+interface StreamJsonMessage {
+  type?: unknown;
+  subtype?: unknown;
+  total_cost_usd?: number;
+  result?: string;
+}
+
 /**
  * Parse a stream-json JSONL log (--output-format stream-json --verbose).
  * Scans for the final message with type === "result" and extracts
@@ -69,19 +77,16 @@ export interface StreamJsonResult {
  */
 export function parseStreamJsonResult(stdout: string): StreamJsonResult {
   if (!stdout.trim()) return { found: false, success: false, costUsd: 0, output: '' };
-  for (const line of stdout.trim().split('\n').reverse()) {
-    try {
-      const msg = JSON.parse(line.trim());
-      if (msg.type === 'result') {
-        return {
-          found: true,
-          success: msg.subtype !== 'error_during_generation',
-          // total_cost_usd is a top-level field on the result message (not nested in usage)
-          costUsd: msg.total_cost_usd ?? 0,
-          output: msg.result ?? '',
-        };
-      }
-    } catch { continue; }
+  for (const msg of parseJsonLines<StreamJsonMessage>(stdout).reverse()) {
+    if (msg.type === 'result') {
+      return {
+        found: true,
+        success: msg.subtype !== 'error_during_generation',
+        // total_cost_usd is a top-level field on the result message (not nested in usage)
+        costUsd: msg.total_cost_usd ?? 0,
+        output: msg.result ?? '',
+      };
+    }
   }
   return { found: false, success: false, costUsd: 0, output: '' };
 }


### PR DESCRIPTION
## Summary

`review-fix` had one remaining bespoke tolerant JSONL parser for Claude stream-json logs. The shared `parseJsonLines()` helper now owns that behavior elsewhere, so this PR routes `parseStreamJsonResult()` through it and leaves result extraction unchanged.

## What Changed

- Imported `parseJsonLines()` into `scripts/review-fix.ts`.
- Replaced local `stdout.trim().split("\n")` plus `JSON.parse(line.trim())` handling with shared JSONL row parsing.
- Added a source-level invariant so `parseStreamJsonResult()` does not drift back to ad hoc line parsing.

## Validation

- RED confirmed: new invariant failed against the old hand-rolled parser.
- `npm test -- --run scripts/review-fix.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`

Fixes Garsson-io/kaizen#1405
