### PR TITLE
Refactor fallback kaizen clear state IO

### DIFF
--- a/src/hooks/pr-kaizen-clear-fallback.test.ts
+++ b/src/hooks/pr-kaizen-clear-fallback.test.ts
@@ -20,6 +20,7 @@ const HOOK_PATH = path.resolve(
   __dirname,
   'pr-kaizen-clear-fallback.ts',
 );
+const HOOK_SOURCE = fs.readFileSync(HOOK_PATH, 'utf-8');
 
 let testStateDir: string;
 let testAuditDir: string;
@@ -82,6 +83,16 @@ function bashInput(command: string, stdout: string): object {
     tool_response: { stdout, stderr: '', exit_code: '0' },
   };
 }
+
+describe('state IO source invariant', () => {
+  it('routes fallback state reads and writes through shared state helpers', () => {
+    expect(HOOK_SOURCE).toContain('readStateFile');
+    expect(HOOK_SOURCE).toContain('writeStateFile');
+    expect(HOOK_SOURCE).not.toContain('parseStateFile(readFileSync');
+    expect(HOOK_SOURCE).not.toContain('parseStateFile(content)');
+    expect(HOOK_SOURCE).not.toContain('writeFileSync(filepath, serializeStateFile');
+  });
+});
 
 describe('pr-kaizen-clear-fallback: clears gate', () => {
   it('INVARIANT: clears needs_pr_kaizen gate when KAIZEN_IMPEDIMENTS in stdout', () => {

--- a/src/hooks/pr-kaizen-clear-fallback.ts
+++ b/src/hooks/pr-kaizen-clear-fallback.ts
@@ -19,16 +19,16 @@
  * Migrated to TS state functions in #790 gap fix.
  */
 
-import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import { readHookInput, traceNullInput } from './hook-io.js';
 import { gitStdout } from './lib/git-state.js';
 import {
   DEFAULT_AUDIT_DIR,
   DEFAULT_STATE_DIR,
   listStateFilesAnyBranch,
-  parseStateFile,
-  serializeStateFile,
+  readStateFile,
+  writeStateFile,
 } from './state-utils.js';
 
 function currentBranch(): string {
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
 
   // Check if there's an active kaizen gate (any branch — handles cross-worktree leak)
   const hasActive = listStateFilesAnyBranch(stateDir).some((filepath) => {
-    const state = parseStateFile(readFileSync(filepath, 'utf-8'));
+    const state = readStateFile(filepath);
     return state.STATUS === 'needs_pr_kaizen';
   });
 
@@ -71,12 +71,16 @@ async function main(): Promise<void> {
   let lastPrUrl = '';
 
   for (const filepath of listStateFilesAnyBranch(stateDir)) {
-    const content = readFileSync(filepath, 'utf-8');
-    const state = parseStateFile(content);
+    const state = readStateFile(filepath);
     if (state.STATUS !== 'needs_pr_kaizen') continue;
 
-    const updated = { ...state, STATUS: 'kaizen_done' } as Parameters<typeof serializeStateFile>[0];
-    writeFileSync(filepath, serializeStateFile(updated), { mode: 0o600 });
+    const filename = basename(filepath);
+    writeStateFile(stateDir, filename, {
+      PR_URL: state.PR_URL ?? '',
+      STATUS: 'kaizen_done',
+      BRANCH: state.BRANCH ?? '',
+      ROUND: state.ROUND,
+    });
     cleared = true;
     lastPrUrl = state.PR_URL ?? '';
   }


### PR DESCRIPTION
## Story

Once upon a time, the kaizen clear fallback hook was a minimal precompiled path for clearing reflection gates when the primary TS hook timed out.

One day, issue #1441 showed that this fallback still had its own state-file IO mechanism: direct `readFileSync` + `parseStateFile` reads and direct `writeFileSync` + `serializeStateFile` mutation.

Because of that, this PR routes fallback gate detection through `readStateFile()` and fallback status mutation through `writeStateFile()`. The fallback path now uses the same key/value state file read/write boundaries as the rest of the hook state system.

Because of that, the fallback test now includes a source invariant preventing those local IO patterns from coming back.

Until finally, the focused fallback and adjacent state tests pass, typecheck passes, and the source scan shows only shared helper usage plus the invariant assertions.

Fixes Garsson-io/kaizen#1441

## Architecture

```text
pr-kaizen-clear-fallback
      |
      +--> listStateFilesAnyBranch(stateDir)
      |         |
      |         v
      |    readStateFile(filepath)
      |
      +--> writeStateFile(stateDir, filename, updatedState)
```

## Design Decisions

| Decision | Why | Tradeoff |
| --- | --- | --- |
| Reuse `readStateFile()` for both scans | Active-gate detection and mutation read the same state format | Keeps fallback behavior aligned with normal hook state readers |
| Reuse `writeStateFile()` for mutation | Avoids a fallback-only serialize/write path | Rewrites via the canonical state writer rather than in-place manual serialization |
| Preserve lenient metadata handling | Existing fallback cleared active status even when PR metadata was partial | Missing `PR_URL` remains an empty value during rewrite |

## What's In This PR

| File | Purpose |
| --- | --- |
| `src/hooks/pr-kaizen-clear-fallback.ts` | Uses shared state read/write helpers for fallback gate clear state IO |
| `src/hooks/pr-kaizen-clear-fallback.test.ts` | Adds source invariant blocking fallback-local state IO patterns |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Coverage |
| --- | --- | --- |
| Fallback state reads and writes use shared helpers | Source invariant | `pr-kaizen-clear-fallback.test.ts` |
| Fallback active-gate clear behavior remains stable | Focused tests | `pr-kaizen-clear-fallback.test.ts` |
| Adjacent primary clear seams still pass | Focused seam tests | `pr-kaizen-clear-seams.test.ts` |
| Shared state helper remains covered | Focused unit tests | `state-utils.test.ts` |
| Type and patch hygiene | Tooling | `npm run typecheck`, `git diff --check`, source scan |

## Validation

- [x] RED: `npm test -- --run src/hooks/pr-kaizen-clear-fallback.test.ts` failed on the new source invariant before production changes.
- [x] GREEN: `npm test -- --run src/hooks/pr-kaizen-clear-fallback.test.ts src/hooks/pr-kaizen-clear-seams.test.ts src/hooks/state-utils.test.ts` passed: 3 files, 56 tests.
- [x] `npm run typecheck` passed.
- [x] `git diff --check` passed.
- [x] `rg -n "parseStateFile\\(readFileSync|const content = readFileSync|parseStateFile\\(content\\)|writeFileSync\\(filepath, serializeStateFile|readStateFile|writeStateFile" src/hooks/pr-kaizen-clear-fallback.ts src/hooks/pr-kaizen-clear-fallback.test.ts` shows only shared helper usage and invariant assertions.

## Known Limitations

This PR does not change fallback trigger semantics, validation behavior, audit log format, or primary `pr-kaizen-clear.ts` behavior.