### PR TITLE
Use command-target branch resolution in PreToolUse gates

### DIFF
--- a/src/hooks/enforce-pr-reflect.test.ts
+++ b/src/hooks/enforce-pr-reflect.test.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeStateFile } from './state-utils.js';
 import { processPreToolUse } from './enforce-pr-reflect.js';
 
 const TEST_STATE_DIR = '/tmp/.test-enforce-pr-reflect';
 const TEST_BRANCH = 'worktree-reflect-test';
+const REFLECT_SOURCE = readFileSync(new URL('./enforce-pr-reflect.ts', import.meta.url), 'utf-8');
 
 function createReflectionGate(prUrl: string) {
   writeStateFile(TEST_STATE_DIR, `kaizen-${Date.now()}`, {
@@ -21,6 +22,13 @@ beforeEach(() => {
 
 afterEach(() => {
   if (existsSync(TEST_STATE_DIR)) rmSync(TEST_STATE_DIR, { recursive: true });
+});
+
+describe('branch helper source invariant', () => {
+  it('passes the Bash command into command-target branch resolution', () => {
+    expect(REFLECT_SOURCE).toContain('const branch = getCurrentBranch(command);');
+    expect(REFLECT_SOURCE).not.toContain('const branch = getCurrentBranch();');
+  });
 });
 
 describe('enforce-pr-reflect PreToolUse', () => {

--- a/src/hooks/enforce-pr-reflect.ts
+++ b/src/hooks/enforce-pr-reflect.ts
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
   if (!input) { traceNullInput("enforce-pr-reflect"); process.exit(0); }
 
   const command = input.tool_input?.command ?? '';
-  const branch = getCurrentBranch();
+  const branch = getCurrentBranch(command);
 
   const result = processPreToolUse(command, branch);
 

--- a/src/hooks/enforce-pr-review.test.ts
+++ b/src/hooks/enforce-pr-review.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeStateFile } from './state-utils.js';
 import { processPreToolUse } from './enforce-pr-review.js';
@@ -6,6 +6,7 @@ import type { ToolContext } from './enforce-pr-review.js';
 
 const TEST_STATE_DIR = '/tmp/.test-enforce-pr-review';
 const TEST_BRANCH = 'worktree-review-test';
+const REVIEW_SOURCE = readFileSync(new URL('./enforce-pr-review.ts', import.meta.url), 'utf-8');
 
 function createReviewGate(prUrl: string, round: string = '1') {
   writeStateFile(TEST_STATE_DIR, `review-${Date.now()}`, {
@@ -23,6 +24,13 @@ beforeEach(() => {
 
 afterEach(() => {
   if (existsSync(TEST_STATE_DIR)) rmSync(TEST_STATE_DIR, { recursive: true });
+});
+
+describe('branch helper source invariant', () => {
+  it('passes the Bash command into command-target branch resolution', () => {
+    expect(REVIEW_SOURCE).toContain('const branch = getCurrentBranch(command);');
+    expect(REVIEW_SOURCE).not.toContain('const branch = getCurrentBranch();');
+  });
 });
 
 describe('enforce-pr-review PreToolUse — Bash commands', () => {

--- a/src/hooks/enforce-pr-review.ts
+++ b/src/hooks/enforce-pr-review.ts
@@ -112,7 +112,7 @@ async function main(): Promise<void> {
   if (!input) { traceNullInput("enforce-pr-review"); process.exit(0); }
 
   const command = input.tool_input?.command ?? '';
-  const branch = getCurrentBranch();
+  const branch = getCurrentBranch(command);
 
   const result = processPreToolUse(command, branch, undefined, {
     toolName: input.tool_name,


### PR DESCRIPTION
## Story

The hook I/O layer already knows how to resolve a branch from the target worktree in a Bash command. That matters when a command is aimed at another worktree, for example `cd /work/wt && ...`; the hook should evaluate gates for that target branch, not whichever branch the agent process inherited.

The review and reflection PreToolUse gates were still calling `getCurrentBranch()` without passing the command. This PR routes both gates through the existing command-target-aware path by passing `command` into `getCurrentBranch(command)`.

Closes #1459

## Architecture

```text
PreToolUse input
  -> command = input.tool_input?.command ?? ''
  -> getCurrentBranch(command)
       -> hook-io resolveTargetWorktree(command, cwd)
       -> git -C <target> rev-parse --abbrev-ref HEAD
  -> processPreToolUse(command, branch, ...)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Reuse `hook-io.getCurrentBranch(command)` | The target-worktree resolution already exists and is tested in `hook-io` | This PR only fixes call sites; it does not change the resolver itself |
| Add source invariants in both gate tests | The regression was a missing argument at the I/O boundary | Source invariants are structural, so existing unit tests still carry behavior coverage |
| Leave `processPreToolUse` signatures unchanged | The pure decision functions already receive a branch and should stay easy to unit test | The command-target behavior remains in `main()` wiring |

## What's in this PR

| File | Purpose |
|---|---|
| `src/hooks/enforce-pr-review.ts` | Passes the Bash command into branch resolution before enforcing review gates |
| `src/hooks/enforce-pr-review.test.ts` | Adds invariant that `main()` calls `getCurrentBranch(command)` |
| `src/hooks/enforce-pr-reflect.ts` | Passes the Bash command into branch resolution before enforcing reflection gates |
| `src/hooks/enforce-pr-reflect.test.ts` | Adds invariant that `main()` calls `getCurrentBranch(command)` |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | `enforce-pr-review.ts` resolves its branch using the Bash command target | code | Source invariant | `src/hooks/enforce-pr-review.test.ts` | Tested |
| 2 | `enforce-pr-reflect.ts` resolves its branch using the Bash command target | code | Source invariant | `src/hooks/enforce-pr-reflect.test.ts` | Tested |
| 3 | Existing review/reflection gate decision behavior remains unchanged | code | Unit regression | `src/hooks/enforce-pr-review.test.ts`, `src/hooks/enforce-pr-reflect.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] Confirmed branch was created in a fresh worktree from `origin/main`
- [x] Confirmed no existing all-state PR for `case/260628-k1459-pretool-command-branch` before PR creation
- [x] `npm test -- --run src/hooks/enforce-pr-review.test.ts src/hooks/enforce-pr-reflect.test.ts` (29 tests)
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms both gates call `getCurrentBranch(command)` and the commandless pattern only appears in rejecting tests

## Known Limitations

This PR fixes the two PreToolUse gate call sites in #1459. Other hooks that intentionally resolve the current process branch are left unchanged.
