### PR TITLE
Refactor kaizen doctor JSON value parsing

### DIFF
--- a/scripts/kaizen-doctor.test.ts
+++ b/scripts/kaizen-doctor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -47,6 +47,19 @@ function writeHook(projectRoot: string, rel: string, executable = true): string 
   else chmodSync(p, 0o644);
   return p;
 }
+
+describe('safe JSON parsing', () => {
+  it('delegates safeReadJson parsing to the shared value helper', () => {
+    const source = readFileSync(new URL('./kaizen-doctor.ts', import.meta.url), 'utf-8');
+    const helperSection = source.slice(
+      source.indexOf('function safeReadJson'),
+      source.indexOf('function sha256File'),
+    );
+
+    expect(helperSection).toContain('parseJsonValue');
+    expect(helperSection).not.toContain('JSON.parse');
+  });
+});
 
 describe('resolveHookPath', () => {
   it('expands ${CLAUDE_PLUGIN_ROOT} against projectRoot', () => {

--- a/scripts/kaizen-doctor.ts
+++ b/scripts/kaizen-doctor.ts
@@ -31,6 +31,7 @@ import { dirname } from 'node:path';
 import { join, resolve, isAbsolute } from 'node:path';
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
+import { parseJsonValue } from '../src/lib/json-value.js';
 
 export type CheckStatus = 'PASS' | 'WARN' | 'FAIL';
 
@@ -76,7 +77,7 @@ const REQUIRED_CODEX_FEATURES = ['shell_tool', 'unified_exec', 'hooks'] as const
 
 function safeReadJson(path: string): unknown | null {
   try {
-    return JSON.parse(readFileSync(path, 'utf-8'));
+    return parseJsonValue(readFileSync(path, 'utf-8'));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- Replace `kaizen-doctor`'s local `safeReadJson()` parse-null JSON logic with the shared `parseJsonValue()` helper.
- Preserve file-read failure handling in `safeReadJson()`.
- Add a focused invariant so the helper does not drift back to local `JSON.parse(...)`.

Fixes Garsson-io/kaizen#1431

## Validation

- RED: `npm test -- --run scripts/kaizen-doctor.test.ts src/lib/json-value.test.ts` failed before implementation because `safeReadJson()` did not use `parseJsonValue`.
- GREEN: `npm test -- --run scripts/kaizen-doctor.test.ts src/lib/json-value.test.ts`
- `npm run typecheck`
- `git diff --check`