### PR TITLE
refactor(hook-gym): share log jsonl parsing

### DIFF
--- a/scripts/hook-gym-stream.test.ts
+++ b/scripts/hook-gym-stream.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   parseHookDecision,
   createHookStreamProcessor,
@@ -447,5 +449,17 @@ describe('parseLogFile', () => {
     const tl = parseLogFile(log);
     expect(tl.events).toHaveLength(1);
     expect(tl.events[0].hookName).toBe('SessionStart:startup');
+  });
+
+  it('delegates JSONL row parsing to the shared helper', () => {
+    const source = readFileSync(resolve(process.cwd(), 'scripts/hook-gym-stream.ts'), 'utf8');
+    const functionBody = source.slice(
+      source.indexOf('export function parseLogFile'),
+      source.indexOf('return processor.getTimeline();') + 'return processor.getTimeline();'.length,
+    );
+
+    expect(functionBody).toContain('parseJsonLines');
+    expect(functionBody).not.toContain("logContent.split('\\n')");
+    expect(functionBody).not.toContain('JSON.parse(trimmed)');
   });
 });

--- a/scripts/hook-gym-stream.ts
+++ b/scripts/hook-gym-stream.ts
@@ -16,6 +16,7 @@ import type {
   HookTimeline,
 } from './hook-gym-schema.js';
 import { parseGateSignal } from '../src/hooks/lib/gate-signal.js';
+import { parseJsonLines } from '../src/lib/json-lines.js';
 
 // ── Gate detection patterns ────────────────────────────────────────
 
@@ -290,15 +291,8 @@ export function createHookStreamProcessor() {
  */
 export function parseLogFile(logContent: string): HookTimeline {
   const processor = createHookStreamProcessor();
-  for (const line of logContent.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      const msg = JSON.parse(trimmed);
-      processor.process(msg);
-    } catch {
-      // Skip non-JSON lines
-    }
+  for (const msg of parseJsonLines<Record<string, any>>(logContent)) {
+    processor.process(msg);
   }
   return processor.getTimeline();
 }


### PR DESCRIPTION
## Summary

`hook-gym-stream.parseLogFile()` had its own complete-log JSONL parser. This PR routes that row parsing through the shared `parseJsonLines()` helper while preserving the existing hook timeline processing.

## What Changed

- Imported `parseJsonLines()` into `scripts/hook-gym-stream.ts`.
- Replaced local `logContent.split("\n")` plus `JSON.parse(trimmed)` parsing in `parseLogFile()`.
- Added a source-level invariant in `scripts/hook-gym-stream.test.ts` so the parser stays delegated to the shared helper.

## Validation

- RED confirmed: the new invariant failed against the old hand-rolled parser.
- `npm test -- --run scripts/hook-gym-stream.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`

Fixes Garsson-io/kaizen#1409
