### PR TITLE
refactor: centralize JSON file persistence

### DIFF
--- a/scripts/kaizen-uninstall-plugin.test.ts
+++ b/scripts/kaizen-uninstall-plugin.test.ts
@@ -57,14 +57,18 @@ describe('runUninstall — TS implementation', () => {
 
   it('removes enabledPlugins entry', () => {
     runUninstall({ plugin: 'kaizen@kaizen', homeDir: home, projectRoot: proj, skipNpmInstall: true });
-    const settings = JSON.parse(readFileSync(join(proj, '.claude/settings.json'), 'utf-8'));
+    const content = readFileSync(join(proj, '.claude/settings.json'), 'utf-8');
+    const settings = JSON.parse(content);
     expect(settings.enabledPlugins).toBeUndefined();
+    expect(content).not.toMatch(/\n$/);
   });
 
   it('removes installed_plugins record', () => {
     runUninstall({ plugin: 'kaizen@kaizen', homeDir: home, projectRoot: proj, skipNpmInstall: true });
-    const data = JSON.parse(readFileSync(join(home, '.claude/plugins/installed_plugins.json'), 'utf-8'));
+    const content = readFileSync(join(home, '.claude/plugins/installed_plugins.json'), 'utf-8');
+    const data = JSON.parse(content);
     expect(data.plugins['kaizen@kaizen']).toBeUndefined();
+    expect(content).not.toMatch(/\n$/);
   });
 
   it('removes cache dir', () => {
@@ -155,14 +159,17 @@ describe('stepRemove* return values — idempotency surface for the test-quality
   });
 });
 
-describe('JSON object parsing', () => {
-  it('delegates JSON object file reads to the shared file helper', () => {
+describe('JSON object file persistence', () => {
+  it('delegates JSON object file reads and writes to the shared file helper', () => {
     const source = readFileSync(new URL('./kaizen-uninstall-plugin.ts', import.meta.url), 'utf-8');
 
-    expect(source).toContain('../src/lib/json-file.js');
+    expect(source).toContain('readJsonObjectFile');
+    expect(source).toContain('writeJsonObjectFile');
     expect(source).not.toContain('function readJsonOrNull');
+    expect(source).not.toContain('function writeJson');
     expect(source).not.toContain('parseJsonObject(readFileSync');
     expect(source).not.toContain('JSON.parse(raw)');
+    expect(source).not.toContain('JSON.stringify(data, null, 2)');
   });
 });
 

--- a/scripts/kaizen-uninstall-plugin.ts
+++ b/scripts/kaizen-uninstall-plugin.ts
@@ -21,7 +21,6 @@
 
 import {
   existsSync,
-  writeFileSync,
   rmSync,
   realpathSync,
   statSync,
@@ -29,7 +28,7 @@ import {
 import { join, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
-import { readJsonObjectFile } from '../src/lib/json-file.js';
+import { readJsonObjectFile, writeJsonObjectFile } from '../src/lib/json-file.js';
 
 export interface UninstallOpts {
   plugin: string;
@@ -62,10 +61,6 @@ function shortNameOf(plugin: string): string {
   return idx < 0 ? plugin : plugin.slice(0, idx);
 }
 
-function writeJson(path: string, data: unknown): void {
-  writeFileSync(path, JSON.stringify(data, null, 2));
-}
-
 function safeRealpath(p: string): string {
   try { return realpathSync(p); } catch { return resolve(p); }
 }
@@ -91,7 +86,7 @@ export function stepRemoveEnabledPlugin(
   delete enabled[plugin];
   if (Object.keys(enabled).length === 0) delete (data as Record<string, unknown>).enabledPlugins;
   else (data as Record<string, unknown>).enabledPlugins = enabled;
-  writeJson(path, data);
+  writeJsonObjectFile(path, data, { trailingNewline: false });
   return { changed: true, detail: `removed enabledPlugins[${plugin}]` };
 }
 
@@ -107,7 +102,7 @@ export function stepRemoveInstalledRecord(
   if (!(plugin in plugins)) return { changed: false, detail: `record for ${plugin} already absent` };
   delete plugins[plugin];
   (data as Record<string, unknown>).plugins = plugins;
-  writeJson(path, data);
+  writeJsonObjectFile(path, data, { trailingNewline: false });
   return { changed: true, detail: `removed installed_plugins record for ${plugin}` };
 }
 

--- a/scripts/review-fix.test.ts
+++ b/scripts/review-fix.test.ts
@@ -131,6 +131,21 @@ describe('parseStreamJsonResult', () => {
   });
 });
 
+describe('review-fix state JSON file helper source invariant', () => {
+  it('delegates state JSON file reads and writes to shared helpers', () => {
+    const source = readFileSync(new URL('./review-fix.ts', import.meta.url), 'utf8');
+    const stateSection = source.slice(
+      source.indexOf('export function loadState'),
+      source.indexOf('// ── Transition guard'),
+    );
+
+    expect(stateSection).toContain('readJsonValueFile');
+    expect(stateSection).toContain('writeJsonObjectFile');
+    expect(stateSection).not.toContain('JSON.parse(readFileSync(path');
+    expect(stateSection).not.toContain('JSON.stringify(state, null, 2)');
+  });
+});
+
 // ── applyFixRunningPhase ─────────────────────────────────────────────
 
 function makeState(overrides: Partial<Parameters<typeof applyFixRunningPhase>[0]> = {}) {
@@ -480,6 +495,7 @@ describe('loadState / saveState (integration: real temp files)', () => {
         rounds: [{ round: 1, verdict: 'fixed' as const, fixCost: 0.55, reviewCost: 0 }],
       };
       saveState(state, dir);
+      expect(readFileSync(join(dir, `${stateKey(state.prUrl)}.json`), 'utf-8')).not.toMatch(/\n$/);
       const loaded = loadState(state.prUrl, dir);
       expect(loaded).toEqual(normalizeReviewFixState(state));
     } finally { teardown(); }

--- a/scripts/review-fix.ts
+++ b/scripts/review-fix.ts
@@ -38,6 +38,7 @@ import {
 } from '../src/review-battery.js';
 import { addSection, writeAttachment } from '../src/section-editor.js';
 import { parseJsonLines } from '../src/lib/json-lines.js';
+import { readJsonValueFile, writeJsonObjectFile } from '../src/lib/json-file.js';
 import { ghExec } from './auto-dent-github.js';
 import { buildCodexExecArgs, parseCodexJsonl } from './auto-dent-codex.js';
 import {
@@ -329,8 +330,10 @@ export function loadState(prUrl: string, dir?: string): ReviewFixState | null {
   const d = dir ?? stateDir();
   const path = join(d, `${stateKey(prUrl)}.json`);
   if (!existsSync(path)) return null;
+  const raw = readJsonValueFile(path);
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
   try {
-    return normalizeReviewFixState(JSON.parse(readFileSync(path, 'utf8')) as ReviewFixState);
+    return normalizeReviewFixState(raw as ReviewFixState);
   } catch {
     return null;
   }
@@ -339,7 +342,7 @@ export function loadState(prUrl: string, dir?: string): ReviewFixState | null {
 export function saveState(state: ReviewFixState, dir?: string): void {
   const d = dir ?? stateDir();
   const path = join(d, `${stateKey(state.prUrl)}.json`);
-  writeFileSync(path, JSON.stringify(state, null, 2));
+  writeJsonObjectFile(path, state as unknown as Record<string, unknown>, { trailingNewline: false });
 }
 
 // ── Transition guard (#929, #939) ────────────────────────────────────

--- a/src/hooks/bump-plugin-version.test.ts
+++ b/src/hooks/bump-plugin-version.test.ts
@@ -49,11 +49,13 @@ function trackingGitRaw(mainPluginJson: string) {
 const mockGit = (mainVersion: string) => trackingGit(mainVersion).exec;
 
 describe('JSON helper source invariant', () => {
-  it('uses shared JSON helpers for plugin manifest parsing', () => {
+  it('uses shared JSON helpers for plugin manifest parsing and writing', () => {
     expect(BUMP_PLUGIN_VERSION_SOURCE).toContain('parseJsonObject');
     expect(BUMP_PLUGIN_VERSION_SOURCE).toContain('readJsonObjectFile');
+    expect(BUMP_PLUGIN_VERSION_SOURCE).toContain('writeJsonObjectFile');
     expect(BUMP_PLUGIN_VERSION_SOURCE).not.toContain('JSON.parse(raw)');
     expect(BUMP_PLUGIN_VERSION_SOURCE).not.toContain('JSON.parse(readFileSync(pluginJson');
+    expect(BUMP_PLUGIN_VERSION_SOURCE).not.toContain('JSON.stringify(content, null, 2)');
   });
 });
 
@@ -80,8 +82,10 @@ describe('bumpPluginVersion', () => {
       projectRoot: TEST_DIR,
     });
     expect(result).toContain('1.0.5 -> 1.0.6');
-    const updated = JSON.parse(readFileSync(PLUGIN_JSON, 'utf-8'));
+    const content = readFileSync(PLUGIN_JSON, 'utf-8');
+    const updated = JSON.parse(content);
     expect(updated.version).toBe('1.0.6');
+    expect(content).toMatch(/\n$/);
   });
 
   it('skips when already bumped (different from main)', () => {

--- a/src/hooks/bump-plugin-version.ts
+++ b/src/hooks/bump-plugin-version.ts
@@ -12,12 +12,12 @@
  * Part of kAIzen Agent Control Flow — kaizen #775
  */
 
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { readHookInput, traceNullInput } from './hook-io.js';
 import { isGhPrCommand, stripHeredocBody } from './parse-command.js';
 import { createDefaultGitExec, resolveTargetWorktree, type GitExec } from './lib/git-state.js';
-import { readJsonObjectFile } from '../lib/json-file.js';
+import { readJsonObjectFile, writeJsonObjectFile } from '../lib/json-file.js';
 import { parseJsonObject } from '../lib/json-value.js';
 
 export function bumpPluginVersion(
@@ -80,7 +80,7 @@ export function bumpPluginVersion(
   const parts = currentVersion.split('.');
   const newVersion = `${parts[0]}.${parts[1]}.${Number(parts[2]) + 1}`;
   content.version = newVersion;
-  writeFileSync(pluginJson, JSON.stringify(content, null, 2) + '\n');
+  writeJsonObjectFile(pluginJson, content);
 
   // Stage, commit, and push (#919: push so gh pr create doesn't fail).
   // argv form — the filename is a discrete array element, never interpolated

--- a/src/hooks/lib/gate-manager.test.ts
+++ b/src/hooks/lib/gate-manager.test.ts
@@ -55,9 +55,11 @@ describe('state file read helper source invariant', () => {
 });
 
 describe('deferred items JSON helper source invariant', () => {
-  it('uses the shared JSON file helper for deferred items reads', () => {
+  it('uses the shared JSON file helper for deferred items reads and writes', () => {
     expect(GATE_MANAGER_SOURCE).toContain('readJsonValueFile');
+    expect(GATE_MANAGER_SOURCE).toContain('writeJsonValueFile');
     expect(GATE_MANAGER_SOURCE).not.toContain('JSON.parse(readFileSync');
+    expect(GATE_MANAGER_SOURCE).not.toContain('JSON.stringify(deferred, null, 2)');
   });
 });
 
@@ -221,6 +223,7 @@ describe('handleUnfinishedEscape', () => {
     expect(deferred!.branch).toBe(TEST_BRANCH);
     expect(deferred!.items).toHaveLength(1);
     expect(deferred!.items[0].type).toBe('review');
+    expect(readFileSync(join(TEST_STATE_DIR, '.kaizen-deferred-items.json'), 'utf-8')).not.toMatch(/\n$/);
   });
 
   it('does not write deferred file when no gates exist', () => {

--- a/src/hooks/lib/gate-manager.ts
+++ b/src/hooks/lib/gate-manager.ts
@@ -18,7 +18,6 @@ import {
   readFileSync,
   statSync,
   unlinkSync,
-  writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -28,7 +27,7 @@ import {
   parseStateFile,
   readStateFile,
 } from '../state-utils.js';
-import { readJsonValueFile } from '../../lib/json-file.js';
+import { readJsonValueFile, writeJsonValueFile } from '../../lib/json-file.js';
 
 export interface PendingGate {
   type: 'review' | 'reflection' | 'post_merge';
@@ -171,7 +170,7 @@ export function handleUnfinishedEscape(
     };
     const targetDir = deferredDir || stateDir;
     const filepath = join(targetDir, DEFERRED_ITEMS_FILE);
-    writeFileSync(filepath, JSON.stringify(deferred, null, 2));
+    writeJsonValueFile(filepath, deferred, { trailingNewline: false });
   }
 
   return report.gates;

--- a/src/kaizen-setup.test.ts
+++ b/src/kaizen-setup.test.ts
@@ -25,13 +25,16 @@ afterEach(() => {
 });
 
 describe("setup JSON file parsing", () => {
-  it("delegates runtime JSON object file reads to the shared file helper", () => {
+  it("delegates runtime JSON object file reads and writes to the shared file helper", () => {
     const source = readFileSync(new URL("./kaizen-setup.ts", import.meta.url), "utf-8");
 
-    expect(source).toContain("./lib/json-file.js");
+    expect(source).toContain("readJsonObjectFile");
+    expect(source).toContain("writeJsonObjectFile");
     expect(source).not.toContain("JSON.parse(readFileSync");
     expect(source).not.toContain("function readJsonObjectFile");
     expect(source).not.toContain("parseJsonObject(readFileSync");
+    expect(source).not.toContain("JSON.stringify(config, null, 2)");
+    expect(source).not.toContain("JSON.stringify(data, null, 2)");
   });
 });
 
@@ -64,6 +67,7 @@ describe("generateConfig", () => {
     expect(config.host.repo).toBe("org/my-project");
     expect(config.kaizen.repo).toBe("Garsson-io/kaizen");
     expect(config.notifications.channel).toBe("none");
+    expect(readFileSync(join(tempDir, "kaizen.config.json"), "utf-8")).toMatch(/\n$/);
   });
 
   it("handles special characters in name", () => {
@@ -473,6 +477,7 @@ describe("enablePlugin (#1063 — --step enable)", () => {
     expect(r).toEqual({ step: "enable", status: "ok", path: join(tempDir, ".claude/settings.json"), changed: true });
     const parsed = JSON.parse(readFileSync(r.path!, "utf-8"));
     expect(parsed.enabledPlugins["kaizen@kaizen"]).toBe(true);
+    expect(readFileSync(r.path!, "utf-8")).toMatch(/\n$/);
   });
 
   it("adds enabledPlugins to an existing settings.json without clobbering other keys", () => {

--- a/src/kaizen-setup.ts
+++ b/src/kaizen-setup.ts
@@ -20,7 +20,7 @@ import { join } from "path";
 import { parseArgs } from "util";
 import { loadAllSkillMetadata, validateSkillDependencies, validateSkillVersions } from "./skill-metadata.js";
 import { installGitHooks, buildThinWrapper, type InstallResult } from "./setup-git-hooks.js";
-import { readJsonObjectFile } from "./lib/json-file.js";
+import { readJsonObjectFile, writeJsonObjectFile } from "./lib/json-file.js";
 
 // ── Types ──
 
@@ -146,7 +146,7 @@ export function generateConfig(input: ConfigInput, cwd: string): ConfigResult {
   };
 
   const path = join(cwd, "kaizen.config.json");
-  writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+  writeJsonObjectFile(path, config);
   return { step: "config", status: "ok", path };
 }
 
@@ -182,7 +182,7 @@ export function enablePlugin(cwd: string, pluginName = "kaizen@kaizen"): EnableR
   }
   enabled[pluginName] = true;
   data.enabledPlugins = enabled;
-  writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+  writeJsonObjectFile(path, data);
   return { step: "enable", status: "ok", path, changed: true };
 }
 

--- a/src/lib/json-file.test.ts
+++ b/src/lib/json-file.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { readJsonObjectFile, readJsonValueFile } from './json-file.js';
+import { readJsonObjectFile, readJsonValueFile, writeJsonObjectFile, writeJsonValueFile } from './json-file.js';
 
 let dir: string;
 
@@ -57,5 +57,35 @@ describe('readJsonObjectFile', () => {
     expect(readJsonObjectFile(malformedPath)).toBeNull();
     expect(readJsonObjectFile(blankPath)).toBeNull();
     expect(readJsonObjectFile(join(dir, 'missing.json'))).toBeNull();
+  });
+});
+
+describe('writeJsonValueFile', () => {
+  it('writes pretty JSON with a trailing newline by default', () => {
+    const path = join(dir, 'value.json');
+
+    writeJsonValueFile(path, { ok: true });
+
+    expect(readFileSync(path, 'utf-8')).toBe('{\n  "ok": true\n}\n');
+    expect(readJsonValueFile(path)).toEqual({ ok: true });
+  });
+
+  it('can preserve existing no-trailing-newline output contracts', () => {
+    const path = join(dir, 'array.json');
+
+    writeJsonValueFile(path, ['x'], { trailingNewline: false });
+
+    expect(readFileSync(path, 'utf-8')).toBe('[\n  "x"\n]');
+    expect(readJsonValueFile(path)).toEqual(['x']);
+  });
+});
+
+describe('writeJsonObjectFile', () => {
+  it('writes object JSON through the shared value writer', () => {
+    const path = join(dir, 'object-write.json');
+
+    writeJsonObjectFile(path, { ok: true });
+
+    expect(readJsonObjectFile(path)).toEqual({ ok: true });
   });
 });

--- a/src/lib/json-file.ts
+++ b/src/lib/json-file.ts
@@ -1,5 +1,10 @@
-import { readFileSync } from 'node:fs';
+import { closeSync, openSync, readFileSync, writeFileSync } from 'node:fs';
 import { parseJsonObject, parseJsonValue } from './json-value.js';
+
+export interface WriteJsonFileOptions {
+  space?: number;
+  trailingNewline?: boolean;
+}
 
 export function readJsonValueFile(path: string): unknown | null {
   try {
@@ -15,4 +20,31 @@ export function readJsonObjectFile(path: string): Record<string, unknown> | null
   } catch {
     return null;
   }
+}
+
+export function serializeJsonFile(value: unknown, options: WriteJsonFileOptions = {}): string {
+  const space = options.space ?? 2;
+  const trailingNewline = options.trailingNewline ?? true;
+  return JSON.stringify(value, null, space) + (trailingNewline ? '\n' : '');
+}
+
+export function writeJsonValueFile(
+  path: string,
+  value: unknown,
+  options?: WriteJsonFileOptions,
+): void {
+  const fd = openSync(path, 'w', 0o600);
+  try {
+    writeFileSync(fd, serializeJsonFile(value, options));
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function writeJsonObjectFile(
+  path: string,
+  value: Record<string, unknown>,
+  options?: WriteJsonFileOptions,
+): void {
+  writeJsonValueFile(path, value, options);
 }


### PR DESCRIPTION
## Story

Once upon a time, kaizen already had shared JSON parsing helpers in `src/lib/json-file.ts`, and several runtime paths used them for reads.

Every day, those same paths still wrote JSON by hand: setup config, plugin uninstall records, deferred gate state, plugin version bumps, and review-fix state each had their own `JSON.stringify(..., null, 2)` plus `writeFileSync` variant.

One day, the duplication became visible as a drift risk: the readers had converged, but the writers had not. Some files historically ended with a newline and some did not, and that behavior was encoded only in scattered local calls.

Because of that, this PR adds shared JSON file serialization/writer helpers beside the existing readers and migrates five runtime paths through them.

Because of that, each migrated caller now makes its formatting contract explicit. Setup and bump-plugin-version keep the trailing newline they already wrote; uninstall records, gate deferred items, and review-fix state preserve their no-trailing-newline behavior.

Until finally, the focused suite covers both the shared helper and the migrated behavior: 187 tests pass across the touched modules, plus typecheck and whitespace validation pass.

And ever since, JSON file persistence has one reusable mechanism with source invariants preventing these paths from drifting back to local stringify/write helpers.

Fixes #1477

## Architecture

```text
Runtime JSON file callers
  ├─ readJsonValueFile / readJsonObjectFile
  └─ writeJsonValueFile / writeJsonObjectFile
          └─ serializeJsonFile({ space, trailingNewline })
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Put writes in `src/lib/json-file.ts` beside reads | The parsing abstraction already existed there; persistence belongs with it | Keeps this focused on JSON files, not generic filesystem writes |
| Keep `trailingNewline` explicit | Migrated call sites had different existing byte-level output contracts | Slightly more explicit call sites, but prevents accidental behavior drift |
| Use source invariants plus behavior tests | Source checks prevent backsliding; behavior tests prove the contracts still hold | More tests, but they protect the mechanism rather than one call site |
| Leave auto-dent atomic state alone | It has backup/temp/rename semantics that are a distinct persistence contract | Follow-up can extract atomic JSON persistence separately if needed |

## What's In This PR

| File | Purpose |
|---|---|
| `src/lib/json-file.ts` | Adds shared JSON serialization and write helpers |
| `src/lib/json-file.test.ts` | Covers parseable writes and trailing-newline option |
| `src/kaizen-setup.ts` | Routes setup config/settings JSON writes through the shared helper |
| `scripts/kaizen-uninstall-plugin.ts` | Removes local `writeJson()` and routes settings/installed record writes through the shared helper |
| `src/hooks/lib/gate-manager.ts` | Routes deferred item JSON writes through the shared helper |
| `src/hooks/bump-plugin-version.ts` | Routes plugin manifest writes through the shared helper |
| `scripts/review-fix.ts` | Routes state JSON load/save through shared JSON file helpers |
| Touched tests | Add source invariants and behavior checks for migrated paths |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status | Evidence |
|---|---|---|---|---|
| 1 | Shared JSON file writer serializes pretty JSON and optional trailing newline | Unit | Tested | `src/lib/json-file.test.ts` |
| 2 | Setup config/settings writes use shared persistence | Source + behavior | Tested | `src/kaizen-setup.test.ts` |
| 3 | Plugin uninstall writes use shared persistence | Source + behavior | Tested | `scripts/kaizen-uninstall-plugin.test.ts` |
| 4 | Gate deferred items writes use shared persistence | Source + behavior | Tested | `src/hooks/lib/gate-manager.test.ts` |
| 5 | Bump plugin version manifest write uses shared persistence | Source + behavior | Tested | `src/hooks/bump-plugin-version.test.ts` |
| 6 | Review-fix state load/save uses shared JSON file helpers | Source + behavior | Tested | `scripts/review-fix.test.ts` |

## Validation

- [x] `npm test -- --run src/lib/json-file.test.ts src/kaizen-setup.test.ts scripts/kaizen-uninstall-plugin.test.ts src/hooks/lib/gate-manager.test.ts src/hooks/bump-plugin-version.test.ts scripts/review-fix.test.ts` — 187 tests passed
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Source sweep found no remaining migrated-path local `JSON.stringify(..., null, 2)` + `writeFileSync` persistence patterns

## Known Limitations

This PR does not extract the auto-dent atomic backup/temp/rename state writer. That path has a different durability contract and should be handled as a separate refactor if we want shared atomic JSON persistence.