### PR TITLE
Refactor pre-push branch fallback through shared helper

### DIFF
--- a/src/hooks/lib/current-branch.test.ts
+++ b/src/hooks/lib/current-branch.test.ts
@@ -13,6 +13,10 @@ describe('currentHookBranch', () => {
     expect(currentHookBranch({ readBranch: () => '' })).toBe('unknown');
   });
 
+  it('uses caller-provided fallback when branch lookup returns empty output', () => {
+    expect(currentHookBranch({ readBranch: () => '', fallback: '' })).toBe('');
+  });
+
   it('falls back to unknown when branch lookup throws', () => {
     expect(
       currentHookBranch({
@@ -21,5 +25,16 @@ describe('currentHookBranch', () => {
         },
       }),
     ).toBe('unknown');
+  });
+
+  it('uses caller-provided fallback when branch lookup throws', () => {
+    expect(
+      currentHookBranch({
+        readBranch: () => {
+          throw new Error('git failed');
+        },
+        fallback: '',
+      }),
+    ).toBe('');
   });
 });

--- a/src/hooks/lib/current-branch.ts
+++ b/src/hooks/lib/current-branch.ts
@@ -2,13 +2,15 @@ import { getCurrentBranch } from '../hook-io.js';
 
 export interface CurrentBranchOptions {
   readBranch?: () => string;
+  fallback?: string;
 }
 
 export function currentHookBranch(options: CurrentBranchOptions = {}): string {
+  const fallback = options.fallback ?? 'unknown';
   try {
     const branch = (options.readBranch ?? getCurrentBranch)().trim();
-    return branch || 'unknown';
+    return branch || fallback;
   } catch {
-    return 'unknown';
+    return fallback;
   }
 }

--- a/src/hooks/pre-push.test.ts
+++ b/src/hooks/pre-push.test.ts
@@ -49,6 +49,17 @@ describe('trace helper source invariant', () => {
   });
 });
 
+describe('branch helper source invariant', () => {
+  it('routes current branch fallback through currentHookBranch with empty fallback', () => {
+    expect(PRE_PUSH_SOURCE).toContain('currentHookBranch');
+    expect(PRE_PUSH_SOURCE).toContain("from './lib/current-branch.js'");
+    expect(PRE_PUSH_SOURCE).toContain("fallback: ''");
+    expect(PRE_PUSH_SOURCE).not.toContain(
+      "gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], '')",
+    );
+  });
+});
+
 describe('detectAgentEnv', () => {
   it('returns detected=false when no agent vars set (I-A)', () => {
     const result = detectAgentEnv({});

--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -28,6 +28,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { DEFAULT_STATE_DIR, ensureStateDir, prUrlToStateKey, readStateFile, writeStateFile } from './state-utils.js';
+import { currentHookBranch } from './lib/current-branch.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
 import { queryBranchPrState, type BranchPrQueryResult } from '../lib/github-pr.js';
@@ -231,7 +232,7 @@ export function detectRepo(): string {
 }
 
 export function getCurrentBranch(): string {
-  return gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], '');
+  return currentHookBranch({ fallback: '' });
 }
 
 /**


### PR DESCRIPTION
## Story

Most hook current-branch fallback now lives in `src/hooks/lib/current-branch.ts`, but `pre-push.ts` still carried one local `git rev-parse --abbrev-ref HEAD` helper because its fallback policy is intentionally different: it returns an empty string, not `unknown`.

This PR makes that fallback policy explicit on the shared helper. `currentHookBranch()` still defaults to `unknown`, while `pre-push.ts` can now delegate through `currentHookBranch({ fallback: '' })` without changing its existing behavior.

Closes #1457

## Architecture

```text
pre-push.ts getCurrentBranch()
  -> currentHookBranch({ fallback: '' })
       -> hook-io getCurrentBranch()
       -> fallback from caller or default 'unknown'
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add `fallback?: string` to `currentHookBranch()` | Lets callers share branch lookup while preserving different fallback semantics | Slightly wider helper API |
| Keep `pre-push.ts` exported `getCurrentBranch()` wrapper | Avoids changing the module's public surface for existing tests/callers | Leaves a thin wrapper, but no duplicated git invocation |
| Add source invariant in `pre-push.test.ts` | Prevents the direct `gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'], '')` lookup from returning | Source invariants are structural, so they complement rather than replace behavior tests |

## What's in this PR

| File | Purpose |
|---|---|
| `src/hooks/lib/current-branch.ts` | Adds caller-provided fallback support while preserving default `unknown` |
| `src/hooks/lib/current-branch.test.ts` | Covers default fallback and explicit empty-string fallback for empty/throwing readers |
| `src/hooks/pre-push.ts` | Routes branch lookup through `currentHookBranch({ fallback: '' })` |
| `src/hooks/pre-push.test.ts` | Adds invariant that pre-push imports the helper, supplies empty fallback, and does not restore the direct local git fallback |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | `currentHookBranch()` defaults to `unknown` for empty/throwing branch reads | code | Unit | `src/hooks/lib/current-branch.test.ts` | Tested |
| 2 | `currentHookBranch()` supports caller-provided fallback strings | code | Unit | `src/hooks/lib/current-branch.test.ts` | Tested |
| 3 | `pre-push.ts` uses the shared branch helper while preserving empty-string fallback | code | Source invariant + existing process tests | `src/hooks/pre-push.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] Confirmed branch was created in a fresh worktree from `origin/main`
- [x] Confirmed no existing all-state PR for `case/260628-k1457-prepush-branch-helper` before PR creation
- [x] `npm test -- --run src/hooks/lib/current-branch.test.ts src/hooks/pre-push.test.ts` (57 tests)
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms the old direct pre-push branch lookup only appears inside the rejecting test invariant

## Known Limitations

This only removes the pre-push branch lookup duplication covered by #1457. Any remaining branch fallback cleanup should get its own issue and fresh branch.
