### PR TITLE
refactor(auto-dent): share analyze log jsonl parsing

### DIFF
--- a/scripts/auto-dent-analyze.test.ts
+++ b/scripts/auto-dent-analyze.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -85,6 +86,17 @@ function createTmpBatch(runLogs: string[][]): string {
 }
 
 describe('analyzeRunLog', () => {
+  it('delegates JSONL row parsing to the shared helper', () => {
+    const source = readFileSync(fileURLToPath(new URL('./auto-dent-analyze.ts', import.meta.url)), 'utf8');
+    const analyzeSection = source.slice(
+      source.indexOf('export function analyzeRunLog'),
+      source.indexOf('export function analyzeBatch'),
+    );
+
+    expect(analyzeSection).toContain('parseJsonLines');
+    expect(analyzeSection).not.toContain('JSON.parse(line)');
+  });
+
   it('extracts cold-start time from first Edit/Write tool call', () => {
     const log = createTmpLog([
       initMsg(),
@@ -176,6 +188,20 @@ describe('analyzeRunLog', () => {
     expect(result.toolCalls).toBe(0);
     expect(result.coldStartSec).toBeNaN();
     expect(result.totalDurationSec).toBe(0);
+  });
+
+  it('skips malformed rows while preserving valid tool events', () => {
+    const log = createTmpLog([
+      'not json',
+      initMsg(),
+      userMsg('2026-03-22T22:00:00.000Z'),
+      '{broken',
+      assistantToolUse('Read', { file_path: '/foo.ts' }),
+    ]);
+
+    const result = analyzeRunLog(log);
+    expect(result.toolCalls).toBe(1);
+    expect(result.toolEvents[0].name).toBe('Read');
   });
 
   it('handles non-JSON lines gracefully', () => {

--- a/scripts/auto-dent-analyze.ts
+++ b/scripts/auto-dent-analyze.ts
@@ -20,6 +20,7 @@ import { join, basename, resolve } from 'path';
 import { execSync } from 'child_process';
 import { readState, type BatchState } from './auto-dent-run.js';
 import { truncateDisplay } from './auto-dent-display.js';
+import { parseJsonLines } from '../src/lib/json-lines.js';
 
 // Types
 
@@ -515,7 +516,6 @@ export function formatRegressionReports(reports: RegressionReport[]): string {
  */
 export function analyzeRunLog(logPath: string): RunAnalysis {
   const content = readFileSync(logPath, 'utf8');
-  const lines = content.split('\n');
 
   const toolEvents: ToolEvent[] = [];
   const phaseEvents: PhaseEvent[] = [];
@@ -523,16 +523,7 @@ export function analyzeRunLog(logPath: string): RunAnalysis {
   let firstTimestampMs: number | null = null;
   let lastKnownTimestampMs: number | null = null;
 
-  for (const line of lines) {
-    if (!line.trim()) continue;
-
-    let msg: Record<string, any>;
-    try {
-      msg = JSON.parse(line);
-    } catch {
-      continue;
-    }
-
+  for (const msg of parseJsonLines<Record<string, any>>(content)) {
     // Track timestamps from any message that has one (primarily `user` messages)
     if (msg.timestamp) {
       const ts = new Date(msg.timestamp).getTime();


### PR DESCRIPTION
## Summary

`auto-dent-analyze.analyzeRunLog()` still had a local tolerant JSONL parser for run logs. This PR routes that row parsing through the shared `parseJsonLines()` helper while keeping timestamp, tool, and phase analysis unchanged.

## What Changed

- Imported `parseJsonLines()` into `scripts/auto-dent-analyze.ts`.
- Replaced the local `content.split("\n")` plus `JSON.parse(line)` loop in `analyzeRunLog()`.
- Added a source invariant so `analyzeRunLog()` stays on the shared helper.
- Added behavior coverage that malformed rows are skipped without losing later valid tool events.

## Validation

- RED confirmed: the new invariant failed against the old local parser.
- `npm test -- --run scripts/auto-dent-analyze.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`

Fixes Garsson-io/kaizen#1417
