### PR TITLE
refactor(hooks): share hook signal json parsing

### DIFF
--- a/scripts/hook-signals.test.ts
+++ b/scripts/hook-signals.test.ts
@@ -10,6 +10,17 @@ import { formatHookOutput } from '../src/hooks/lib/gate-signal.js';
  * relying on English prose. See issue #1102.
  */
 describe('detectHookSignals', () => {
+  it('delegates tolerant JSON object parsing to the shared helper', () => {
+    const source = readFileSync(fileURLToPath(new URL('./hook-signals.ts', import.meta.url)), 'utf8');
+    const parseSection = source.slice(
+      source.indexOf('function jsonSignalFromText'),
+      source.indexOf('function yamlSignals'),
+    );
+
+    expect(parseSection).toContain('parseJsonObject');
+    expect(parseSection).not.toContain('JSON.parse(trimmed)');
+  });
+
   it('detects a PreToolUse permissionDecision:"deny" envelope', () => {
     // Exact shape emitted by enforce-plan-stored.ts (stdout JSON).
     const log = [

--- a/scripts/hook-signals.ts
+++ b/scripts/hook-signals.ts
@@ -38,6 +38,7 @@
 
 import { z } from 'zod';
 import { parseHookOutputs } from '../src/hooks/lib/gate-signal.js';
+import { parseJsonObject } from '../src/lib/json-value.js';
 
 export type HookSignalSource = 'permission-decision' | 'stop-decision' | 'canonical-yaml';
 
@@ -72,15 +73,11 @@ const StopDecisionSchema = z.object({
  */
 function jsonSignalFromText(text: string): HookSignal | null {
   const trimmed = text.trim();
-  // Cheap pre-filter: only attempt JSON.parse on text that looks like an object.
+  // Cheap pre-filter: only attempt JSON object parsing on object-like text.
   if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    return null;
-  }
+  const parsed = parseJsonObject(trimmed);
+  if (!parsed) return null;
 
   const perm = PermissionDecisionSchema.safeParse(parsed);
   if (perm.success && perm.data.hookSpecificOutput.permissionDecision === 'deny') {
@@ -165,13 +162,8 @@ export function detectHookSignals(log: string): HookSignal[] {
     // (b) stream-json envelope — re-scan de-escaped string leaves for the same
     //     JSON and canonical-YAML shapes nested inside output/stdout/etc.
     if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-      let env: unknown;
-      try {
-        env = JSON.parse(trimmed);
-      } catch {
-        env = null;
-      }
-      if (env && typeof env === 'object') {
+      const env = parseJsonObject(trimmed);
+      if (env) {
         const leaves: string[] = [];
         collectStringLeaves(env, leaves);
         for (const leaf of leaves) {


### PR DESCRIPTION
## Summary

`hook-signals` had two local tolerant JSON object parse paths on the harness/hook boundary. This PR routes both through the shared `parseJsonObject()` helper so object parsing behavior stays centralized.

## What Changed

- Imported `parseJsonObject()` into `scripts/hook-signals.ts`.
- Replaced local `try { JSON.parse(trimmed) } catch { ... }` blocks for hook payloads and stream-json envelopes.
- Added a source-level invariant in `scripts/hook-signals.test.ts` so this detector stays on the shared JSON-value helper.

## Validation

- RED confirmed: the new invariant failed against the old local parser.
- `npm test -- --run scripts/hook-signals.test.ts src/lib/json-value.test.ts`
- `npm run typecheck`
- `git diff --check`

Fixes Garsson-io/kaizen#1411
