### PR TITLE
refactor(hooks): reuse json file reader

### DIFF
--- a/src/hooks/lib/gate-manager.test.ts
+++ b/src/hooks/lib/gate-manager.test.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeStateFile } from '../state-utils.js';
@@ -50,6 +51,13 @@ describe('state file read helper source invariant', () => {
     expect(GATE_MANAGER_SOURCE).toContain('readStateFile');
     expect(GATE_MANAGER_SOURCE).not.toContain('function readStateFromFile');
     expect(GATE_MANAGER_SOURCE).not.toContain('parseStateFile(readFileSync');
+  });
+});
+
+describe('deferred items JSON helper source invariant', () => {
+  it('uses the shared JSON file helper for deferred items reads', () => {
+    expect(GATE_MANAGER_SOURCE).toContain('readJsonValueFile');
+    expect(GATE_MANAGER_SOURCE).not.toContain('JSON.parse(readFileSync');
   });
 });
 
@@ -294,6 +302,17 @@ describe('scanStateDirectoryDiagnostics', () => {
 describe('readDeferredItems / clearDeferredItems', () => {
   it('returns null when no deferred items exist', () => {
     expect(readDeferredItems(TEST_STATE_DIR)).toBeNull();
+  });
+
+  it('returns null when deferred items file is malformed JSON', () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'gate-manager-malformed-'));
+    try {
+      writeFileSync(join(stateDir, '.kaizen-deferred-items.json'), '{not json');
+
+      expect(readDeferredItems(stateDir)).toBeNull();
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it('clears deferred items file', () => {

--- a/src/hooks/lib/gate-manager.ts
+++ b/src/hooks/lib/gate-manager.ts
@@ -28,6 +28,7 @@ import {
   parseStateFile,
   readStateFile,
 } from '../state-utils.js';
+import { readJsonValueFile } from '../../lib/json-file.js';
 
 export interface PendingGate {
   type: 'review' | 'reflection' | 'post_merge';
@@ -42,6 +43,13 @@ export interface GateReport {
   gates: PendingGate[];
   message: string;
   shouldBlock: boolean;
+}
+
+export interface DeferredItems {
+  timestamp: string;
+  branch: string;
+  reason: string;
+  items: Array<{ type: string; prUrl: string; label: string }>;
 }
 
 const DEFERRED_ITEMS_FILE = '.kaizen-deferred-items.json';
@@ -175,14 +183,10 @@ export function handleUnfinishedEscape(
  */
 export function readDeferredItems(
   stateDir: string = DEFAULT_STATE_DIR,
-): { timestamp: string; branch: string; reason: string; items: Array<{ type: string; prUrl: string; label: string }> } | null {
+): DeferredItems | null {
   const filepath = join(stateDir, DEFERRED_ITEMS_FILE);
   if (!existsSync(filepath)) return null;
-  try {
-    return JSON.parse(readFileSync(filepath, 'utf-8'));
-  } catch {
-    return null;
-  }
+  return readJsonValueFile(filepath) as DeferredItems | null;
 }
 
 /**


### PR DESCRIPTION
Once upon a time, deferred stop-gate items had their own tiny JSON reader inside `gate-manager.ts`: `JSON.parse(readFileSync(...))` wrapped in a local try/catch. Every day that worked, but it meant runtime JSON file parsing stayed split even after `src/lib/json-file.ts` became the shared helper for parse-file-and-return-null behavior.

One day, the DRY scan found that `readDeferredItems()` was still carrying that local parse path. Because of that, this PR routes the deferred-items read through `readJsonValueFile()` while preserving the existing missing/malformed behavior. Until finally, a focused source invariant now rejects the local `JSON.parse(readFileSync` pattern so this duplicate path does not come back.

Closes #1445

## Architecture

```text
readDeferredItems(stateDir)
  -> .kaizen-deferred-items.json path
  -> exists check
  -> readJsonValueFile(path)
       -> readFileSync + parseJsonValue
       -> null on read/parse failure
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use `readJsonValueFile()` rather than `readJsonObjectFile()` | Matches the old `JSON.parse` boundary most closely: any valid JSON value parses, malformed/read failure returns `null` | The function still trusts the persisted deferred-items shape, as it did before |
| Add a named `DeferredItems` interface | Keeps the cast readable after moving parsing behind the shared helper | Slightly expands exported type surface in the module |
| Keep the existing existence check | Preserves the explicit missing-file branch and avoids changing surrounding flow | The helper would also return `null` for missing files, so this is conservative duplication around existence only |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/lib/gate-manager.ts` | Replaces local deferred-items JSON parse with `readJsonValueFile()` and names the deferred-items type |
| `src/hooks/lib/gate-manager.test.ts` | Adds malformed JSON coverage and a source invariant preventing the local parse path from returning |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Test File |
|---|---|---|---|---|---|
| 1 | Valid deferred-items files still round-trip through `readDeferredItems()` | code | Unit | tested | `src/hooks/lib/gate-manager.test.ts` |
| 2 | Missing or malformed deferred-items files return `null` | code | Unit | tested | `src/hooks/lib/gate-manager.test.ts` |
| 3 | Deferred-items JSON parsing uses the shared helper instead of local parse-file code | code | Unit/source invariant | tested | `src/hooks/lib/gate-manager.test.ts` |

No behavior is deferred.

## Validation

- [x] RED: `npm test -- --run src/hooks/lib/gate-manager.test.ts` failed on the new source invariant before implementation.
- [x] GREEN: `npm test -- --run src/hooks/lib/gate-manager.test.ts` -> 25 tests passed.
- [x] Typecheck: `npm run typecheck`.
- [x] Diff hygiene: `git diff --check`.
- [x] Source scan: `readDeferredItems()` now uses `readJsonValueFile`; no `JSON.parse(readFileSync` remains in `gate-manager.ts`.

## Known Limitations

This PR does not validate the deferred-items schema. It preserves the existing parse-and-cast behavior while moving file JSON parsing onto the shared helper.
