### PR TITLE
[rescue] preserve local hook observability work

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -2928,3 +2928,23 @@ describe('extractPlanText — plan section regex extraction (kaizen #901)', () =
     expect(result).toContain('Lowercase header');
   });
 });
+
+describe('classifyFailure live wiring (#1102 regression guard)', () => {
+  // The log-based heuristic branch (hook_rejection, infrastructure, timeout...)
+  // is dead code unless the live call site passes the run log. This test pins
+  // that the production call in auto-dent-run.ts passes a log argument, so the
+  // branch can never be silently re-orphaned.
+  const source = readFileSync(join(__dirname, 'auto-dent-run.ts'), 'utf8');
+
+  it('reads the run log before classifying', () => {
+    expect(source).toMatch(/readFileSync\(logFile, 'utf8'\)/);
+  });
+
+  it('passes a non-empty second argument to classifyFailure', () => {
+    // Match the production call (not a bare metrics-only call). The second arg
+    // must be the run log variable.
+    const call = source.match(/classifyFailure\(runMetrics,\s*([A-Za-z0-9_]+)\)/);
+    expect(call).not.toBeNull();
+    expect(call![1]).not.toBe('');
+  });
+});

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -26,6 +26,7 @@ import { readFileSync, writeFileSync, appendFileSync, existsSync, renameSync, co
 import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
+import { firstHookReason } from './hook-signals.js';
 import { claimNextItem, markItem, resetAssignedItems } from './auto-dent-plan.js';
 import { writeAttachment, addSection } from '../src/section-editor.js';
 import {
@@ -177,6 +178,8 @@ export interface RunMetrics {
   prompt_hash?: string;
   /** Structured failure classification (populated post-run) */
   failure_class?: string;
+  /** Reason a hook blocked this run, when failure_class is hook_rejection (#1102) */
+  hook_rejection_reason?: string;
   /** Number of lifecycle ordering violations detected post-run */
   lifecycle_violations?: number;
   /** Review battery verdict for PRs created in this run */
@@ -1939,8 +1942,14 @@ async function main(): Promise<void> {
     review_verdict: reviewVerdict,
     review_cost_usd: reviewCostUsd,
   };
-  // Classify failure: wall-clock timeout is authoritative (#686), then heuristics
-  runMetrics.failure_class = result.timedOut ? 'timeout' : classifyFailure(runMetrics);
+  // Classify failure: wall-clock timeout is authoritative (#686), then heuristics.
+  // Feed the run log so the log-based branch (hook_rejection, infrastructure,
+  // etc.) actually runs — without this argument it was dead code (#1102).
+  const runLog = existsSync(logFile) ? readFileSync(logFile, 'utf8') : undefined;
+  runMetrics.failure_class = result.timedOut ? 'timeout' : classifyFailure(runMetrics, runLog);
+  if (runMetrics.failure_class === 'hook_rejection' && runLog) {
+    runMetrics.hook_rejection_reason = firstHookReason(runLog);
+  }
   if (!freshState.run_history) freshState.run_history = [];
   freshState.run_history.push(runMetrics);
 

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -1221,11 +1221,30 @@ describe('classifyFailure', () => {
     expect(classifyFailure(makeRunMetrics({ exit_code: 1, prs: [] }))).toBe('crash');
   });
 
-  it('classifies hook rejection from log', () => {
+  it('classifies hook rejection from log (legacy English-prose fallback)', () => {
     expect(classifyFailure(
       makeRunMetrics({ exit_code: 1, prs: [] }),
       'Error: hook rejected the commit',
     )).toBe('hook_rejection');
+  });
+
+  it('classifies hook rejection from a structured deny envelope without any prose (#1102)', () => {
+    // No English "hook rejected/blocked/failed" string anywhere — detection must
+    // come from the structured contract, not prose.
+    const log = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'BLOCKED: No plan stored for issue #5.',
+      },
+    });
+    expect(log.toLowerCase()).not.toContain('hook rejected');
+    expect(classifyFailure(makeRunMetrics({ exit_code: 1, prs: [] }), log)).toBe('hook_rejection');
+  });
+
+  it('classifies hook rejection from a stop-gate block envelope (#1102)', () => {
+    const log = JSON.stringify({ decision: 'block', reason: 'PR REVIEW required' });
+    expect(classifyFailure(makeRunMetrics({ exit_code: 1, prs: [] }), log)).toBe('hook_rejection');
   });
 
   it('classifies infrastructure failure from log', () => {

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -8,6 +8,7 @@
  */
 
 import type { RunMetrics, RunResult, MergeStatus } from './auto-dent-run.js';
+import { hasHookRejection } from './hook-signals.js';
 
 /**
  * Structured failure taxonomy for auto-dent runs.
@@ -45,7 +46,15 @@ export function classifyFailure(
   if (metrics.exit_code === 0 && !hasArtifacts) return 'empty_success';
 
   if (logOutput) {
+    // Structured detection first: consume the canonical hook contract
+    // (permissionDecision:"deny", decision:"block", gate-signal YAML) instead
+    // of guessing from English prose. See scripts/hook-signals.ts (#1102).
+    if (hasHookRejection(logOutput)) {
+      return 'hook_rejection';
+    }
     const log = logOutput.toLowerCase();
+    // Legacy fallback: pre-commit / framework hooks that don't speak the kaizen
+    // structured contract still surface as English prose. Kept as a safety net.
     if (log.includes('hook rejected') || log.includes('hook blocked') || log.includes('pre-commit hook') || log.includes('hook failed')) {
       return 'hook_rejection';
     }

--- a/scripts/hook-signals.test.ts
+++ b/scripts/hook-signals.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { detectHookSignals, hasHookRejection, firstHookReason } from './hook-signals.js';
+import { formatHookOutput } from '../src/hooks/lib/gate-signal.js';
+
+/**
+ * These tests pin the harness↔hook boundary contract: anything a kaizen hook
+ * emits as a structured deny/block must be detectable by the harness, without
+ * relying on English prose. See issue #1102.
+ */
+describe('detectHookSignals', () => {
+  it('detects a PreToolUse permissionDecision:"deny" envelope', () => {
+    // Exact shape emitted by enforce-plan-stored.ts (stdout JSON).
+    const log = [
+      'some prior tool output',
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'BLOCKED: No plan stored for issue #5.',
+        },
+      }),
+      'trailing output',
+    ].join('\n');
+
+    const signals = detectHookSignals(log);
+    expect(signals.length).toBe(1);
+    expect(signals[0].kind).toBe('deny');
+    expect(signals[0].source).toBe('permission-decision');
+    expect(signals[0].reason).toContain('No plan stored');
+  });
+
+  it('detects a stop-gate decision:"block" envelope', () => {
+    // Exact shape emitted by stop-gate.ts.
+    const log = JSON.stringify({
+      decision: 'block',
+      reason: 'PR REVIEW required — run /kaizen-review-pr',
+    });
+
+    const signals = detectHookSignals(log);
+    expect(signals.length).toBe(1);
+    expect(signals[0].kind).toBe('block');
+    expect(signals[0].source).toBe('stop-decision');
+    expect(signals[0].reason).toContain('PR REVIEW');
+  });
+
+  it('BOUNDARY CONTRACT: output of formatHookOutput({type:"deny"}) is detected', () => {
+    // This is the compound-interest test: any hook that emits via the canonical
+    // gate-signal schema is automatically observable to the harness. If the
+    // schema drifts from what the harness parses, this fails.
+    const yaml = formatHookOutput({
+      hook: 'check-dirty-files',
+      type: 'deny',
+      reason: 'Dirty files present at gh pr create.',
+    });
+    const log = `==> hook output\n${yaml}\n==> next`;
+
+    const signals = detectHookSignals(log);
+    expect(signals.some((s) => s.kind === 'deny')).toBe(true);
+    const sig = signals.find((s) => s.kind === 'deny')!;
+    expect(sig.source).toBe('canonical-yaml');
+    expect(sig.hook).toBe('check-dirty-files');
+    expect(sig.reason).toContain('Dirty files');
+  });
+
+  it('BOUNDARY CONTRACT: canonical block signal is detected', () => {
+    const yaml = formatHookOutput({
+      hook: 'stop-gate',
+      type: 'block',
+      reason: 'Pending review gate.',
+    });
+    const signals = detectHookSignals(`prefix\n${yaml}`);
+    expect(signals.some((s) => s.kind === 'block' && s.source === 'canonical-yaml')).toBe(true);
+  });
+
+  it('does not flag a clean log (no false positives)', () => {
+    const log = [
+      'AUTO_DENT_PHASE: PICK | issue=#5',
+      'Running tests... 12 passed',
+      'gate-set needs_review (this is fine, not a deny/block)',
+      JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } }),
+    ].join('\n');
+    expect(detectHookSignals(log)).toEqual([]);
+    expect(hasHookRejection(log)).toBe(false);
+  });
+
+  it('hasHookRejection is true when any deny/block is present', () => {
+    const log = JSON.stringify({ decision: 'block', reason: 'gate' });
+    expect(hasHookRejection(log)).toBe(true);
+  });
+
+  it('firstHookReason surfaces the first rejection reason for observability', () => {
+    const log = [
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'first reason',
+        },
+      }),
+      JSON.stringify({ decision: 'block', reason: 'second reason' }),
+    ].join('\n');
+    expect(firstHookReason(log)).toContain('first reason');
+  });
+
+  it('ignores malformed JSON lines without throwing', () => {
+    const log = '{not valid json\n{"decision":"block","reason":"ok"}\nhalf {';
+    const signals = detectHookSignals(log);
+    expect(signals.length).toBe(1);
+    expect(signals[0].kind).toBe('block');
+  });
+});

