### PR TITLE
Refactor auto-dent harness replay JSONL parsing

### DIFF
--- a/scripts/auto-dent-harness.test.ts
+++ b/scripts/auto-dent-harness.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { existsSync, readdirSync, mkdtempSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, mkdtempSync, writeFileSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
@@ -139,6 +139,17 @@ describe('replay: edge cases', () => {
     const capture = replayLog(mixedLog);
     expect(capture.rawMessages).toHaveLength(2); // only JSON lines
     expect(capture.result.cost).toBe(0.5);
+  });
+
+  it('uses the shared JSONL parser for replay logs', () => {
+    const source = readFileSync(new URL('./auto-dent-harness.ts', import.meta.url), 'utf8');
+    const replaySection = source.slice(
+      source.indexOf('export function replayLog'),
+      source.indexOf('// Layer 4: Live probe'),
+    );
+
+    expect(replaySection).toContain('parseJsonLines');
+    expect(replaySection).not.toContain('JSON.parse(line)');
   });
 });
 

--- a/scripts/auto-dent-harness.ts
+++ b/scripts/auto-dent-harness.ts
@@ -37,6 +37,7 @@ import {
   scoreRunResult,
   type RunScore,
 } from './auto-dent-score.js';
+import { parseJsonLines } from '../src/lib/json-lines.js';
 
 // Result types
 
@@ -168,17 +169,7 @@ export function runStream(
 // Layer 3: Log replay
 
 export function replayLog(logPath: string, opts: RunStreamOpts = {}): StreamCapture {
-  const lines = readFileSync(logPath, 'utf8').split('\n').filter(Boolean);
-  const messages: Record<string, any>[] = [];
-
-  for (const line of lines) {
-    try {
-      messages.push(JSON.parse(line));
-    } catch {
-      // Non-JSON line (e.g. stderr, metadata) — skip
-    }
-  }
-
+  const messages = parseJsonLines<Record<string, any>>(readFileSync(logPath, 'utf8'));
   return runStream(messages, opts);
 }
 


### PR DESCRIPTION
## Summary

- Replace `replayLog()`'s local tolerant JSONL loop with the shared `parseJsonLines()` helper.
- Add a focused invariant that keeps replay-log parsing on the shared helper while leaving the live readline parser out of scope.

Fixes Garsson-io/kaizen#1419

## Validation

- RED: `npm test -- --run scripts/auto-dent-harness.test.ts` failed before implementation because `replayLog()` did not contain `parseJsonLines`.
- GREEN: `npm test -- --run scripts/auto-dent-harness.test.ts src/lib/json-lines.test.ts`
- `npm run typecheck`
- `git diff --check`
