### PR TITLE
refactor(review-battery): share stream jsonl parsing

### DIFF
--- a/src/review-battery.test.ts
+++ b/src/review-battery.test.ts
@@ -699,6 +699,18 @@ describe('spawnReview', () => {
     const { costUsd } = await spawnReview({ dimension: 'requirements', repo: 'test/test' });
     expect(costUsd).toBeCloseTo(0.05);
   });
+
+  it('delegates stream-json row parsing to the shared JSONL helper', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/review-battery.ts'), 'utf8');
+    const parsingBlock = source.slice(
+      source.indexOf('// Parse text and cost from stream-json JSONL output.'),
+      source.indexOf('resolve({ text, costUsd, durationMs, exitCode: code ?? -1 });'),
+    );
+
+    expect(parsingBlock).toContain('parseJsonLines');
+    expect(parsingBlock).not.toContain("stdout.split('\\n')");
+    expect(parsingBlock).not.toContain('JSON.parse(line)');
+  });
 });
 
 // Tier 1: reviewBattery (mocked spawnReview)

--- a/src/review-battery.ts
+++ b/src/review-battery.ts
@@ -15,6 +15,7 @@ import { spawn } from 'node:child_process';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve, dirname, basename } from 'node:path';
 import { readYamlFrontmatter, stripYamlFrontmatter } from './lib/frontmatter.js';
+import { parseJsonLines } from './lib/json-lines.js';
 import { firstMarkdownFence, markdownFences } from './lib/markdown-fence.js';
 import { resolveProjectRoot, type GitRunner } from './lib/resolve-project-root.js';
 import { retrievePlan, issueTarget } from './structured-data.js';
@@ -58,6 +59,19 @@ export interface DimensionReview {
 export type ReviewFailureClass =
   | 'claude_review_failed'
   | 'codex_review_unsupported';
+
+interface StreamJsonContentBlock {
+  type?: unknown;
+  text?: string;
+}
+
+interface StreamJsonMessage {
+  type?: unknown;
+  total_cost_usd?: number;
+  message?: {
+    content?: unknown;
+  };
+}
 
 export interface ReviewProvider {
   provider: 'claude' | 'codex';
@@ -497,19 +511,19 @@ async function runClaude(
       // actual text lives in assistant message content blocks.
       let costUsd = 0;
       let text = '';
-      for (const line of stdout.split('\n')) {
-        if (!line.trim()) continue;
-        try {
-          const msg = JSON.parse(line);
-          if (msg.type === 'result') {
-            costUsd = msg.total_cost_usd ?? 0;
-          } else if (msg.type === 'assistant') {
-            const content = msg.message?.content ?? [];
-            for (const block of content) {
-              if (block.type === 'text') text += block.text;
+      for (const msg of parseJsonLines<StreamJsonMessage>(stdout)) {
+        if (msg.type === 'result') {
+          costUsd = msg.total_cost_usd ?? 0;
+        } else if (msg.type === 'assistant') {
+          const content = Array.isArray(msg.message?.content)
+            ? msg.message.content as StreamJsonContentBlock[]
+            : [];
+          for (const block of content) {
+            if (block.type === 'text') {
+              text += block.text ?? '';
             }
           }
-        } catch { continue; }
+        }
       }
 
       resolve({ text, costUsd, durationMs, exitCode: code ?? -1 });


### PR DESCRIPTION
## Summary

`review-battery` still had a local tolerant JSONL parser for Claude stream-json output. This PR routes that row parsing through the shared `parseJsonLines()` helper while keeping the review text/cost extraction behavior in place.

## What Changed

- Imported `parseJsonLines()` into `src/review-battery.ts`.
- Replaced the local `stdout.split("\n")` plus `JSON.parse(line)` loop in the Claude stream-json parser.
- Added a source-level invariant in `src/review-battery.test.ts` so this parser stays delegated to the shared helper.

## Validation

- RED confirmed: the new invariant failed against the old hand-rolled parser.
- `npm test -- --run src/review-battery.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`

Fixes Garsson-io/kaizen#1407
