### PR TITLE
Refactor PR review loop branch fallback through shared helper

### DIFF
--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -85,6 +85,16 @@ describe('trace helper source invariant', () => {
   });
 });
 
+describe('branch helper source invariant', () => {
+  it('routes default branch fallback through currentHookBranch', () => {
+    expect(PR_REVIEW_LOOP_SOURCE).toContain('currentHookBranch');
+    expect(PR_REVIEW_LOOP_SOURCE).toContain("from './lib/current-branch.js'");
+    expect(PR_REVIEW_LOOP_SOURCE).not.toContain(
+      "gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown')",
+    );
+  });
+});
+
 /** Run the hook with JSON input and return stdout. */
 function runHook(input: object): string {
   const json = JSON.stringify(input);

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -31,6 +31,7 @@ import {
 } from '../review-sentinel.js';
 import { findOpenPrUrlForBranch } from '../lib/github-pr.js';
 import { type HookInput, readHookInput, traceHookEvent, writeHookOutput } from './hook-io.js';
+import { currentHookBranch } from './lib/current-branch.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
 import {
@@ -239,8 +240,7 @@ export function processHookInput(
   const cmdLine = stripHeredocBody(command);
   const stateDir =
     options.stateDir ?? process.env.STATE_DIR ?? DEFAULT_STATE_DIR;
-  const branch =
-    options.branch ?? gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown');
+  const branch = options.branch ?? currentHookBranch();
   const repoFromGit = options.repoFromGit ?? detectGhRepo();
   const getDiffLines = options.computeDiffLines ?? diffLines;
   const isShaValid = options.checkShaExists ?? shaExists;


### PR DESCRIPTION
Closes #1455

## Story

The hook runtime now has a branch-focused fallback helper in `src/hooks/lib/current-branch.ts`. Most of the PR kaizen clear path already uses it, but `pr-review-loop.ts` still computed its default branch with a direct `gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown')` call.

That left one more competing current-branch mechanism in a central runtime hook. This PR routes only that default branch fallback through `currentHookBranch()` while preserving explicit `options.branch` injection and leaving unrelated git operations untouched.

## Architecture

```
hook-io.ts::getCurrentBranch()
          |
          v
hooks/lib/current-branch.ts::currentHookBranch()
          |
          +--> hooks/pr-review-loop.ts default branch fallback
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use `currentHookBranch()` only for default branch fallback | Removes the duplicated branch mechanism without widening scope | Other git reads remain in this file |
| Preserve `options.branch ?? ...` | Existing tests and callers rely on branch injection | None; this is behavior-preserving |
| Add a source invariant | Prevents the direct fallback from returning | Narrow source test tied to this seam |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/pr-review-loop.ts` | Imports `currentHookBranch()` and uses it for default branch fallback |
| `src/hooks/pr-review-loop.test.ts` | Adds source invariant for branch helper reuse and direct fallback rejection |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Coverage |
|---|----------|-------------|-------|----------|
| 1 | Explicit `options.branch` still wins over default branch lookup | code | Unit/integration | Covered by existing `src/hooks/pr-review-loop.test.ts` process/state tests |
| 2 | Default branch fallback routes through `currentHookBranch()` | code | Source invariant | Tested in `src/hooks/pr-review-loop.test.ts` |
| 3 | Non-branch git operations stay on existing mechanisms | code | Source invariant | Source scan confirms unrelated `gitStdout()` calls remain for diff/SHA/worktree operations |

No behavior is deferred.

## Validation

- [x] `npm test -- --run src/hooks/pr-review-loop.test.ts` - 36 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms the direct branch fallback is absent from production and only appears as a rejected test string

## Known Limitations

This PR intentionally does not refactor unrelated git operations in `pr-review-loop.ts`; those are separate mechanisms from current-branch fallback.
