### PR TITLE
Serialize review loop SHA metadata through state utils

### DIFF
--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -76,6 +76,14 @@ describe('state file read helper source invariant', () => {
   });
 });
 
+describe('state file write helper source invariant', () => {
+  it('routes review SHA metadata writes through writeStateFile', () => {
+    expect(PR_REVIEW_LOOP_SOURCE).toContain('LAST_REVIEWED_SHA');
+    expect(PR_REVIEW_LOOP_SOURCE).toContain('LAST_FULL_REVIEW_SHA');
+    expect(PR_REVIEW_LOOP_SOURCE).not.toContain('appendFileSync(fp,');
+  });
+});
+
 describe('trace helper source invariant', () => {
   it('routes trace writes through hook-io traceHookEvent', () => {
     expect(PR_REVIEW_LOOP_SOURCE).toContain('traceHookEvent');

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -20,7 +20,7 @@
  * Migration: kaizen #320 (Phase 3 of #223)
  */
 
-import { appendFileSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   buildReviewSentinelRecord,
@@ -314,17 +314,14 @@ export function processHookInput(
     }
 
     const key = prUrlToStateKey(prUrl);
-    const fp = writeStateFile(stateDir, key, {
+    const sha = gitStdout(['rev-parse', 'HEAD']);
+    writeStateFile(stateDir, key, {
       PR_URL: prUrl,
       ROUND: '1',
       STATUS: 'needs_review',
       BRANCH: branch,
+      ...(sha ? { LAST_REVIEWED_SHA: sha, LAST_FULL_REVIEW_SHA: sha } : {}),
     });
-    const sha = gitStdout(['rev-parse', 'HEAD']);
-    if (sha) {
-      appendFileSync(fp, `LAST_REVIEWED_SHA=${sha}\n`);
-      appendFileSync(fp, `LAST_FULL_REVIEW_SHA=${sha}\n`);
-    }
 
     const createMsg = `\n\ud83d\udccb PR created: ${prUrl}\n\nMANDATORY SELF-REVIEW LOOP \u2014 you MUST complete this before proceeding.\nROUND 1/${MAX_ROUNDS}: Start your review now.\n${printChecklist(prUrl, '1', MAX_ROUNDS)}\nTrack your round: "ROUND N/${MAX_ROUNDS}: [reviewing|issues found|clean]"\n`;
     return decide('create_gate', 'pr_created', createMsg, { prUrl },
@@ -382,15 +379,15 @@ export function processHookInput(
     // review-fix push — it must always require a new review round,
     // regardless of size. (Bug found via hook-gym TDD, kaizen #1053.)
     if (found.status !== 'passed' && incrementalLines > 0 && incrementalLines <= SMALL_PUSH_THRESHOLD && cumulativeLines <= CUMULATIVE_CAP) {
-      const fp = writeStateFile(stateDir, prUrlToStateKey(found.prUrl), {
+      const sha = gitStdout(['rev-parse', 'HEAD']);
+      writeStateFile(stateDir, prUrlToStateKey(found.prUrl), {
         PR_URL: found.prUrl,
         ROUND: String(nextRound),
         STATUS: 'passed',
         BRANCH: branch,
+        ...(sha ? { LAST_REVIEWED_SHA: sha } : {}),
+        ...(lastFullReviewSha ? { LAST_FULL_REVIEW_SHA: lastFullReviewSha } : {}),
       });
-      const sha = gitStdout(['rev-parse', 'HEAD']);
-      if (sha) appendFileSync(fp, `LAST_REVIEWED_SHA=${sha}\n`);
-      if (lastFullReviewSha) appendFileSync(fp, `LAST_FULL_REVIEW_SHA=${lastFullReviewSha}\n`);
       return decide('auto_pass', 'small_incremental_and_cumulative',
         `\n\ud83d\udd0d Small push (${incrementalLines} lines, ${cumulativeLines} cumulative) \u2014 abbreviated review (round ${nextRound}/${MAX_ROUNDS}). Auto-passed.\n`,
         diffContext);
@@ -444,17 +441,14 @@ export function processHookInput(
       return decide('needs_review', reason, msg, { prUrl: found.prUrl, round: found.round, sentinelReason: sentinelResult.reason });
     }
 
-    const fp = writeStateFile(stateDir, prUrlToStateKey(found.prUrl), {
+    const sha = gitStdout(['rev-parse', 'HEAD']);
+    writeStateFile(stateDir, prUrlToStateKey(found.prUrl), {
       PR_URL: found.prUrl,
       ROUND: found.round,
       STATUS: 'passed',
       BRANCH: branch,
+      ...(sha ? { LAST_REVIEWED_SHA: sha, LAST_FULL_REVIEW_SHA: sha } : {}),
     });
-    const sha = gitStdout(['rev-parse', 'HEAD']);
-    if (sha) {
-      appendFileSync(fp, `LAST_REVIEWED_SHA=${sha}\n`);
-      appendFileSync(fp, `LAST_FULL_REVIEW_SHA=${sha}\n`);
-    }
 
     const msg = `\n\ud83d\udccb REVIEW ROUND ${found.round}/${MAX_ROUNDS}\n${printChecklist(found.prUrl, found.round, MAX_ROUNDS)}\n\u2705 REVIEW PASSED (round ${found.round}/${MAX_ROUNDS})\n`;
     return decide('review_passed', 'diff_reviewed', msg, { prUrl: found.prUrl, round: found.round },

--- a/src/hooks/state-utils.test.ts
+++ b/src/hooks/state-utils.test.ts
@@ -94,6 +94,20 @@ describe('serializeStateFile', () => {
     });
     expect(content).toContain('ROUND=2');
   });
+
+  it('includes additional metadata fields after canonical fields', () => {
+    const content = serializeStateFile({
+      PR_URL: 'url',
+      STATUS: 'needs_review',
+      BRANCH: 'main',
+      ROUND: '2',
+      LAST_REVIEWED_SHA: 'abc123',
+      LAST_FULL_REVIEW_SHA: 'def456',
+    });
+
+    expect(content).toContain('LAST_REVIEWED_SHA=abc123');
+    expect(content).toContain('LAST_FULL_REVIEW_SHA=def456');
+  });
 });
 
 describe('writeStateFile', () => {

--- a/src/hooks/state-utils.ts
+++ b/src/hooks/state-utils.ts
@@ -30,6 +30,7 @@ export interface StateFile {
   STATUS: string;
   BRANCH: string;
   ROUND?: string;
+  [key: string]: string | undefined;
 }
 
 /**
@@ -72,6 +73,11 @@ export function serializeStateFile(state: StateFile): string {
   let content = `PR_URL=${state.PR_URL}\nSTATUS=${state.STATUS}\nBRANCH=${state.BRANCH}\n`;
   if (state.ROUND) {
     content += `ROUND=${state.ROUND}\n`;
+  }
+  const canonicalKeys = new Set(['PR_URL', 'STATUS', 'BRANCH', 'ROUND']);
+  for (const key of Object.keys(state).filter(key => !canonicalKeys.has(key)).sort()) {
+    const value = state[key];
+    if (value) content += `${key}=${value}\n`;
   }
   return content;
 }


### PR DESCRIPTION
## Story

`pr-review-loop.ts` had one remaining split-brain state write path: the canonical gate fields were written through `writeStateFile()`, but review SHA metadata was appended afterward with local `appendFileSync(fp, ...)` calls in three separate branches.

This PR makes `state-utils` serialize additional metadata fields and moves `LAST_REVIEWED_SHA` / `LAST_FULL_REVIEW_SHA` into the same `writeStateFile()` calls as the rest of the state. The resulting state files keep the same key/value content, but the serialization path is now single and reusable.

Closes #1465

## Architecture

```text
pr-review-loop transition
  -> writeStateFile(stateDir, key, {
       PR_URL, STATUS, BRANCH, ROUND,
       LAST_REVIEWED_SHA?, LAST_FULL_REVIEW_SHA?
     })
       -> serializeStateFile()
          -> canonical fields
          -> sorted extra metadata fields
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add an index signature to `StateFile` | State files already carry optional metadata beyond the canonical gate fields | Callers can pass arbitrary string metadata, so source invariants matter |
| Serialize canonical fields first, extras sorted after | Keeps existing output stable while making metadata deterministic | Extra field order is alphabetical, not caller insertion order |
| Remove `appendFileSync(fp, ...)` from review-loop state transitions | Keeps all state serialization in `state-utils` | `writeStateFile` now owns a slightly broader format |

## What's in this PR

| File | Purpose |
|---|---|
| `src/hooks/state-utils.ts` | Allows extra state metadata fields and serializes them deterministically |
| `src/hooks/state-utils.test.ts` | Covers extra metadata serialization |
| `src/hooks/pr-review-loop.ts` | Writes review SHA metadata through `writeStateFile()` for PR create, auto-pass, and review-pass transitions |
| `src/hooks/pr-review-loop.test.ts` | Adds invariant preventing local state metadata appends from returning |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | `serializeStateFile()` preserves additional metadata fields | code | Unit | `src/hooks/state-utils.test.ts` | Tested |
| 2 | `pr-review-loop.ts` writes SHA metadata through `writeStateFile()` | code | Source invariant | `src/hooks/pr-review-loop.test.ts` | Tested |
| 3 | PR create still records review SHA metadata | code | Unit/integration regression | `src/hooks/pr-review-loop.test.ts` | Tested |
| 4 | Review-pass still records review SHA metadata | code | Unit/integration regression | `src/hooks/pr-review-loop.test.ts` | Tested |
| 5 | Small auto-pass preserves full-review SHA metadata | code | Unit/integration regression | `src/hooks/pr-review-loop.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] Confirmed branch was created in a fresh worktree from `origin/main`
- [x] Confirmed no existing all-state PR for `case/260628-k1465-state-metadata-writer` before PR creation
- [x] `npm test -- --run src/hooks/state-utils.test.ts src/hooks/pr-review-loop.test.ts` (73 tests)
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms no `appendFileSync(fp, ...)` state metadata appends remain

## Known Limitations

This PR centralizes review-loop SHA metadata serialization only. Other append-only logs and sentinel files are different artifacts and intentionally remain outside `writeStateFile()`.
