### PR TITLE
Refactor JSONL malformed row diagnostics

### DIFF
--- a/scripts/hook-gym-schema.test.ts
+++ b/scripts/hook-gym-schema.test.ts
@@ -39,4 +39,24 @@ describe('hook-gym fixture schema validation', () => {
     expect(() => parseHookGymFixtureContent(malformedFixture)).toThrow(/Invalid hook-gym fixture/);
     expect(HookResponseEventSchema.safeParse(response).success).toBe(false);
   });
+
+  it('reports malformed JSONL fixture rows with source line numbers', () => {
+    expect(() => parseHookGymFixtureContent([
+      '{"type":"rate_limit_event"}',
+      '',
+      '{not-json',
+    ].join('\n'))).toThrow(/line 3 is not valid JSON/);
+  });
+
+  it('delegates JSONL fixture parsing to the shared diagnostics helper', () => {
+    const source = readFileSync(new URL('./hook-gym-schema.ts', import.meta.url), 'utf8');
+    const parserSource = source.slice(
+      source.indexOf('function parseFixtureJson'),
+      source.indexOf('export function parseHookGymFixtureContent'),
+    );
+
+    expect(parserSource).toContain('parseJsonLinesWithMalformedRows');
+    expect(parserSource).not.toContain('JSON.parse(line)');
+    expect(parserSource).not.toContain(".split('\\n')");
+  });
 });

--- a/scripts/hook-gym-schema.ts
+++ b/scripts/hook-gym-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { parseJsonLinesWithMalformedRows } from '../src/lib/json-lines.js';
 
 /**
  * hook-gym-schema.ts — TypeScript types for Hook Gym.
@@ -80,13 +81,12 @@ function parseFixtureJson(raw: string): unknown[] {
     return parsed;
   }
 
-  return trimmed.split('\n').map((line, index) => {
-    try {
-      return JSON.parse(line);
-    } catch (error) {
-      throw new Error(`Invalid hook-gym fixture: line ${index + 1} is not valid JSON`, { cause: error });
-    }
-  });
+  const parsed = parseJsonLinesWithMalformedRows(raw);
+  const firstMalformed = parsed.malformed[0];
+  if (firstMalformed) {
+    throw new Error(`Invalid hook-gym fixture: line ${firstMalformed.lineNumber} is not valid JSON`);
+  }
+  return parsed.rows;
 }
 
 export function parseHookGymFixtureContent(raw: string): HookGymFixtureEvent[] {

--- a/src/lib/json-lines.test.ts
+++ b/src/lib/json-lines.test.ts
@@ -19,5 +19,9 @@ describe('parseJsonLines', () => {
 
     expect(result.rows).toEqual([{ a: 1 }, { b: 2 }]);
     expect(result.malformedRows).toEqual(['not-json', '{bad']);
+    expect(result.malformed).toEqual([
+      { lineNumber: 3, raw: 'not-json' },
+      { lineNumber: 5, raw: '{bad' },
+    ]);
   });
 });

--- a/src/lib/json-lines.ts
+++ b/src/lib/json-lines.ts
@@ -1,21 +1,24 @@
 export interface ParsedJsonLines<T = unknown> {
   rows: T[];
   malformedRows: string[];
+  malformed: Array<{ lineNumber: number; raw: string }>;
 }
 
 export function parseJsonLinesWithMalformedRows<T = unknown>(text: string): ParsedJsonLines<T> {
   const rows: T[] = [];
   const malformedRows: string[] = [];
-  for (const raw of text.split(/\r?\n/)) {
+  const malformed: Array<{ lineNumber: number; raw: string }> = [];
+  for (const [index, raw] of text.split(/\r?\n/).entries()) {
     const trimmed = raw.trim();
     if (!trimmed) continue;
     try {
       rows.push(JSON.parse(trimmed) as T);
     } catch {
       malformedRows.push(raw);
+      malformed.push({ lineNumber: index + 1, raw });
     }
   }
-  return { rows, malformedRows };
+  return { rows, malformedRows, malformed };
 }
 
 export function parseJsonLines<T = unknown>(text: string): T[] {


### PR DESCRIPTION
## Summary

- Extend the shared JSONL parser diagnostics with malformed row line numbers while preserving the existing `malformedRows` API.
- Refactor `hook-gym-schema` JSONL fixture parsing onto the shared diagnostic helper.
- Add regression coverage for source line numbers and a source invariant against local `JSON.parse(line)` parsing in the runtime parser.

Fixes Garsson-io/kaizen#1421

## Validation

- RED: `npm test -- --run src/lib/json-lines.test.ts scripts/hook-gym-schema.test.ts` failed before implementation because diagnostics lacked `malformed` line metadata and `hook-gym-schema` still parsed lines locally.
- GREEN: `npm test -- --run src/lib/json-lines.test.ts scripts/hook-gym-schema.test.ts`
- `npm run typecheck`
- `git diff --check`
