### PR TITLE
Refactor hook state file reads

### DIFF
--- a/src/hooks/lib/gate-manager.test.ts
+++ b/src/hooks/lib/gate-manager.test.ts
@@ -13,6 +13,10 @@ import {
 
 const TEST_STATE_DIR = '/tmp/.test-gate-manager';
 const TEST_BRANCH = 'worktree-test-branch';
+const GATE_MANAGER_SOURCE = readFileSync(
+  new URL('./gate-manager.ts', import.meta.url),
+  'utf-8',
+);
 
 function createState(
   filename: string,
@@ -39,6 +43,14 @@ afterEach(() => {
   if (existsSync(TEST_STATE_DIR)) {
     rmSync(TEST_STATE_DIR, { recursive: true });
   }
+});
+
+describe('state file read helper source invariant', () => {
+  it('uses the shared readStateFile helper for gate state reads', () => {
+    expect(GATE_MANAGER_SOURCE).toContain('readStateFile');
+    expect(GATE_MANAGER_SOURCE).not.toContain('function readStateFromFile');
+    expect(GATE_MANAGER_SOURCE).not.toContain('parseStateFile(readFileSync');
+  });
 });
 
 describe('readAllPendingGates', () => {

--- a/src/hooks/lib/gate-manager.ts
+++ b/src/hooks/lib/gate-manager.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_STATE_DIR,
   findAllStatesWithStatus,
   parseStateFile,
+  readStateFile,
 } from '../state-utils.js';
 
 export interface PendingGate {
@@ -59,7 +60,7 @@ export function readAllPendingGates(
   // Check review gates
   const reviews = findAllStatesWithStatus('needs_review', currentBranch, stateDir, maxAge);
   for (const r of reviews) {
-    const state = readStateFromFile(r.filepath);
+    const state = readStateFile(r.filepath);
     const round = state.ROUND || '1';
     gates.push({
       type: 'review',
@@ -195,17 +196,6 @@ export function clearDeferredItems(stateDir: string = DEFAULT_STATE_DIR): void {
     }
   } catch {
     // ignore
-  }
-}
-
-// Helpers
-
-function readStateFromFile(filepath: string): Record<string, string> {
-  try {
-    const content = readFileSync(filepath, 'utf-8');
-    return parseStateFile(content) as Record<string, string>;
-  } catch {
-    return {};
   }
 }
 

--- a/src/hooks/state-utils.test.ts
+++ b/src/hooks/state-utils.test.ts
@@ -26,6 +26,10 @@ import {
 } from './state-utils.js';
 
 const TEST_STATE_DIR = '/tmp/.test-state-utils-ts';
+const STATE_UTILS_SOURCE = readFileSync(
+  new URL('./state-utils.ts', import.meta.url),
+  'utf-8',
+);
 
 beforeEach(() => {
   if (existsSync(TEST_STATE_DIR)) {
@@ -114,6 +118,13 @@ describe('writeStateFile', () => {
       BRANCH: 'branch',
     });
     expect(existsSync(join(subDir, 'test'))).toBe(true);
+  });
+});
+
+describe('state file read helper source invariant', () => {
+  it('routes runtime state file reads through readStateFile', () => {
+    expect(STATE_UTILS_SOURCE).toContain('export function readStateFile');
+    expect(STATE_UTILS_SOURCE).not.toContain('parseStateFile(readFileSync');
   });
 });
 

--- a/src/hooks/state-utils.ts
+++ b/src/hooks/state-utils.ts
@@ -57,6 +57,16 @@ export function parseStateFile(content: string): Partial<StateFile> {
   return result as Partial<StateFile>;
 }
 
+/** Read and parse a state file, returning empty state when it cannot be read. */
+export function readStateFile(filepath: string): Partial<StateFile> {
+  try {
+    const content = readFileSync(filepath, 'utf-8');
+    return parseStateFile(content);
+  } catch {
+    return {};
+  }
+}
+
 /** Serialize a state file to key=value format. */
 export function serializeStateFile(state: StateFile): string {
   let content = `PR_URL=${state.PR_URL}\nSTATUS=${state.STATUS}\nBRANCH=${state.BRANCH}\n`;
@@ -108,9 +118,7 @@ function isStateForCurrentWorktree(
   // Without a branch, we can't scope — fail closed to prevent cross-session contamination.
   if (!currentBranch) return false;
 
-  // Read and parse
-  const content = readFileSync(filepath, 'utf-8');
-  const state = parseStateFile(content);
+  const state = readStateFile(filepath);
 
   // Skip legacy state files without BRANCH
   if (!state.BRANCH) return false;
@@ -163,8 +171,7 @@ export function listStateFilesAnyBranch(
   for (const entry of readdirSync(stateDir)) {
     const filepath = join(stateDir, entry);
     try {
-      const content = readFileSync(filepath, 'utf-8');
-      const state = parseStateFile(content);
+      const state = readStateFile(filepath);
       if (!state.BRANCH) continue;
 
       files.push(filepath);
@@ -268,7 +275,7 @@ export function findStateWithStatus(
     stateDir,
     maxAge,
   )) {
-    const state = parseStateFile(readFileSync(filepath, 'utf-8'));
+    const state = readStateFile(filepath);
     if (state.STATUS === wantedStatus) {
       return { prUrl: state.PR_URL ?? '', status: state.STATUS, round: state.ROUND, filepath };
     }
@@ -317,7 +324,7 @@ export function findAllStatesWithStatus(
     stateDir,
     maxAge,
   )) {
-    const state = parseStateFile(readFileSync(filepath, 'utf-8'));
+    const state = readStateFile(filepath);
     if (state.STATUS === wantedStatus) {
       results.push({
         prUrl: state.PR_URL ?? '',
@@ -370,7 +377,7 @@ export function findStateWithStatusAnyBranch(
   maxAge: number = DEFAULT_MAX_STATE_AGE,
 ): StateQueryResult | null {
   for (const filepath of listStateFilesAnyBranch(stateDir, maxAge)) {
-    const state = parseStateFile(readFileSync(filepath, 'utf-8'));
+    const state = readStateFile(filepath);
     if (state.STATUS === wantedStatus) {
       return { prUrl: state.PR_URL ?? '', status: state.STATUS, filepath };
     }
@@ -390,7 +397,7 @@ export function clearStateWithStatusAnyBranch(
   specificPrUrl?: string,
 ): boolean {
   for (const filepath of listStateFilesAnyBranch(stateDir, maxAge)) {
-    const state = parseStateFile(readFileSync(filepath, 'utf-8'));
+    const state = readStateFile(filepath);
     if (state.STATUS !== wantedStatus) continue;
     if (specificPrUrl && state.PR_URL !== specificPrUrl) continue;
     try {
@@ -417,7 +424,7 @@ export function findNewestStateWithStatusAnyBranch(
   let newestMtime = 0;
 
   for (const filepath of listStateFilesAnyBranch(stateDir, maxAge)) {
-    const state = parseStateFile(readFileSync(filepath, 'utf-8'));
+    const state = readStateFile(filepath);
     if (state.STATUS !== wantedStatus) continue;
 
     const mtime = statSync(filepath).mtimeMs;


### PR DESCRIPTION
## Story

Once upon a time, `state-utils.ts` was the canonical hook state module, but runtime callers still crossed the file boundary themselves with repeated `readFileSync` + `parseStateFile` patterns.

One day, issue #1437 identified that this duplication had spread into both branch-scoped state queries and `gate-manager`'s local `readStateFromFile()` wrapper. Those paths all need the same behavior for missing or unreadable state files, so each local copy was another place for drift.

Because of that, this PR exports a shared `readStateFile()` helper from `state-utils` and routes the duplicated runtime reads through it. `gate-manager` now uses the same helper instead of owning a private wrapper.

Because of that, tests now include source invariants that reject reintroducing the duplicated `parseStateFile(readFileSync(...))` runtime pattern or the local gate-manager wrapper.

Until finally, the focused hook suites pass with the helper in place, typecheck passes, and the source scan shows only the helper, its callers, and the invariant tests.

Fixes Garsson-io/kaizen#1437

## Architecture

```text
state file on disk
      |
      v
state-utils.readStateFile(filepath)
      |
      +--> state-utils branch/current-worktree queries
      +--> state-utils any-branch queries
      +--> gate-manager review round lookup
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Return `{}` when a state file cannot be read | Matches the existing local fallback behavior and keeps gate reads fail-closed for malformed/missing files | Callers still distinguish validity through required fields like `BRANCH` and `STATUS` |
| Keep diagnostics reading content directly | `scanStateDirectoryDiagnostics` needs to report read errors separately and pair content with mtime | One diagnostic read path remains, but not the duplicated runtime query pattern covered by this issue |
| Add source invariants | This is a DRY regression-prone pattern, not a new user-visible behavior | Tests inspect source text for this narrow runtime boundary |

## What's In This PR

| File | Purpose |
| --- | --- |
| `src/hooks/state-utils.ts` | Adds `readStateFile()` and migrates branch-scoped and any-branch runtime state queries |
| `src/hooks/lib/gate-manager.ts` | Uses `readStateFile()` for review gate round lookup and removes `readStateFromFile()` |
| `src/hooks/state-utils.test.ts` | Adds invariant blocking direct runtime `parseStateFile(readFileSync(...))` reads |
| `src/hooks/lib/gate-manager.test.ts` | Adds invariant blocking the local wrapper from returning |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Coverage |
| --- | --- | --- |
| Runtime hook state reads use one shared file-boundary helper | Source invariant | Tested in `state-utils.test.ts` and `gate-manager.test.ts` |
| Existing state query and gate behavior remains unchanged | Focused unit tests | Tested by 74 passing hook tests |
| Type-level compatibility | Typecheck | `npm run typecheck` |
| Patch hygiene | Diff check | `git diff --check` |
| Duplicate pattern is gone | Source scan | Planned `rg` scan completed |

## Validation

- [x] RED: `npm test -- --run src/hooks/state-utils.test.ts src/hooks/lib/gate-manager.test.ts` failed on the new invariants before production changes.
- [x] GREEN: `npm test -- --run src/hooks/state-utils.test.ts src/hooks/lib/gate-manager.test.ts src/hooks/pr-kaizen-clear-seams.test.ts src/hooks/stop-gate.test.ts` passed: 4 files, 74 tests.
- [x] `npm run typecheck` passed.
- [x] `git diff --check` passed.
- [x] `rg -n "parseStateFile\\(readFileSync|function readStateFromFile|readStateFile" src/hooks/state-utils.ts src/hooks/lib/gate-manager.ts src/hooks/state-utils.test.ts src/hooks/lib/gate-manager.test.ts` shows only the helper, callers, and invariant tests.

## Known Limitations

This PR does not change the state file format, deferred JSON item reads, hook gate messages, or diagnostic scanning behavior.