### PR TITLE
Route auto-dent aggregate JSONL writes through shared helper

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -1014,6 +1014,10 @@ describe('readAggregate', () => {
       source.indexOf('export interface AggregateStats'),
     );
 
+    expect(source).toContain('appendJsonLine');
+    expect(source).toContain("from '../src/lib/json-lines.js'");
+    expect(aggregateSource).not.toContain('appendFileSync');
+    expect(aggregateSource).not.toContain("JSON.stringify(record) + '\\n'");
     expect(aggregateSource).not.toMatch(/JSON\.parse\(line\)/);
     expect(aggregateSource).not.toMatch(/\.split\(['"]\\n['"]\)/);
   });

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -19,7 +19,7 @@
  *   npx tsx scripts/auto-dent-ctl.ts watchdog --threshold 600
  */
 
-import { readdirSync, readFileSync, existsSync, writeFileSync, appendFileSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import type { BatchState, RunMetrics } from './auto-dent-run.js';
@@ -41,7 +41,7 @@ import {
   type ReadOutcomesDeps,
 } from './batch-outcome.js';
 import { truncateDisplay } from './auto-dent-display.js';
-import { parseJsonLines } from '../src/lib/json-lines.js';
+import { appendJsonLine, parseJsonLines } from '../src/lib/json-lines.js';
 
 function getRepoRoot(): string {
   try {
@@ -847,7 +847,7 @@ export function appendBatchToAggregate(
   }
 
   const record = buildAggregateBatchRecord(batch);
-  appendFileSync(aggregatePath, JSON.stringify(record) + '\n');
+  appendJsonLine(aggregatePath, record);
   return { action: 'appended', path: aggregatePath };
 }
 


### PR DESCRIPTION
## Story

The aggregate history path already reads `aggregate.jsonl` through the shared tolerant JSONL parser, but its writer still appended records by hand with `appendFileSync(JSON.stringify(record) + '\n')`.

That left cross-batch aggregate persistence with shared parse behavior but a duplicated write mechanism. This PR routes `appendBatchToAggregate()` through `appendJsonLine()` so aggregate records use the same JSONL row append primitive as the other telemetry writers.

## Architecture

```text
appendBatchToAggregate(logsDir, batch)
        |
        v
buildAggregateBatchRecord(batch)
        |
        v
appendJsonLine(aggregate.jsonl, record)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Reuse `appendJsonLine()` in `auto-dent-ctl.ts` | Keeps aggregate JSONL write behavior aligned with shared parser usage | `auto-dent-ctl.ts` now imports both JSONL helpers from `src/lib/json-lines.ts` |
| Keep duplicate detection before append | Preserves existing idempotency behavior | No behavior change to record replacement or update semantics |
| Add source invariant to aggregate tests | Prevents direct aggregate JSONL appends from returning | The invariant is scoped to the aggregate source slice |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-ctl.ts` | Replaces direct aggregate JSONL append with `appendJsonLine()` |
| `scripts/auto-dent-ctl.test.ts` | Extends aggregate parser invariant to cover shared append routing |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|----------|-------------|-------|-----------|--------|
| 1 | `appendBatchToAggregate()` routes JSONL append through the shared helper | code | Source invariant | `scripts/auto-dent-ctl.test.ts` | Tested |
| 2 | First aggregate append still writes one parseable record | code | Unit regression | `scripts/auto-dent-ctl.test.ts` | Tested |
| 3 | Duplicate aggregate append remains idempotent | code | Unit regression | `scripts/auto-dent-ctl.test.ts` | Tested |
| 4 | `readAggregate()` still parses aggregate JSONL through shared parser | code | Unit/source regression | `scripts/auto-dent-ctl.test.ts` | Tested |

No behavior is deferred.

## Validation

- [x] RED: `npm test -- --run scripts/auto-dent-ctl.test.ts` failed before implementation because `auto-dent-ctl.ts` did not import `appendJsonLine` and still used direct aggregate append
- [x] `npm test -- --run scripts/auto-dent-ctl.test.ts src/lib/json-lines.test.ts` — 72 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source scan confirms aggregate writes route through `appendJsonLine()` and the only production `appendFileSync` in the scan is the shared helper

## Known Limitations

This does not change aggregate retention, cloud sync, or cross-batch steering behavior. It only centralizes the aggregate JSONL row append primitive for the scoped duplication issue.

Fixes Garsson-io/kaizen#1473
