### PR TITLE
Refactor plugin uninstall JSON object parsing

### DIFF
--- a/scripts/kaizen-uninstall-plugin.test.ts
+++ b/scripts/kaizen-uninstall-plugin.test.ts
@@ -155,6 +155,19 @@ describe('stepRemove* return values — idempotency surface for the test-quality
   });
 });
 
+describe('JSON object parsing', () => {
+  it('delegates readJsonOrNull object parsing to the shared helper', () => {
+    const source = readFileSync(new URL('./kaizen-uninstall-plugin.ts', import.meta.url), 'utf-8');
+    const helperSection = source.slice(
+      source.indexOf('function readJsonOrNull'),
+      source.indexOf('function writeJson'),
+    );
+
+    expect(helperSection).toContain('parseJsonObject');
+    expect(helperSection).not.toContain('JSON.parse(raw)');
+  });
+});
+
 describe('CLI — end-to-end via execFileSync', () => {
   let home: string, proj: string;
   beforeEach(() => { const s = setup(); home = s.home; proj = s.proj; });

--- a/scripts/kaizen-uninstall-plugin.ts
+++ b/scripts/kaizen-uninstall-plugin.ts
@@ -30,6 +30,7 @@ import {
 import { join, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { parseJsonObject } from '../src/lib/json-value.js';
 
 export interface UninstallOpts {
   plugin: string;
@@ -64,9 +65,7 @@ function shortNameOf(plugin: string): string {
 
 function readJsonOrNull(path: string): Record<string, unknown> | null {
   try {
-    const raw = readFileSync(path, 'utf-8');
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
+    return parseJsonObject(readFileSync(path, 'utf-8'));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- Replace `kaizen-uninstall-plugin`'s local JSON parse/object-shape check with the shared `parseJsonObject()` helper.
- Preserve unreadable/malformed file behavior by keeping the file-read guard in `readJsonOrNull()`.
- Add a focused invariant to prevent the helper drifting back to local `JSON.parse(raw)` parsing.

Fixes Garsson-io/kaizen#1429

## Validation

- RED: `npm test -- --run scripts/kaizen-uninstall-plugin.test.ts src/lib/json-value.test.ts` failed before implementation because `readJsonOrNull()` did not use `parseJsonObject`.
- GREEN: `npm test -- --run scripts/kaizen-uninstall-plugin.test.ts src/lib/json-value.test.ts`
- `npm run typecheck`
- `git diff --check`
