### PR TITLE
Route auto-dent event JSONL writes through shared helper

### DIFF
--- a/scripts/auto-dent-events.test.ts
+++ b/scripts/auto-dent-events.test.ts
@@ -9,6 +9,8 @@ import {
   type EventEnvelope,
 } from './auto-dent-events.js';
 
+const AUTO_DENT_EVENTS_SOURCE = readFileSync(new URL('./auto-dent-events.ts', import.meta.url), 'utf8');
+
 function readEvents(filePath: string): EventEnvelope[] {
   const content = readFileSync(filePath, 'utf8');
   return content
@@ -36,6 +38,13 @@ describe('EventEmitter', () => {
 
   it('writes events.jsonl to the log directory', () => {
     expect(emitter.getFilePath()).toBe(join(tmpDir, 'events.jsonl'));
+  });
+
+  it('routes event JSONL appends through appendJsonLine', () => {
+    expect(AUTO_DENT_EVENTS_SOURCE).toContain('appendJsonLine');
+    expect(AUTO_DENT_EVENTS_SOURCE).toContain("from '../src/lib/json-lines.js'");
+    expect(AUTO_DENT_EVENTS_SOURCE).not.toContain('appendFileSync');
+    expect(AUTO_DENT_EVENTS_SOURCE).not.toContain("JSON.stringify(envelope) + '\\n'");
   });
 
   it('creates the file on first emit', () => {
@@ -385,7 +394,7 @@ describe('EventEmitter', () => {
   });
 
   it('silently handles write errors without throwing', () => {
-    // Point at a non-existent deep path — appendFileSync will fail
+    // Point at a non-existent deep path so the best-effort append fails.
     const badEmitter = new EventEmitter('/nonexistent/deeply/nested/path');
     expect(() =>
       badEmitter.emit({

--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -15,8 +15,8 @@
  * See issue #647, parent horizon #249 (Observability).
  */
 
-import { appendFileSync } from 'fs';
 import { resolve } from 'path';
+import { appendJsonLine } from '../src/lib/json-lines.js';
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
 
 // Event type definitions
@@ -169,7 +169,7 @@ export class EventEmitter {
       event,
     };
     try {
-      appendFileSync(this.filePath, JSON.stringify(envelope) + '\n');
+      appendJsonLine(this.filePath, envelope);
     } catch {
       // Telemetry is best-effort — never break the run
     }


### PR DESCRIPTION
## Story

The JSONL append helper now covers hook traces, session telemetry, and reflection persistence. Auto-dent event telemetry still had its own event-envelope append path in `scripts/auto-dent-events.ts`, where `EventEmitter.emitAt()` directly stringified the envelope and appended a newline.

That kept `events.jsonl` on a separate runtime mechanism from the other JSONL writers. This PR routes auto-dent event envelopes through `appendJsonLine()` so every covered telemetry JSONL row shares the same append behavior.

## Architecture

```text
EventEmitter.emitAt(when, event)
        |
        v
{ timestamp, event }
        |
        v
appendJsonLine(events.jsonl, envelope)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Reuse `appendJsonLine()` from `scripts/auto-dent-events.ts` | Keeps JSONL row append mechanics centralized | Script code now imports from `src/lib/json-lines.ts`, matching existing script imports from `src/lib` |
| Keep best-effort catch in `emitAt()` | Event telemetry must not break auto-dent runs | Filesystem errors remain intentionally swallowed by the emitter |
| Add a source invariant | Prevents direct `appendFileSync(JSON.stringify(...))` from returning to the emitter | The invariant is targeted to this drift pattern |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-events.ts` | Replaces direct event JSONL append with `appendJsonLine()` |
| `scripts/auto-dent-events.test.ts` | Adds source invariant proving the emitter routes through the shared helper |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | Auto-dent EventEmitter routes JSONL append through the shared helper | code | Source invariant | `scripts/auto-dent-events.test.ts` | Tested |
| 2 | Event envelopes still append as one parseable JSON row per line | code | Unit regression | `scripts/auto-dent-events.test.ts` | Tested |
| 3 | `emitAt()` still preserves explicit timestamps | code | Unit regression | `scripts/auto-dent-events.test.ts` | Tested |
| 4 | Event writes remain best-effort and non-throwing | code | Unit regression | `scripts/auto-dent-events.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] RED: `npm test -- --run scripts/auto-dent-events.test.ts` failed before implementation because `auto-dent-events.ts` still imported `appendFileSync` and did not import `appendJsonLine`
- [x] `npm test -- --run scripts/auto-dent-events.test.ts src/lib/json-lines.test.ts` — 23 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms `scripts/auto-dent-events.ts` no longer imports or calls `appendFileSync`

## Known Limitations

This does not change auto-dent telemetry storage retention, artifact upload, or cross-batch durability. It only centralizes the event JSONL row append primitive for the scoped duplication issue.

Fixes Garsson-io/kaizen#1471
