### PR TITLE
Refactor remaining hook state reads

### DIFF
--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -59,6 +59,7 @@ function runHookRaw(rawStdin: string, extraEnv: Record<string, string> = {}): st
 
 let testStateDir: string;
 const HOOK_PATH = path.resolve(__dirname, 'pr-review-loop.ts');
+const PR_REVIEW_LOOP_SOURCE = fs.readFileSync(HOOK_PATH, 'utf-8');
 
 beforeEach(() => {
   testStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-review-test-'));
@@ -66,6 +67,13 @@ beforeEach(() => {
 
 afterEach(() => {
   fs.rmSync(testStateDir, { recursive: true, force: true });
+});
+
+describe('state file read helper source invariant', () => {
+  it('routes runtime state file reads through readStateFile', () => {
+    expect(PR_REVIEW_LOOP_SOURCE).toContain('readStateFile');
+    expect(PR_REVIEW_LOOP_SOURCE).not.toContain('parseStateFile(readFileSync');
+  });
 });
 
 /** Run the hook with JSON input and return stdout. */

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -43,8 +43,8 @@ import {
   DEFAULT_STATE_DIR,
   ensureStateDir,
   listStateFilesForCurrentWorktree,
-  parseStateFile,
   prUrlToStateKey,
+  readStateFile,
   writeStateFile,
 } from './state-utils.js';
 
@@ -180,7 +180,7 @@ function findStateByStatuses(
   let latestMtime = 0;
 
   for (const fp of listStateFilesForCurrentWorktree(branch, stateDir)) {
-    const state = parseStateFile(readFileSync(fp, 'utf-8'));
+    const state = readStateFile(fp);
     if (state.STATUS && statusSet.has(state.STATUS)) {
       const mtime = statSync(fp).mtimeMs;
       if (mtime > latestMtime) {
@@ -367,7 +367,7 @@ export function processHookInput(
     const nextRound = round + 1;
 
     // Diff-size scaling (kaizen #117, #909)
-    const rawState = parseStateFile(readFileSync(found.filepath, 'utf-8'));
+    const rawState = readStateFile(found.filepath);
     const lastPushSha = (rawState as Record<string, string>).LAST_REVIEWED_SHA ?? '';
     const lastFullReviewSha = (rawState as Record<string, string>).LAST_FULL_REVIEW_SHA ?? lastPushSha;
 

--- a/src/hooks/pre-push.test.ts
+++ b/src/hooks/pre-push.test.ts
@@ -29,7 +29,16 @@ import {
   type PrePushDecision,
 } from './pre-push.js';
 
+const PRE_PUSH_SOURCE = fs.readFileSync(new URL('./pre-push.ts', import.meta.url), 'utf-8');
+
 // ── detectAgentEnv ────────────────────────────────────────────────────
+
+describe('state file read helper source invariant', () => {
+  it('routes existing-round state reads through readStateFile', () => {
+    expect(PRE_PUSH_SOURCE).toContain('readStateFile');
+    expect(PRE_PUSH_SOURCE).not.toContain('parseStateFile(readFileSync');
+  });
+});
 
 describe('detectAgentEnv', () => {
   it('returns detected=false when no agent vars set (I-A)', () => {

--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -25,9 +25,9 @@
  *   I-F: --force-with-lease push option → allow even on merged branch
  */
 
-import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { appendFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { DEFAULT_STATE_DIR, ensureStateDir, parseStateFile, prUrlToStateKey, writeStateFile } from './state-utils.js';
+import { DEFAULT_STATE_DIR, ensureStateDir, prUrlToStateKey, readStateFile, writeStateFile } from './state-utils.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
 import { queryBranchPrState, type BranchPrQueryResult } from '../lib/github-pr.js';
@@ -347,13 +347,9 @@ export function processPrePush(
 export function readExistingRound(stateDir: string, prUrl: string): number | undefined {
   const filepath = join(stateDir, prUrlToStateKey(prUrl));
   if (!existsSync(filepath)) return undefined;
-  try {
-    const state = parseStateFile(readFileSync(filepath, 'utf-8'));
-    const r = parseInt(state.ROUND ?? '', 10);
-    return Number.isFinite(r) && r > 0 ? r : undefined;
-  } catch {
-    return undefined;
-  }
+  const state = readStateFile(filepath);
+  const r = parseInt(state.ROUND ?? '', 10);
+  return Number.isFinite(r) && r > 0 ? r : undefined;
 }
 
 // ── CLI entry ─────────────────────────────────────────────────────────

--- a/src/hooks/session-cleanup.test.ts
+++ b/src/hooks/session-cleanup.test.ts
@@ -1,9 +1,13 @@
-import { existsSync, mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanupMergedReviewStates } from './session-cleanup.js';
 
 const TEST_STATE_DIR = '/tmp/.test-session-cleanup';
+const SESSION_CLEANUP_SOURCE = readFileSync(
+  new URL('./session-cleanup.ts', import.meta.url),
+  'utf-8',
+);
 
 beforeEach(() => {
   if (existsSync(TEST_STATE_DIR)) {
@@ -32,6 +36,15 @@ function makeStale(filename: string) {
   const old = new Date(Date.now() - 3 * 3600 * 1000); // 3 hours ago
   utimesSync(filepath, old, old);
 }
+
+describe('state file read helper source invariant', () => {
+  it('routes cleanup state file scans through readStateFile', () => {
+    expect(SESSION_CLEANUP_SOURCE).toContain('readStateFile');
+    expect(SESSION_CLEANUP_SOURCE).not.toMatch(
+      /const content = readFileSync\(filepath, 'utf-8'\);\s*const state = parseStateFile\(content\);/,
+    );
+  });
+});
 
 describe('cleanupMergedReviewStates', () => {
   it('returns 0 when no state files exist', () => {

--- a/src/hooks/session-cleanup.ts
+++ b/src/hooks/session-cleanup.ts
@@ -8,13 +8,13 @@
  * Bash predecessor deleted in #790.
  */
 
-import { existsSync, readdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { existsSync, readdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { readHookInput } from './hook-io.js';
 import {
   DEFAULT_STATE_DIR,
-  parseStateFile,
   pruneStaleStateFiles,
+  readStateFile,
 } from './state-utils.js';
 import { gh } from '../lib/gh-exec.js';
 
@@ -44,8 +44,7 @@ export function cleanupMergedReviewStates(
   for (const entry of readdirSync(stateDir)) {
     const filepath = join(stateDir, entry);
     try {
-      const content = readFileSync(filepath, 'utf-8');
-      const state = parseStateFile(content);
+      const state = readStateFile(filepath);
 
       if (state.STATUS !== 'needs_review') continue;
       if (!state.PR_URL) continue;


### PR DESCRIPTION
## Story

Once upon a time, PR #1438 introduced `readStateFile()` as the shared state file read-and-parse boundary for hook state files.

One day, issue #1439 confirmed the mechanism was still only partially adopted: `pr-review-loop.ts`, `pre-push.ts`, and `session-cleanup.ts` still had their own runtime reads of the same key/value state file format.

Because of that, this PR routes those remaining runtime state reads through `readStateFile()`. Review-loop state selection, push round lookup, and session cleanup now use the same unreadable-file fallback behavior owned by `state-utils`.

Because of that, each affected hook test file now carries a focused source invariant preventing `parseStateFile(readFileSync(...))` and the cleanup content-then-parse pattern from returning.

Until finally, the focused hook suite passes with 140 tests, typecheck passes, and the source scan shows only the helper, callers, and invariant tests.

Fixes Garsson-io/kaizen#1439

## Architecture

```text
state file on disk
      |
      v
state-utils.readStateFile(filepath)
      |
      +--> pr-review-loop state lookup and SHA metadata reads
      +--> pre-push existing-round lookup
      +--> session-cleanup review-state scans
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Reuse `readStateFile()` directly | It is now the contract owner for hook state file reads | Keeps hook modules dependent on `state-utils`, which already owns state format |
| Leave review sentinel reads alone | Sentinels are JSON records with separate validation, not hook key/value state files | This PR only DRYs the state-file format boundary |
| Keep source invariants local to affected hooks | The problem is a recurring direct-read pattern in these modules | Source assertions are narrow and intentional rather than broad linting |

## What's In This PR

| File | Purpose |
| --- | --- |
| `src/hooks/pr-review-loop.ts` | Uses `readStateFile()` for review state selection and push SHA metadata reads |
| `src/hooks/pre-push.ts` | Uses `readStateFile()` in `readExistingRound()` |
| `src/hooks/session-cleanup.ts` | Uses `readStateFile()` when scanning cleanup candidates |
| `src/hooks/pr-review-loop.test.ts` | Adds source invariant for direct runtime state reads |
| `src/hooks/pre-push.test.ts` | Adds source invariant for existing-round state reads |
| `src/hooks/session-cleanup.test.ts` | Adds source invariant for cleanup scan reads |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Coverage |
| --- | --- | --- |
| Remaining runtime hook state reads use `readStateFile()` | Source invariant | Tested in the three affected hook test files |
| Review-loop round and SHA behavior remains stable | Focused tests | `pr-review-loop.test.ts` and `pr-review-loop-scenarios.test.ts` |
| Pre-push existing-round behavior remains stable | Focused tests | `pre-push.test.ts` |
| Session cleanup behavior remains stable | Focused tests | `session-cleanup.test.ts` |
| Shared helper remains covered | Focused tests | `state-utils.test.ts` |
| Type and patch hygiene | Tooling | `npm run typecheck`, `git diff --check`, source scan |

## Validation

- [x] RED: `npm test -- --run src/hooks/pr-review-loop.test.ts src/hooks/pre-push.test.ts src/hooks/session-cleanup.test.ts` failed on the new source invariants before production changes.
- [x] GREEN: `npm test -- --run src/hooks/pr-review-loop.test.ts src/hooks/pr-review-loop-scenarios.test.ts src/hooks/pre-push.test.ts src/hooks/session-cleanup.test.ts src/hooks/state-utils.test.ts` passed: 5 files, 140 tests.
- [x] `npm run typecheck` passed.
- [x] `git diff --check` passed.
- [x] `rg -U -n "parseStateFile\\(readFileSync|const content = readFileSync\\(filepath, 'utf-8'\\);\\n\\s*const state = parseStateFile|readStateFile" src/hooks/pr-review-loop.ts src/hooks/pre-push.ts src/hooks/session-cleanup.ts src/hooks/pr-review-loop.test.ts src/hooks/pre-push.test.ts src/hooks/session-cleanup.test.ts` shows only the helper, callers, and invariant tests.

## Known Limitations

This PR does not change the state file format, review-loop round semantics, pre-push merged-branch policy, or session-cleanup PR-state querying.