### PR TITLE
refactor(hooks): share json array parsing

### DIFF
--- a/src/hooks/pr-kaizen-clear.test.ts
+++ b/src/hooks/pr-kaizen-clear.test.ts
@@ -199,6 +199,17 @@ describe('pr-kaizen-clear: empty array', () => {
 });
 
 describe('pr-kaizen-clear: validation', () => {
+  it('delegates tolerant JSON array parsing to the shared helper', () => {
+    const source = fs.readFileSync(HOOK_PATH, 'utf8');
+    const extractSection = source.slice(
+      source.indexOf('function extractImpedimentsJson'),
+      source.indexOf('/**\n * Extract kaizen-bg results'),
+    );
+
+    expect(extractSection).toContain('parseJsonArrayOrNull');
+    expect(extractSection).not.toContain('Array.isArray(JSON.parse');
+  });
+
   it('rejects missing impediment/finding field', () => {
     const json = JSON.stringify([{ disposition: 'filed', ref: '#1' }]);
     const output = runHook(impedimentsInput(json));

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -23,6 +23,7 @@ import { formatGateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
 import { verifyIssueRef, type RefStatus } from './lib/issue-ref-verifier.js';
 import { parseGithubPrUrl } from '../lib/github-pr.js';
+import { parseJsonArrayOrNull } from '../lib/json-value.js';
 import { resolveProjectRoot } from '../lib/resolve-project-root.js';
 import { stripHeredocBody } from './parse-command.js';
 import {
@@ -251,9 +252,7 @@ function extractImpedimentsJson(
   // Fallback: stdout as raw JSON array (kaizen #313)
   if (!raw && stdout) {
     const trimmed = stdout.replace(/\n/g, ' ').trim();
-    try {
-      if (Array.isArray(JSON.parse(trimmed))) raw = trimmed;
-    } catch {}
+    if (parseJsonArrayOrNull(trimmed)) raw = trimmed;
   }
 
   // Fallback: heredoc body from full command (kaizen #313)
@@ -263,9 +262,7 @@ function extractImpedimentsJson(
     );
     if (heredocMatch) {
       const body = heredocMatch[1].replace(/\n/g, ' ').trim();
-      try {
-        if (Array.isArray(JSON.parse(body))) raw = body;
-      } catch {}
+      if (parseJsonArrayOrNull(body)) raw = body;
     }
   }
 
@@ -278,10 +275,8 @@ function extractImpedimentsJson(
   if (!raw) return { json: null, emptyReason: '' };
 
   // Try full parse
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) return { json: parsed, emptyReason: '' };
-  } catch {}
+  const parsed = parseJsonArrayOrNull(raw);
+  if (parsed) return { json: parsed, emptyReason: '' };
 
   // "[] reason" format
   const emptyMatch = raw.match(/^\[\]\s*(.*)/);

--- a/src/lib/json-value.test.ts
+++ b/src/lib/json-value.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseJsonArray, parseJsonObject, parseJsonValue } from './json-value.js';
+import { parseJsonArray, parseJsonArrayOrNull, parseJsonObject, parseJsonValue } from './json-value.js';
 
 describe('parseJsonValue', () => {
   it('returns parsed JSON values', () => {
@@ -20,6 +20,16 @@ describe('parseJsonArray', () => {
     expect(parseJsonArray('[{"url":"u"}]')).toEqual([{ url: 'u' }]);
     expect(parseJsonArray('{"url":"u"}')).toEqual([]);
     expect(parseJsonArray('{not json')).toEqual([]);
+  });
+});
+
+describe('parseJsonArrayOrNull', () => {
+  it('distinguishes valid empty arrays from malformed or non-array input', () => {
+    expect(parseJsonArrayOrNull('[]')).toEqual([]);
+    expect(parseJsonArrayOrNull('[{"ok":true}]')).toEqual([{ ok: true }]);
+    expect(parseJsonArrayOrNull('{"ok":true}')).toBeNull();
+    expect(parseJsonArrayOrNull('{not json')).toBeNull();
+    expect(parseJsonArrayOrNull('')).toBeNull();
   });
 });
 

--- a/src/lib/json-value.ts
+++ b/src/lib/json-value.ts
@@ -9,8 +9,12 @@ export function parseJsonValue(text: string): unknown | null {
 }
 
 export function parseJsonArray(text: string): unknown[] {
+  return parseJsonArrayOrNull(text) ?? [];
+}
+
+export function parseJsonArrayOrNull(text: string): unknown[] | null {
   const parsed = parseJsonValue(text);
-  return Array.isArray(parsed) ? parsed : [];
+  return Array.isArray(parsed) ? parsed : null;
 }
 
 export function parseJsonObject(text: string): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary

`pr-kaizen-clear` repeated tolerant JSON-array parsing in three paths. The existing shared `parseJsonArray()` helper is intentionally lossy, so this PR adds a non-lossy companion and routes the hook through it.

## What Changed

- Added `parseJsonArrayOrNull()` to `src/lib/json-value.ts` for callers that must distinguish valid `[]` from invalid/non-array input.
- Kept `parseJsonArray()` behavior unchanged by delegating through the new helper and falling back to `[]`.
- Replaced local `Array.isArray(JSON.parse(...))` checks in `pr-kaizen-clear` JSON extraction.
- Added invariants covering both the helper contract and the hook delegation.

## Validation

- RED confirmed: helper and hook-delegation invariants failed before implementation.
- `npm test -- --run src/hooks/pr-kaizen-clear.test.ts src/lib/json-value.test.ts`
- `npm run typecheck`
- `git diff --check`

Fixes Garsson-io/kaizen#1413
