### PR TITLE
Refactor auto-dent live probe JSON parsing

### DIFF
--- a/scripts/auto-dent-harness.test.ts
+++ b/scripts/auto-dent-harness.test.ts
@@ -151,6 +151,17 @@ describe('replay: edge cases', () => {
     expect(replaySection).toContain('parseJsonLines');
     expect(replaySection).not.toContain('JSON.parse(line)');
   });
+
+  it('uses the shared JSON object parser for live probe stream lines', () => {
+    const source = readFileSync(new URL('./auto-dent-harness.ts', import.meta.url), 'utf8');
+    const liveSection = source.slice(
+      source.indexOf('export async function runLiveProbe'),
+      source.indexOf('// Assertion helpers'),
+    );
+
+    expect(liveSection).toContain('parseJsonObject');
+    expect(liveSection).not.toContain('JSON.parse(line)');
+  });
 });
 
 // Synthetic stream tests — verify phase marker extraction

--- a/scripts/auto-dent-harness.ts
+++ b/scripts/auto-dent-harness.ts
@@ -38,6 +38,7 @@ import {
   type RunScore,
 } from './auto-dent-score.js';
 import { parseJsonLines } from '../src/lib/json-lines.js';
+import { parseJsonObject } from '../src/lib/json-value.js';
 
 // Result types
 
@@ -238,13 +239,12 @@ export async function runLiveProbe(opts: LiveProbeOpts): Promise<StreamCapture &
         writeFileSync(logFile, line + '\n', { flag: 'a' });
       } catch { /* best effort */ }
 
+      const parsed = parseJsonObject(line);
+      if (!parsed) return;
+      rawMessages.push(parsed);
       try {
-        const parsed = JSON.parse(line);
-        rawMessages.push(parsed);
         processStreamMessage(parsed, result, start);
-      } catch {
-        // Non-JSON
-      }
+      } catch { /* skip malformed stream messages */ }
     });
 
     child.stderr?.on('data', () => {


### PR DESCRIPTION
## Summary

- Replace `runLiveProbe()`'s live stdout `JSON.parse(line)` path with the shared `parseJsonObject()` helper.
- Preserve raw log writing, valid message capture, and stream message processing.
- Add a focused source invariant for the live probe parser.

Fixes Garsson-io/kaizen#1425

## Validation

- RED: `npm test -- --run scripts/auto-dent-harness.test.ts src/lib/json-value.test.ts` failed before implementation because `runLiveProbe()` did not use `parseJsonObject`.
- GREEN: `npm test -- --run scripts/auto-dent-harness.test.ts src/lib/json-value.test.ts`
- `npm run typecheck`
- `git diff --check`