--- a/scripts/hook-signals.ts
+++ b/scripts/hook-signals.ts
@@ -1,0 +1,142 @@
+/**
+ * hook-signals.ts — Structured detection of kaizen hook rejections in a run log.
+ *
+ * The auto-dent harness and the kaizen hooks share a structured contract for
+ * "this tool/stop/push was blocked". This module lets the harness consume that
+ * contract instead of guessing from English prose (issue #1102).
+ *
+ * Three structured shapes a kaizen hook can emit into a run log:
+ *
+ *   1. PreToolUse deny (JSON, e.g. enforce-plan-stored, check-dirty-files):
+ *        {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+ *          "permissionDecision":"deny","permissionDecisionReason":"..."}}
+ *
+ *   2. Stop / decision block (JSON, e.g. stop-gate):
+ *        {"decision":"block","reason":"..."}
+ *
+ *   3. Canonical hook output (YAML, gate-signal.ts via formatHookOutput):
+ *        ---
+ *        hook: check-dirty-files
+ *        type: deny|block
+ *        reason: ...
+ *        ---
+ *
+ * All three are deterministic. We never match English substrings here — that
+ * stays in classifyFailure() only as a documented legacy fallback.
+ */
+
+import { z } from 'zod';
+import { parseHookOutput } from '../src/hooks/lib/gate-signal.js';
+
+export type HookSignalSource = 'permission-decision' | 'stop-decision' | 'canonical-yaml';
+
+export interface HookSignal {
+  /** 'deny' = PreToolUse blocked; 'block' = Stop/session blocked. */
+  kind: 'deny' | 'block';
+  /** Which structured shape it was parsed from. */
+  source: HookSignalSource;
+  /** Hook name, when the shape carries one (canonical YAML). */
+  hook?: string;
+  /** Human-readable rejection reason, for observability. */
+  reason?: string;
+}
+
+// Zod schemas for the two JSON envelopes — no hand-rolled parsing (invariant I29).
+const PermissionDecisionSchema = z.object({
+  hookSpecificOutput: z.object({
+    permissionDecision: z.string(),
+    permissionDecisionReason: z.string().optional(),
+  }),
+});
+
+const StopDecisionSchema = z.object({
+  decision: z.string(),
+  reason: z.string().optional(),
+});
+
+/**
+ * Try to parse a single line as one of the JSON deny/block envelopes.
+ * Returns a signal only for genuine rejections (deny / block).
+ */
+function jsonSignalFromLine(line: string): HookSignal | null {
+  const trimmed = line.trim();
+  // Cheap pre-filter: only attempt JSON.parse on lines that look like an object.
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  const perm = PermissionDecisionSchema.safeParse(parsed);
+  if (perm.success && perm.data.hookSpecificOutput.permissionDecision === 'deny') {
+    return {
+      kind: 'deny',
+      source: 'permission-decision',
+      reason: perm.data.hookSpecificOutput.permissionDecisionReason,
+    };
+  }
+
+  const stop = StopDecisionSchema.safeParse(parsed);
+  if (stop.success && stop.data.decision === 'block') {
+    return { kind: 'block', source: 'stop-decision', reason: stop.data.reason };
+  }
+
+  return null;
+}
+
+/**
+ * Extract canonical-YAML hook outputs (gate-signal.ts) of type deny/block.
+ * The YAML blocks are delimited by `---` fences and may appear anywhere in the
+ * log, so we scan each fenced block independently.
+ */
+function yamlSignals(log: string): HookSignal[] {
+  const signals: HookSignal[] = [];
+  // Match each `---\n...\n---` fenced block; parseHookOutput validates content.
+  const fenceRe = /^---\n[\s\S]*?\n---/gm;
+  const blocks = log.match(fenceRe);
+  if (!blocks) return signals;
+  for (const block of blocks) {
+    const output = parseHookOutput(block);
+    if (output && (output.type === 'deny' || output.type === 'block')) {
+      signals.push({
+        kind: output.type,
+        source: 'canonical-yaml',
+        hook: output.hook,
+        reason: output.reason,
+      });
+    }
+  }
+  return signals;
+}
+
+/**
+ * Detect all structured hook rejections (deny/block) in a run log.
+ */
+export function detectHookSignals(log: string): HookSignal[] {
+  if (!log) return [];
+  const signals: HookSignal[] = [];
+
+  for (const line of log.split('\n')) {
+    const sig = jsonSignalFromLine(line);
+    if (sig) signals.push(sig);
+  }
+  signals.push(...yamlSignals(log));
+
+  return signals;
+}
+
+/** True if the run log contains any structured hook deny/block. */
+export function hasHookRejection(log: string): boolean {
+  return detectHookSignals(log).length > 0;
+}
+
+/** First rejection reason in the log, for compact observability display. */
+export function firstHookReason(log: string): string | undefined {
+  for (const sig of detectHookSignals(log)) {
+    if (sig.reason) return sig.reason;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Rescue Notice

This is a draft rescue PR for local-only committed work found in:

`/home/aviad/projects/kaizen/.claude/worktrees/2606261001-5cae`

The branch had no prior PR history and no remote branch. The commit was local-only, so I pushed it and opened this draft PR to make the content reviewable before cleanup.

## Important Context

This appears to be an earlier cut of the hook-observability work for `#1102`. Merged PR `#1114` already landed hook-observability work and includes follow-up fixes, so this rescue PR may be fully superseded. It exists to preserve provenance and make that decision explicit instead of deleting local-only content silently.

## Validation Status

No validation has been run for this rescue PR in this pass. Treat it as raw preserved work; likely action is compare against `#1114` and close as superseded if no unique value remains.

## Preserved Commit

`bd3b25f feat(auto-dent): make hook rejections observable to the harness (Closes #1102)`
