### PR TITLE
refactor(auto-dent): share Codex stream contract

### DIFF
--- a/scripts/auto-dent-codex.test.ts
+++ b/scripts/auto-dent-codex.test.ts
@@ -4,7 +4,11 @@ import {
   buildCodexExecArgs,
   parseCodexJsonl,
   extractCodexPhaseMarkers,
+  normalizeCodexEventToStreamMessages,
+  normalizeCodexFinalTextToStreamMessages,
 } from './auto-dent-codex.js';
+import { processStreamMessage } from './auto-dent-stream.js';
+import { makeRunResult } from './auto-dent-test-helpers.js';
 
 describe('buildCodexExecArgs (#1144)', () => {
   it('constructs codex exec argv for externally sandboxed synthetic runs', () => {
@@ -116,5 +120,87 @@ describe('parseCodexJsonl (#1144)', () => {
       'AUTO_DENT_PHASE: IMPLEMENT | case=synthetic',
       'AUTO_DENT_PHASE: PR | url=https://example.test/pull/1',
     ]);
+  });
+});
+
+describe('normalizeCodexEventToStreamMessages (#1488)', () => {
+  it('turns Codex agent messages into canonical assistant text messages', () => {
+    const messages = normalizeCodexEventToStreamMessages({
+      type: 'item.completed',
+      item: {
+        type: 'agent_message',
+        text: 'AUTO_DENT_PHASE: PICK | issue=#1488 | title=Codex stream contract',
+      },
+    });
+
+    const result = makeRunResult();
+    for (const message of messages) {
+      processStreamMessage(message, result, Date.now());
+    }
+
+    expect(result.pickedIssue).toBe('#1488');
+    expect(result.pickedIssueTitle).toBe('Codex stream contract');
+  });
+
+  it('turns Codex command executions into shared tool-use and tool-result messages', () => {
+    const messages = normalizeCodexEventToStreamMessages({
+      type: 'item.completed',
+      item: {
+        type: 'command_execution',
+        command: 'gh pr create',
+        aggregated_output: 'https://github.com/Garsson-io/kaizen/pull/1499\n',
+        exit_code: 0,
+        status: 'completed',
+      },
+    });
+
+    const result = makeRunResult();
+    const ctx = {};
+    for (const message of messages) {
+      processStreamMessage(message, result, Date.now(), ctx);
+    }
+
+    expect(result.toolCalls).toBe(1);
+    expect(result.prs).toEqual(['https://github.com/Garsson-io/kaizen/pull/1499']);
+    expect(ctx).toMatchObject({ lastActivity: expect.stringContaining('gh pr create') });
+  });
+
+  it('turns Codex final messages into canonical result messages for final claim parsing', () => {
+    const claim = {
+      schema_version: 1,
+      selected_issue: '#1488',
+      case_worktree: '260628-k1488-codex-stream-contract',
+      tests: { status: 'pass', command: 'npm test', count: 3, evidence: ['3 passed'] },
+      pr_url: 'https://github.com/Garsson-io/kaizen/pull/1499',
+      review_status: 'pass',
+      reflection_status: 'done',
+      stop_reason: null,
+      blockers: [],
+    };
+
+    const messages = normalizeCodexEventToStreamMessages({
+      type: 'final_message',
+      message: JSON.stringify(claim),
+    });
+
+    const result = makeRunResult();
+    for (const message of messages) {
+      processStreamMessage(message, result, Date.now());
+    }
+
+    expect(result.finalClaimStatus).toBe('valid');
+    expect(result.finalClaim?.selected_issue).toBe('#1488');
+  });
+
+  it('preserves parsed final-text fallback through the canonical result path', () => {
+    const result = makeRunResult();
+    for (const message of normalizeCodexFinalTextToStreamMessages('AUTO_DENT_PHASE: TEST | result=pass | count=3')) {
+      processStreamMessage(message, result, Date.now());
+    }
+
+    expect(result.progressSteps?.find((s) => s.phase === 'TEST')).toMatchObject({
+      state: 'pass',
+      detail: '3 tests',
+    });
   });
 });

--- a/scripts/auto-dent-codex.ts
+++ b/scripts/auto-dent-codex.ts
@@ -15,6 +15,8 @@ export interface ParsedCodexJsonl {
   malformedLines: string[];
 }
 
