### PR TITLE
Use command-target branch resolution in post-merge clear

### DIFF
--- a/src/hooks/post-merge-clear.test.ts
+++ b/src/hooks/post-merge-clear.test.ts
@@ -252,3 +252,12 @@ describe('git runner invariant', () => {
     expect(source).toContain("gitStdout(['worktree', 'list', '--porcelain'])");
   });
 });
+
+describe('branch helper source invariant', () => {
+  it('passes the Bash command into command-target branch resolution', () => {
+    const source = readFileSync(new URL('./post-merge-clear.ts', import.meta.url), 'utf-8');
+
+    expect(source).toContain('const branch = getCurrentBranch(command);');
+    expect(source).not.toContain('const branch = getCurrentBranch();');
+  });
+});

--- a/src/hooks/post-merge-clear.ts
+++ b/src/hooks/post-merge-clear.ts
@@ -98,7 +98,8 @@ async function main(): Promise<void> {
   if (!input) { traceNullInput("post-merge-clear"); process.exit(0); }
 
   const toolName = input.tool_name ?? '';
-  const branch = getCurrentBranch();
+  const command = input.tool_input?.command ?? '';
+  const branch = getCurrentBranch(command);
 
   const output = processPostMergeClear(
     toolName,


### PR DESCRIPTION
## Story

`post-merge-clear.ts` already receives the PostToolUse Bash command and parses it to detect merge confirmation from `gh pr view`. But it resolved the branch with `getCurrentBranch()` before handling that command, which skipped the command-target-aware branch resolution already provided by `hook-io`.

This PR passes the Bash command into `getCurrentBranch(command)`. For Skill triggers, the command is still an empty string, so the existing current-worktree fallback remains unchanged.

Closes #1461

## Architecture

```text
PostToolUse input
  -> command = input.tool_input?.command ?? ''
  -> getCurrentBranch(command)
       -> hook-io resolveTargetWorktree(command, cwd)
       -> git -C <target> rev-parse --abbrev-ref HEAD
  -> processPostMergeClear(toolName, toolInput, toolResponse, branch)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Resolve branch from the PostToolUse command in `main()` | Keeps branch selection at the I/O boundary where hook input is available | Pure `processPostMergeClear` stays unchanged and branch-injected |
| Leave Skill triggers on empty-command fallback | Skills do not provide a Bash target command | Same behavior as before for `/kaizen` and `/kaizen-reflect` clearing |
| Add a source invariant | The bug is a missing argument at a small call site | Structural test complements the existing behavior tests |

## What's in this PR

| File | Purpose |
|---|---|
| `src/hooks/post-merge-clear.ts` | Passes `command` into `getCurrentBranch(command)` before post-merge processing |
| `src/hooks/post-merge-clear.test.ts` | Adds invariant preventing commandless branch lookup from returning |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | `post-merge-clear.ts` resolves its branch using the PostToolUse Bash command target | code | Source invariant | `src/hooks/post-merge-clear.test.ts` | Tested |
| 2 | Skill-trigger post-merge clearing remains unchanged when no Bash command exists | code | Unit regression | `src/hooks/post-merge-clear.test.ts` | Tested |
| 3 | Bash MERGED detection/promotion behavior remains unchanged | code | Unit regression | `src/hooks/post-merge-clear.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] Confirmed branch was created in a fresh worktree from `origin/main`
- [x] Confirmed no existing all-state PR for `case/260628-k1461-postmerge-command-branch` before PR creation
- [x] `npm test -- --run src/hooks/post-merge-clear.test.ts` (14 tests)
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms `post-merge-clear.ts` calls `getCurrentBranch(command)` and the commandless lookup only appears inside the rejecting test invariant

## Known Limitations

This PR only changes the PostToolUse post-merge clear hook covered by #1461. Stop-hook branch resolution has no Bash command target to pass through and is left unchanged.
