### PR TITLE
refactor(auto-dent): consolidate durable json persistence

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -30,6 +30,8 @@ import {
 import type { RunMetrics } from './auto-dent-run.js';
 import { makeBatchState } from './auto-dent-test-utils.js';
 
+const AUTO_DENT_CTL_SOURCE = readFileSync(new URL('./auto-dent-ctl.ts', import.meta.url), 'utf8');
+
 function makeBatchInfo(overrides: Partial<BatchInfo> = {}): BatchInfo {
   return {
     batchId: 'batch-260322-2100-a1b2',
@@ -768,6 +770,19 @@ describe('buildReflectionTemplateVars', () => {
 // Reflection persistence tests (#603)
 
 describe('persistReflectionSummary', () => {
+  it('routes reflection JSON persistence through shared JSON file contracts', () => {
+    const persistSection = AUTO_DENT_CTL_SOURCE.slice(
+      AUTO_DENT_CTL_SOURCE.indexOf('export function persistReflectionSummary'),
+      AUTO_DENT_CTL_SOURCE.indexOf('export interface AggregateBatchRecord'),
+    );
+
+    expect(persistSection).toContain('readJsonValueFile');
+    expect(persistSection).toContain('writeJsonValueFile');
+    expect(persistSection).not.toContain("JSON.parse(readFileSync(historyPath, 'utf8'))");
+    expect(persistSection).not.toContain('JSON.stringify(summary, null, 2)');
+    expect(persistSection).not.toContain('JSON.stringify(history, null, 2)');
+  });
+
   it('writes reflection-summary.json to the batch directory', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'reflect-persist-'));
     const batch = makeBatchInfo({
@@ -791,6 +806,7 @@ describe('persistReflectionSummary', () => {
     expect(data.insights).toBeInstanceOf(Array);
     expect(data.avoidIssues).toBeInstanceOf(Array);
     expect(data.timestamp).toBeTruthy();
+    expect(readFileSync(path!, 'utf8')).toMatch(/\n$/);
   });
 
   it('extracts issue numbers from failure insights into avoidIssues', () => {
@@ -857,6 +873,22 @@ describe('persistReflectionSummary', () => {
     history = JSON.parse(readFileSync(historyPath, 'utf8'));
     expect(history).toHaveLength(2);
     expect(history[1].insights[0].message).toBe('Testing works well');
+    expect(readFileSync(historyPath, 'utf8')).toMatch(/\n$/);
+  });
+
+  it('resets corrupted reflection history through the shared JSON reader contract', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'reflect-history-corrupt-'));
+    const batch = makeBatchInfo({ dir: tmpDir });
+    const historyPath = join(tmpDir, 'reflection-history.json');
+    writeFileSync(historyPath, '{not json');
+
+    const reflection = buildBatchReflection(batch);
+    reflection.insights = [{ type: 'recommendation', message: 'Fresh history' }];
+    persistReflectionSummary(batch, reflection);
+
+    const history = JSON.parse(readFileSync(historyPath, 'utf8'));
+    expect(history).toHaveLength(1);
+    expect(history[0].insights[0].message).toBe('Fresh history');
   });
 });
 

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -42,6 +42,7 @@ import {
 } from './batch-outcome.js';
 import { truncateDisplay } from './auto-dent-display.js';
 import { appendJsonLine, parseJsonLines } from '../src/lib/json-lines.js';
+import { readJsonValueFile, writeJsonValueFile } from '../src/lib/json-file.js';
 
 function getRepoRoot(): string {
   try {
@@ -686,18 +687,17 @@ export function persistReflectionSummary(
   };
 
   try {
-    writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + '\n');
+    writeJsonValueFile(summaryPath, summary);
 
     // Append to reflection history so consecutive reflections can see prior conclusions
     const historyPath = join(batch.dir, 'reflection-history.json');
     let history: PersistedReflection[] = [];
-    try {
-      if (existsSync(historyPath)) {
-        history = JSON.parse(readFileSync(historyPath, 'utf8'));
-      }
-    } catch { /* start fresh if corrupted */ }
+    const persistedHistory = readJsonValueFile(historyPath);
+    if (Array.isArray(persistedHistory)) {
+      history = persistedHistory as PersistedReflection[];
+    }
     history.push(summary);
-    writeFileSync(historyPath, JSON.stringify(history, null, 2) + '\n');
+    writeJsonValueFile(historyPath, history);
 
     console.log(`  [reflect] persisted reflection summary to ${summaryPath} (history: ${history.length} entries)`);
     return summaryPath;

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -58,6 +58,8 @@ import {
 import * as github from './auto-dent-github.js';
 import { makeBatchState, makeRunResult } from './auto-dent-test-utils.js';
 
+const AUTO_DENT_RUN_SOURCE = readFileSync(new URL('./auto-dent-run.ts', import.meta.url), 'utf8');
+
 describe('buildPrompt', () => {
   it('includes run tag with batch id and run number', () => {
     const state = makeBatchState();
@@ -206,6 +208,17 @@ describe('buildTemplateVars', () => {
 // Reflection feedback loop (#603)
 
 describe('loadReflectionInsights', () => {
+  it('routes reflection JSON reads through the shared JSON file contract', () => {
+    const reflectionSection = AUTO_DENT_RUN_SOURCE.slice(
+      AUTO_DENT_RUN_SOURCE.indexOf('export function loadReflectionInsights'),
+      AUTO_DENT_RUN_SOURCE.indexOf('/**\n * Build template variables'),
+    );
+
+    expect(reflectionSection).toContain('readJsonValueFile');
+    expect(reflectionSection).not.toContain("JSON.parse(readFileSync(summaryPath, 'utf8'))");
+    expect(reflectionSection).not.toContain("JSON.parse(readFileSync(historyPath, 'utf8'))");
+  });
+
   it('returns empty when no reflection-summary.json exists', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'no-reflect-'));
     const result = loadReflectionInsights(tmpDir);
@@ -2968,6 +2981,21 @@ describe('atomic state I/O', () => {
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'state-io-'));
     stateFile = join(dir, 'state.json');
+  });
+
+  it('routes state persistence through the shared durable JSON contract', () => {
+    const stateSection = AUTO_DENT_RUN_SOURCE.slice(
+      AUTO_DENT_RUN_SOURCE.indexOf('// State I/O'),
+      AUTO_DENT_RUN_SOURCE.indexOf('// Resolve repo root'),
+    );
+
+    expect(stateSection).toContain('readDurableJsonValueFile');
+    expect(stateSection).toContain('writeDurableJsonValueFile');
+    expect(stateSection).not.toContain("JSON.parse(readFileSync(stateFile, 'utf8'))");
+    expect(stateSection).not.toContain("JSON.parse(readFileSync(bak, 'utf8'))");
+    expect(stateSection).not.toContain("const tmp = stateFile + '.tmp'");
+    expect(stateSection).not.toContain("copyFileSync(stateFile, stateFile + '.bak')");
+    expect(stateSection).not.toContain('renameSync(tmp, stateFile)');
   });
 
   it('writeState creates atomic temp-then-rename', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -22,7 +22,7 @@
 
 import { spawn, execFileSync, execSync } from 'child_process';
 import { createHash } from 'crypto';
-import { readFileSync, writeFileSync, appendFileSync, existsSync, renameSync, copyFileSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
 import { createInterface } from 'readline';
 import { dirname, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, formatIssuesClosedLine, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
@@ -58,6 +58,7 @@ import {
 } from './auto-dent-progress.js';
 import { truncateAtWordBoundary } from './auto-dent-display.js';
 import { parseJsonObject } from '../src/lib/json-value.js';
+import { readDurableJsonValueFile, readJsonValueFile, writeDurableJsonValueFile } from '../src/lib/json-file.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -407,31 +408,16 @@ export { extractPlanText };
 // State I/O
 
 export function readState(stateFile: string): BatchState {
-  try {
-    return JSON.parse(readFileSync(stateFile, 'utf8'));
-  } catch {
-    // Primary file corrupt/missing — try backup
-    const bak = stateFile + '.bak';
-    if (existsSync(bak)) {
-      console.error(`[state-io] Primary state corrupt, falling back to ${bak}`);
-      return JSON.parse(readFileSync(bak, 'utf8'));
-    }
-    throw new Error(`State file corrupt and no backup available: ${stateFile}`);
-  }
+  const state = readDurableJsonValueFile(stateFile, {
+    backup: true,
+    onBackupRead: (bak) => console.error(`[state-io] Primary state corrupt, falling back to ${bak}`),
+  });
+  if (state && typeof state === 'object' && !Array.isArray(state)) return state as BatchState;
+  throw new Error(`State file corrupt and no backup available: ${stateFile}`);
 }
 
 export function writeState(stateFile: string, state: BatchState): void {
-  const tmp = stateFile + '.tmp';
-  const content = JSON.stringify(state, null, 2) + '\n';
-  // Validate we can round-trip before writing
-  JSON.parse(content);
-  // Backup current state before overwriting
-  if (existsSync(stateFile)) {
-    copyFileSync(stateFile, stateFile + '.bak');
-  }
-  // Atomic write: write to temp, then rename
-  writeFileSync(tmp, content);
-  renameSync(tmp, stateFile);
+  writeDurableJsonValueFile(stateFile, state, { backup: true });
 }
 
 // Resolve repo root
@@ -463,12 +449,14 @@ export function loadReflectionInsights(logDir: string): { text: string; avoidIss
   const summaryPath = resolve(logDir, 'reflection-summary.json');
   try {
     if (!existsSync(summaryPath)) return { text: '', avoidIssues: [] };
-    const raw = JSON.parse(readFileSync(summaryPath, 'utf8'));
-    const insights: Array<{ type: string; message: string }> = raw.insights || [];
-    if (insights.length === 0) return { text: '', avoidIssues: raw.avoidIssues || [] };
+    const raw = readJsonValueFile(summaryPath);
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { text: '', avoidIssues: [] };
+    const summary = raw as Record<string, any>;
+    const insights: Array<{ type: string; message: string }> = Array.isArray(summary.insights) ? summary.insights : [];
+    if (insights.length === 0) return { text: '', avoidIssues: summary.avoidIssues || [] };
 
     const lines = [
-      `_Mid-batch reflection (after run ${raw.runCount}, success rate: ${(raw.successRate * 100).toFixed(0)}%):_`,
+      `_Mid-batch reflection (after run ${summary.runCount}, success rate: ${(summary.successRate * 100).toFixed(0)}%):_`,
       '',
     ];
     for (const insight of insights) {
@@ -478,7 +466,7 @@ export function loadReflectionInsights(logDir: string): { text: string; avoidIss
       lines.push(`- **[${icon}]** ${insight.message}`);
     }
 
-    return { text: lines.join('\n'), avoidIssues: raw.avoidIssues || [] };
+    return { text: lines.join('\n'), avoidIssues: summary.avoidIssues || [] };
   } catch {
     return { text: '', avoidIssues: [] };
   }
@@ -492,7 +480,7 @@ export function loadReflectionHistory(logDir: string): string {
   const historyPath = resolve(logDir, 'reflection-history.json');
   try {
     if (!existsSync(historyPath)) return '';
-    const entries = JSON.parse(readFileSync(historyPath, 'utf8'));
+    const entries = readJsonValueFile(historyPath);
     if (!Array.isArray(entries) || entries.length === 0) return '';
 
     return entries.map((entry: any, idx: number) => {

--- a/scripts/auto-dent.test.ts
+++ b/scripts/auto-dent.test.ts
@@ -17,6 +17,8 @@ import {
 } from './auto-dent.js';
 import { readState, writeState, type BatchState } from './auto-dent-run.js';
 
+const AUTO_DENT_SOURCE = readFileSync(new URL('./auto-dent.ts', import.meta.url), 'utf8');
+
 const baseOpts: AutoDentOptions = {
   maxRuns: 0,
   cooldown: 30,
@@ -167,6 +169,11 @@ describe('createInitialState', () => {
 });
 
 describe('state helpers', () => {
+  it('creates initial batch state through the canonical durable state writer', () => {
+    expect(AUTO_DENT_SOURCE).toContain('writeState(stateFile, state)');
+    expect(AUTO_DENT_SOURCE).not.toContain("writeFileSync(stateFile, JSON.stringify(state, null, 2) + '\\n')");
+  });
+
   it('reads and updates state atomically with backups', () => {
     const { dir, stateFile } = tempState();
     try {

--- a/scripts/auto-dent.ts
+++ b/scripts/auto-dent.ts
@@ -572,7 +572,7 @@ async function main(): Promise<void> {
   const haltFile = join(logDir, 'HALT');
   const stateFile = join(logDir, 'state.json');
   const state = createInitialState(batchId, opts.guidance, batchStart, opts, repos);
-  writeFileSync(stateFile, JSON.stringify(state, null, 2) + '\n');
+  writeState(stateFile, state);
 
   let shuttingDown = false;
   const handleShutdown = () => {

--- a/src/lib/json-file.test.ts
+++ b/src/lib/json-file.test.ts
@@ -2,7 +2,14 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { readJsonObjectFile, readJsonValueFile, writeJsonObjectFile, writeJsonValueFile } from './json-file.js';
+import {
+  readDurableJsonValueFile,
+  readJsonObjectFile,
+  readJsonValueFile,
+  writeDurableJsonValueFile,
+  writeJsonObjectFile,
+  writeJsonValueFile,
+} from './json-file.js';
 
 let dir: string;
 
@@ -87,5 +94,38 @@ describe('writeJsonObjectFile', () => {
     writeJsonObjectFile(path, { ok: true });
 
     expect(readJsonObjectFile(path)).toEqual({ ok: true });
+  });
+});
+
+describe('durable JSON file contract', () => {
+  it('writes through a temp file and can back up the previous primary', () => {
+    const path = join(dir, 'state.json');
+
+    writeDurableJsonValueFile(path, { run: 1 }, { backup: true });
+    writeDurableJsonValueFile(path, { run: 2 }, { backup: true });
+
+    expect(readJsonValueFile(path)).toEqual({ run: 2 });
+    expect(readJsonValueFile(`${path}.bak`)).toEqual({ run: 1 });
+    expect(readFileSync(path, 'utf-8')).toMatch(/\n$/);
+    expect(readFileSync(`${path}.bak`, 'utf-8')).toMatch(/\n$/);
+    expect(() => readFileSync(`${path}.tmp`, 'utf-8')).toThrow();
+  });
+
+  it('reads a backup when the primary is missing or malformed', () => {
+    const path = join(dir, 'recoverable.json');
+    writeJsonValueFile(`${path}.bak`, { from: 'backup' });
+
+    expect(readDurableJsonValueFile(path, { backup: true })).toEqual({ from: 'backup' });
+
+    writeFileSync(path, '{not json');
+    expect(readDurableJsonValueFile(path, { backup: true })).toEqual({ from: 'backup' });
+  });
+
+  it('returns null when both durable primary and backup are unreadable', () => {
+    const path = join(dir, 'unrecoverable.json');
+    writeFileSync(path, '{not json');
+    writeFileSync(`${path}.bak`, '{also bad');
+
+    expect(readDurableJsonValueFile(path, { backup: true })).toBeNull();
   });
 });

--- a/src/lib/json-file.ts
+++ b/src/lib/json-file.ts
@@ -1,9 +1,24 @@
-import { closeSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  copyFileSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
 import { parseJsonObject, parseJsonValue } from './json-value.js';
 
 export interface WriteJsonFileOptions {
   space?: number;
   trailingNewline?: boolean;
+}
+
+export interface DurableJsonFileOptions extends WriteJsonFileOptions {
+  backup?: boolean;
+  backupPath?: string;
+  tempPath?: string;
+  onBackupRead?: (backupPath: string) => void;
 }
 
 export function readJsonValueFile(path: string): unknown | null {
@@ -47,4 +62,56 @@ export function writeJsonObjectFile(
   options?: WriteJsonFileOptions,
 ): void {
   writeJsonValueFile(path, value, options);
+}
+
+export function readDurableJsonValueFile(
+  path: string,
+  options: Pick<DurableJsonFileOptions, 'backup' | 'backupPath' | 'onBackupRead'> = {},
+): unknown | null {
+  const primary = readJsonValueFile(path);
+  if (primary !== null || !options.backup) return primary;
+
+  const backupPath = options.backupPath ?? `${path}.bak`;
+  if (!existsSync(backupPath)) return null;
+  options.onBackupRead?.(backupPath);
+  return readJsonValueFile(backupPath);
+}
+
+export function readDurableJsonObjectFile(
+  path: string,
+  options: Pick<DurableJsonFileOptions, 'backup' | 'backupPath' | 'onBackupRead'> = {},
+): Record<string, unknown> | null {
+  const value = readDurableJsonValueFile(path, options);
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function writeDurableJsonValueFile(
+  path: string,
+  value: unknown,
+  options: DurableJsonFileOptions = {},
+): void {
+  const tempPath = options.tempPath ?? `${path}.tmp`;
+  const backupPath = options.backupPath ?? `${path}.bak`;
+  const content = serializeJsonFile(value, options);
+
+  // Preserve the old auto-dent contract: fail before touching disk if the
+  // serialized value cannot round-trip as JSON.
+  JSON.parse(content);
+
+  if (options.backup && existsSync(path)) {
+    copyFileSync(path, backupPath);
+  }
+
+  writeJsonValueFile(tempPath, value, options);
+  renameSync(tempPath, path);
+}
+
+export function writeDurableJsonObjectFile(
+  path: string,
+  value: Record<string, unknown>,
+  options?: DurableJsonFileOptions,
+): void {
+  writeDurableJsonValueFile(path, value, options);
 }


### PR DESCRIPTION
## Story

Once upon a time, auto-dent had one robust state writer: `writeState()` wrote through `.tmp`, kept `.bak`, and `readState()` recovered from backup.

Every day, nearby auto-dent paths still defined their own state-like JSON contracts: initial batch creation wrote `state.json` directly, reflection summary/history had local parse/stringify behavior, and the durable temp/backup semantics lived inside `auto-dent-run.ts`.

One day, the DRY/refactor epic made the actual failure mode explicit: similar runtime concepts with slightly different contracts are the problem. This was not just duplicate code; it was duplicate persistence contracts.

Because of that, this PR moves durable JSON semantics into `src/lib/json-file.ts`: temp-then-rename writes, optional previous-primary backup, primary-with-backup reads, and caller-controlled formatting.

Because of that, auto-dent state and reflection persistence now share the same JSON file contract:
- `readState()` / `writeState()` are BatchState wrappers over the durable JSON helpers.
- initial batch `state.json` creation uses the same writer as later updates.
- reflection summary/history reads and writes use the shared JSON file helpers.
- source invariants prevent local `.tmp` / `.bak` / `JSON.parse(readFileSync(...))` variants from returning.

Until finally, the focused suite proves both the contract and migrated callers: 407 tests passed, typecheck passed, diff check passed, and a source sweep found no targeted local persistence variants.

And ever since, auto-dent has one durable JSON persistence contract instead of several slight variants.

Fixes #1484
Parent: #1482

## Architecture

`src/lib/json-file.ts` now owns two related contracts:

| Contract | Responsibility |
| --- | --- |
| `readJsonValueFile` / `writeJsonValueFile` | Shared plain JSON file parsing and formatting. |
| `readDurableJsonValueFile` / `writeDurableJsonValueFile` | Shared durable JSON semantics: temp write, optional backup, and backup fallback. |

The durable contract is intentionally in `src/lib` instead of an auto-dent script because other runtime state files can now reuse it instead of inventing their own almost-compatible persistence rules.

## What Changed

- Added durable JSON helpers with object wrappers and tests.
- Migrated auto-dent state reads/writes to the shared durable contract.
- Migrated initial auto-dent `state.json` creation to the same writer used for later updates.
- Migrated reflection summary/history persistence to shared JSON helpers.
- Added source invariants that block reintroducing targeted local parse/stringify/temp/backup variants.

## Test Plan

| Area | Coverage |
| --- | --- |
| Shared durable JSON writer creates temp-then-rename output and optional backup | `src/lib/json-file.test.ts` |
| Shared durable JSON reader falls back to backup on missing/corrupt primary | `src/lib/json-file.test.ts` |
| `auto-dent-run` state I/O routes through shared durable helpers | `scripts/auto-dent-run.test.ts` |
| Initial auto-dent batch state creation uses same durable writer | `scripts/auto-dent.test.ts` |
| Reflection summary/history persistence uses shared JSON helpers | `scripts/auto-dent-ctl.test.ts` |
| Migrated formatting contracts preserved | focused tests |

## Validation

- `npm test -- --run src/lib/json-file.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent.test.ts scripts/auto-dent-ctl.test.ts` — 407 tests passed
- `npm run typecheck`
- `git diff --check`
- Source sweep for targeted local state/reflection JSON persistence variants

## Related Issue Sweep

- Scope issue: #1484
- Parent epic: #1482
- Broader refactor epics #940 and #691 are related context, but this PR only closes #1484.

## Known Limitations

This PR does not migrate every JSON file in the repository. It consolidates the durable auto-dent state/reflection contract first, with the shared helper now available for follow-up subissues under #1482.
