### PR TITLE
Refactor auto-dent runner stream JSON parsing

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -3186,6 +3186,20 @@ describe('module wiring: re-exported symbols used locally must be imported', () 
   });
 });
 
+describe('runOnce stream-json line parsing', () => {
+  it('delegates supervised stdout JSON object parsing to the shared helper', () => {
+    const source = readFileSync(new URL('./auto-dent-run.ts', import.meta.url), 'utf-8');
+    const parserStart = source.indexOf('const rl = createInterface');
+    const parserSection = source.slice(
+      parserStart,
+      source.indexOf("child.stderr?.on('data'", parserStart),
+    );
+
+    expect(parserSection).toContain('parseJsonObject');
+    expect(parserSection).not.toContain('JSON.parse(line)');
+  });
+});
+
 describe('findExistingProgressIssue', () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -57,6 +57,7 @@ import {
   type RunProgressStep,
 } from './auto-dent-progress.js';
 import { truncateAtWordBoundary } from './auto-dent-display.js';
+import { parseJsonObject } from '../src/lib/json-value.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -1832,8 +1833,10 @@ async function runClaude(
       appendFileSync(logFile, line + '\n');
       lastOutputTime = Date.now();
 
+      const msg = parseJsonObject(line);
+      if (!msg) return;
+
       try {
-        const msg = JSON.parse(line);
         processStreamMessage(msg, result, runStart, ctx);
 
         // Start post-result kill timer when result is received
@@ -1859,9 +1862,7 @@ async function runClaude(
             }
           }, POST_RESULT_GRACE_MS);
         }
-      } catch {
-        // Non-JSON line
-      }
+      } catch { /* skip malformed stream messages */ }
     });
 
     child.stderr?.on('data', (data: Buffer) => {


### PR DESCRIPTION
## Summary

- Replace the supervised auto-dent runner stdout `JSON.parse(line)` path with the shared `parseJsonObject()` helper.
- Preserve log appends, liveness tracking, stream-message processing, and post-result watchdog scheduling.
- Add a focused source invariant for the runner line parser.

Fixes Garsson-io/kaizen#1427

## Validation

- RED: `npm test -- --run scripts/auto-dent-run.test.ts src/lib/json-value.test.ts` failed before implementation because the supervised line parser did not use `parseJsonObject`.
- GREEN: `npm test -- --run scripts/auto-dent-run.test.ts src/lib/json-value.test.ts`
- `npm run typecheck`
- `git diff --check`
