### PR TITLE
refactor(hooks): share trace writer

### DIFF
--- a/src/hooks/hook-io.test.ts
+++ b/src/hooks/hook-io.test.ts
@@ -3,8 +3,10 @@ import { Readable } from 'node:stream';
 import { readFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { writeHookOutput, getCurrentBranch, readHookInput, traceNullInput } from './hook-io.js';
+import { writeHookOutput, getCurrentBranch, readHookInput, traceHookEvent, traceNullInput } from './hook-io.js';
 import type { GitExec } from './lib/git-state.js';
+
+const HOOK_IO_SOURCE = readFileSync(new URL('./hook-io.ts', import.meta.url), 'utf-8');
 
 describe('hook-io', () => {
   afterEach(() => {
@@ -241,6 +243,35 @@ describe('hook-io', () => {
         traceNullInput('any-hook');
         // MUST NOT have written any trace file
         expect(existsSync(traceFile)).toBe(false);
+      } finally {
+        if (origTrace !== undefined) process.env.KAIZEN_HOOK_TRACE = origTrace;
+        else delete process.env.KAIZEN_HOOK_TRACE;
+        rmSync(traceDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('traceHookEvent source invariant', () => {
+    it('INVARIANT: exposes shared trace writer with explicit trace-file override support', () => {
+      expect(HOOK_IO_SOURCE).toContain('traceHookEvent');
+      expect(HOOK_IO_SOURCE).toContain('traceFile?: string');
+      expect(HOOK_IO_SOURCE).toContain('options.traceFile');
+    });
+
+    it('INVARIANT: writes to explicit trace file override', () => {
+      const traceDir = mkdtempSync(join(tmpdir(), 'hook-io-override-'));
+      const traceFile = join(traceDir, 'trace.jsonl');
+      const origTrace = process.env.KAIZEN_HOOK_TRACE;
+      delete process.env.KAIZEN_HOOK_TRACE;
+
+      try {
+        traceHookEvent('test-hook', { action: 'observe', reason: 'override_path' }, { traceFile });
+        expect(existsSync(traceFile)).toBe(true);
+        const entry = JSON.parse(readFileSync(traceFile, 'utf8').trim());
+        expect(entry.hook).toBe('test-hook');
+        expect(entry.action).toBe('observe');
+        expect(entry.reason).toBe('override_path');
+        expect(entry.ts).toBeDefined();
       } finally {
         if (origTrace !== undefined) process.env.KAIZEN_HOOK_TRACE = origTrace;
         else delete process.env.KAIZEN_HOOK_TRACE;

--- a/src/hooks/hook-io.ts
+++ b/src/hooks/hook-io.ts
@@ -8,7 +8,12 @@
 import { appendFileSync } from 'node:fs';
 import { createDefaultGitExec, resolveTargetWorktree, type GitExec } from './lib/git-state.js';
 
-const getTraceFile = (): string => process.env.KAIZEN_HOOK_TRACE ?? '/tmp/.kaizen-hook-trace.jsonl';
+export interface HookTraceOptions {
+  traceFile?: string;
+}
+
+const getTraceFile = (options: HookTraceOptions = {}): string =>
+  options.traceFile ?? process.env.KAIZEN_HOOK_TRACE ?? '/tmp/.kaizen-hook-trace.jsonl';
 const isTraceEnabled = (): boolean => process.env.KAIZEN_HOOK_TRACE !== '0';
 
 export interface HookInput {
@@ -34,19 +39,10 @@ export async function readHookInput(): Promise<HookInput | null> {
   try {
     return JSON.parse(raw) as HookInput;
   } catch {
-    if (isTraceEnabled()) {
-      try {
-        appendFileSync(
-          getTraceFile(),
-          JSON.stringify({
-            ts: new Date().toISOString(),
-            hook: 'hook-io',
-            error: 'json_parse_failed',
-            raw_length: raw.length,
-          }) + '\n',
-        );
-      } catch { /* never fail on trace */ }
-    }
+    traceHookEvent('hook-io', {
+      error: 'json_parse_failed',
+      raw_length: raw.length,
+    });
     return null;
   }
 }
@@ -56,11 +52,15 @@ export async function readHookInput(): Promise<HookInput | null> {
  * The shared primitive behind hook observability — use it to leave a durable
  * signal when a hook takes (or skips) an action that would otherwise be silent.
  */
-export function traceHookEvent(hook: string, fields: Record<string, unknown>): void {
+export function traceHookEvent(
+  hook: string,
+  fields: Record<string, unknown>,
+  options: HookTraceOptions = {},
+): void {
   if (!isTraceEnabled()) return;
   try {
     appendFileSync(
-      getTraceFile(),
+      getTraceFile(options),
       JSON.stringify({ ts: new Date().toISOString(), hook, ...fields }) + '\n',
     );
   } catch { /* never fail on trace */ }

--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -76,6 +76,15 @@ describe('state file read helper source invariant', () => {
   });
 });
 
+describe('trace helper source invariant', () => {
+  it('routes trace writes through hook-io traceHookEvent', () => {
+    expect(PR_REVIEW_LOOP_SOURCE).toContain('traceHookEvent');
+    expect(PR_REVIEW_LOOP_SOURCE).not.toContain('const getTraceFile');
+    expect(PR_REVIEW_LOOP_SOURCE).not.toContain('const isTraceEnabled');
+    expect(PR_REVIEW_LOOP_SOURCE).not.toContain('appendFileSync(getTraceFile');
+  });
+});
+
 /** Run the hook with JSON input and return stdout. */
 function runHook(input: object): string {
   const json = JSON.stringify(input);

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -30,7 +30,7 @@ import {
   type ReviewSentinelValidation,
 } from '../review-sentinel.js';
 import { findOpenPrUrlForBranch } from '../lib/github-pr.js';
-import { type HookInput, readHookInput, writeHookOutput } from './hook-io.js';
+import { type HookInput, readHookInput, traceHookEvent, writeHookOutput } from './hook-io.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
 import {
@@ -67,22 +67,13 @@ export interface HookDecision {
   gateSignal?: GateSignal;
 }
 
-const getTraceFile = (): string => process.env.KAIZEN_HOOK_TRACE ?? '/tmp/.kaizen-hook-trace.jsonl';
-const isTraceEnabled = (): boolean => process.env.KAIZEN_HOOK_TRACE !== '0';
-
 function trace(decision: HookDecision, trigger: string): void {
-  if (!isTraceEnabled()) return;
-  try {
-    const entry = JSON.stringify({
-      ts: new Date().toISOString(),
-      hook: 'pr-review-loop',
-      trigger,
-      action: decision.action,
-      reason: decision.reason,
-      ...decision.context,
-    });
-    appendFileSync(getTraceFile(), entry + '\n');
-  } catch { /* never fail on trace */ }
+  traceHookEvent('pr-review-loop', {
+    trigger,
+    action: decision.action,
+    reason: decision.reason,
+    ...decision.context,
+  });
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/hooks/pre-push.test.ts
+++ b/src/hooks/pre-push.test.ts
@@ -40,6 +40,15 @@ describe('state file read helper source invariant', () => {
   });
 });
 
+describe('trace helper source invariant', () => {
+  it('routes trace writes through hook-io traceHookEvent', () => {
+    expect(PRE_PUSH_SOURCE).toContain('traceHookEvent');
+    expect(PRE_PUSH_SOURCE).not.toContain("import { appendFileSync");
+    expect(PRE_PUSH_SOURCE).not.toContain('function getTraceFile');
+    expect(PRE_PUSH_SOURCE).not.toContain('function isTraceEnabled');
+  });
+});
+
 describe('detectAgentEnv', () => {
   it('returns detected=false when no agent vars set (I-A)', () => {
     const result = detectAgentEnv({});

--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -25,12 +25,13 @@
  *   I-F: --force-with-lease push option → allow even on merged branch
  */
 
-import { appendFileSync, existsSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { DEFAULT_STATE_DIR, ensureStateDir, prUrlToStateKey, readStateFile, writeStateFile } from './state-utils.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
 import { queryBranchPrState, type BranchPrQueryResult } from '../lib/github-pr.js';
+import { traceHookEvent, type HookTraceOptions } from './hook-io.js';
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -71,9 +72,8 @@ export interface PrePushDecision {
 /** Branch PR-state query result used by the pre-push decision. */
 export type PrQueryResult = BranchPrQueryResult;
 
-export interface PrePushOptions {
+export interface PrePushOptions extends HookTraceOptions {
   stateDir?: string;
-  traceFile?: string;
   queryPrState?: (repo: string, branch: string) => PrQueryResult;
   now?: () => number;
 }
@@ -242,38 +242,18 @@ export function defaultQueryPrState(repo: string, branch: string): PrQueryResult
   return queryBranchPrState({ repo, branch });
 }
 
-// ── Trace ─────────────────────────────────────────────────────────────
-
-function getTraceFile(options: PrePushOptions): string {
-  return options.traceFile ?? process.env.KAIZEN_HOOK_TRACE ?? '/tmp/.kaizen-hook-trace.jsonl';
-}
-
-function isTraceEnabled(): boolean {
-  return process.env.KAIZEN_HOOK_TRACE !== '0';
-}
-
 export function trace(
   decision: PrePushDecision,
   envDetection: { detected: boolean; vars: string[] },
   options: PrePushOptions = {},
 ): void {
-  if (!isTraceEnabled()) return;
-  try {
-    appendFileSync(
-      getTraceFile(options),
-      JSON.stringify({
-        ts: new Date().toISOString(),
-        hook: 'pre-push',
-        agent_detected: envDetection.detected,
-        env_vars_seen: envDetection.vars,
-        action: decision.action,
-        reason: decision.reason,
-        ...(decision.context ?? {}),
-      }) + '\n',
-    );
-  } catch {
-    /* never fail on trace */
-  }
+  traceHookEvent('pre-push', {
+    agent_detected: envDetection.detected,
+    env_vars_seen: envDetection.vars,
+    action: decision.action,
+    reason: decision.reason,
+    ...(decision.context ?? {}),
+  }, options);
 }
 
 // ── Side-effecting orchestration (idempotent gate write) ──────────────


### PR DESCRIPTION
Once upon a time, hook observability had a shared home in `hook-io.ts`, but two runtime hooks still carried local copies of the same trace policy. Every trace write needed the same default path, `KAIZEN_HOOK_TRACE=0` suppression, JSONL append, timestamp, and best-effort error handling.

One day, while continuing the DRY pass through hook runtime code, `pre-push.ts` and `pr-review-loop.ts` showed the same local `getTraceFile` / `isTraceEnabled` implementations even though `hook-io.ts` already exported `traceHookEvent`. Because of that, this PR extends the shared writer with the one missing capability, an explicit trace-file override for `pre-push` tests, then routes both hook callers through it.

Because of that, existing trace shapes stay stable: `pre-push` still emits `agent_detected`, `env_vars_seen`, action, reason, context, and timestamp; `pr-review-loop` still emits trigger/action/reason/context; `hook-io` parse failures still emit `json_parse_failed` and `raw_length`. Until finally, the focused tests, wrapper smoke tests, live pre-push test, typecheck, diff check, and source scan all verify the duplicate trace plumbing is gone without changing hook-visible behavior.

Closes #1443

## Architecture

```text
hook callers
  pre-push.trace(...)
  pr-review-loop trace(...)
  readHookInput parse-failure path
        |
        v
hook-io.traceHookEvent(hook, fields, { traceFile? })
        |
        v
KAIZEN_HOOK_TRACE=0 suppression + path resolution + JSONL append + best-effort catch
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Extend `traceHookEvent` instead of adding a new helper | `hook-io.ts` already owns shared hook I/O and trace append behavior | Slightly broadens the helper signature |
| Keep `pre-push.trace()` exported | Tests and callers already use that API | The wrapper remains, but no longer owns trace policy |
| Keep source invariants in hook tests | Prevents the local helper copies from returning | Source assertions are intentionally narrow to avoid policing unrelated implementation details |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/hook-io.ts` | Adds `HookTraceOptions`, explicit trace-file override support, and routes parse failures through `traceHookEvent` |
| `src/hooks/pre-push.ts` | Removes local trace file/enablement/append code and delegates to `traceHookEvent` |
| `src/hooks/pr-review-loop.ts` | Removes local trace file/enablement/append code and delegates to `traceHookEvent` |
| `src/hooks/hook-io.test.ts` | Covers override-path writing and shared-writer source invariant |
| `src/hooks/pre-push.test.ts` | Adds invariant requiring `pre-push` trace delegation |
| `src/hooks/pr-review-loop.test.ts` | Adds invariant requiring `pr-review-loop` trace delegation |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Test File |
|---|---|---|---|---|---|
| 1 | Shared trace writer accepts an explicit trace file override while preserving default env/suppression behavior | code | Unit | tested | `src/hooks/hook-io.test.ts` |
| 2 | `pre-push.trace()` keeps its exported API and JSON field shape while delegating to the shared writer | code | Unit | tested | `src/hooks/pre-push.test.ts` |
| 3 | `pr-review-loop` decision and null-input tracing keep externally visible JSON shape through the shared writer | hook/subprocess | System | tested | `src/hooks/pr-review-loop.test.ts` |
| 4 | Duplicate trace plumbing does not return to migrated hooks | code | Unit/source invariant | tested | `src/hooks/hook-io.test.ts`, `src/hooks/pre-push.test.ts`, `src/hooks/pr-review-loop.test.ts` |

No behavior is deferred.

## Validation

- [x] RED: focused suite failed on the new trace invariants before implementation.
- [x] GREEN: `npm test -- --run src/hooks/hook-io.test.ts src/hooks/pre-push.test.ts src/hooks/pr-review-loop.test.ts` -> 103 tests passed.
- [x] Integration: `npm test -- --run src/hooks/wrapper-smoke.test.ts src/e2e/pre-push-live.test.ts` -> 25 tests passed.
- [x] Typecheck: `npm run typecheck`.
- [x] Diff hygiene: `git diff --check`.
- [x] Source scan: local `getTraceFile` / `isTraceEnabled` removed from `pre-push.ts` and `pr-review-loop.ts`; remaining definitions live in `hook-io.ts`.

## Known Limitations

This PR does not change trace payload schemas or introduce a new observability format. It only consolidates the existing writer behavior behind the shared hook I/O helper.
