### PR TITLE
refactor(hooks): reuse json manifest readers

### DIFF
--- a/src/hooks/bump-plugin-version.test.ts
+++ b/src/hooks/bump-plugin-version.test.ts
@@ -1,5 +1,6 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { bumpPluginVersion } from './bump-plugin-version.js';
 import type { GitExec } from './lib/git-state.js';
@@ -7,6 +8,10 @@ import type { GitExec } from './lib/git-state.js';
 const TEST_DIR = '/tmp/.test-bump-plugin';
 const PLUGIN_DIR = join(TEST_DIR, '.claude-plugin');
 const PLUGIN_JSON = join(PLUGIN_DIR, 'plugin.json');
+const BUMP_PLUGIN_VERSION_SOURCE = readFileSync(
+  new URL('./bump-plugin-version.ts', import.meta.url),
+  'utf-8',
+);
 
 function writePluginAt(root: string, version: string) {
   const dir = join(root, '.claude-plugin');
@@ -21,13 +26,17 @@ function writePlugin(version: string) {
 // argv-safe GitExec seam (git-state.ts contract). Records each git argv so
 // tests can assert command ordering AND -C worktree anchoring (#1073/#240).
 function trackingGit(mainVersion: string) {
+  return trackingGitRaw(JSON.stringify({ version: mainVersion }));
+}
+
+function trackingGitRaw(mainPluginJson: string) {
   const calls: string[][] = [];
   const exec: GitExec = (args) => {
     const argv = [...args];
     calls.push(argv);
     const joined = argv.join(' ');
     if (joined.includes('show origin/main:.claude-plugin/plugin.json')) {
-      return { stdout: JSON.stringify({ version: mainVersion }), stderr: '', exitCode: 0 };
+      return { stdout: mainPluginJson, stderr: '', exitCode: 0 };
     }
     if (joined.includes('rev-parse --show-toplevel')) {
       return { stdout: TEST_DIR, stderr: '', exitCode: 0 };
@@ -38,6 +47,15 @@ function trackingGit(mainVersion: string) {
 }
 
 const mockGit = (mainVersion: string) => trackingGit(mainVersion).exec;
+
+describe('JSON helper source invariant', () => {
+  it('uses shared JSON helpers for plugin manifest parsing', () => {
+    expect(BUMP_PLUGIN_VERSION_SOURCE).toContain('parseJsonObject');
+    expect(BUMP_PLUGIN_VERSION_SOURCE).toContain('readJsonObjectFile');
+    expect(BUMP_PLUGIN_VERSION_SOURCE).not.toContain('JSON.parse(raw)');
+    expect(BUMP_PLUGIN_VERSION_SOURCE).not.toContain('JSON.parse(readFileSync(pluginJson');
+  });
+});
 
 beforeEach(() => {
   if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
@@ -80,6 +98,61 @@ describe('bumpPluginVersion', () => {
       projectRoot: TEST_DIR,
     });
     expect(result).toBeNull();
+  });
+
+  it('fails open when origin/main plugin JSON is malformed', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'bump-plugin-main-json-'));
+    try {
+      writePluginAt(projectRoot, '1.0.5');
+      const result = bumpPluginVersion('gh pr create --title "test"', {
+        exec: trackingGitRaw('{not json').exec,
+        projectRoot,
+      });
+
+      expect(result).toBeNull();
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fails open when current plugin.json is malformed', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'bump-plugin-current-json-'));
+    try {
+      const pluginDir = join(projectRoot, '.claude-plugin');
+      const pluginJson = join(pluginDir, 'plugin.json');
+      mkdirSync(pluginDir, { recursive: true });
+      writeFileSync(pluginJson, '{not json');
+
+      expect(() => bumpPluginVersion('gh pr create --title "test"', {
+        exec: mockGit('1.0.5'),
+        projectRoot,
+      })).not.toThrow();
+      expect(bumpPluginVersion('gh pr create --title "test"', {
+        exec: mockGit('1.0.5'),
+        projectRoot,
+      })).toBeNull();
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fails open when current plugin.json is not an object', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'bump-plugin-current-array-'));
+    try {
+      const pluginDir = join(projectRoot, '.claude-plugin');
+      const pluginJson = join(pluginDir, 'plugin.json');
+      mkdirSync(pluginDir, { recursive: true });
+      writeFileSync(pluginJson, '[]');
+
+      const result = bumpPluginVersion('gh pr create --title "test"', {
+        exec: mockGit('0.0.0'),
+        projectRoot,
+      });
+
+      expect(result).toBeNull();
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 
   it('does not create temp files', () => {

--- a/src/hooks/bump-plugin-version.ts
+++ b/src/hooks/bump-plugin-version.ts
@@ -12,11 +12,13 @@
  * Part of kAIzen Agent Control Flow — kaizen #775
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { readHookInput, traceNullInput } from './hook-io.js';
 import { isGhPrCommand, stripHeredocBody } from './parse-command.js';
 import { createDefaultGitExec, resolveTargetWorktree, type GitExec } from './lib/git-state.js';
+import { readJsonObjectFile } from '../lib/json-file.js';
+import { parseJsonObject } from '../lib/json-value.js';
 
 export function bumpPluginVersion(
   command: string,
@@ -60,16 +62,14 @@ export function bumpPluginVersion(
 
   // Compare version on current branch vs main
   const mainVersion = (() => {
-    try {
-      const raw = git(['show', 'origin/main:.claude-plugin/plugin.json']);
-      return raw ? JSON.parse(raw).version || '0.0.0' : '0.0.0';
-    } catch {
-      return '0.0.0';
-    }
+    const raw = git(['show', 'origin/main:.claude-plugin/plugin.json']);
+    const parsed = raw ? parseJsonObject(raw) : null;
+    return typeof parsed?.version === 'string' ? parsed.version : '0.0.0';
   })();
 
-  const content = JSON.parse(readFileSync(pluginJson, 'utf-8'));
-  const currentVersion: string = content.version || '0.0.0';
+  const content = readJsonObjectFile(pluginJson);
+  if (!content) return null;
+  const currentVersion = typeof content.version === 'string' ? content.version : '0.0.0';
 
   if (mainVersion !== currentVersion) {
     // Already bumped (author did minor/major, or previous auto-bump)


### PR DESCRIPTION
Once upon a time, the plugin-version bump hook was already a TypeScript advisory hook with a clear fail-open contract: detect `gh pr create`, bump `.claude-plugin/plugin.json` when needed, and never block the agent. Every day that worked for valid manifests, but the hook still carried two local JSON parse paths: one for `origin/main:.claude-plugin/plugin.json`, and one for the worktree manifest file.

One day, the DRY scan found those parse paths after the rest of the runtime had started moving onto `parseJsonObject()` and `readJsonObjectFile()`. Because of that, this PR routes both plugin manifest reads through the shared helpers and pins the advisory behavior around bad manifests: malformed or non-object current plugin JSON returns `null` instead of throwing, and malformed `origin/main` JSON falls back to the existing `0.0.0` comparison behavior.

Until finally, valid manifests still bump exactly as before (`1.0.5 -> 1.0.6`), while bad manifest inputs are explicitly non-blocking and source invariants prevent `JSON.parse(raw)` / `JSON.parse(readFileSync(...pluginJson...))` from coming back.

Closes #1447

## Architecture

```text
bumpPluginVersion(command)
  -> git show origin/main:.claude-plugin/plugin.json
       -> parseJsonObject(raw) -> mainVersion | 0.0.0
  -> .claude-plugin/plugin.json in target worktree
       -> readJsonObjectFile(path) -> current manifest | null
  -> compare versions, bump patch, write manifest, git add/commit/push
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use `parseJsonObject()` for git-show output | The content comes from git stdout, not a local file path | Keeps the git read and parsing as separate steps |
| Use `readJsonObjectFile()` for the worktree manifest | Matches the shared file JSON helper used by other runtime config/manifest readers | Malformed/non-object current manifests now return `null` from direct function calls instead of throwing |
| Treat bad current manifests as advisory skip | The hook header says it is advisory and always exits 0 | It does not attempt to repair malformed manifests in this refactor |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/bump-plugin-version.ts` | Replaces local plugin JSON parsing with shared JSON helpers |
| `src/hooks/bump-plugin-version.test.ts` | Adds source invariant and malformed/non-object manifest fail-open coverage |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Status | Test File |
|---|---|---|---|---|---|
| 1 | Valid plugin manifests still bump patch version and write the updated manifest | code | Unit | tested | `src/hooks/bump-plugin-version.test.ts` |
| 2 | Malformed `origin/main` plugin JSON fails open to `0.0.0` comparison and does not throw | code | Unit | tested | `src/hooks/bump-plugin-version.test.ts` |
| 3 | Malformed or non-object current plugin manifest returns `null` and does not throw | code | Unit | tested | `src/hooks/bump-plugin-version.test.ts` |
| 4 | `bump-plugin-version.ts` uses shared JSON helpers for both JSON inputs | code | Unit/source invariant | tested | `src/hooks/bump-plugin-version.test.ts` |

No behavior is deferred.

## Validation

- [x] RED: `npm test -- --run src/hooks/bump-plugin-version.test.ts` failed on the new source invariant, malformed current JSON throw, and non-object current JSON bump behavior.
- [x] GREEN: `npm test -- --run src/hooks/bump-plugin-version.test.ts` -> 13 tests passed.
- [x] Typecheck: `npm run typecheck`.
- [x] Diff hygiene: `git diff --check`.
- [x] Source scan: production `bump-plugin-version.ts` now uses `parseJsonObject` and `readJsonObjectFile`; the targeted local parse patterns are absent.

## Known Limitations

This PR does not validate semantic version structure or repair malformed plugin manifests. It only consolidates JSON parsing and preserves the hook's advisory skip behavior for invalid inputs.
