### PR TITLE
Refactor plan gate branch fallback through shared helper

### DIFF
--- a/src/hooks/enforce-plan-stored.test.ts
+++ b/src/hooks/enforce-plan-stored.test.ts
@@ -118,6 +118,20 @@ describe('git runner invariant', () => {
   });
 });
 
+describe('branch helper source invariant', () => {
+  it('routes default current branch lookup through currentHookBranch with empty fallback', () => {
+    const source = readFileSync(
+      new URL('./enforce-plan-stored.ts', import.meta.url),
+      'utf-8',
+    );
+
+    expect(source).toContain('currentHookBranch');
+    expect(source).toContain("from './lib/current-branch.js'");
+    expect(source).toContain("fallback: ''");
+    expect(source).not.toContain("gitStdout(['rev-parse', '--abbrev-ref', 'HEAD']");
+  });
+});
+
 
 // ── Gate 1: Edit/Write ──────────────────────────────────────────────
 

--- a/src/hooks/enforce-plan-stored.ts
+++ b/src/hooks/enforce-plan-stored.ts
@@ -17,6 +17,7 @@
 
 import { appendFileSync } from 'node:fs';
 import { readHookInput, traceNullInput } from './hook-io.js';
+import { currentHookBranch } from './lib/current-branch.js';
 import { gitStdout } from './lib/git-state.js';
 import { isGhPrCommand, stripHeredocBody, extractRepoFlag } from './parse-command.js';
 import { CaseSystem } from '../case-system.js';
@@ -54,7 +55,7 @@ export interface PlanCheckDeps {
 // ── Defaults ────────────────────────────────────────────────────────
 
 function currentGitBranch(): string {
-  return gitStdout(['rev-parse', '--abbrev-ref', 'HEAD']);
+  return currentHookBranch({ fallback: '' });
 }
 
 function gitCommonDir(): string {


### PR DESCRIPTION
## Story

Most hook current-branch fallback paths now use `src/hooks/lib/current-branch.ts`, including callers that need an empty-string fallback. The plan gate was still carrying its own `git rev-parse --abbrev-ref HEAD` wrapper, so one more runtime hook could drift from the shared branch helper.

This PR keeps the plan gate's behavior the same while routing its default branch lookup through `currentHookBranch({ fallback: '' })`.

Closes #1463

## Architecture

```text
enforce-plan-stored currentGitBranch()
  -> currentHookBranch({ fallback: '' })
       -> hook-io getCurrentBranch()
       -> empty fallback on missing/failed branch lookup
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep `currentGitBranch()` as a local wrapper | `DEFAULT_DEPS` and escape-hatch logging already depend on that local boundary | The wrapper remains, but the git lookup mechanism is shared |
| Use `fallback: ''` | Preserves the plan gate's existing empty-string failure behavior | Callers must read the option to see fallback policy |
| Add a source invariant | Prevents the direct `gitStdout(['rev-parse', '--abbrev-ref', 'HEAD'])` lookup from returning | Structural check complements existing behavior tests |

## What's in this PR

| File | Purpose |
|---|---|
| `src/hooks/enforce-plan-stored.ts` | Imports `currentHookBranch` and delegates the default current branch lookup through it |
| `src/hooks/enforce-plan-stored.test.ts` | Adds an invariant that enforces the shared helper import, empty fallback, and no direct branch `gitStdout` lookup |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | `enforce-plan-stored.ts` default branch lookup uses the shared hook branch helper | code | Source invariant | `src/hooks/enforce-plan-stored.test.ts` | Tested |
| 2 | Empty-string fallback behavior for unknown branch remains unchanged | code | Unit | `src/hooks/lib/current-branch.test.ts`, existing `src/hooks/enforce-plan-stored.test.ts` | Tested |
| 3 | Explicit issue binding and case-branch cross-check behavior remains unchanged | code | Unit regression | `src/hooks/enforce-plan-stored.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] Confirmed branch was created in a fresh worktree from `origin/main`
- [x] Confirmed no existing all-state PR for `case/260628-k1463-plan-branch-helper` before PR creation
- [x] `npm test -- --run src/hooks/enforce-plan-stored.test.ts src/hooks/lib/current-branch.test.ts` (66 tests)
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms the old direct branch lookup only appears inside the rejecting test invariant

## Known Limitations

This PR only removes the plan gate's local current-branch mechanism. Other non-branch git lookups in `enforce-plan-stored.ts` are intentionally left alone because they serve different repository/worktree checks.
