### PR TITLE
Refactor JSON file parse-null helpers

### DIFF
--- a/scripts/kaizen-doctor.test.ts
+++ b/scripts/kaizen-doctor.test.ts
@@ -49,15 +49,13 @@ function writeHook(projectRoot: string, rel: string, executable = true): string 
 }
 
 describe('safe JSON parsing', () => {
-  it('delegates safeReadJson parsing to the shared value helper', () => {
+  it('delegates JSON value file reads to the shared file helper', () => {
     const source = readFileSync(new URL('./kaizen-doctor.ts', import.meta.url), 'utf-8');
-    const helperSection = source.slice(
-      source.indexOf('function safeReadJson'),
-      source.indexOf('function sha256File'),
-    );
 
-    expect(helperSection).toContain('parseJsonValue');
-    expect(helperSection).not.toContain('JSON.parse');
+    expect(source).toContain('../src/lib/json-file.js');
+    expect(source).not.toContain('function safeReadJson');
+    expect(source).not.toContain('parseJsonValue(readFileSync');
+    expect(source).not.toContain('JSON.parse(readFileSync');
   });
 });
 

--- a/scripts/kaizen-doctor.ts
+++ b/scripts/kaizen-doctor.ts
@@ -31,7 +31,7 @@ import { dirname } from 'node:path';
 import { join, resolve, isAbsolute } from 'node:path';
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
-import { parseJsonValue } from '../src/lib/json-value.js';
+import { readJsonValueFile } from '../src/lib/json-file.js';
 
 export type CheckStatus = 'PASS' | 'WARN' | 'FAIL';
 
@@ -74,14 +74,6 @@ export interface CodexReadinessOpts {
 const DEFAULT_PLUGIN = 'kaizen@kaizen';
 const MIN_CODEX_VERSION = '0.142.3';
 const REQUIRED_CODEX_FEATURES = ['shell_tool', 'unified_exec', 'hooks'] as const;
-
-function safeReadJson(path: string): unknown | null {
-  try {
-    return parseJsonValue(readFileSync(path, 'utf-8'));
-  } catch {
-    return null;
-  }
-}
 
 function sha256File(path: string): string | null {
   try {
@@ -158,7 +150,7 @@ export function tokenize(input: string): string[] {
 /** Check 1: project-scope double install. */
 export function checkPluginDoubleInstall(opts: DoctorOpts): CheckResult {
   const plugin = opts.pluginName ?? DEFAULT_PLUGIN;
-  const settings = safeReadJson(join(opts.projectRoot, '.claude/settings.json')) as
+  const settings = readJsonValueFile(join(opts.projectRoot, '.claude/settings.json')) as
     | Record<string, unknown>
     | null;
   const enabled = (settings?.enabledPlugins ?? {}) as Record<string, unknown>;
@@ -195,7 +187,7 @@ export function checkDanglingHookPaths(opts: DoctorOpts): CheckResult {
   const missing: string[] = [];
   let total = 0;
   for (const cfg of cfgs) {
-    const data = safeReadJson(cfg.path);
+    const data = readJsonValueFile(cfg.path);
     if (!data) continue;
     for (const c of collectHookCommands(data)) {
       total++;
@@ -235,7 +227,7 @@ export function checkStalePluginCache(opts: DoctorOpts): CheckResult {
   const cacheDir = join(opts.homeDir, `.claude/plugins/cache/${shortName}`);
   const normalizedRoot = normalizeProjectRoot(opts.projectRoot);
 
-  const installed = safeReadJson(installedPath) as
+  const installed = readJsonValueFile(installedPath) as
     | { plugins?: Record<string, Array<Record<string, unknown>> | Record<string, unknown>> }
     | null;
   const entry = installed?.plugins?.[plugin];
@@ -338,7 +330,7 @@ export function checkRestartNeeded(opts: DoctorOpts): CheckResult {
       detail: `no session-start snapshot (${snapPath}) — cannot detect drift. Install kaizen-session-snapshot SessionStart hook to enable this check.`,
     };
   }
-  const snap = safeReadJson(snapPath) as SessionSnapshot | null;
+  const snap = readJsonValueFile(snapPath) as SessionSnapshot | null;
   if (!snap || typeof snap !== 'object' || !snap.hashes) {
     return {
       name: 'restart-needed',
@@ -379,8 +371,8 @@ export function checkRestartNeeded(opts: DoctorOpts): CheckResult {
  *  PASS when ≤1 source is non-empty (or neither — host project with no hooks).
  */
 export function checkSingleRegistrationPath(opts: DoctorOpts): CheckResult {
-  const settings = safeReadJson(join(opts.projectRoot, '.claude/settings.json'));
-  const plugin = safeReadJson(join(opts.projectRoot, '.claude-plugin/plugin.json'));
+  const settings = readJsonValueFile(join(opts.projectRoot, '.claude/settings.json'));
+  const plugin = readJsonValueFile(join(opts.projectRoot, '.claude-plugin/plugin.json'));
   const settingsHooks = collectHookCommands(
     (settings as { hooks?: unknown } | null)?.hooks,
   );
@@ -415,7 +407,7 @@ export function checkHookExecSmoke(opts: DoctorOpts): CheckResult {
   const nonExec: string[] = [];
   let total = 0;
   for (const cfgPath of cfgs) {
-    const data = safeReadJson(cfgPath);
+    const data = readJsonValueFile(cfgPath);
     if (!data) continue;
     for (const c of collectHookCommands(data)) {
       const hookPath = resolveHookPath(c, opts.projectRoot);

--- a/scripts/kaizen-uninstall-plugin.test.ts
+++ b/scripts/kaizen-uninstall-plugin.test.ts
@@ -156,15 +156,13 @@ describe('stepRemove* return values — idempotency surface for the test-quality
 });
 
 describe('JSON object parsing', () => {
-  it('delegates readJsonOrNull object parsing to the shared helper', () => {
+  it('delegates JSON object file reads to the shared file helper', () => {
     const source = readFileSync(new URL('./kaizen-uninstall-plugin.ts', import.meta.url), 'utf-8');
-    const helperSection = source.slice(
-      source.indexOf('function readJsonOrNull'),
-      source.indexOf('function writeJson'),
-    );
 
-    expect(helperSection).toContain('parseJsonObject');
-    expect(helperSection).not.toContain('JSON.parse(raw)');
+    expect(source).toContain('../src/lib/json-file.js');
+    expect(source).not.toContain('function readJsonOrNull');
+    expect(source).not.toContain('parseJsonObject(readFileSync');
+    expect(source).not.toContain('JSON.parse(raw)');
   });
 });
 

--- a/scripts/kaizen-uninstall-plugin.ts
+++ b/scripts/kaizen-uninstall-plugin.ts
@@ -21,7 +21,6 @@
 
 import {
   existsSync,
-  readFileSync,
   writeFileSync,
   rmSync,
   realpathSync,
@@ -30,7 +29,7 @@ import {
 import { join, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
-import { parseJsonObject } from '../src/lib/json-value.js';
+import { readJsonObjectFile } from '../src/lib/json-file.js';
 
 export interface UninstallOpts {
   plugin: string;
@@ -63,14 +62,6 @@ function shortNameOf(plugin: string): string {
   return idx < 0 ? plugin : plugin.slice(0, idx);
 }
 
-function readJsonOrNull(path: string): Record<string, unknown> | null {
-  try {
-    return parseJsonObject(readFileSync(path, 'utf-8'));
-  } catch {
-    return null;
-  }
-}
-
 function writeJson(path: string, data: unknown): void {
   writeFileSync(path, JSON.stringify(data, null, 2));
 }
@@ -93,7 +84,7 @@ export function stepRemoveEnabledPlugin(
 ): { changed: boolean; detail: string } {
   const path = join(projectRoot, '.claude', 'settings.json');
   if (!existsSync(path)) return { changed: false, detail: `no ${path}` };
-  const data = readJsonOrNull(path);
+  const data = readJsonObjectFile(path);
   if (!data) return { changed: false, detail: `unreadable ${path}` };
   const enabled = (data.enabledPlugins ?? {}) as Record<string, unknown>;
   if (!(plugin in enabled)) return { changed: false, detail: `enabledPlugins[${plugin}] already absent` };
@@ -110,7 +101,7 @@ export function stepRemoveInstalledRecord(
 ): { changed: boolean; detail: string } {
   const path = join(homeDir, '.claude', 'plugins', 'installed_plugins.json');
   if (!existsSync(path)) return { changed: false, detail: `no ${path}` };
-  const data = readJsonOrNull(path);
+  const data = readJsonObjectFile(path);
   if (!data) return { changed: false, detail: `unreadable ${path}` };
   const plugins = (data.plugins ?? {}) as Record<string, unknown>;
   if (!(plugin in plugins)) return { changed: false, detail: `record for ${plugin} already absent` };

--- a/src/kaizen-setup.test.ts
+++ b/src/kaizen-setup.test.ts
@@ -25,11 +25,13 @@ afterEach(() => {
 });
 
 describe("setup JSON file parsing", () => {
-  it("delegates runtime JSON object file reads to the shared parser", () => {
+  it("delegates runtime JSON object file reads to the shared file helper", () => {
     const source = readFileSync(new URL("./kaizen-setup.ts", import.meta.url), "utf-8");
 
-    expect(source).toContain("parseJsonObject");
+    expect(source).toContain("./lib/json-file.js");
     expect(source).not.toContain("JSON.parse(readFileSync");
+    expect(source).not.toContain("function readJsonObjectFile");
+    expect(source).not.toContain("parseJsonObject(readFileSync");
   });
 });
 

--- a/src/kaizen-setup.ts
+++ b/src/kaizen-setup.ts
@@ -20,7 +20,7 @@ import { join } from "path";
 import { parseArgs } from "util";
 import { loadAllSkillMetadata, validateSkillDependencies, validateSkillVersions } from "./skill-metadata.js";
 import { installGitHooks, buildThinWrapper, type InstallResult } from "./setup-git-hooks.js";
-import { parseJsonObject } from "./lib/json-value.js";
+import { readJsonObjectFile } from "./lib/json-file.js";
 
 // ── Types ──
 
@@ -81,14 +81,6 @@ export interface VerifyResult {
 interface PluginManifestRead {
   manifest: Record<string, unknown> | null;
   failure?: VerifyCheck;
-}
-
-function readJsonObjectFile(path: string): Record<string, unknown> | null {
-  try {
-    return parseJsonObject(readFileSync(path, "utf-8"));
-  } catch {
-    return null;
-  }
 }
 
 function readPluginManifest(pluginRoot: string): PluginManifestRead {

--- a/src/lib/json-file.test.ts
+++ b/src/lib/json-file.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readJsonObjectFile, readJsonValueFile } from './json-file.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'kaizen-json-file-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('readJsonValueFile', () => {
+  it('returns arbitrary JSON values and null for unreadable or malformed input', () => {
+    const objectPath = join(dir, 'object.json');
+    const arrayPath = join(dir, 'array.json');
+    const stringPath = join(dir, 'string.json');
+    const malformedPath = join(dir, 'malformed.json');
+    const blankPath = join(dir, 'blank.json');
+
+    writeFileSync(objectPath, '{"ok":true}');
+    writeFileSync(arrayPath, '[1,2]');
+    writeFileSync(stringPath, '"text"');
+    writeFileSync(malformedPath, '{not json');
+    writeFileSync(blankPath, '  ');
+
+    expect(readJsonValueFile(objectPath)).toEqual({ ok: true });
+    expect(readJsonValueFile(arrayPath)).toEqual([1, 2]);
+    expect(readJsonValueFile(stringPath)).toBe('text');
+    expect(readJsonValueFile(malformedPath)).toBeNull();
+    expect(readJsonValueFile(blankPath)).toBeNull();
+    expect(readJsonValueFile(join(dir, 'missing.json'))).toBeNull();
+  });
+});
+
+describe('readJsonObjectFile', () => {
+  it('returns objects and rejects unreadable, malformed, blank, array, or primitive input', () => {
+    const objectPath = join(dir, 'object.json');
+    const arrayPath = join(dir, 'array.json');
+    const primitivePath = join(dir, 'primitive.json');
+    const malformedPath = join(dir, 'malformed.json');
+    const blankPath = join(dir, 'blank.json');
+
+    writeFileSync(objectPath, '{"ok":true}');
+    writeFileSync(arrayPath, '[1,2]');
+    writeFileSync(primitivePath, '"text"');
+    writeFileSync(malformedPath, '{not json');
+    writeFileSync(blankPath, '  ');
+
+    expect(readJsonObjectFile(objectPath)).toEqual({ ok: true });
+    expect(readJsonObjectFile(arrayPath)).toBeNull();
+    expect(readJsonObjectFile(primitivePath)).toBeNull();
+    expect(readJsonObjectFile(malformedPath)).toBeNull();
+    expect(readJsonObjectFile(blankPath)).toBeNull();
+    expect(readJsonObjectFile(join(dir, 'missing.json'))).toBeNull();
+  });
+});

--- a/src/lib/json-file.ts
+++ b/src/lib/json-file.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { parseJsonObject, parseJsonValue } from './json-value.js';
+
+export function readJsonValueFile(path: string): unknown | null {
+  try {
+    return parseJsonValue(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function readJsonObjectFile(path: string): Record<string, unknown> | null {
+  try {
+    return parseJsonObject(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Story

The JSON parsing cleanup has been moving inward: first shared JSON text parsing, then setup/uninstall/doctor each delegated their local parse logic to those text helpers. After that, the next duplicate layer became clear: each runtime caller still owned its own file-read wrapper around the shared parser.

That left three places with the same boundary semantics: read a file, parse a JSON value or object, and return `null` for missing, blank, malformed, or unreadable input. If that boundary changed later, setup, uninstall, and doctor could drift again.

This PR introduces `src/lib/json-file.ts` as the shared file boundary and migrates the three callers to it. The caller-specific behavior stays the same; the duplicated mechanism moves to one tested module.

Fixes Garsson-io/kaizen#1435

## Architecture

```text
file path
  -> readJsonValueFile(path)
      -> readFileSync(path, utf-8)
      -> parseJsonValue(text)

file path
  -> readJsonObjectFile(path)
      -> readFileSync(path, utf-8)
      -> parseJsonObject(text)

callers:
  kaizen-doctor            -> readJsonValueFile
  kaizen-setup             -> readJsonObjectFile
  kaizen-uninstall-plugin  -> readJsonObjectFile
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Add a small `json-file` module instead of expanding `json-value` | Keeps text parsing and file I/O boundaries separate. | One more tiny module in `src/lib`. |
| Provide both value and object file helpers | Doctor legitimately reads arbitrary JSON values, while setup/uninstall require objects. | Callers still choose the right semantic helper. |
| Leave throwing/domain-specific JSON reads alone | Some reads intentionally fail fast or require domain validation. | This PR does not eliminate every `JSON.parse(readFileSync(...))` in the repo. |

## What Changed

| File | Purpose |
| --- | --- |
| `src/lib/json-file.ts` | Shared parse-null JSON file helpers. |
| `src/lib/json-file.test.ts` | Unit coverage for missing, blank, malformed, object, array, and primitive inputs. |
| `src/kaizen-setup.ts` | Uses shared object-file helper instead of local `readJsonObjectFile()`. |
| `scripts/kaizen-uninstall-plugin.ts` | Uses shared object-file helper instead of local `readJsonOrNull()`. |
| `scripts/kaizen-doctor.ts` | Uses shared value-file helper instead of local `safeReadJson()`. |
| Existing caller tests | Source invariants now require the shared file helper and reject local wrappers. |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Coverage | Evidence |
| --- | --- | --- | --- |
| Shared helper handles missing, blank, malformed, object, array, and primitive JSON file inputs | Unit | Tested | `src/lib/json-file.test.ts` |
| Setup/uninstall/doctor no longer define local parse-null file wrappers | Source invariant | Tested | Existing caller tests assert shared `json-file` imports and absence of local helpers. |
| Existing malformed setup/uninstall/doctor behavior remains intact | Focused regression | Tested | Focused suites for all three callers passed. |
| Type-level import paths and exports are valid | Static | Tested | `npm run typecheck` |

## Validation

- RED: `npm test -- --run src/kaizen-setup.test.ts scripts/kaizen-uninstall-plugin.test.ts scripts/kaizen-doctor.test.ts src/lib/json-value.test.ts` failed on the three source invariants before implementation.
- GREEN: `npm test -- --run src/lib/json-file.test.ts src/lib/json-value.test.ts src/kaizen-setup.test.ts scripts/kaizen-uninstall-plugin.test.ts scripts/kaizen-doctor.test.ts`
- `npm run typecheck`
- `git diff --check`
- Source scan: `rg -n "function (readJsonObjectFile|readJsonOrNull|safeReadJson)|parseJson(Object|Value)\(readFileSync|readJson(Value|Object)File" src/kaizen-setup.ts scripts/kaizen-uninstall-plugin.ts scripts/kaizen-doctor.ts src/lib/json-file.ts`

## Known Limitations

This PR only migrates parse-null runtime JSON file reads. Reads that intentionally throw, parse command output, or need domain-specific validation remain out of scope.