### PR TITLE
Refactor kaizen.config JSON reads through shared file helper

### DIFF
--- a/src/hooks/pr-kaizen-clear.test.ts
+++ b/src/hooks/pr-kaizen-clear.test.ts
@@ -51,6 +51,7 @@ import {
 let testStateDir: string;
 let testAuditDir: string;
 const HOOK_PATH = path.resolve(__dirname, 'pr-kaizen-clear.ts');
+const HOOK_SOURCE = fs.readFileSync(HOOK_PATH, 'utf-8');
 
 beforeEach(() => {
   testStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kaizen-clear-test-'));
@@ -71,6 +72,13 @@ afterEach(() => {
   fs.rmSync(testStateDir, { recursive: true, force: true });
   fs.rmSync(testAuditDir, { recursive: true, force: true });
   delete process.env.AUDIT_DIR;
+});
+
+describe('config JSON helper source invariant', () => {
+  it('routes kaizen.config.json reads through readJsonObjectFile', () => {
+    expect(HOOK_SOURCE).toContain('readJsonObjectFile');
+    expect(HOOK_SOURCE).not.toContain("readFileSync(join(root, 'kaizen.config.json')");
+  });
 });
 
 function runHook(input: object): string {

--- a/src/hooks/pr-kaizen-clear.ts
+++ b/src/hooks/pr-kaizen-clear.ts
@@ -15,9 +15,10 @@
  * Migration: kaizen #320 (Phase 3 of #223)
  */
 
-import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { gh } from '../lib/gh-exec.js';
+import { readJsonObjectFile } from '../lib/json-file.js';
 import { type HookInput, readHookInput, writeHookOutput, traceNullInput, traceHookEvent } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
@@ -54,6 +55,12 @@ interface Impediment {
 }
 
 type GhRunner = (args: string[]) => string;
+
+function objectOrNull(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
 
 // ── Audit logging ────────────────────────────────────────────────────
 
@@ -113,10 +120,10 @@ function getCandidateRepos(gatePrUrl: string): string[] {
   if (parsedPrUrl) repos.push(parsedPrUrl.repo);
   try {
     const root = resolveProjectRoot(process.cwd());
-    const cfg = JSON.parse(
-      readFileSync(join(root, 'kaizen.config.json'), 'utf-8'),
-    );
-    for (const r of [cfg?.issues?.repo, cfg?.host?.repo, cfg?.kaizen?.repo]) {
+    const cfg = readJsonObjectFile(join(root, 'kaizen.config.json'));
+    const candidateRepoFields = ['issues', 'host', 'kaizen']
+      .map((section) => objectOrNull(cfg?.[section])?.repo);
+    for (const r of candidateRepoFields) {
       if (typeof r === 'string' && r) repos.push(r);
     }
   } catch {

--- a/src/issue-backend.test.ts
+++ b/src/issue-backend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -10,6 +10,15 @@ import {
   CustomCliBackend,
   type IssueBackendConfig,
 } from "./issue-backend.js";
+
+const ISSUE_BACKEND_SOURCE = readFileSync(new URL("./issue-backend.ts", import.meta.url), "utf-8");
+
+describe("config JSON helper source invariant", () => {
+  it("routes kaizen.config.json reads through readJsonObjectFile", () => {
+    expect(ISSUE_BACKEND_SOURCE).toContain("readJsonObjectFile");
+    expect(ISSUE_BACKEND_SOURCE).not.toContain("JSON.parse(readFileSync(configPath");
+  });
+});
 
 describe("readIssueConfig", () => {
   let tempDir: string;
@@ -57,6 +66,20 @@ describe("readIssueConfig", () => {
     const config = readIssueConfig(tempDir);
     expect(config.backend).toBe("custom");
     expect(config.config?.customCli).toBe("linear-issue-cli");
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    ["malformed", "{not json"],
+    ["blank", "   "],
+    ["array", "[]"],
+    ["primitive", "\"text\""],
+  ])("returns github default when config file is %s", (_name, content) => {
+    tempDir = mkdtempSync(join(tmpdir(), "issue-be-test-"));
+    writeFileSync(join(tempDir, "kaizen.config.json"), content);
+
+    expect(readIssueConfig(tempDir).backend).toBe("github");
+
     rmSync(tempDir, { recursive: true, force: true });
   });
 });

--- a/src/issue-backend.ts
+++ b/src/issue-backend.ts
@@ -27,10 +27,10 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { gh } from "./lib/gh-exec.js";
+import { readJsonObjectFile } from "./lib/json-file.js";
 
 // ── Types ──
 
@@ -287,16 +287,26 @@ export function readIssueConfig(projectRoot?: string): IssueBackendConfig {
   const root = projectRoot ?? process.cwd();
   const configPath = join(root, "kaizen.config.json");
 
-  if (!existsSync(configPath)) {
+  const config = readJsonObjectFile(configPath);
+  if (!config) {
     return { backend: "github" };
   }
 
-  const config = JSON.parse(readFileSync(configPath, "utf-8"));
-  const issues = config.issues ?? {};
+  const rawIssues = config.issues;
+  const issues = rawIssues && typeof rawIssues === "object" && !Array.isArray(rawIssues)
+    ? rawIssues as Record<string, unknown>
+    : {};
+  const rawIssueConfig = issues.config;
+  const issueConfig = rawIssueConfig && typeof rawIssueConfig === "object" && !Array.isArray(rawIssueConfig)
+    ? rawIssueConfig as Record<string, unknown>
+    : {};
+  const customCli = typeof issueConfig.customCli === "string"
+    ? issueConfig.customCli
+    : undefined;
 
   return {
-    backend: issues.backend ?? "github",
-    config: issues.config,
+    backend: issues.backend === "custom" ? "custom" : "github",
+    config: customCli ? { customCli } : undefined,
   };
 }
 


### PR DESCRIPTION
Closes #1449

## Story

`kaizen.config.json` already has a shared object reader in `src/lib/json-file.ts`, and setup code uses that path. The runtime paths had drifted: `readIssueConfig()` and `pr-kaizen-clear.ts` each still parsed the config with local `JSON.parse(readFileSync(...))` calls.

That made invalid config handling inconsistent. A malformed or blank config could throw in `readIssueConfig()`, while the hook had its own catch-all fallback. This PR routes both runtime config readers through `readJsonObjectFile()` and treats missing, malformed, blank, and non-object config as the same default/fallback case.

## Architecture

```
kaizen.config.json
        |
        v
src/lib/json-file.ts::readJsonObjectFile()
        |
        +--> src/issue-backend.ts::readIssueConfig()
        +--> src/hooks/pr-kaizen-clear.ts::getCandidateRepos()
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use `readJsonObjectFile()` for both runtime config reads | Reuses the existing missing/malformed/non-object guardrail | Invalid config now falls back instead of surfacing a parse exception in `readIssueConfig()` |
| Normalize `issues.config.customCli` before returning it | Keeps `IssueBackendConfig` typed and avoids passing arbitrary config shapes through | Only the currently supported custom CLI field is preserved |
| Add source invariants for the removed parse paths | Prevents the duplicate `JSON.parse(readFileSync(...kaizen.config.json...))` patterns from returning | Source tests are narrow and intentionally tied to these runtime readers |

## What's In This PR

| File | Purpose |
|---|---|
| `src/issue-backend.ts` | Reads `kaizen.config.json` through `readJsonObjectFile()` and defaults invalid config to GitHub |
| `src/issue-backend.test.ts` | Covers malformed, blank, array, and primitive config fallback plus the source invariant |
| `src/hooks/pr-kaizen-clear.ts` | Uses the shared reader for candidate repo config lookup |
| `src/hooks/pr-kaizen-clear.test.ts` | Adds a source invariant for the hook config reader |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Coverage |
|---|----------|-------------|-------|----------|
| 1 | `readIssueConfig()` returns configured backend for valid config | code | Unit | Tested by existing `src/issue-backend.test.ts` valid GitHub/custom config cases |
| 2 | `readIssueConfig()` returns GitHub default for missing, malformed, blank, or non-object config | code | Unit | Tested in `src/issue-backend.test.ts` for missing, malformed, blank, array, and primitive config |
| 3 | `pr-kaizen-clear.ts` candidate repo config reading uses shared helper and keeps fallback behavior on invalid config | code | Unit/source invariant | Tested by `src/hooks/pr-kaizen-clear.test.ts` source invariant |
| 4 | Local `kaizen.config.json` parse-file code does not return in either runtime reader | code | Unit/source invariant | Tested by source invariants in both touched test files |

No behavior is deferred.

## Validation

- [x] `npm test -- --run src/issue-backend.test.ts src/hooks/pr-kaizen-clear.test.ts` - 111 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms helper usage and old direct parse patterns are absent from production paths

## Known Limitations

The hook coverage for invalid config remains source-invariant focused because `getCandidateRepos()` is private and exercised through shell-driven hook tests. The issue-backend behavior has direct unit coverage for the invalid config cases.
