### PR TITLE
Refactor kaizen setup JSON object parsing

### DIFF
--- a/src/kaizen-setup.test.ts
+++ b/src/kaizen-setup.test.ts
@@ -24,6 +24,15 @@ afterEach(() => {
   rmSync(tempDir, { recursive: true, force: true });
 });
 
+describe("setup JSON file parsing", () => {
+  it("delegates runtime JSON object file reads to the shared parser", () => {
+    const source = readFileSync(new URL("./kaizen-setup.ts", import.meta.url), "utf-8");
+
+    expect(source).toContain("parseJsonObject");
+    expect(source).not.toContain("JSON.parse(readFileSync");
+  });
+});
+
 describe("detectInstall", () => {
   it("detects plugin install via CLAUDE_PLUGIN_ROOT", () => {
     const result = detectInstall({ cwd: tempDir, env: { CLAUDE_PLUGIN_ROOT: "/plugins/kaizen" } });
@@ -189,6 +198,21 @@ describe("verifySetup", () => {
     expect(result.checks.some(c => c.name.startsWith("hook-"))).toBe(true);
     expect(result.checks.some(c => c.name.startsWith("skill-"))).toBe(true);
     expect(result.checks.some(c => c.name.startsWith("matcher-"))).toBe(true);
+  });
+
+  it("reports invalid plugin.json during setup verification without reparsing it", () => {
+    const pluginRoot = join(tempDir, "plugin");
+    mkdirSync(join(pluginRoot, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(pluginRoot, ".claude-plugin", "plugin.json"), "not json");
+    writeFileSync(join(tempDir, "kaizen.config.json"), JSON.stringify({ host: { name: "p", repo: "o/r" }, kaizen: { repo: "g/k" } }));
+    mkdirSync(join(tempDir, ".agents", "kaizen", "local"), { recursive: true });
+    writeFileSync(join(tempDir, ".agents", "kaizen", "local", "policies-local.md"), "# Policies");
+    writeFileSync(join(tempDir, "CLAUDE.md"), "# kaizen");
+
+    const result = verifySetup(tempDir, { pluginRoot });
+    const pluginJsonCheck = result.checks.find(c => c.name === "plugin-json");
+    expect(result.status).toBe("failed");
+    expect(pluginJsonCheck).toMatchObject({ ok: false, detail: "invalid JSON" });
   });
 });
 

--- a/src/kaizen-setup.ts
+++ b/src/kaizen-setup.ts
@@ -20,6 +20,7 @@ import { join } from "path";
 import { parseArgs } from "util";
 import { loadAllSkillMetadata, validateSkillDependencies, validateSkillVersions } from "./skill-metadata.js";
 import { installGitHooks, buildThinWrapper, type InstallResult } from "./setup-git-hooks.js";
+import { parseJsonObject } from "./lib/json-value.js";
 
 // ── Types ──
 
@@ -75,6 +76,37 @@ export interface VerifyResult {
   checks: VerifyCheck[];
   passed: number;
   failed: number;
+}
+
+interface PluginManifestRead {
+  manifest: Record<string, unknown> | null;
+  failure?: VerifyCheck;
+}
+
+function readJsonObjectFile(path: string): Record<string, unknown> | null {
+  try {
+    return parseJsonObject(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function readPluginManifest(pluginRoot: string): PluginManifestRead {
+  const pluginJsonPath = join(pluginRoot, ".claude-plugin", "plugin.json");
+  if (!existsSync(pluginJsonPath)) {
+    return {
+      manifest: null,
+      failure: { name: "plugin-json", ok: false, detail: "plugin.json not found" },
+    };
+  }
+
+  const manifest = readJsonObjectFile(pluginJsonPath);
+  return manifest
+    ? { manifest }
+    : {
+        manifest: null,
+        failure: { name: "plugin-json", ok: false, detail: "invalid JSON" },
+      };
 }
 
 // ── Functions ──
@@ -143,12 +175,11 @@ export function enablePlugin(cwd: string, pluginName = "kaizen@kaizen"): EnableR
 
   let data: Record<string, unknown> = {};
   if (existsSync(path)) {
-    try {
-      data = JSON.parse(readFileSync(path, "utf-8"));
-      if (!data || typeof data !== "object") data = {};
-    } catch (e) {
-      return { step: "enable", status: "error", path, error: `settings.json parse error: ${String(e)}` };
+    const parsed = readJsonObjectFile(path);
+    if (!parsed) {
+      return { step: "enable", status: "error", path, error: "settings.json parse error: invalid JSON object" };
     }
+    data = parsed;
   } else {
     mkdirSync(dir, { recursive: true });
   }
@@ -214,22 +245,13 @@ interface PluginContractCheck {
   matchers: VerifyCheck[];
 }
 
-export function verifyPluginContract(pluginRoot: string): PluginContractCheck {
+function verifyPluginContractFromManifest(pluginRoot: string, manifestRead: PluginManifestRead): PluginContractCheck {
   const result: PluginContractCheck = { hookPaths: [], skillDirs: [], matchers: [] };
-  const pluginJsonPath = join(pluginRoot, ".claude-plugin", "plugin.json");
-
-  if (!existsSync(pluginJsonPath)) {
-    result.hookPaths.push({ name: "plugin-json", ok: false, detail: "plugin.json not found" });
+  if (!manifestRead.manifest) {
+    result.hookPaths.push(manifestRead.failure ?? { name: "plugin-json", ok: false, detail: "invalid JSON" });
     return result;
   }
-
-  let manifest: Record<string, unknown>;
-  try {
-    manifest = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
-  } catch {
-    result.hookPaths.push({ name: "plugin-json", ok: false, detail: "invalid JSON" });
-    return result;
-  }
+  const manifest = manifestRead.manifest;
 
   // Validate hook command paths
   const hooks = manifest.hooks as Record<string, unknown[]> | undefined;
@@ -287,14 +309,18 @@ export function verifyPluginContract(pluginRoot: string): PluginContractCheck {
   return result;
 }
 
+export function verifyPluginContract(pluginRoot: string): PluginContractCheck {
+  return verifyPluginContractFromManifest(pluginRoot, readPluginManifest(pluginRoot));
+}
+
 export function verifySetup(cwd: string, opts?: { pluginRoot?: string }): VerifyResult {
   const checks: VerifyCheck[] = [];
 
   // Config
   const configPath = join(cwd, "kaizen.config.json");
   if (existsSync(configPath)) {
-    try {
-      const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const config = readJsonObjectFile(configPath);
+    if (config) {
       checks.push({ name: "config-valid", ok: true });
       for (const field of ["host.name", "host.repo", "kaizen.repo"]) {
         const parts = field.split(".");
@@ -302,7 +328,7 @@ export function verifySetup(cwd: string, opts?: { pluginRoot?: string }): Verify
         for (const p of parts) val = (val as Record<string, unknown>)?.[p];
         checks.push({ name: `config-field-${field}`, ok: !!val, detail: val ? String(val) : "missing" });
       }
-    } catch {
+    } else {
       checks.push({ name: "config-valid", ok: false, detail: "invalid JSON" });
     }
   } else {
@@ -333,14 +359,12 @@ export function verifySetup(cwd: string, opts?: { pluginRoot?: string }): Verify
   // Plugin contract validation
   const pluginRoot = opts?.pluginRoot;
   if (pluginRoot) {
-    const contract = verifyPluginContract(pluginRoot);
+    const pluginManifest = readPluginManifest(pluginRoot);
+    const contract = verifyPluginContractFromManifest(pluginRoot, pluginManifest);
     checks.push(...contract.hookPaths, ...contract.skillDirs, ...contract.matchers);
 
     // Skill metadata validation
-    const pluginJsonPath = join(pluginRoot, ".claude-plugin", "plugin.json");
-    const skillsPath = existsSync(pluginJsonPath)
-      ? (JSON.parse(readFileSync(pluginJsonPath, "utf-8")).skills as string | undefined)
-      : undefined;
+    const skillsPath = pluginManifest.manifest?.skills as string | undefined;
 
     if (skillsPath) {
       const skillsDir = join(pluginRoot, skillsPath);
@@ -359,9 +383,9 @@ export function verifySetup(cwd: string, opts?: { pluginRoot?: string }): Verify
       }
 
       let pluginVersion: string | undefined;
-      try {
-        pluginVersion = JSON.parse(readFileSync(pluginJsonPath, "utf-8")).version as string;
-      } catch { /* ignore */ }
+      if (typeof pluginManifest.manifest?.version === "string") {
+        pluginVersion = pluginManifest.manifest.version;
+      }
 
       if (pluginVersion) {
         const versionIssues = validateSkillVersions(skills, pluginVersion);


### PR DESCRIPTION
## Story

`kaizen-setup` is the install and verification path for host projects, so its JSON handling is part of the runtime surface rather than test-only glue. Recent DRY work centralized JSON text parsing in `src/lib/json-value.ts`, but setup still had several local `JSON.parse(readFileSync(...))` paths for settings, config, and plugin manifests.

That meant the same parse-null/object decisions were maintained in multiple places. The most brittle case was `verifySetup()`: it validated the plugin contract, then reparsed the same `plugin.json` again for skill metadata and version checks.

This PR moves setup JSON object file reads through one local helper backed by `parseJsonObject()`, and threads the already-read plugin manifest through contract and skill metadata validation. Malformed setup files still become setup verification failures instead of being overwritten or silently accepted.

Fixes Garsson-io/kaizen#1433

## Architecture

```text
file path
  -> readJsonObjectFile(path)
  -> parseJsonObject(text)
  -> enablePlugin / verifySetup / verifyPluginContract

pluginRoot
  -> readPluginManifest(pluginRoot)
  -> verifyPluginContractFromManifest(...)
  -> skill dependency/version checks
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Keep file reading local to `kaizen-setup.ts` | The shared primitive today is text-to-JSON; adding a repo-wide file API would be premature for this small setup-only cleanup. | Other modules still have their own file-read wrappers until they are refactored deliberately. |
| Use `parseJsonObject()` rather than `parseJsonValue()` for setup files | The runtime callers expect JSON objects: settings, config, and plugin manifests. | Non-object JSON is treated as invalid setup input. |
| Pass the parsed plugin manifest through verification | Avoids reparsing `plugin.json` and lets malformed manifests produce one consistent failed check. | Adds a small internal `PluginManifestRead` carrier. |

## What Changed

| File | Purpose |
| --- | --- |
| `src/kaizen-setup.ts` | Adds the shared-parser-backed JSON object file helper and removes inline runtime `JSON.parse(readFileSync(...))` paths. |
| `src/kaizen-setup.test.ts` | Adds a source invariant and a malformed `plugin.json` verification regression test. |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Coverage | Evidence |
| --- | --- | --- | --- |
| Setup runtime JSON object reads delegate to the shared parser | Unit/source invariant | Tested | `src/kaizen-setup.test.ts` asserts `kaizen-setup.ts` contains `parseJsonObject` and not inline `JSON.parse(readFileSync`. |
| Malformed `plugin.json` is reported as setup verification failure | Unit behavior | Tested | `verifySetup()` test checks failed `plugin-json` result instead of a thrown reparse. |
| Existing setup behavior remains intact | Focused regression | Tested | `npm test -- --run src/kaizen-setup.test.ts src/lib/json-value.test.ts` passes 48 tests. |
| Type-level import and helper wiring are valid | Static | Tested | `npm run typecheck`. |

## Validation

- RED: `npm test -- --run src/kaizen-setup.test.ts src/lib/json-value.test.ts` failed before implementation because `kaizen-setup.ts` did not use `parseJsonObject`.
- GREEN: `npm test -- --run src/kaizen-setup.test.ts src/lib/json-value.test.ts`
- `npm run typecheck`
- `git diff --check`
- Source scan: `rg -n "JSON\.parse\(readFileSync|parseJsonObject|readJsonObject|readPluginManifest|verifyPluginContractFromManifest" src/kaizen-setup.ts src/kaizen-setup.test.ts`

## Known Limitations

This does not introduce a repository-wide JSON file reader. The shared mechanism remains `parseJsonObject()` for JSON text, with setup owning the file-read boundary for now.