### PR TITLE
Share JSONL append helper across telemetry writers

### DIFF
--- a/src/hooks/reflection-persistence.test.ts
+++ b/src/hooks/reflection-persistence.test.ts
@@ -8,6 +8,19 @@ import {
   type ReflectionRecord,
 } from './reflection-persistence.js';
 
+const REFLECTION_PERSISTENCE_SOURCE = readFileSync(
+  new URL('./reflection-persistence.ts', import.meta.url),
+  'utf-8',
+);
+
+describe('json-lines helper source invariant', () => {
+  it('routes reflection JSONL appends through appendJsonLine', () => {
+    expect(REFLECTION_PERSISTENCE_SOURCE).toContain('appendJsonLine');
+    expect(REFLECTION_PERSISTENCE_SOURCE).toContain("from '../lib/json-lines.js'");
+    expect(REFLECTION_PERSISTENCE_SOURCE).not.toContain('appendFileSync(filePath, JSON.stringify');
+  });
+});
+
 describe('buildReflectionRecord', () => {
   it('builds record with correct disposition counts', () => {
     const impediments: ReflectionImpediment[] = [

--- a/src/hooks/reflection-persistence.ts
+++ b/src/hooks/reflection-persistence.ts
@@ -11,8 +11,8 @@
  * Part of horizon #249 (Observability), issue #272.
  */
 
-import { appendFileSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { appendJsonLine } from '../lib/json-lines.js';
 import { resolveTelemetryDir } from './session-telemetry.js';
 
 export interface ReflectionImpediment {
@@ -86,9 +86,8 @@ export function persistReflection(
 ): void {
   try {
     const dir = options?.telemetryDir ?? resolveTelemetryDir();
-    mkdirSync(dir, { recursive: true });
     const filePath = resolve(dir, 'reflections.jsonl');
-    appendFileSync(filePath, JSON.stringify(record) + '\n');
+    appendJsonLine(filePath, record);
   } catch {
     // Best-effort — never break the hook
   }

--- a/src/hooks/session-telemetry.test.ts
+++ b/src/hooks/session-telemetry.test.ts
@@ -10,6 +10,16 @@ import {
   type SessionStopGateEvent,
 } from './session-telemetry.js';
 
+const SESSION_TELEMETRY_SOURCE = readFileSync(new URL('./session-telemetry.ts', import.meta.url), 'utf-8');
+
+describe('json-lines helper source invariant', () => {
+  it('routes telemetry JSONL appends through appendJsonLine', () => {
+    expect(SESSION_TELEMETRY_SOURCE).toContain('appendJsonLine');
+    expect(SESSION_TELEMETRY_SOURCE).toContain("from '../lib/json-lines.js'");
+    expect(SESSION_TELEMETRY_SOURCE).not.toContain('appendFileSync(filePath, JSON.stringify');
+  });
+});
+
 describe('emitSessionEvent', () => {
   it('writes a pr_created event with correct envelope', () => {
     const dir = `/tmp/.test-st-${Date.now()}-a`;

--- a/src/hooks/session-telemetry.ts
+++ b/src/hooks/session-telemetry.ts
@@ -14,8 +14,8 @@
  * Part of horizon #249 (Observability), issue #671.
  */
 
-import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { appendJsonLine } from '../lib/json-lines.js';
 
 // Session event types — lightweight versions of auto-dent events
 
@@ -89,16 +89,13 @@ export function emitSessionEvent(
 ): void {
   try {
     const dir = options?.telemetryDir ?? resolveTelemetryDir();
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-    }
     const filePath = resolve(dir, 'events.jsonl');
     const envelope: SessionEventEnvelope = {
       timestamp: (options?.now ?? new Date()).toISOString(),
       source: 'interactive',
       event,
     };
-    appendFileSync(filePath, JSON.stringify(envelope) + '\n');
+    appendJsonLine(filePath, envelope);
   } catch {
     // Telemetry is best-effort — never break the hook
   }

--- a/src/lib/json-lines.test.ts
+++ b/src/lib/json-lines.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { parseJsonLines, parseJsonLinesWithMalformedRows } from './json-lines.js';
+import { appendJsonLine, parseJsonLines, parseJsonLinesWithMalformedRows } from './json-lines.js';
 
 describe('parseJsonLines', () => {
   it('parses valid JSON lines while skipping blanks and malformed rows', () => {
@@ -23,5 +25,24 @@ describe('parseJsonLines', () => {
       { lineNumber: 3, raw: 'not-json' },
       { lineNumber: 5, raw: '{bad' },
     ]);
+  });
+});
+
+describe('appendJsonLine', () => {
+  it('creates parent directories and appends one JSON value per line', () => {
+    const dir = `/tmp/.test-json-lines-${Date.now()}-a`;
+    const filePath = join(dir, 'nested', 'events.jsonl');
+
+    try {
+      appendJsonLine(filePath, { a: 1 });
+      appendJsonLine(filePath, { b: 2 });
+
+      const lines = readFileSync(filePath, 'utf-8').trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0])).toEqual({ a: 1 });
+      expect(JSON.parse(lines[1])).toEqual({ b: 2 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/json-lines.ts
+++ b/src/lib/json-lines.ts
@@ -1,3 +1,6 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
 export interface ParsedJsonLines<T = unknown> {
   rows: T[];
   malformedRows: string[];
@@ -23,4 +26,9 @@ export function parseJsonLinesWithMalformedRows<T = unknown>(text: string): Pars
 
 export function parseJsonLines<T = unknown>(text: string): T[] {
   return parseJsonLinesWithMalformedRows<T>(text).rows;
+}
+
+export function appendJsonLine(filepath: string, value: unknown): void {
+  mkdirSync(dirname(filepath), { recursive: true });
+  appendFileSync(filepath, JSON.stringify(value) + '\n');
 }


### PR DESCRIPTION
## Story

The repo already had `src/lib/json-lines.ts` as the shared home for JSONL parsing, but two runtime telemetry writers still owned their own append mechanics. Every session event and reflection record recreated the same directory setup and `JSON.stringify(...) + '\n'` write path.

That duplication made newline handling, directory creation, and future JSONL behavior easy to drift between telemetry streams. This PR moves the append responsibility into the same JSONL utility module and leaves each telemetry caller responsible only for choosing its destination file and preserving its best-effort error boundary.

## Architecture

```text
emitSessionEvent()        persistReflection()
      |                         |
      v                         v
resolve events.jsonl      resolve reflections.jsonl
      \                         /
       \                       /
        v                     v
        appendJsonLine(filepath, value)
              |
              v
      mkdir parent + append JSON row
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Put `appendJsonLine()` in `src/lib/json-lines.ts` | Keeps parse and append JSONL primitives together | The helper uses sync filesystem APIs because existing hook telemetry paths already do |
| Keep try/catch in callers | Existing telemetry behavior is best-effort and must not break hooks | The shared helper throws normally; callers define failure policy |
| Add source invariants for both telemetry writers | Prevents direct `appendFileSync(filePath, JSON.stringify(...))` writes from returning | Source checks are narrow by design and only guard this duplication pattern |

## What's In This PR

| File | Purpose |
|---|---|
| `src/lib/json-lines.ts` | Adds `appendJsonLine(filepath, value)` with parent directory creation and newline-delimited JSON append |
| `src/hooks/session-telemetry.ts` | Routes session event writes through the shared helper |
| `src/hooks/reflection-persistence.ts` | Routes reflection persistence writes through the shared helper |
| `src/lib/json-lines.test.ts` | Covers helper directory creation and one-value-per-line append behavior |
| `src/hooks/session-telemetry.test.ts` | Adds source invariant while preserving existing write/error behavior tests |
| `src/hooks/reflection-persistence.test.ts` | Adds source invariant while preserving existing write/error behavior tests |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | Shared JSONL append helper writes one JSON value plus newline and creates parent directories | code | Unit | `src/lib/json-lines.test.ts` | Tested |
| 2 | Session telemetry uses the shared JSONL append helper | code | Source invariant + regression | `src/hooks/session-telemetry.test.ts` | Tested |
| 3 | Reflection persistence uses the shared JSONL append helper | code | Source invariant + regression | `src/hooks/reflection-persistence.test.ts` | Tested |
| 4 | Telemetry write errors remain best-effort and non-throwing | code | Unit regression | `src/hooks/session-telemetry.test.ts`, `src/hooks/reflection-persistence.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] RED: focused tests failed before implementation because `appendJsonLine` was missing and telemetry modules still used direct append paths
- [x] `npm test -- --run src/lib/json-lines.test.ts src/hooks/session-telemetry.test.ts src/hooks/reflection-persistence.test.ts` — 18 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms the old telemetry direct append pattern is gone from the two callers

## Known Limitations

This does not solve broader telemetry storage retention, rotation, or durability concerns tracked in larger observability issues. It only centralizes the JSONL row append primitive required by the scoped issue.

Fixes Garsson-io/kaizen#1467
