### PR TITLE
Refactor hook-gym live stream JSON parsing

### DIFF
--- a/scripts/hook-gym-harness.test.ts
+++ b/scripts/hook-gym-harness.test.ts
@@ -121,6 +121,19 @@ describe('RunResult.gates', () => {
   });
 });
 
+describe('runHookGymScenario stream parsing', () => {
+  it('delegates live JSON object parsing to the shared helper', () => {
+    const source = readFileSync(fileURLToPath(new URL('./hook-gym-harness.ts', import.meta.url)), 'utf8');
+    const liveSection = source.slice(
+      source.indexOf("child.stdout?.on('data'"),
+      source.indexOf("if (debug) child.stderr"),
+    );
+
+    expect(liveSection).toContain('parseJsonObject');
+    expect(liveSection).not.toContain('JSON.parse(line)');
+  });
+});
+
 describe('RunResult.agent', () => {
   it('delegates stream JSON parsing to the shared helper', () => {
     const source = readFileSync(fileURLToPath(new URL('./hook-gym-harness.ts', import.meta.url)), 'utf8');

--- a/scripts/hook-gym-harness.ts
+++ b/scripts/hook-gym-harness.ts
@@ -27,6 +27,7 @@ import { renderPrompt } from './hook-gym-scenarios.js';
 import { validateAgainstScenario, validateFixtureFile, formatValidationReport, type ValidationReport } from './hook-gym-validate.js';
 import { formatTimeline } from './hook-gym-format.js';
 import { parseJsonLines } from '../src/lib/json-lines.js';
+import { parseJsonObject } from '../src/lib/json-value.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -529,11 +530,12 @@ export async function runScenario(
         buf = buf.slice(idx + 1);
         if (!line) continue;
         streamLines.push(line);
+        const msg = parseJsonObject(line);
+        if (!msg) continue;
         try {
-          const msg = JSON.parse(line);
           const wasHook = processor.process(msg);
           if (wasHook && debug) process.stderr.write(`[hook] ${line}\n`);
-        } catch { /* skip non-JSON */ }
+        } catch { /* skip malformed stream messages */ }
       }
     });
 


### PR DESCRIPTION
## Summary

- Replace the hook-gym live stdout `JSON.parse(line)` path with the shared `parseJsonObject()` helper.
- Preserve stream-line capture, hook processing, and debug output behavior.
- Add a focused invariant so the live run loop does not drift back to local line parsing.

Fixes Garsson-io/kaizen#1423

## Validation

- RED: `npm test -- --run scripts/hook-gym-harness.test.ts src/lib/json-value.test.ts` failed before implementation because the live run loop did not use `parseJsonObject`.
- GREEN: `npm test -- --run scripts/hook-gym-harness.test.ts src/lib/json-value.test.ts`
- `npm run typecheck`
- `git diff --check`
