### PR TITLE
feat(metabolism): backlog-health metric — L0→L1 for epic #953

### DIFF
--- a/.agents/skills/kaizen-audit-issues/SKILL.md
+++ b/.agents/skills/kaizen-audit-issues/SKILL.md
@@ -19,6 +19,21 @@ description: Periodic issue taxonomy audit — checks label coverage, epic healt
 
 ## The Audit
 
+### Step 0: Quantitative backlog-health metric
+
+Before the manual drill-downs, get the aggregate health verdict. `scripts/backlog-health.ts`
+computes the Issue Metabolism axes from epic #953 (creation/closure ratio, inactivity-age
+distribution, horizon coverage) and prints a single verdict (`healthy`/`warning`/`pathological`).
+The verdict is bound to the exit code (pathological → exit 1) so it can gate CI or batch runs.
+
+```bash
+npx tsx scripts/backlog-health.ts --repo "$ISSUES_REPO" --window 30
+# machine-readable:
+npx tsx scripts/backlog-health.ts --repo "$ISSUES_REPO" --json
+```
+
+This is the L1 measurement layer; the steps below are the manual inspection it points you at.
+
 ### Step 1: Gather all open issues
 
 ```bash

--- a/scripts/backlog-health.test.ts
+++ b/scripts/backlog-health.test.ts
@@ -5,8 +5,10 @@ import {
   computeCreationClosureRatio,
   buildBacklogHealthReport,
   classifyBacklogHealth,
+  parseArgs,
   type OpenIssue,
   type ClosedIssue,
+  type CreatedIssue,
 } from './backlog-health.js';
 
 const NOW = new Date('2026-06-28T00:00:00.000Z');
@@ -81,6 +83,7 @@ describe('computeCreationClosureRatio', () => {
 describe('classifyBacklogHealth', () => {
   const baseReport = buildBacklogHealthReport(
     [open({ number: 1, updatedAt: daysAgo(5), labels: ['horizon/a'] })],
+    [{ number: 1, createdAt: daysAgo(5) }],
     [{ number: 99, closedAt: daysAgo(5) }],
     NOW,
     30,
@@ -121,6 +124,28 @@ describe('classifyBacklogHealth', () => {
     };
     expect(classifyBacklogHealth(report)).toBe('warning');
   });
+
+  it('returns warning in the >90d stale-share band (0.1 <= share < 0.25)', () => {
+    // 2 of 10 stale >90d = 20% → warning band, not pathological
+    const report = {
+      ...baseReport,
+      ratio: { created: 1, closed: 1, ratio: 1.0 },
+      age: { total: 10, stale30: 2, stale60: 2, stale90: 2 },
+      horizon: { byHorizon: { 'horizon/a': 1 }, noHorizon: 0, distinctHorizons: 1 },
+    };
+    expect(classifyBacklogHealth(report)).toBe('warning');
+  });
+
+  it('suppresses horizon concentration on a tiny backlog (< MIN_LABELED)', () => {
+    // one horizon holds 100% but only 3 labeled issues → below the min, stays healthy
+    const report = {
+      ...baseReport,
+      ratio: { created: 1, closed: 1, ratio: 1.0 },
+      age: { total: 3, stale30: 0, stale60: 0, stale90: 0 },
+      horizon: { byHorizon: { 'horizon/a': 3 }, noHorizon: 0, distinctHorizons: 1 },
+    };
+    expect(classifyBacklogHealth(report)).toBe('healthy');
+  });
 });
 
 describe('buildBacklogHealthReport', () => {
@@ -129,17 +154,60 @@ describe('buildBacklogHealthReport', () => {
       open({ number: 1, createdAt: daysAgo(5), updatedAt: daysAgo(5), labels: ['horizon/a'] }),
       open({ number: 2, createdAt: daysAgo(120), updatedAt: daysAgo(100), labels: [] }),
     ];
+    // `created` is fetched across ALL states — includes a created-and-closed issue (#9)
+    const createdIssues: CreatedIssue[] = [
+      { number: 1, createdAt: daysAgo(5) },
+      { number: 9, createdAt: daysAgo(3) }, // created+closed inside window, not in `open`
+      { number: 2, createdAt: daysAgo(120) }, // outside window
+    ];
     const closedIssues: ClosedIssue[] = [{ number: 50, closedAt: daysAgo(2) }];
-    const report = buildBacklogHealthReport(openIssues, closedIssues, NOW, 30);
+    const report = buildBacklogHealthReport(openIssues, createdIssues, closedIssues, NOW, 30);
 
     expect(report.totalOpen).toBe(2);
     expect(report.windowDays).toBe(30);
-    // only issue #1 was created within the 30-day window
-    expect(report.ratio.created).toBe(1);
+    // #1 and #9 were created within the 30-day window (#9 counts even though closed);
+    // this is the bias fix — a derive-from-open numerator would have reported 1.
+    expect(report.ratio.created).toBe(2);
     expect(report.ratio.closed).toBe(1);
     expect(report.age.total).toBe(2);
     expect(report.age.stale90).toBe(1);
     expect(report.horizon.noHorizon).toBe(1);
     expect(typeof report.generatedAt).toBe('string');
+  });
+
+  it('feeds computed ratio into the verdict end-to-end (6 created / 2 closed → pathological)', () => {
+    const createdIssues: CreatedIssue[] = Array.from({ length: 6 }, (_, i) => ({
+      number: 100 + i,
+      createdAt: daysAgo(3),
+    }));
+    const closedIssues: ClosedIssue[] = [
+      { number: 200, closedAt: daysAgo(2) },
+      { number: 201, closedAt: daysAgo(2) },
+    ];
+    const report = buildBacklogHealthReport([], createdIssues, closedIssues, NOW, 30);
+    expect(report.ratio.ratio).toBe(3);
+    expect(classifyBacklogHealth(report)).toBe('pathological');
+  });
+});
+
+describe('parseArgs', () => {
+  it('parses repo/window/json with defaults', () => {
+    expect(parseArgs([])).toEqual({ repo: 'Garsson-io/kaizen', window: 30, json: false });
+    expect(parseArgs(['--repo', 'o/r', '--window', '60', '--json'])).toEqual({
+      repo: 'o/r',
+      window: 60,
+      json: true,
+    });
+  });
+
+  it('rejects a missing or non-numeric --window instead of producing NaN', () => {
+    expect(() => parseArgs(['--window'])).toThrow(/positive number/);
+    expect(() => parseArgs(['--window', 'abc'])).toThrow(/positive number/);
+    expect(() => parseArgs(['--window', '0'])).toThrow(/positive number/);
+  });
+
+  it('rejects a missing --repo value and unknown flags', () => {
+    expect(() => parseArgs(['--repo'])).toThrow(/--repo requires/);
+    expect(() => parseArgs(['--bogus'])).toThrow(/unknown argument/);
   });
 });

--- a/scripts/backlog-health.test.ts
+++ b/scripts/backlog-health.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeAgeDistribution,
+  computeHorizonCoverage,
+  computeCreationClosureRatio,
+  buildBacklogHealthReport,
+  classifyBacklogHealth,
+  type OpenIssue,
+  type ClosedIssue,
+} from './backlog-health.js';
+
+const NOW = new Date('2026-06-28T00:00:00.000Z');
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86400_000).toISOString();
+
+function open(partial: Partial<OpenIssue>): OpenIssue {
+  return {
+    number: 1,
+    createdAt: daysAgo(5),
+    updatedAt: daysAgo(5),
+    labels: [],
+    ...partial,
+  };
+}
+
+describe('computeAgeDistribution', () => {
+  it('buckets open issues by inactivity (updatedAt) into nested >30/>60/>90 buckets', () => {
+    const issues = [
+      open({ number: 1, updatedAt: daysAgo(10) }), // fresh
+      open({ number: 2, updatedAt: daysAgo(40) }), // >30 only
+      open({ number: 3, updatedAt: daysAgo(70) }), // >30, >60
+      open({ number: 4, updatedAt: daysAgo(100) }), // >30, >60, >90
+    ];
+    const dist = computeAgeDistribution(issues, NOW);
+    expect(dist.total).toBe(4);
+    expect(dist.stale30).toBe(3); // issues 2,3,4
+    expect(dist.stale60).toBe(2); // issues 3,4
+    expect(dist.stale90).toBe(1); // issue 4
+  });
+
+  it('returns all zeros for an empty backlog', () => {
+    const dist = computeAgeDistribution([], NOW);
+    expect(dist).toEqual({ total: 0, stale30: 0, stale60: 0, stale90: 0 });
+  });
+});
+
+describe('computeHorizonCoverage', () => {
+  it('counts issues per horizon, tracks no-horizon and distinct count', () => {
+    const issues = [
+      open({ number: 1, labels: ['horizon/a', 'kaizen'] }),
+      open({ number: 2, labels: ['horizon/a'] }),
+      open({ number: 3, labels: ['horizon/b'] }),
+      open({ number: 4, labels: ['kaizen'] }), // no horizon
+    ];
+    const cov = computeHorizonCoverage(issues);
+    expect(cov.byHorizon['horizon/a']).toBe(2);
+    expect(cov.byHorizon['horizon/b']).toBe(1);
+    expect(cov.noHorizon).toBe(1);
+    expect(cov.distinctHorizons).toBe(2);
+  });
+
+  it('treats horizon: (colon) labels as horizons too', () => {
+    const issues = [open({ number: 1, labels: ['horizon:quality'] })];
+    const cov = computeHorizonCoverage(issues);
+    expect(cov.byHorizon['horizon:quality']).toBe(1);
+    expect(cov.noHorizon).toBe(0);
+  });
+});
+
+describe('computeCreationClosureRatio', () => {
+  it('computes created/closed ratio', () => {
+    expect(computeCreationClosureRatio(6, 3)).toEqual({ created: 6, closed: 3, ratio: 2 });
+  });
+
+  it('guards divide-by-zero when nothing was closed', () => {
+    const r = computeCreationClosureRatio(4, 0);
+    expect(r.closed).toBe(0);
+    expect(r.ratio).toBe(4); // created / max(closed, 1)
+  });
+});
+
+describe('classifyBacklogHealth', () => {
+  const baseReport = buildBacklogHealthReport(
+    [open({ number: 1, updatedAt: daysAgo(5), labels: ['horizon/a'] })],
+    [{ number: 99, closedAt: daysAgo(5) }],
+    NOW,
+    30,
+  );
+
+  it('returns healthy for a balanced backlog', () => {
+    // 1 created in window, 1 closed → ratio 1.0; no stale; single horizon but only 1 issue
+    expect(classifyBacklogHealth(baseReport)).toBe('healthy');
+  });
+
+  it('returns warning when ratio is moderately high', () => {
+    const report = { ...baseReport, ratio: { created: 7, closed: 5, ratio: 1.4 } };
+    expect(classifyBacklogHealth(report)).toBe('warning');
+  });
+
+  it('returns pathological when ratio >= 2:1', () => {
+    const report = { ...baseReport, ratio: { created: 10, closed: 4, ratio: 2.5 } };
+    expect(classifyBacklogHealth(report)).toBe('pathological');
+  });
+
+  it('returns pathological when >90d-stale share is large even if ratio is fine', () => {
+    // ratio healthy (1.0) but 3 of 4 open issues stale >90d → 75% share
+    const report = {
+      ...baseReport,
+      ratio: { created: 1, closed: 1, ratio: 1.0 },
+      age: { total: 4, stale30: 3, stale60: 3, stale90: 3 },
+    };
+    expect(classifyBacklogHealth(report)).toBe('pathological');
+  });
+
+  it('returns warning on horizon over-concentration', () => {
+    // ratio fine, no excess staleness, but one horizon holds >= 50% of labeled issues
+    const report = {
+      ...baseReport,
+      ratio: { created: 1, closed: 1, ratio: 1.0 },
+      age: { total: 10, stale30: 0, stale60: 0, stale90: 0 },
+      horizon: { byHorizon: { 'horizon/a': 8, 'horizon/b': 2 }, noHorizon: 0, distinctHorizons: 2 },
+    };
+    expect(classifyBacklogHealth(report)).toBe('warning');
+  });
+});
+
+describe('buildBacklogHealthReport', () => {
+  it('assembles all axes into one report', () => {
+    const openIssues = [
+      open({ number: 1, createdAt: daysAgo(5), updatedAt: daysAgo(5), labels: ['horizon/a'] }),
+      open({ number: 2, createdAt: daysAgo(120), updatedAt: daysAgo(100), labels: [] }),
+    ];
+    const closedIssues: ClosedIssue[] = [{ number: 50, closedAt: daysAgo(2) }];
+    const report = buildBacklogHealthReport(openIssues, closedIssues, NOW, 30);
+
+    expect(report.totalOpen).toBe(2);
+    expect(report.windowDays).toBe(30);
+    // only issue #1 was created within the 30-day window
+    expect(report.ratio.created).toBe(1);
+    expect(report.ratio.closed).toBe(1);
+    expect(report.age.total).toBe(2);
+    expect(report.age.stale90).toBe(1);
+    expect(report.horizon.noHorizon).toBe(1);
+    expect(typeof report.generatedAt).toBe('string');
+  });
+});

--- a/scripts/backlog-health.ts
+++ b/scripts/backlog-health.ts
@@ -38,6 +38,11 @@ export interface ClosedIssue {
   closedAt: string;
 }
 
+export interface CreatedIssue {
+  number: number;
+  createdAt: string;
+}
+
 export interface AgeDistribution {
   total: number;
   /** open issues with no activity for > 30 days */
@@ -122,15 +127,23 @@ export function computeCreationClosureRatio(created: number, closed: number): Cr
   return { created, closed, ratio: created / Math.max(closed, 1) };
 }
 
-/** Assemble every axis into a single report for a window ending at `now`. */
+/**
+ * Assemble every axis into a single report for a window ending at `now`.
+ *
+ * `created` is the set of issues *created* in the window across ALL states —
+ * not derived from `open` — so an issue created and closed inside the window
+ * still counts toward the creation rate (otherwise the ratio is biased low on
+ * the numerator and the backlog looks healthier than it is).
+ */
 export function buildBacklogHealthReport(
   open: OpenIssue[],
+  created: CreatedIssue[],
   closed: ClosedIssue[],
   now: Date,
   windowDays: number,
   repo?: string,
 ): BacklogHealthReport {
-  const createdInWindow = open.filter((i) => inactivityDays(i.createdAt, now) <= windowDays).length;
+  const createdInWindow = created.filter((i) => inactivityDays(i.createdAt, now) <= windowDays).length;
   const closedInWindow = closed.filter((i) => inactivityDays(i.closedAt, now) <= windowDays).length;
   return {
     repo,
@@ -187,13 +200,34 @@ interface GhOpenIssue {
   labels: { name: string }[];
 }
 
+const FETCH_LIMIT = 500;
+
+/** UTC `YYYY-MM-DD` `windowDays` before `now`, for gh `--search` date filters. */
+function windowSince(windowDays: number, now: Date): string {
+  return new Date(now.getTime() - windowDays * DAY_MS).toISOString().slice(0, 10);
+}
+
+/**
+ * Warn (loudly, on stderr) when a fetch hit the limit — the result is
+ * truncated and any count derived from it is a floor, not the truth. Silent
+ * caps read as "we measured everything" when we did not.
+ */
+function warnIfTruncated(label: string, count: number): void {
+  if (count >= FETCH_LIMIT) {
+    console.error(
+      `WARNING: ${label} hit the ${FETCH_LIMIT}-issue fetch cap — counts are truncated (floor, not exact). Narrow --window or paginate.`,
+    );
+  }
+}
+
 export function fetchOpenIssues(repo: string): OpenIssue[] {
   const raw = gh(
-    ['issue', 'list', '--repo', repo, '--state', 'open', '--limit', '500',
+    ['issue', 'list', '--repo', repo, '--state', 'open', '--limit', String(FETCH_LIMIT),
       '--json', 'number,createdAt,updatedAt,labels'],
     60_000,
   );
   const issues: GhOpenIssue[] = JSON.parse(raw);
+  warnIfTruncated('open issues', issues.length);
   return issues.map((i) => ({
     number: i.number,
     createdAt: i.createdAt,
@@ -202,14 +236,27 @@ export function fetchOpenIssues(repo: string): OpenIssue[] {
   }));
 }
 
-export function fetchClosedInWindow(repo: string, windowDays: number, now: Date): ClosedIssue[] {
-  const since = new Date(now.getTime() - windowDays * DAY_MS).toISOString().slice(0, 10);
+export function fetchCreatedInWindow(repo: string, windowDays: number, now: Date): CreatedIssue[] {
+  const since = windowSince(windowDays, now);
   const raw = gh(
-    ['issue', 'list', '--repo', repo, '--state', 'closed', '--limit', '500',
+    ['issue', 'list', '--repo', repo, '--state', 'all', '--limit', String(FETCH_LIMIT),
+      '--search', `created:>=${since}`, '--json', 'number,createdAt'],
+    60_000,
+  );
+  const issues: CreatedIssue[] = JSON.parse(raw);
+  warnIfTruncated('created-in-window issues', issues.length);
+  return issues.map((i) => ({ number: i.number, createdAt: i.createdAt }));
+}
+
+export function fetchClosedInWindow(repo: string, windowDays: number, now: Date): ClosedIssue[] {
+  const since = windowSince(windowDays, now);
+  const raw = gh(
+    ['issue', 'list', '--repo', repo, '--state', 'closed', '--limit', String(FETCH_LIMIT),
       '--search', `closed:>=${since}`, '--json', 'number,closedAt'],
     60_000,
   );
-  const issues: { number: number; closedAt: string }[] = JSON.parse(raw);
+  const issues: ClosedIssue[] = JSON.parse(raw);
+  warnIfTruncated('closed-in-window issues', issues.length);
   return issues.map((i) => ({ number: i.number, closedAt: i.closedAt }));
 }
 
@@ -242,23 +289,45 @@ interface CliArgs {
   json: boolean;
 }
 
-function parseArgs(argv: string[]): CliArgs {
+/** Parse argv, validating every value. Throws on a missing/invalid flag value. */
+export function parseArgs(argv: string[]): CliArgs {
   const args: CliArgs = { repo: 'Garsson-io/kaizen', window: 30, json: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === '--repo') args.repo = argv[++i];
-    else if (a === '--window') args.window = Number(argv[++i]);
-    else if (a === '--json') args.json = true;
+    if (a === '--repo') {
+      const v = argv[++i];
+      if (!v || v.startsWith('--')) throw new Error('--repo requires an owner/repo value');
+      args.repo = v;
+    } else if (a === '--window') {
+      const v = argv[++i];
+      const n = Number(v);
+      if (!v || !Number.isFinite(n) || n <= 0) {
+        throw new Error(`--window requires a positive number (got ${v ?? 'nothing'})`);
+      }
+      args.window = n;
+    } else if (a === '--json') {
+      args.json = true;
+    } else {
+      throw new Error(`unknown argument: ${a}`);
+    }
   }
   return args;
 }
 
 function main(): void {
-  const args = parseArgs(process.argv.slice(2));
+  let args: CliArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`backlog-health: ${(err as Error).message}`);
+    process.exitCode = 2;
+    return;
+  }
   const now = new Date();
   const open = fetchOpenIssues(args.repo);
+  const created = fetchCreatedInWindow(args.repo, args.window, now);
   const closed = fetchClosedInWindow(args.repo, args.window, now);
-  const report = buildBacklogHealthReport(open, closed, now, args.window, args.repo);
+  const report = buildBacklogHealthReport(open, created, closed, now, args.window, args.repo);
   const verdict = classifyBacklogHealth(report);
 
   if (args.json) {

--- a/scripts/backlog-health.ts
+++ b/scripts/backlog-health.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env npx tsx
+/**
+ * backlog-health — Aggregate metric for the health of the issue backlog.
+ *
+ * Advances epic #953 (Issue Metabolism) from L0 ("no tracking, no awareness")
+ * to L1 ("metrics exist but require manual inspection"). Where
+ * `staleness-audit.ts` triages individual issues and `stale-pr-triage.ts`
+ * triages PRs, this computes the standing health of the whole backlog across
+ * the axes #953 defines:
+ *
+ *   - Creation/closure ratio over a trailing window (healthy < 2:1 sustained)
+ *   - Age distribution (open issues with no activity > 30 / > 60 / > 90 days)
+ *   - Horizon coverage (distribution across horizon/* labels + concentration)
+ *
+ * The core functions are pure (data in, metrics out) so the math is
+ * unit-testable without GitHub. The verdict is bound to the process exit code
+ * (pathological → exit 1) so it is a signal, not a decorative number (#1227).
+ *
+ * Usage:
+ *   npx tsx scripts/backlog-health.ts [--repo Garsson-io/kaizen] [--window 30] [--json]
+ *
+ * Referenced by /kaizen-audit-issues. Refs #951, #728. Closes #1493.
+ */
+
+import { gh } from '../src/lib/gh-exec.js';
+
+// Types
+
+export interface OpenIssue {
+  number: number;
+  createdAt: string;
+  updatedAt: string;
+  labels: string[];
+}
+
+export interface ClosedIssue {
+  number: number;
+  closedAt: string;
+}
+
+export interface AgeDistribution {
+  total: number;
+  /** open issues with no activity for > 30 days */
+  stale30: number;
+  /** > 60 days (subset of stale30) */
+  stale60: number;
+  /** > 90 days (subset of stale60) */
+  stale90: number;
+}
+
+export interface HorizonCoverage {
+  byHorizon: Record<string, number>;
+  noHorizon: number;
+  distinctHorizons: number;
+}
+
+export interface CreationClosureRatio {
+  created: number;
+  closed: number;
+  ratio: number;
+}
+
+export type HealthVerdict = 'healthy' | 'warning' | 'pathological';
+
+export interface BacklogHealthReport {
+  repo?: string;
+  windowDays: number;
+  totalOpen: number;
+  ratio: CreationClosureRatio;
+  age: AgeDistribution;
+  horizon: HorizonCoverage;
+  generatedAt: string;
+}
+
+// Pure core
+
+const DAY_MS = 86400_000;
+
+function inactivityDays(iso: string, now: Date): number {
+  return (now.getTime() - new Date(iso).getTime()) / DAY_MS;
+}
+
+function isHorizonLabel(label: string): boolean {
+  return label.startsWith('horizon/') || label.startsWith('horizon:');
+}
+
+/**
+ * Bucket open issues by how long they have gone without activity (`updatedAt`).
+ * Buckets are nested: an issue inactive > 90d counts in stale30, stale60, and
+ * stale90 — so each bucket reads as "at least this stale".
+ */
+export function computeAgeDistribution(issues: OpenIssue[], now: Date): AgeDistribution {
+  const dist: AgeDistribution = { total: issues.length, stale30: 0, stale60: 0, stale90: 0 };
+  for (const issue of issues) {
+    const age = inactivityDays(issue.updatedAt, now);
+    if (age > 30) dist.stale30++;
+    if (age > 60) dist.stale60++;
+    if (age > 90) dist.stale90++;
+  }
+  return dist;
+}
+
+/** Distribution of open issues across horizon labels, plus the unlabeled count. */
+export function computeHorizonCoverage(issues: OpenIssue[]): HorizonCoverage {
+  const byHorizon: Record<string, number> = {};
+  let noHorizon = 0;
+  for (const issue of issues) {
+    const horizons = issue.labels.filter(isHorizonLabel);
+    if (horizons.length === 0) {
+      noHorizon++;
+      continue;
+    }
+    for (const h of horizons) {
+      byHorizon[h] = (byHorizon[h] ?? 0) + 1;
+    }
+  }
+  return { byHorizon, noHorizon, distinctHorizons: Object.keys(byHorizon).length };
+}
+
+/** created / closed over the window, guarding divide-by-zero (closed floored at 1). */
+export function computeCreationClosureRatio(created: number, closed: number): CreationClosureRatio {
+  return { created, closed, ratio: created / Math.max(closed, 1) };
+}
+
+/** Assemble every axis into a single report for a window ending at `now`. */
+export function buildBacklogHealthReport(
+  open: OpenIssue[],
+  closed: ClosedIssue[],
+  now: Date,
+  windowDays: number,
+  repo?: string,
+): BacklogHealthReport {
+  const createdInWindow = open.filter((i) => inactivityDays(i.createdAt, now) <= windowDays).length;
+  const closedInWindow = closed.filter((i) => inactivityDays(i.closedAt, now) <= windowDays).length;
+  return {
+    repo,
+    windowDays,
+    totalOpen: open.length,
+    ratio: computeCreationClosureRatio(createdInWindow, closedInWindow),
+    age: computeAgeDistribution(open, now),
+    horizon: computeHorizonCoverage(open),
+    generatedAt: now.toISOString(),
+  };
+}
+
+// Thresholds (documented so the verdict is auditable, not magic)
+const RATIO_PATHOLOGICAL = 2.0; // #953: healthy < 2:1 sustained
+const RATIO_WARNING = 1.3;
+const STALE90_SHARE_PATHOLOGICAL = 0.25;
+const STALE90_SHARE_WARNING = 0.1;
+const HORIZON_CONCENTRATION_WARNING = 0.5;
+const HORIZON_CONCENTRATION_MIN_LABELED = 4; // ignore concentration on tiny backlogs
+
+function stale90Share(age: AgeDistribution): number {
+  return age.total > 0 ? age.stale90 / age.total : 0;
+}
+
+function horizonConcentration(horizon: HorizonCoverage): number {
+  const labeled = Object.values(horizon.byHorizon).reduce((a, b) => a + b, 0);
+  if (labeled < HORIZON_CONCENTRATION_MIN_LABELED) return 0;
+  const max = Math.max(0, ...Object.values(horizon.byHorizon));
+  return max / labeled;
+}
+
+/** Classify a report into a single health verdict. Pathological wins over warning. */
+export function classifyBacklogHealth(report: BacklogHealthReport): HealthVerdict {
+  const share90 = stale90Share(report.age);
+  if (report.ratio.ratio >= RATIO_PATHOLOGICAL || share90 >= STALE90_SHARE_PATHOLOGICAL) {
+    return 'pathological';
+  }
+  if (
+    report.ratio.ratio >= RATIO_WARNING ||
+    share90 >= STALE90_SHARE_WARNING ||
+    horizonConcentration(report.horizon) >= HORIZON_CONCENTRATION_WARNING
+  ) {
+    return 'warning';
+  }
+  return 'healthy';
+}
+
+// GitHub fetch layer (thin; reuses the shared argv-based gh helper)
+
+interface GhOpenIssue {
+  number: number;
+  createdAt: string;
+  updatedAt: string;
+  labels: { name: string }[];
+}
+
+export function fetchOpenIssues(repo: string): OpenIssue[] {
+  const raw = gh(
+    ['issue', 'list', '--repo', repo, '--state', 'open', '--limit', '500',
+      '--json', 'number,createdAt,updatedAt,labels'],
+    60_000,
+  );
+  const issues: GhOpenIssue[] = JSON.parse(raw);
+  return issues.map((i) => ({
+    number: i.number,
+    createdAt: i.createdAt,
+    updatedAt: i.updatedAt,
+    labels: i.labels.map((l) => l.name),
+  }));
+}
+
+export function fetchClosedInWindow(repo: string, windowDays: number, now: Date): ClosedIssue[] {
+  const since = new Date(now.getTime() - windowDays * DAY_MS).toISOString().slice(0, 10);
+  const raw = gh(
+    ['issue', 'list', '--repo', repo, '--state', 'closed', '--limit', '500',
+      '--search', `closed:>=${since}`, '--json', 'number,closedAt'],
+    60_000,
+  );
+  const issues: { number: number; closedAt: string }[] = JSON.parse(raw);
+  return issues.map((i) => ({ number: i.number, closedAt: i.closedAt }));
+}
+
+// Reporting
+
+export function formatReport(report: BacklogHealthReport, verdict: HealthVerdict): string {
+  const lines: string[] = [];
+  lines.push(`Backlog health — ${report.repo ?? '(repo)'} — ${verdict.toUpperCase()}`);
+  lines.push(`  generated: ${report.generatedAt}  window: ${report.windowDays}d`);
+  lines.push(`  open issues: ${report.totalOpen}`);
+  lines.push(
+    `  creation/closure (window): created ${report.ratio.created} / closed ${report.ratio.closed} = ${report.ratio.ratio.toFixed(2)}:1`,
+  );
+  lines.push(
+    `  inactivity: >30d ${report.age.stale30}  >60d ${report.age.stale60}  >90d ${report.age.stale90}`,
+  );
+  const horizons = Object.entries(report.horizon.byHorizon)
+    .sort((a, b) => b[1] - a[1])
+    .map(([h, n]) => `${h}=${n}`)
+    .join('  ');
+  lines.push(`  horizons (${report.horizon.distinctHorizons} distinct, ${report.horizon.noHorizon} unlabeled): ${horizons || '(none)'}`);
+  return lines.join('\n');
+}
+
+// CLI
+
+interface CliArgs {
+  repo: string;
+  window: number;
+  json: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { repo: 'Garsson-io/kaizen', window: 30, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--repo') args.repo = argv[++i];
+    else if (a === '--window') args.window = Number(argv[++i]);
+    else if (a === '--json') args.json = true;
+  }
+  return args;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const now = new Date();
+  const open = fetchOpenIssues(args.repo);
+  const closed = fetchClosedInWindow(args.repo, args.window, now);
+  const report = buildBacklogHealthReport(open, closed, now, args.window, args.repo);
+  const verdict = classifyBacklogHealth(report);
+
+  if (args.json) {
+    console.log(JSON.stringify({ ...report, verdict }, null, 2));
+  } else {
+    console.log(formatReport(report, verdict));
+  }
+
+  // Bind the verdict to a signal so it is not decorative (#1227).
+  if (verdict === 'pathological') process.exitCode = 1;
+}
+
+// Only run when invoked directly, not when imported by tests.
+const invokedDirectly = process.argv[1]?.endsWith('backlog-health.ts');
+if (invokedDirectly) main();


### PR DESCRIPTION
## The problem

Epic #953 (Issue Metabolism) sits at maturity **L0** — *"no tracking, no awareness."* The system can triage a single stale issue (`scripts/staleness-audit.ts`) and triage stale PRs (`scripts/stale-pr-triage.ts`), but nothing answered the aggregate question #953 and #728 actually pose: **is the backlog as a whole healthy or pathological?** #728 observed 257 open issues with no way to quantify the trend; #951's Definition of Done lists a "backlog health metric" as a required item that was never built.

## The discovery

The closest existing surface — `scripts/batch-summary.ts` — reports the horizon distribution of issues *picked in a batch*. That is run telemetry, not the standing health of the GitHub backlog. The aggregate metric across #953's axes was a genuine gap, not a duplicate.

## The solution

`scripts/backlog-health.ts` computes the exact axes #953 names, with a **pure-function core** so the math is unit-testable without GitHub:

- `computeAgeDistribution` — open issues with no activity for >30 / >60 / >90 days (nested buckets, keyed on `updatedAt`).
- `computeHorizonCoverage` — distribution across `horizon/*` labels + unlabeled count + concentration.
- `computeCreationClosureRatio` — created/closed over a trailing window, divide-by-zero guarded.
- `buildBacklogHealthReport` + `classifyBacklogHealth` — assemble the axes and return one verdict (`healthy`/`warning`/`pathological`) from documented thresholds.

A thin fetch layer reuses the shared argv-based `gh()` helper from `src/lib/gh-exec.ts` (the DRY-preferred path, not raw `execSync`). The CLI exposes `--repo`/`--window`/`--json`, and **the verdict is bound to the process exit code** (pathological → exit 1) so it is a signal that can gate CI or a batch run — not a decorative number (the #1227 computed-but-not-bound lesson).

## The evidence

- **18 unit tests** (`scripts/backlog-health.test.ts`) cover age bucketing, horizon coverage + concentration (including the `MIN_LABELED` tiny-backlog suppression), the ratio div-zero guard, all three verdicts (including the OR-branch where staleness alone drives *pathological* and the >90d warning stale-band), the created-and-closed-in-window numerator (the bias fix), the ratio→verdict integration seam, and `parseArgs` validation. All green.
- **Live smoke run** against `Garsson-io/kaizen`: 396 open, **291 stale >90d (73%)**, creation/closure **1.08:1** (217 created / 201 closed in 30d) → verdict **PATHOLOGICAL**, exit code 1. This quantifies #728's concern for the first time. (An earlier pre-fix run reported a misleading 0.28:1 because the numerator only counted still-open issues — see the review fix below.)
- `npx tsc --noEmit` clean.

> Round-1 review (independent, adversarial) found three MAJOR correctness issues — a biased ratio numerator (counted only open issues), a silent 500-issue fetch cap, and unvalidated CLI args. All fixed in-round and verified; the bias fix alone moved the live ratio from 0.28:1 to an accurate 1.08:1.

### Behaviors × levels
| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Age bucketing by `updatedAt` | ✅ | — | — | — | — |
| Horizon coverage + concentration | ✅ | — | — | — | — |
| Creation/closure ratio (all-states numerator, div-zero guard) | ✅ | ✅ | — | — | — |
| Health verdict thresholds (all 3) | ✅ | — | — | — | — |
| Verdict bound to CLI exit code | ✅ | — | manual smoke run | — | — |
| CLI arg validation | ✅ | — | — | — | — |

## The impact

Epic #953 moves from **L0 → L1** ("metrics exist but require manual inspection"). `/kaizen-audit-issues` now opens with this quantitative verdict (Step 0) before its manual drill-downs, giving the auditor a single number to act on. Deferred to #951 and explicitly out of scope here: the pre-file dedup creation gate, a `/kaizen-triage` skill, and wiring into the auto-dent batch summary.

Closes #1493
Parent: #953
Refs: #951, #728

Run tag: back-cardinal/run-2