+export type AutoDentStreamMessage = Record<string, any>;
+
 export function buildCodexExecArgs(repoRoot: string): string[] {
   return [
     'exec',
@@ -50,6 +52,100 @@ function isFinalEvent(event: unknown): boolean {
   if (!event || typeof event !== 'object') return false;
   const type = String((event as Record<string, unknown>).type ?? '').toLowerCase();
   return type.includes('final') || type === 'result';
+}
+
+function textFrom(value: unknown): string {
+  const chunks: string[] = [];
+  collectText(value, chunks);
+  return chunks.join('\n');
+}
+
+function assistantText(text: string): AutoDentStreamMessage {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'text', text }],
+    },
+  };
+}
+
+function resultText(text: string): AutoDentStreamMessage {
+  return {
+    type: 'result',
+    subtype: 'success',
+    result: text,
+  };
+}
+
+export function normalizeCodexFinalTextToStreamMessages(text: string): AutoDentStreamMessage[] {
+  return text ? [resultText(text)] : [];
+}
+
+function extractPullRequestUrl(text: string): string | undefined {
+  return text.match(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/)?.[0];
+}
+
+/**
+ * Normalize provider-specific Codex JSONL rows into the same stream-json shape
+ * that `processStreamMessage()` already consumes for Claude.
+ */
+export function normalizeCodexEventToStreamMessages(event: unknown): AutoDentStreamMessage[] {
+  if (!event || typeof event !== 'object') return [];
+
+  const obj = event as Record<string, unknown>;
+  const item = obj.item;
+  if (item && typeof item === 'object') {
+    const itemObj = item as Record<string, unknown>;
+    if (itemObj.type === 'agent_message') {
+      const text = textFrom(itemObj.text);
+      return text ? [assistantText(text)] : [];
+    }
+
+    if (itemObj.type === 'command_execution') {
+      const messages: AutoDentStreamMessage[] = [];
+      const command = typeof itemObj.command === 'string' ? itemObj.command : '';
+      if (command) {
+        messages.push({
+          type: 'assistant',
+          message: {
+            content: [{
+              type: 'tool_use',
+              name: 'Bash',
+              input: { command },
+            }],
+          },
+        });
+      }
+
+      const output = textFrom(itemObj.aggregated_output ?? itemObj.output);
+      if (output) {
+        const toolResult: AutoDentStreamMessage = {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', content: output }],
+          },
+        };
+        const prUrl = extractPullRequestUrl(output);
+        if (prUrl) {
+          toolResult.tool_use_result = {
+            gitOperation: {
+              pr: {
+                action: 'created',
+                url: prUrl,
+              },
+            },
+          };
+        }
+        messages.push(toolResult);
+      }
+
+      return messages;
+    }
+  }
+
+  if (!isFinalEvent(event)) return [];
+  const text = textFrom(event);
+  return normalizeCodexFinalTextToStreamMessages(text);
 }
 
 export function parseCodexJsonl(jsonl: string): ParsedCodexJsonl {

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -3226,6 +3226,17 @@ describe('runOnce stream-json line parsing', () => {
     expect(parserSection).toContain('parseJsonObject');
     expect(parserSection).not.toContain('JSON.parse(line)');
   });
+
+  it('routes Codex JSONL rows through normalized shared stream messages (#1488)', () => {
+    const source = readFileSync(new URL('./auto-dent-run.ts', import.meta.url), 'utf-8');
+    const runCodexStart = source.indexOf('async function runCodex');
+    const runCodexEnd = source.indexOf('// Execute one run', runCodexStart);
+    const runCodexSection = source.slice(runCodexStart, runCodexEnd);
+
+    expect(runCodexSection).toContain('normalizeCodexEventToStreamMessages');
+    expect(runCodexSection).toContain('processStreamMessage(streamMessage');
+    expect(runCodexSection).not.toContain('extractArtifacts([parsed.text, parsed.finalText]');
+  });
 });
 
 describe('findExistingProgressIssue', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -151,7 +151,6 @@ import {
 } from './auto-dent-github.js';
 import {
   color,
-  extractArtifacts,
   processStreamMessage,
   parsePhaseMarkers,
   postInFlightUpdate,
@@ -162,12 +161,13 @@ import {
 import {
   buildCodexExecArgs,
   extractCodexPhaseMarkers,
+  normalizeCodexEventToStreamMessages,
+  normalizeCodexFinalTextToStreamMessages,
   parseCodexJsonl,
 } from './auto-dent-codex.js';
 import {
   compareFinalClaimToEvidence,
   foldFinalClaimWarningsIntoProcess,
-  parseFinalRunClaim,
   writeFinalClaimArtifact,
   type FinalClaimStatus,
   type FinalRunClaim,
@@ -1562,6 +1562,7 @@ async function runCodex(
   return new Promise((resolvePromise) => {
     let processExited = false;
     let raw = '';
+    const ctx: StreamContext = {};
     const child = spawn('codex', buildCodexExecArgs(input.repoRoot), {
       cwd: input.repoRoot,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -1580,10 +1581,21 @@ async function runCodex(
       }
     }, maxRunMs);
 
-    child.stdout?.on('data', (data: Buffer) => {
-      const s = data.toString();
-      raw += s;
-      appendFileSync(rawFile, s);
+    const rl = createInterface({ input: child.stdout! });
+    rl.on('line', (line) => {
+      raw += line + '\n';
+      appendFileSync(rawFile, line + '\n');
+
+      const event = parseJsonObject(line);
+      if (!event) return;
+
+      try {
+        for (const streamMessage of normalizeCodexEventToStreamMessages(event)) {
+          processStreamMessage(streamMessage, input.result, runStart, ctx);
+        }
+      } catch {
+        // Raw JSONL remains durable; a malformed display row should not hide run completion.
+      }
     });
 
     child.stderr?.on('data', (data: Buffer) => {
@@ -1595,8 +1607,11 @@ async function runCodex(
       processExited = true;
       clearTimeout(wallTimer);
       const parsed = parseCodexJsonl(raw);
-      input.result.toolCalls = parsed.events.length;
-      extractArtifacts([parsed.text, parsed.finalText].join('\n'), input.result);
+      if (!input.result.finalClaimStatus && parsed.finalText) {
+        for (const streamMessage of normalizeCodexFinalTextToStreamMessages(parsed.finalText)) {
+          processStreamMessage(streamMessage, input.result, runStart, ctx);
+        }
+      }
 
       appendFileSync(input.logFile, `\n--- codex final text ---\n${parsed.finalText || parsed.text}\n`);
       const markers = extractCodexPhaseMarkers(parsed);
@@ -1606,10 +1621,6 @@ async function runCodex(
       if (parsed.malformedLines.length > 0) {
         appendFileSync(input.logFile, `\n[codex] malformed_jsonl_lines=${parsed.malformedLines.length}\n`);
       }
-      const claimResult = parseFinalRunClaim(parsed.finalText || parsed.text);
-      input.result.finalClaimStatus = claimResult.status;
-      input.result.finalClaim = claimResult.claim;
-      input.result.finalClaimWarnings = claimResult.warnings;
 
       const duration = Math.floor((Date.now() - runStart) / 1000);
       resolvePromise({


### PR DESCRIPTION
Once upon a time, Claude-backed auto-dent runs had a live stream contract: stream-json rows flowed through `processStreamMessage()`, which owned phase markers, PR extraction, progress rows, final claims, and terminal activity.

Every day, Codex-backed runs preserved rich JSONL, but they used a separate runtime path: append raw rows during execution, then fold `parsed.text`/`parsed.finalText` into artifacts after exit. One day, #1488 called out that this was not just missing output; it was a competing provider contract blocking Claude/Codex parity.

Because of that, this PR adds a pure Codex-to-stream adapter. Codex `agent_message`, `command_execution`, and final/result rows now normalize into the same assistant/user/result message shapes that Claude already feeds to `processStreamMessage()`.

Because of that, `runCodex()` now streams each parsed JSONL row through the shared processor as it arrives. Post-exit parsing remains only for raw-log summaries, lifecycle marker display, malformed-line accounting, and final-text fallback through the same result-message path.

Until finally, the focused Codex/run-loop test suite proves phase markers, PR URL extraction, command activity, final claims, and the source invariant all go through the shared stream boundary.

Run tag: fuzzy-hoverfly/run-1

Closes #1488
Parent: #1482
Related: #1208

## Architecture

```
Codex JSONL row
  -> normalizeCodexEventToStreamMessages()
  -> processStreamMessage()
  -> RunResult + progress steps + terminal output + final claim parsing

post-exit parseCodexJsonl()
  -> log summaries / malformed-row accounting
  -> normalizeCodexFinalTextToStreamMessages() only when no explicit final result was seen
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep provider-specific normalization in `auto-dent-codex.ts` | Prevents Codex raw schema branches from leaking into `auto-dent-stream.ts` | Adapter must track supported Codex row shapes |
| Map Codex PR output to Claude-style `tool_use_result.gitOperation.pr` | Reuses existing PR extraction instead of adding a second bare-URL parser | Only PR-looking command output gets metadata |
| Preserve final-text fallback via canonical result messages | Keeps old `parseCodexJsonl()` behavior for runs without explicit final events | A last agent message may also be processed as a final result, matching old final-text semantics |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-codex.ts` | Adds Codex row/final-text normalization into canonical stream messages |
| `scripts/auto-dent-run.ts` | Feeds Codex stdout rows through `processStreamMessage()` live and removes Codex-only artifact/final-claim parsing |
| `scripts/auto-dent-codex.test.ts` | Covers agent messages, command executions, PR metadata, final claims, and final-text fallback |
| `scripts/auto-dent-run.test.ts` | Adds source invariant that Codex run loop delegates to shared stream messages |

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Codex `agent_message` rows become canonical assistant text messages | tested in `scripts/auto-dent-codex.test.ts` | not needed | not needed | not needed | not needed |
| Codex `command_execution` rows become shared tool-use/tool-result messages | tested in `scripts/auto-dent-codex.test.ts` | not needed | not needed | not needed | not needed |
| Codex final/result rows use canonical result messages for final claim parsing | tested in `scripts/auto-dent-codex.test.ts` | not needed | not needed | not needed | not needed |
| Codex run loop delegates normalized rows to `processStreamMessage()` | source invariant in `scripts/auto-dent-run.test.ts` | tested | not needed | not needed | not needed |

## Validation

- `npx vitest run scripts/auto-dent-codex.test.ts scripts/auto-dent-run.test.ts` — 322 tests passed
- `npm run build` — passed
- `npx vitest run src/e2e/synthetic-workflow.test.ts src/hooks/kaizen-reflect.test.ts` — 35 tests passed
- `npm test` — ran twice; both full-suite runs hit the same two unrelated 10s timeout failures under concurrency in `src/e2e/synthetic-workflow.test.ts` and `src/hooks/kaizen-reflect.test.ts`; those exact files passed in isolation
