### PR TITLE
Route hook trace JSONL writes through shared helper

### DIFF
--- a/src/hooks/hook-io.test.ts
+++ b/src/hooks/hook-io.test.ts
@@ -258,6 +258,13 @@ describe('hook-io', () => {
       expect(HOOK_IO_SOURCE).toContain('options.traceFile');
     });
 
+    it('INVARIANT: routes hook trace JSONL appends through appendJsonLine', () => {
+      expect(HOOK_IO_SOURCE).toContain('appendJsonLine');
+      expect(HOOK_IO_SOURCE).toContain("from '../lib/json-lines.js'");
+      expect(HOOK_IO_SOURCE).not.toContain('appendFileSync');
+      expect(HOOK_IO_SOURCE).not.toContain("JSON.stringify({ ts: new Date().toISOString(), hook, ...fields }) + '\\n'");
+    });
+
     it('INVARIANT: writes to explicit trace file override', () => {
       const traceDir = mkdtempSync(join(tmpdir(), 'hook-io-override-'));
       const traceFile = join(traceDir, 'trace.jsonl');
@@ -277,6 +284,12 @@ describe('hook-io', () => {
         else delete process.env.KAIZEN_HOOK_TRACE;
         rmSync(traceDir, { recursive: true, force: true });
       }
+    });
+
+    it('INVARIANT: trace write errors remain best-effort', () => {
+      expect(() => {
+        traceHookEvent('test-hook', { action: 'observe' }, { traceFile: '/dev/null/impossible/trace.jsonl' });
+      }).not.toThrow();
     });
   });
 });

--- a/src/hooks/hook-io.ts
+++ b/src/hooks/hook-io.ts
@@ -5,7 +5,7 @@
  * This module handles the boilerplate.
  */
 
-import { appendFileSync } from 'node:fs';
+import { appendJsonLine } from '../lib/json-lines.js';
 import { createDefaultGitExec, resolveTargetWorktree, type GitExec } from './lib/git-state.js';
 
 export interface HookTraceOptions {
@@ -59,10 +59,7 @@ export function traceHookEvent(
 ): void {
   if (!isTraceEnabled()) return;
   try {
-    appendFileSync(
-      getTraceFile(options),
-      JSON.stringify({ ts: new Date().toISOString(), hook, ...fields }) + '\n',
-    );
+    appendJsonLine(getTraceFile(options), { ts: new Date().toISOString(), hook, ...fields });
   } catch { /* never fail on trace */ }
 }
 


### PR DESCRIPTION
## Story

After PR #1468, JSONL parsing and append mechanics live together in `src/lib/json-lines.ts`. The hook trace writer was the remaining hook-side runtime path still building a JSON object, stringifying it with a newline, and writing it directly with `appendFileSync()`.

That made `traceHookEvent()` a second JSONL append implementation even though it is already the shared trace primitive for hooks. This PR routes hook trace writes through `appendJsonLine()` so hook observability uses the same newline and parent-directory behavior as the other JSONL telemetry writers.

## Architecture

```text
traceHookEvent(hook, fields)
        |
        v
{ ts, hook, ...fields }
        |
        v
appendJsonLine(traceFile, event)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Reuse `appendJsonLine()` in `hook-io.ts` | Keeps all runtime JSONL row append mechanics in one helper | `hook-io.ts` now depends on the shared lib module |
| Keep `traceHookEvent()` try/catch unchanged | Trace writes are best-effort and must never break hooks | Filesystem failures are still intentionally swallowed by the caller |
| Add source invariants in `hook-io.test.ts` | Prevents direct hook trace JSONL appends from returning | Narrow invariant only guards this specific drift pattern |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/hook-io.ts` | Replaces direct `appendFileSync(JSON.stringify(...) + '\n')` with `appendJsonLine()` |
| `src/hooks/hook-io.test.ts` | Adds source invariant and best-effort write-error regression coverage |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | Hook trace writer routes JSONL append through the shared helper | code | Source invariant | `src/hooks/hook-io.test.ts` | Tested |
| 2 | Hook trace events still append parseable JSONL rows with timestamp and hook fields | code | Unit regression | `src/hooks/hook-io.test.ts` | Tested |
| 3 | Hook trace disable behavior remains unchanged | code | Unit regression | `src/hooks/hook-io.test.ts` | Tested |
| 4 | Hook trace write errors remain best-effort and non-throwing | code | Unit | `src/hooks/hook-io.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] RED: `npm test -- --run src/hooks/hook-io.test.ts` failed before implementation because `hook-io.ts` did not import `appendJsonLine` and still used `appendFileSync`
- [x] `npm test -- --run src/hooks/hook-io.test.ts src/lib/json-lines.test.ts` — 23 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms `hook-io.ts` no longer imports or calls `appendFileSync`

## Known Limitations

This only routes the hook trace JSONL write through the shared helper. It does not change trace retention, telemetry storage architecture, or broader observability persistence.

Fixes Garsson-io/kaizen#1469
