### PR TITLE
fix(auto-dent): gate auto-merge on verdicts

### DIFF
--- a/.agents/kaizen/docs/hook-catalog.md
+++ b/.agents/kaizen/docs/hook-catalog.md
@@ -24,6 +24,7 @@ Computer-level installation (`kaizen@kaizen` in `~/.claude/settings.json`) is **
 | Hook | Level | Blocking | Purpose |
 |------|-------|----------|---------|
 | `kaizen-enforce-pr-review-ts.sh` → `enforce-pr-review.ts` | L3 | Yes (deny) | **Gate**: Blocks Bash commands when PR review is pending (`needs_review` state). Issue #775. |
+| `kaizen-enforce-merge-verdict-ts.sh` → `enforce-merge-verdict.ts` | L2/L3 | Yes (deny) | **Gate**: Blocks direct `gh pr merge` when the latest stored review round derives `FAIL`; explicit override is traced. Issue #1220. |
 | `kaizen-enforce-case-worktree.sh` | L1 | No (advisory) | Warns on `git commit`/`push` outside a worktree. |
 | `kaizen-pr-quality-checks-ts.sh` → `pr-quality-checks.ts` | L1 | No (advisory) | Consolidated PR quality advisories: test coverage (#8), verification (#10), code quality (#89), practices (#210). Consolidation #800. |
 | `kaizen-check-dirty-files-ts.sh` → `check-dirty-files.ts` | L3 | Yes (deny on PR create) / Warn (push/merge) | Dirty file check. Push downgraded to warn. Skips during merge. Issue #775. |
@@ -89,6 +90,7 @@ All enforcement hooks are now in TypeScript. Each `-ts.sh` shim is a thin bash w
 | `pr-kaizen-clear-ts.sh` | `src/hooks/pr-kaizen-clear.ts` | 84 |
 | `kaizen-stop-gate.sh` | `src/hooks/stop-gate.ts` + `src/hooks/lib/gate-manager.ts` | 21 |
 | `kaizen-enforce-pr-review-ts.sh` | `src/hooks/enforce-pr-review.ts` | 6 |
+| `kaizen-enforce-merge-verdict-ts.sh` | `src/hooks/enforce-merge-verdict.ts` | 16 |
 | `kaizen-enforce-pr-reflect-ts.sh` | `src/hooks/enforce-pr-reflect.ts` | 8 |
 | `kaizen-check-dirty-files-ts.sh` | `src/hooks/check-dirty-files.ts` | 13 |
 | `kaizen-bump-plugin-version-ts.sh` | `src/hooks/bump-plugin-version.ts` | 5 |

--- a/.agents/kaizen/docs/hook-design-principles.md
+++ b/.agents/kaizen/docs/hook-design-principles.md
@@ -58,17 +58,20 @@ Every arrow is enforced by hooks. The agent cannot skip steps — hooks block to
 
 ## Merge Workflow (Autonomous)
 
-Branch protection has `strict: true` status checks. Auto-merge is enabled. The agent handles the full merge loop:
+Branch protection has `strict: true` status checks. Auto-merge is enabled. Modern kaizen runs split merge ownership by context:
 
-1. **Queue**: `gh pr merge <url> --repo Garsson-io/kaizen --squash --delete-branch --auto`
-2. **Wait**: `gh pr checks <url> --repo Garsson-io/kaizen --watch` or `gh run watch <id>`
-3. **Verify**: `gh pr view <url> --json state --jq .state` → expect `MERGED`
-4. **Sync**: `MAIN_CHECKOUT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"; git -C "$MAIN_CHECKOUT" fetch origin main && git -C "$MAIN_CHECKOUT" merge origin/main --no-edit`
+1. **Auto-dent/headless queue**: the harness, not the worker prompt, queues merge only after review/process/lifecycle verdicts pass. If a verdict is unsafe, it blocks queueing and disables any existing auto-merge request.
+2. **Interactive direct merge**: `kaizen-enforce-merge-verdict-ts.sh` checks direct `gh pr merge` commands against the latest stored review round. A derived `FAIL` denies the merge unless `KAIZEN_ALLOW_MERGE_ON_FAIL=1` is set; that override is traced with PR, repo, and verdict.
+3. **L3 repo backstop**: branch protection should require `Review verdict gate / Review verdict gate`, which fails when the latest stored review round derives `FAIL`.
+4. **Wait**: `gh pr checks <url> --repo Garsson-io/kaizen --watch` or `gh run watch <id>`
+5. **Verify**: `gh pr view <url> --json state --jq .state` → expect `MERGED`
+6. **Sync**: `MAIN_CHECKOUT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"; git -C "$MAIN_CHECKOUT" fetch origin main && git -C "$MAIN_CHECKOUT" merge origin/main --no-edit`
 
 **Failure handling** (agent does this autonomously, no human needed):
 - **CI fails**: fix the issue, commit, push. Auto-merge stays queued, CI re-runs.
 - **Branch behind main**: `git fetch origin main && git merge origin/main --no-edit && git push`. CI re-runs, auto-merge retries.
 - **Auto-merge not completing**: check `gh pr view --json mergeStateStatus` and fix.
+- **Review verdict gate fails**: fix findings and store a new review round summary. Do not bypass unless a human explicitly sets `KAIZEN_ALLOW_MERGE_ON_FAIL=1` for a direct merge and accepts the traced override.
 
 **Do NOT ask the user** for merge issues — handle them. Only escalate after multiple failed retries with different root causes.
 

--- a/.agents/kaizen/docs/hook-design-principles.md
+++ b/.agents/kaizen/docs/hook-design-principles.md
@@ -1,6 +1,6 @@
 # Autonomous Guardrailed Dev Workflow
 
-How Kaizen dev agents work autonomously with quality enforcement at every step. The agent completes the full cycle — worktree, code, test, PR, review, merge, sync — without human intervention. Hooks enforce quality gates that the agent cannot bypass.
+How Kaizen dev agents work autonomously with quality enforcement at every step. The agent completes the full cycle — worktree, code, test, PR, review, gated merge, sync — without human intervention. Hooks and required checks enforce quality gates that the agent cannot bypass.
 
 ## The Full Dev Cycle
 
@@ -28,8 +28,8 @@ PR Creation (gh pr create)
   │  ─── agent is FORCED to run gh pr diff and complete review ───
   │  Up to 4 rounds of review. If issues remain → escalate to human.
   ▼
-Merge (autonomous)
-  │  gh pr merge --auto --squash --delete-branch
+Merge (gated)
+  │  Auto-dent harness queues only after verdicts pass, or direct merge hook checks stored verdict
   │  Wait for CI (gh run watch / gh pr checks --watch)
   │  Verify state=MERGED
   │  If CI fails → fix, push (auto-merge retries automatically)

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -63,6 +63,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/kaizen-enforce-case-worktree.sh",
             "timeout": 10
           },

--- a/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh
+++ b/.claude/hooks/kaizen-enforce-merge-verdict-ts.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# TS hook shim — enforce direct merge verdict binding (#1220).
+
+source "$(dirname "$0")/lib/scope-guard.sh"
+source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
+run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/enforce-merge-verdict.ts"

--- a/.github/workflows/review-verdict-gate.yml
+++ b/.github/workflows/review-verdict-gate.yml
@@ -1,0 +1,35 @@
+name: Review verdict gate
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number
+        required: true
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: review-verdict-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review-verdict:
+    name: Review verdict gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Check latest stored review verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+        run: npx tsx scripts/review-verdict-status.ts --repo "$GITHUB_REPOSITORY" --pr "$PR_NUMBER"

--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -16,7 +16,7 @@ auto-dent.sh (compatibility wrapper)
               ├── spawns claude with --output-format stream-json
               ├── parses real-time milestones (PRs, issues, costs)
               ├── posts per-run comments to batch progress issue
-              ├── queues auto-merge as safety net
+              ├── queues or blocks auto-merge based on review/process verdicts
               └── writes results back to state.json
 
 auto-dent-ctl.ts (control plane)
@@ -47,7 +47,7 @@ All cross-run state lives in `logs/auto-dent/<batch-id>/state.json`. Key fields:
 | `stop_reason` | string | Why the batch stopped (empty while running) |
 | `progress_issue` | string | GitHub issue URL for batch progress tracking |
 | `run_history` | RunMetrics[] | Per-run duration, cost, tool calls, exit code |
-| `review_verdict` | `"pass"\|"fail"\|"error"\|"skipped"` per run | Advisory requirements review verdict for the PR produced by this run |
+| `review_verdict` | `"pass"\|"fail"\|"error"\|"skipped"` per run | Requirements review verdict for the PR produced by this run; `"fail"` blocks auto-merge |
 | `review_cost_usd` | number per run | Cost of the requirements review for this run (typically $0.10–0.20) |
 
 ### Prompt Templates
@@ -185,9 +185,9 @@ jq '.run_history[] | {run, exit_code, duration_seconds, cost_usd, prs}' logs/aut
 jq '.run_history[] | {run, review_verdict, review_cost_usd}' logs/auto-dent/<batch-id>/state.json
 ```
 
-`review_verdict` is advisory — a `"fail"` does not stop the run. But a high fail rate (>30% across a batch) signals that PRs are closing issues in name only. Investigate the specific runs where verdict is `"fail"` to find systemic gaps.
+`review_verdict="fail"` blocks auto-merge for the run's PRs and disables any existing auto-merge request. A high fail rate (>30% across a batch) still signals that PRs are closing issues in name only. Investigate the specific runs where verdict is `"fail"` to find systemic gaps.
 
-If `review_verdict` is `"error"` or `"skipped"`, the review could not complete (rate limit, timeout, or no PR in that run). These are expected for runs that produce no PR.
+If `review_verdict` is `"error"` or `"skipped"`, the review could not complete (rate limit, timeout, or no PR in that run). These are expected for runs that produce no PR. For PR-producing normal runs, skipped or missing required review also blocks auto-merge.
 
 ### 4. Read the failing run's log
 ```bash
@@ -206,16 +206,22 @@ less logs/auto-dent/<batch-id>/run-N.log
 | Same issue retry | Consecutive failures on same issue | Issue is blocked or broken | Add to exclusion list |
 | OOM / timeout | Run exits with signal 9 or timeout | Agent spawned heavy subprocess | Check for vitest/tsc in hooks (#474) |
 | Hook deadlock | Run hangs indefinitely | Merge conflict markers in hooks | Check `.claude/hooks/` for conflict markers |
-| Auto-merge failure | PRs created but not merged | Branch protection rules | Check repo settings, CI status |
+| Auto-merge blocked | PRs created but not merged | Review/process/lifecycle verdict did not pass | Fix findings, re-run review, or use explicit human override |
+| Auto-merge failure | PRs created but not merged | Branch protection rules or failed `gh pr merge --auto/--disable-auto` | Check repo settings, CI status, and `auto_merge_*_failed` log lines |
 
 ## Post-Batch Hygiene
 
 After a batch completes:
 
-1. **PRs** — The harness queues auto-merge. Check for any stuck PRs:
+1. **PRs** — The harness queues auto-merge only after the review/process/lifecycle gates allow it. Check for any stuck or blocked PRs:
    ```bash
    gh pr list --repo Garsson-io/kaizen --label auto-dent --state open
    ```
+
+   Repositories that want a non-Claude backstop should mark the GitHub Actions
+   check `Review verdict gate / Review verdict gate` as required in branch
+   protection. That check reads the same stored review verdict as the merge hook
+   and fails when the latest round derives `FAIL`.
 
 2. **Worktrees** — Runs create worktrees that should be cleaned up on merge. Check for stale ones:
    ```bash

--- a/docs/review-battery-session-report.md
+++ b/docs/review-battery-session-report.md
@@ -75,7 +75,7 @@ Features:
 - Posted as a PR comment (best effort)
 - Recorded as `review_verdict` and `review_cost_usd` fields on the `RunCompleteEvent` in events.jsonl
 
-The review is **advisory, not blocking**. A failing review does not prevent merge. This is a v1 design decision -- the signal needs more validation before it should block.
+The original v1 review was advisory. Current auto-dent runs consume the verdict as a merge gate: a failing required review blocks auto-merge and disables any existing auto-merge request. Direct interactive `gh pr merge` commands are also guarded by the stored round verdict, with an explicit `KAIZEN_ALLOW_MERGE_ON_FAIL=1` human override.
 
 **kaizen-evaluate** (Phase 5.5): After plan formulation, agents run the plan-coverage review battery via the Agent tool. MISSING findings must be fixed before presenting the plan to the admin; PARTIAL findings are reviewed for intentional scope reductions.
 
@@ -213,12 +213,7 @@ Currently, review cost is tracked in events.jsonl (`review_cost_usd`) but not in
 
 ### Should failed reviews block merge in auto-dent?
 
-Currently the review is advisory. A failing review is logged, posted as a comment, and recorded in events -- but the PR still gets merged if it passes CI and code review. Making it blocking would require:
-1. Higher confidence in the 0% FP rate (27 findings is a small sample)
-2. A mechanism for human override (not all gaps are bugs -- some are intentional scope reductions)
-3. Integration with the auto-dent merge flow (currently `queueAutoMerge` doesn't check review results)
-
-The conservative approach: keep advisory for 2-3 more batches, measure FP rate, then decide.
+This has moved from advisory to binding for merge paths controlled by kaizen. Auto-dent blocks unsafe auto-merge queueing, direct `gh pr merge` is denied when the latest stored round derives `FAIL`, and the `Review verdict gate` GitHub Actions check can be marked required in branch protection for a non-Claude backstop. Human override remains explicit through `KAIZEN_ALLOW_MERGE_ON_FAIL=1`.
 
 ### Expanding review dimensions
 

--- a/docs/security/credential-inventory.md
+++ b/docs/security/credential-inventory.md
@@ -24,7 +24,7 @@ Kaizen is a Claude Code plugin — it runs inside the user's Claude Code session
 | **Read** | `gh pr view`, `gh issue view`, `gh pr diff`, `gh pr list`, `gh api repos/*/check-runs` | Most hooks and scripts |
 | **Write (issues)** | `gh issue create`, `gh issue comment`, `gh issue close`, `gh issue edit --add-label` | `auto-dent-run.ts`, `auto-dent-github.ts`, `pr-kaizen-clear.ts` |
 | **Write (PRs)** | `gh pr create`, `gh pr comment`, `gh pr edit --add-label`, `gh pr close` | `auto-dent-run.ts`, `auto-dent-github.ts` |
-| **Write (merge)** | `gh pr merge --squash --delete-branch --auto` | `auto-dent-run.ts`, `auto-dent-github.ts` |
+| **Write (merge)** | `gh pr merge --squash --delete-branch --auto`, `gh pr merge --disable-auto` | `auto-dent-run.ts`, `auto-dent-github.ts` |
 | **Write (branch)** | `gh api repos/{repo}/pulls/{n}/update-branch -X PUT` | `auto-dent-github.ts` |
 
 **Over-privilege assessment:** The token scope is controlled by the user's `gh auth` configuration, not by kaizen. Kaizen uses whatever scope is available. In auto-dent batch mode, the token needs full `repo` write access. For interactive sessions, read-only would suffice for most hooks but write is needed for reflection (filing issues, commenting on PRs).

--- a/prompts/deep-dive-default.md
+++ b/prompts/deep-dive-default.md
@@ -64,14 +64,13 @@ already resolved, skip it and pick from the backlog as usual.
 
 After creating a PR, you MUST:
 
-1. Queue it for auto-merge:
-     gh pr merge <url> --repo {{host_repo}} --squash --delete-branch --auto
-   Do NOT leave PRs open for manual review — this is an unattended batch.
-   The harness will also attempt auto-merge as a safety net, but do it yourself first.
+1. Leave merge commands to the harness.
+   The auto-dent harness queues auto-merge after review verdicts and process evidence are known.
+   Do NOT run merge commands yourself; the harness owns the terminal action.
 
 2. Explicitly close every issue this PR fixes:
      gh issue close <num> --repo {{host_repo}}
-   Do this immediately after queueing auto-merge — do NOT rely on "Closes #N"
+   Do this after creating the PR — do NOT rely on "Closes #N"
    keywords in the PR body, because GitHub only auto-closes issues that way
    when the PR targets the repository's default branch. Explicit close always works.
 
@@ -131,7 +130,7 @@ Phases and their expected keys:
 | IMPLEMENT | Starting implementation | case=<case-id>, branch=<branch-name> |
 | TEST | After running tests | result=<pass/fail>, count=<number of tests> |
 | PR | After creating a PR | url=<PR URL> |
-| MERGE | After queuing auto-merge | url=<PR URL>, status=<queued/merged> |
+| MERGE | After the harness reports merge status | url=<PR URL>, status=<queued/merged/blocked> |
 | DECOMPOSE | After breaking down an epic/PRD | epic=<#NNN>, issues_created=<#X,#Y,#Z> |
 | REFLECT | After reflection | issues_filed=<N>, issues_closed=<#A,#B,...>, lessons=<short summary> |
 
@@ -141,7 +140,7 @@ Example:
   AUTO_DENT_PHASE: IMPLEMENT | case=260323-1200-k472 | branch=case/260323-1200-k472
   AUTO_DENT_PHASE: TEST | result=pass | count=15
   AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/500
-  AUTO_DENT_PHASE: MERGE | url=https://github.com/Garsson-io/kaizen/pull/500 | status=queued
+  AUTO_DENT_PHASE: MERGE | url=https://github.com/Garsson-io/kaizen/pull/500 | status=observed
   AUTO_DENT_PHASE: REFLECT | issues_filed=1 | lessons=shared helpers reduce test boilerplate
 
 Emit these naturally as you complete each phase. Missing keys are fine — emit what you have.

--- a/prompts/deep-dive-default.md
+++ b/prompts/deep-dive-default.md
@@ -140,7 +140,7 @@ Example:
   AUTO_DENT_PHASE: IMPLEMENT | case=260323-1200-k472 | branch=case/260323-1200-k472
   AUTO_DENT_PHASE: TEST | result=pass | count=15
   AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/500
-  AUTO_DENT_PHASE: MERGE | url=https://github.com/Garsson-io/kaizen/pull/500 | status=observed
+  AUTO_DENT_PHASE: MERGE | url=https://github.com/Garsson-io/kaizen/pull/500 | status=queued
   AUTO_DENT_PHASE: REFLECT | issues_filed=1 | lessons=shared helpers reduce test boilerplate
 
 Emit these naturally as you complete each phase. Missing keys are fine — emit what you have.

--- a/prompts/subtract-prune.md
+++ b/prompts/subtract-prune.md
@@ -30,8 +30,9 @@ PRs already created in this batch (avoid overlapping work): {{prs}}
 
 ## Merge & Labeling Policy
 
-After creating a PR, you MUST queue it for auto-merge:
-  gh pr merge <url> --repo {{kaizen_repo}} --squash --delete-branch --auto
+After creating a PR, do NOT run merge commands yourself.
+The auto-dent harness queues auto-merge after review verdicts and process evidence are known.
+Leave the PR open for the harness-owned terminal action.
 
 ## Subtraction Tasks
 

--- a/prompts/test-task.md
+++ b/prompts/test-task.md
@@ -13,7 +13,7 @@ Run tag: {{run_tag}}
    ```
 3. Commit with message: "test: probe {{run_tag}}"
 4. Create a PR: `gh pr create --title "test: probe {{run_tag}}" --body "Synthetic test task for pipeline validation. Run tag: {{run_tag}}" --repo {{host_repo}}`
-5. Queue auto-merge: `gh pr merge <url> --repo {{host_repo}} --squash --delete-branch --auto`
+5. Leave auto-merge to the harness after review verdicts are known
 
 Do not ask for confirmation. Complete all steps.
 
@@ -36,10 +36,9 @@ PRs already created in this batch (avoid overlapping work): {{prs}}
 
 ## Merge & Labeling Policy
 
-After creating a PR, you MUST queue it for auto-merge:
-  gh pr merge <url> --repo {{host_repo}} --squash --delete-branch --auto
-Do NOT leave PRs open for manual review — this is an unattended batch.
-The harness will also attempt auto-merge as a safety net, but do it yourself first.
+After creating a PR, do NOT run merge commands yourself.
+The auto-dent harness queues auto-merge after review verdicts and process evidence are known.
+Leave the PR open for the harness-owned terminal action.
 
 ## Stopping the Loop
 

--- a/scripts/auto-dent-github.test.ts
+++ b/scripts/auto-dent-github.test.ts
@@ -9,6 +9,7 @@ import {
   classifyMergeView,
   labelArtifacts,
   queueAutoMerge,
+  cancelAutoMerge,
   extractLinkedIssue,
   isIssueClosed,
   cleanupSupersededPRs,
@@ -476,6 +477,47 @@ describe('queueAutoMerge', () => {
     expect(cmds[0]).toContain('pr merge 1');
     expect(cmds[0]).toContain('--squash --delete-branch --auto');
     expect(cmds[1]).toContain('pr merge 2');
+  });
+
+  it('does not queue unsafe auto-merge and disables any existing auto-merge request', () => {
+    mockSpawnSync.mockReturnValue(ok('ok') as any);
+    const result = makeRunResult({
+      prs: ['https://github.com/o/r/pull/1'],
+    });
+
+    queueAutoMerge(result, 'o/r', {
+      allow: false,
+      reasons: ['review verdict fail', 'process verdict process-incomplete'],
+    });
+
+    const cmds = mockSpawnSync.mock.calls.map((c) => joinArgs(c as any));
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0]).toContain('pr merge 1');
+    expect(cmds[0]).toContain('--disable-auto');
+    expect(cmds[0]).not.toContain('--squash');
+    expect(cmds[0]).not.toContain('--delete-branch');
+  });
+});
+
+describe('cancelAutoMerge', () => {
+  beforeEach(() => {
+    mockSpawnSync.mockReset();
+  });
+
+  it('disables auto-merge for each PR', () => {
+    mockSpawnSync.mockReturnValue(ok('ok') as any);
+    const result = makeRunResult({
+      prs: ['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2'],
+    });
+
+    cancelAutoMerge(result);
+
+    const cmds = mockSpawnSync.mock.calls.map((c) => joinArgs(c as any));
+    expect(cmds).toHaveLength(2);
+    expect(cmds[0]).toContain('pr merge 1');
+    expect(cmds[0]).toContain('--disable-auto');
+    expect(cmds[1]).toContain('pr merge 2');
+    expect(cmds[1]).toContain('--disable-auto');
   });
 });
 

--- a/scripts/auto-dent-github.test.ts
+++ b/scripts/auto-dent-github.test.ts
@@ -470,9 +470,15 @@ describe('queueAutoMerge', () => {
       prs: ['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2'],
     });
 
-    queueAutoMerge(result, 'o/r');
+    const queued = queueAutoMerge(result, 'o/r');
 
     expect(mockSpawnSync).toHaveBeenCalledTimes(2);
+    expect(queued).toEqual({
+      queued: ['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2'],
+      blocked: [],
+      cancelFailed: [],
+      queueFailed: [],
+    });
     const cmds = mockSpawnSync.mock.calls.map((c) => joinArgs(c as any));
     expect(cmds[0]).toContain('pr merge 1');
     expect(cmds[0]).toContain('--squash --delete-branch --auto');
@@ -485,17 +491,49 @@ describe('queueAutoMerge', () => {
       prs: ['https://github.com/o/r/pull/1'],
     });
 
-    queueAutoMerge(result, 'o/r', {
+    const queued = queueAutoMerge(result, 'o/r', {
       allow: false,
       reasons: ['review verdict fail', 'process verdict process-incomplete'],
     });
 
+    expect(queued).toEqual({
+      queued: [],
+      blocked: ['https://github.com/o/r/pull/1'],
+      cancelFailed: [],
+      queueFailed: [],
+    });
     const cmds = mockSpawnSync.mock.calls.map((c) => joinArgs(c as any));
     expect(cmds).toHaveLength(1);
     expect(cmds[0]).toContain('pr merge 1');
     expect(cmds[0]).toContain('--disable-auto');
     expect(cmds[0]).not.toContain('--squash');
     expect(cmds[0]).not.toContain('--delete-branch');
+  });
+
+  it('surfaces unsafe auto-merge cancellation failures', () => {
+    mockSpawnSync.mockReturnValue(fail('not queued') as any);
+    const result = makeRunResult({
+      prs: ['https://github.com/o/r/pull/1'],
+    });
+
+    const queued = queueAutoMerge(result, 'o/r', {
+      allow: false,
+      reasons: ['review verdict fail'],
+    });
+
+    expect(queued.cancelFailed).toEqual(['https://github.com/o/r/pull/1']);
+  });
+
+  it('rejects malformed PR URLs instead of passing attacker-controlled flags to gh', () => {
+    mockSpawnSync.mockReturnValue(ok('ok') as any);
+    const result = makeRunResult({
+      prs: ['https://github.com/o/r/pull/1--delete-branch'],
+    });
+
+    const queued = queueAutoMerge(result, 'o/r');
+
+    expect(queued).toEqual({ queued: [], blocked: [], cancelFailed: [], queueFailed: [] });
+    expect(mockSpawnSync).not.toHaveBeenCalled();
   });
 });
 
@@ -510,14 +548,24 @@ describe('cancelAutoMerge', () => {
       prs: ['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2'],
     });
 
-    cancelAutoMerge(result);
+    const failed = cancelAutoMerge(result);
 
+    expect(failed).toEqual([]);
     const cmds = mockSpawnSync.mock.calls.map((c) => joinArgs(c as any));
     expect(cmds).toHaveLength(2);
     expect(cmds[0]).toContain('pr merge 1');
     expect(cmds[0]).toContain('--disable-auto');
     expect(cmds[1]).toContain('pr merge 2');
     expect(cmds[1]).toContain('--disable-auto');
+  });
+
+  it('returns PRs whose auto-merge could not be disabled', () => {
+    mockSpawnSync.mockReturnValue(fail('missing permission') as any);
+    const result = makeRunResult({
+      prs: ['https://github.com/o/r/pull/1'],
+    });
+
+    expect(cancelAutoMerge(result)).toEqual(['https://github.com/o/r/pull/1']);
   });
 });
 

--- a/scripts/auto-dent-github.ts
+++ b/scripts/auto-dent-github.ts
@@ -8,32 +8,13 @@
  * (logging warnings rather than throwing).
  */
 
-import { ghExec, parseGhCommandArgs } from '../src/lib/gh-exec.js';
+import { ghExec, ghResult, parseGhCommandArgs } from '../src/lib/gh-exec.js';
+import { parseGithubIssueUrl, parseGithubPrUrl } from '../src/lib/github-pr.js';
 import type { RunResult } from './auto-dent-run.js';
 import type { AutoMergeSafetyDecision } from './auto-dent-merge-policy.js';
 
 export { ghExec };
 export const parseShellArgs = parseGhCommandArgs;
-
-interface GitHubPullRequestRef {
-  repo: string;
-  number: string;
-}
-
-interface GitHubIssueRef {
-  repo: string;
-  number: string;
-}
-
-function parsePullRequestUrl(url: string): GitHubPullRequestRef | null {
-  const m = url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-  return m ? { repo: m[1], number: m[2] } : null;
-}
-
-function parseIssueUrl(url: string): GitHubIssueRef | null {
-  const m = url.match(/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/);
-  return m ? { repo: m[1], number: m[2] } : null;
-}
 
 // Issue label lookup
 
@@ -69,7 +50,7 @@ export type MergeStatus =
   | 'unknown';
 
 export function checkMergeStatus(prUrl: string): MergeStatus {
-  const pr = parsePullRequestUrl(prUrl);
+  const pr = parseGithubPrUrl(prUrl);
   if (!pr) return 'unknown';
   try {
     const json = ghExec(
@@ -172,7 +153,7 @@ export function classifyMergeView(
 interface PrPollState {
   pr: string;
   repo: string;
-  num: string;
+  num: number;
   status: DriveStatus | 'pending';
   reason?: DriveReason;
   attempts: number;
@@ -188,7 +169,7 @@ export function driveBatchToMerge(
 
   const states: PrPollState[] = [];
   for (const pr of prUrls) {
-    const parsed = parsePullRequestUrl(pr);
+    const parsed = parseGithubPrUrl(pr);
     if (!parsed) continue; // skip invalid URLs (best-effort, module convention)
     states.push({ pr, repo: parsed.repo, num: parsed.number, status: 'pending', attempts: 0 });
   }
@@ -264,14 +245,14 @@ export function driveBatchToMerge(
 
 export function labelArtifacts(result: RunResult, label: string): void {
   for (const pr of result.prs) {
-    const parsed = parsePullRequestUrl(pr);
+    const parsed = parseGithubPrUrl(pr);
     if (parsed) {
       ghExec(`gh pr edit ${parsed.number} --repo ${parsed.repo} --add-label ${label}`);
       console.log(`  [hygiene] labeled PR ${pr}`);
     }
   }
   for (const issue of result.issuesFiled) {
-    const parsed = parseIssueUrl(issue);
+    const parsed = parseGithubIssueUrl(issue);
     if (parsed) {
       ghExec(`gh issue edit ${parsed.number} --repo ${parsed.repo} --add-label ${label}`);
       console.log(`  [hygiene] labeled issue ${issue}`);
@@ -279,42 +260,71 @@ export function labelArtifacts(result: RunResult, label: string): void {
   }
 }
 
-export function cancelAutoMerge(result: RunResult): void {
+export interface AutoMergeQueueResult {
+  queued: string[];
+  blocked: string[];
+  cancelFailed: string[];
+  queueFailed: string[];
+}
+
+export function cancelAutoMerge(result: RunResult): string[] {
+  const failed: string[] = [];
   for (const pr of result.prs) {
-    const parsed = parsePullRequestUrl(pr);
+    const parsed = parseGithubPrUrl(pr);
     if (parsed) {
-      const out = ghExec(
-        `gh pr merge ${parsed.number} --repo ${parsed.repo} --disable-auto`,
-      );
-      if (out) {
+      const out = ghResult([
+        'pr', 'merge', String(parsed.number),
+        '--repo', parsed.repo,
+        '--disable-auto',
+      ]);
+      if (out.status === 0) {
         console.log(`  [hygiene] disabled auto-merge for PR ${pr}`);
+      } else {
+        failed.push(pr);
+        console.log(`  [hygiene] failed to disable auto-merge for PR ${pr}: ${out.stderr || 'gh failed'}`);
       }
     }
   }
+  return failed;
 }
 
 export function queueAutoMerge(
   result: RunResult,
   _hostRepo: string,
   decision: AutoMergeSafetyDecision = { allow: true, reasons: [] },
-): void {
+): AutoMergeQueueResult {
   if (!decision.allow) {
     console.log(`  [hygiene] auto-merge blocked: ${decision.reasons.join('; ')}`);
-    cancelAutoMerge(result);
-    return;
+    return {
+      queued: [],
+      blocked: [...result.prs],
+      cancelFailed: cancelAutoMerge(result),
+      queueFailed: [],
+    };
   }
 
+  const queued: string[] = [];
+  const queueFailed: string[] = [];
   for (const pr of result.prs) {
-    const parsed = parsePullRequestUrl(pr);
+    const parsed = parseGithubPrUrl(pr);
     if (parsed) {
-      const out = ghExec(
-        `gh pr merge ${parsed.number} --repo ${parsed.repo} --squash --delete-branch --auto`,
-      );
-      if (out) {
+      const out = ghResult([
+        'pr', 'merge', String(parsed.number),
+        '--repo', parsed.repo,
+        '--squash',
+        '--delete-branch',
+        '--auto',
+      ]);
+      if (out.status === 0) {
+        queued.push(pr);
         console.log(`  [hygiene] queued auto-merge for PR ${pr}`);
+      } else {
+        queueFailed.push(pr);
+        console.log(`  [hygiene] failed to queue auto-merge for PR ${pr}: ${out.stderr || 'gh failed'}`);
       }
     }
   }
+  return { queued, blocked: [], cancelFailed: [], queueFailed };
 }
 
 // PR cleanup — close superseded PRs whose target issues are already closed
@@ -365,7 +375,7 @@ export function cleanupSupersededPRs(
   const results: CleanupResult[] = [];
 
   for (const prUrl of prUrls) {
-    const parsed = parsePullRequestUrl(prUrl);
+    const parsed = parseGithubPrUrl(prUrl);
     if (!parsed) continue;
 
     try {
@@ -544,13 +554,12 @@ export function verifyIssuesClosed(
   const results: VerifyCloseResult[] = [];
 
   for (const prUrl of prUrls) {
-    const m = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-    if (!m) continue;
-    const [, prRepo, prNum] = m;
+    const parsed = parseGithubPrUrl(prUrl);
+    if (!parsed) continue;
 
     try {
       const json = ghExec(
-        `gh pr view ${prNum} --repo ${prRepo} --json state,body`,
+        `gh pr view ${parsed.number} --repo ${parsed.repo} --json state,body`,
       );
       if (!json) continue;
 
@@ -569,10 +578,10 @@ export function verifyIssuesClosed(
         } else {
           // Force-close the issue
           ghExec(
-            `gh issue close ${issueNum} --repo ${repo} --comment "Auto-closed: PR #${prNum} was merged but GitHub did not auto-close this issue (squash-merge edge case)."`,
+            `gh issue close ${issueNum} --repo ${repo} --comment "Auto-closed: PR #${parsed.number} was merged but GitHub did not auto-close this issue (squash-merge edge case)."`,
           );
           console.log(
-            `  [verify-close] force-closed #${issueNum} (PR #${prNum} merged but issue remained open)`,
+            `  [verify-close] force-closed #${issueNum} (PR #${parsed.number} merged but issue remained open)`,
           );
           forceClosed.push(`#${issueNum}`);
         }

--- a/scripts/auto-dent-github.ts
+++ b/scripts/auto-dent-github.ts
@@ -10,9 +10,30 @@
 
 import { ghExec, parseGhCommandArgs } from '../src/lib/gh-exec.js';
 import type { RunResult } from './auto-dent-run.js';
+import type { AutoMergeSafetyDecision } from './auto-dent-merge-policy.js';
 
 export { ghExec };
 export const parseShellArgs = parseGhCommandArgs;
+
+interface GitHubPullRequestRef {
+  repo: string;
+  number: string;
+}
+
+interface GitHubIssueRef {
+  repo: string;
+  number: string;
+}
+
+function parsePullRequestUrl(url: string): GitHubPullRequestRef | null {
+  const m = url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+  return m ? { repo: m[1], number: m[2] } : null;
+}
+
+function parseIssueUrl(url: string): GitHubIssueRef | null {
+  const m = url.match(/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/);
+  return m ? { repo: m[1], number: m[2] } : null;
+}
 
 // Issue label lookup
 
@@ -48,11 +69,11 @@ export type MergeStatus =
   | 'unknown';
 
 export function checkMergeStatus(prUrl: string): MergeStatus {
-  const m = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-  if (!m) return 'unknown';
+  const pr = parsePullRequestUrl(prUrl);
+  if (!pr) return 'unknown';
   try {
     const json = ghExec(
-      `gh pr view ${m[2]} --repo ${m[1]} --json state,mergeStateStatus,autoMergeRequest`,
+      `gh pr view ${pr.number} --repo ${pr.repo} --json state,mergeStateStatus,autoMergeRequest`,
     );
     if (!json) return 'unknown';
     const data = JSON.parse(json);
@@ -167,9 +188,9 @@ export function driveBatchToMerge(
 
   const states: PrPollState[] = [];
   for (const pr of prUrls) {
-    const m = pr.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-    if (!m) continue; // skip invalid URLs (best-effort, module convention)
-    states.push({ pr, repo: m[1], num: m[2], status: 'pending', attempts: 0 });
+    const parsed = parsePullRequestUrl(pr);
+    if (!parsed) continue; // skip invalid URLs (best-effort, module convention)
+    states.push({ pr, repo: parsed.repo, num: parsed.number, status: 'pending', attempts: 0 });
   }
   if (states.length === 0) return [];
 
@@ -243,27 +264,51 @@ export function driveBatchToMerge(
 
 export function labelArtifacts(result: RunResult, label: string): void {
   for (const pr of result.prs) {
-    const m = pr.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-    if (m) {
-      ghExec(`gh pr edit ${m[2]} --repo ${m[1]} --add-label ${label}`);
+    const parsed = parsePullRequestUrl(pr);
+    if (parsed) {
+      ghExec(`gh pr edit ${parsed.number} --repo ${parsed.repo} --add-label ${label}`);
       console.log(`  [hygiene] labeled PR ${pr}`);
     }
   }
   for (const issue of result.issuesFiled) {
-    const m = issue.match(/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/);
-    if (m) {
-      ghExec(`gh issue edit ${m[2]} --repo ${m[1]} --add-label ${label}`);
+    const parsed = parseIssueUrl(issue);
+    if (parsed) {
+      ghExec(`gh issue edit ${parsed.number} --repo ${parsed.repo} --add-label ${label}`);
       console.log(`  [hygiene] labeled issue ${issue}`);
     }
   }
 }
 
-export function queueAutoMerge(result: RunResult, hostRepo: string): void {
+export function cancelAutoMerge(result: RunResult): void {
   for (const pr of result.prs) {
-    const m = pr.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-    if (m) {
+    const parsed = parsePullRequestUrl(pr);
+    if (parsed) {
       const out = ghExec(
-        `gh pr merge ${m[2]} --repo ${m[1]} --squash --delete-branch --auto`,
+        `gh pr merge ${parsed.number} --repo ${parsed.repo} --disable-auto`,
+      );
+      if (out) {
+        console.log(`  [hygiene] disabled auto-merge for PR ${pr}`);
+      }
+    }
+  }
+}
+
+export function queueAutoMerge(
+  result: RunResult,
+  _hostRepo: string,
+  decision: AutoMergeSafetyDecision = { allow: true, reasons: [] },
+): void {
+  if (!decision.allow) {
+    console.log(`  [hygiene] auto-merge blocked: ${decision.reasons.join('; ')}`);
+    cancelAutoMerge(result);
+    return;
+  }
+
+  for (const pr of result.prs) {
+    const parsed = parsePullRequestUrl(pr);
+    if (parsed) {
+      const out = ghExec(
+        `gh pr merge ${parsed.number} --repo ${parsed.repo} --squash --delete-branch --auto`,
       );
       if (out) {
         console.log(`  [hygiene] queued auto-merge for PR ${pr}`);
@@ -320,15 +365,13 @@ export function cleanupSupersededPRs(
   const results: CleanupResult[] = [];
 
   for (const prUrl of prUrls) {
-    const m = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-    if (!m) continue;
-
-    const [, prRepo, prNum] = m;
+    const parsed = parsePullRequestUrl(prUrl);
+    if (!parsed) continue;
 
     try {
       // Get PR state and body
       const json = ghExec(
-        `gh pr view ${prNum} --repo ${prRepo} --json state,body`,
+        `gh pr view ${parsed.number} --repo ${parsed.repo} --json state,body`,
       );
       if (!json) {
         results.push({ pr: prUrl, action: 'failed' });
@@ -357,10 +400,10 @@ export function cleanupSupersededPRs(
       if (isIssueClosed(issueNum, repo)) {
         // Close the superseded PR
         const closeResult = ghExec(
-          `gh pr close ${prNum} --repo ${prRepo} --comment "Superseded — issue #${issueNum} was already resolved by another PR in this batch."`,
+          `gh pr close ${parsed.number} --repo ${parsed.repo} --comment "Superseded — issue #${issueNum} was already resolved by another PR in this batch."`,
         );
         if (closeResult !== undefined) {
-          console.log(`  [cleanup] closed superseded PR #${prNum} (issue #${issueNum} already resolved)`);
+          console.log(`  [cleanup] closed superseded PR #${parsed.number} (issue #${issueNum} already resolved)`);
           results.push({ pr: prUrl, action: 'closed', issue: `#${issueNum}` });
         } else {
           results.push({ pr: prUrl, action: 'failed', issue: `#${issueNum}` });

--- a/scripts/auto-dent-merge-policy.test.ts
+++ b/scripts/auto-dent-merge-policy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { autoMergeBlockReasons, decideAutoMergeSafety } from './auto-dent-merge-policy.js';
+
+describe('auto-dent merge policy (#1220)', () => {
+  it('allows a PR only when required review passed and no hard process/lifecycle verdict failed', () => {
+    expect(
+      decideAutoMergeSafety({
+        prCount: 1,
+        reviewRequired: true,
+        reviewVerdict: 'pass',
+        processVerdict: 'pass',
+        lifecycleHealth: 'clean',
+      }),
+    ).toEqual({ allow: true, reasons: [] });
+  });
+
+  it.each([
+    ['review FAIL', { reviewVerdict: 'fail' as const }, 'review verdict fail'],
+    ['review skipped', { reviewVerdict: 'skipped' as const }, 'review verdict skipped'],
+    ['review missing', { reviewVerdict: undefined }, 'review verdict missing'],
+    ['process incomplete', { processVerdict: 'process-incomplete' as const }, 'process verdict process-incomplete'],
+    ['critical lifecycle', { lifecycleHealth: 'critical' as const }, 'lifecycle health critical'],
+  ])('blocks auto-merge on %s', (_name, patch, reason) => {
+    expect(
+      autoMergeBlockReasons({
+        prCount: 1,
+        reviewRequired: true,
+        reviewVerdict: 'pass',
+        processVerdict: 'pass',
+        lifecycleHealth: 'clean',
+        ...patch,
+      }),
+    ).toContain(reason);
+  });
+
+  it('does not block non-PR runs', () => {
+    expect(
+      decideAutoMergeSafety({
+        prCount: 0,
+        reviewRequired: true,
+        reviewVerdict: 'skipped',
+        processVerdict: 'process-incomplete',
+        lifecycleHealth: 'critical',
+      }),
+    ).toEqual({ allow: true, reasons: [] });
+  });
+
+  it('allows synthetic non-review runs unless a hard fail was observed', () => {
+    expect(
+      decideAutoMergeSafety({
+        prCount: 1,
+        reviewRequired: false,
+        reviewVerdict: 'skipped',
+        processVerdict: 'pass',
+        lifecycleHealth: 'clean',
+      }).allow,
+    ).toBe(true);
+
+    expect(
+      decideAutoMergeSafety({
+        prCount: 1,
+        reviewRequired: false,
+        reviewVerdict: 'fail',
+        processVerdict: 'pass',
+        lifecycleHealth: 'clean',
+      }).allow,
+    ).toBe(false);
+  });
+});

--- a/scripts/auto-dent-merge-policy.ts
+++ b/scripts/auto-dent-merge-policy.ts
@@ -1,0 +1,50 @@
+import type { LifecycleHealth, ProcessVerdict } from './auto-dent-lifecycle.js';
+
+export type ReviewVerdict = 'pass' | 'fail' | 'skipped';
+
+export interface AutoMergeSafetySignals {
+  /** Number of PRs this terminal action would affect. Non-PR runs have no merge action. */
+  prCount: number;
+  /** False only for explicit synthetic runs where review is intentionally not applicable. */
+  reviewRequired: boolean;
+  reviewVerdict?: ReviewVerdict;
+  processVerdict?: ProcessVerdict;
+  lifecycleHealth?: LifecycleHealth;
+}
+
+export interface AutoMergeSafetyDecision {
+  allow: boolean;
+  reasons: string[];
+}
+
+export function autoMergeBlockReasons(signals: AutoMergeSafetySignals): string[] {
+  if (signals.prCount <= 0) return [];
+
+  const reasons: string[] = [];
+
+  if (signals.reviewVerdict === 'fail') {
+    reasons.push('review verdict fail');
+  } else if (signals.reviewRequired && signals.reviewVerdict === 'skipped') {
+    reasons.push('review verdict skipped');
+  } else if (signals.reviewRequired && signals.reviewVerdict == null) {
+    reasons.push('review verdict missing');
+  }
+
+  if (signals.processVerdict === 'process-incomplete') {
+    reasons.push('process verdict process-incomplete');
+  }
+
+  if (signals.lifecycleHealth === 'critical') {
+    reasons.push('lifecycle health critical');
+  }
+
+  return reasons;
+}
+
+export function decideAutoMergeSafety(signals: AutoMergeSafetySignals): AutoMergeSafetyDecision {
+  const reasons = autoMergeBlockReasons(signals);
+  return {
+    allow: reasons.length === 0,
+    reasons,
+  };
+}

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -118,6 +118,21 @@ describe('buildPrompt', () => {
     expect(prompt).not.toContain('gh pr merge');
     expect(prompt).toContain('Garsson-io/kaizen');
     expect(prompt).toContain('The auto-dent harness queues auto-merge after review');
+    expect(prompt).toContain('status=<queued/merged/blocked>');
+  });
+
+  it('keeps merge policy under harness control in subtract mode', () => {
+    const state = makeBatchState({ host_repo: 'Garsson-io/kaizen', guidance: 'mode:subtract' });
+    const prompt = buildPrompt(state, 1);
+    expect(prompt).not.toContain('gh pr merge');
+    expect(prompt).toContain('The auto-dent harness queues auto-merge after review');
+  });
+
+  it('keeps merge policy under harness control in synthetic test-task mode', () => {
+    const state = makeBatchState({ host_repo: 'Garsson-io/kaizen', test_task: true });
+    const prompt = buildPrompt(state, 1);
+    expect(prompt).not.toContain('gh pr merge');
+    expect(prompt).toContain('The auto-dent harness queues auto-merge after review');
   });
 
   it('includes structured STOP phase marker instructions', () => {

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -3482,14 +3482,16 @@ describe('test-task lifecycle evidence regression guard', () => {
 describe('auto-merge verdict binding wiring (#1220)', () => {
   it('routes post-review safety decisions into queueing and merge babysitting', () => {
     const decisionIndex = AUTO_DENT_RUN_SOURCE.indexOf('const autoMergeDecision = decideAutoMergeSafety({');
-    const queueIndex = AUTO_DENT_RUN_SOURCE.indexOf('queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);');
-    const unsafeSetIndex = AUTO_DENT_RUN_SOURCE.indexOf('new Set(result.prs)');
+    const queueIndex = AUTO_DENT_RUN_SOURCE.indexOf('const autoMergeQueue = queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);');
+    const cancelFailedIndex = AUTO_DENT_RUN_SOURCE.indexOf('const cancelFailed = new Set(autoMergeQueue.cancelFailed);');
+    const unsafeSetIndex = AUTO_DENT_RUN_SOURCE.indexOf('result.prs.filter((pr) => !cancelFailed.has(pr))');
     const filterIndex = AUTO_DENT_RUN_SOURCE.indexOf('filter((pr) => !unsafeCurrentPRs.has(pr))');
     const driveIndex = AUTO_DENT_RUN_SOURCE.indexOf('driveBatchToMerge(allBatchPRs');
 
     expect(decisionIndex).toBeGreaterThan(-1);
     expect(queueIndex).toBeGreaterThan(decisionIndex);
-    expect(unsafeSetIndex).toBeGreaterThan(queueIndex);
+    expect(cancelFailedIndex).toBeGreaterThan(queueIndex);
+    expect(unsafeSetIndex).toBeGreaterThan(cancelFailedIndex);
     expect(filterIndex).toBeGreaterThan(unsafeSetIndex);
     expect(driveIndex).toBeGreaterThan(filterIndex);
   });

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -112,12 +112,12 @@ describe('buildPrompt', () => {
     expect(prompt).not.toContain('avoid overlapping');
   });
 
-  it('includes merge policy with host repo', () => {
+  it('keeps merge policy under harness control after review', () => {
     const state = makeBatchState({ host_repo: 'Garsson-io/kaizen' });
     const prompt = buildPrompt(state, 1);
-    expect(prompt).toContain('gh pr merge');
+    expect(prompt).not.toContain('gh pr merge');
     expect(prompt).toContain('Garsson-io/kaizen');
-    expect(prompt).toContain('--squash --delete-branch --auto');
+    expect(prompt).toContain('The auto-dent harness queues auto-merge after review');
   });
 
   it('includes structured STOP phase marker instructions', () => {
@@ -3476,6 +3476,22 @@ describe('test-task lifecycle evidence regression guard', () => {
 
   it('does not treat skipped review as process-incomplete for synthetic test tasks', () => {
     expect(source).toContain("reviewVerdict: state.test_task ? 'pass' : result.reviewVerdict");
+  });
+});
+
+describe('auto-merge verdict binding wiring (#1220)', () => {
+  it('routes post-review safety decisions into queueing and merge babysitting', () => {
+    const decisionIndex = AUTO_DENT_RUN_SOURCE.indexOf('const autoMergeDecision = decideAutoMergeSafety({');
+    const queueIndex = AUTO_DENT_RUN_SOURCE.indexOf('queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);');
+    const unsafeSetIndex = AUTO_DENT_RUN_SOURCE.indexOf('new Set(result.prs)');
+    const filterIndex = AUTO_DENT_RUN_SOURCE.indexOf('filter((pr) => !unsafeCurrentPRs.has(pr))');
+    const driveIndex = AUTO_DENT_RUN_SOURCE.indexOf('driveBatchToMerge(allBatchPRs');
+
+    expect(decisionIndex).toBeGreaterThan(-1);
+    expect(queueIndex).toBeGreaterThan(decisionIndex);
+    expect(unsafeSetIndex).toBeGreaterThan(queueIndex);
+    expect(filterIndex).toBeGreaterThan(unsafeSetIndex);
+    expect(driveIndex).toBeGreaterThan(filterIndex);
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -1250,7 +1250,7 @@ Example:
   AUTO_DENT_PHASE: IMPLEMENT | case=260323-1200-k472 | branch=case/260323-1200-k472
   AUTO_DENT_PHASE: TEST | result=pass | count=15
   AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/500
-  AUTO_DENT_PHASE: MERGE | url=https://github.com/Garsson-io/kaizen/pull/500 | status=observed
+  AUTO_DENT_PHASE: MERGE | url=https://github.com/Garsson-io/kaizen/pull/500 | status=queued
   AUTO_DENT_PHASE: REFLECT | issues_filed=1 | lessons=shared helpers reduce test boilerplate
 
 Emit these naturally as you complete each phase. Missing keys are fine — emit what you have.`;
@@ -2627,9 +2627,14 @@ async function main(): Promise<void> {
     processVerdict,
     lifecycleHealth,
   });
-  queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);
+  const autoMergeQueue = queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);
   if (!autoMergeDecision.allow) {
     appendFileSync(logFile, `auto_merge_blocked=${autoMergeDecision.reasons.join('; ')}\n`);
+    if (autoMergeQueue.cancelFailed.length > 0) {
+      appendFileSync(logFile, `auto_merge_cancel_failed=${autoMergeQueue.cancelFailed.join(',')}\n`);
+    }
+  } else if (autoMergeQueue.queueFailed.length > 0) {
+    appendFileSync(logFile, `auto_merge_queue_failed=${autoMergeQueue.queueFailed.join(',')}\n`);
   }
 
   for (const pr of result.prs) {
@@ -2650,7 +2655,10 @@ async function main(): Promise<void> {
   // full batch, so PRs continue to be driven across the trampoline without any
   // single run blocking for long. `--auto` stays queued, so GitHub may still
   // merge a "timed_out" PR server-side after the batch ends.
-  const unsafeCurrentPRs = autoMergeDecision.allow ? new Set<string>() : new Set(result.prs);
+  const cancelFailed = new Set(autoMergeQueue.cancelFailed);
+  const unsafeCurrentPRs = autoMergeDecision.allow
+    ? new Set<string>()
+    : new Set(result.prs.filter((pr) => !cancelFailed.has(pr)));
   const allBatchPRs = [...new Set([...state.prs, ...result.prs])].filter((pr) => !unsafeCurrentPRs.has(pr));
   if (allBatchPRs.length > 0) {
     const driveResults = driveBatchToMerge(allBatchPRs, {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -83,6 +83,7 @@ export {
   type EpicSyncResult,
   type VerifyCloseResult,
 } from './auto-dent-github.js';
+import { decideAutoMergeSafety } from './auto-dent-merge-policy.js';
 
 export {
   EventEmitter,
@@ -1175,7 +1176,7 @@ Run tag: ${runTag}
    \`\`\`
 3. Commit with message: "test: probe ${runTag}"
 4. Create a PR: \`gh pr create --title "test: probe ${runTag}" --body "Synthetic test task for pipeline validation. Run tag: ${runTag}" --repo ${hostRepo}\`
-5. Queue auto-merge: \`gh pr merge <url> --repo ${hostRepo} --squash --delete-branch --auto\`
+5. Leave auto-merge to the harness after review verdicts are known
 
 Do not ask for confirmation. Complete all steps.`;
   } else {
@@ -1205,10 +1206,9 @@ Run to completion. Do not ask for confirmation — make autonomous decisions.`;
 
 ## Merge & Labeling Policy
 
-After creating a PR, you MUST queue it for auto-merge:
-  gh pr merge <url> --repo ${hostRepo} --squash --delete-branch --auto
-Do NOT leave PRs open for manual review — this is an unattended batch.
-The harness will also attempt auto-merge as a safety net, but do it yourself first.
+After creating a PR, do NOT run merge commands yourself.
+The auto-dent harness queues auto-merge after review verdicts and process evidence are known.
+Leave the PR open for the harness-owned terminal action.
 
 ## Stopping the Loop
 
@@ -1241,7 +1241,7 @@ Phases and their expected keys:
 | IMPLEMENT | Starting implementation | case=<case-id>, branch=<branch-name> |
 | TEST | After running tests | result=<pass/fail>, count=<number of tests> |
 | PR | After creating a PR | url=<PR URL> |
-| MERGE | After queuing auto-merge | url=<PR URL>, status=<queued/merged> |
+| MERGE | After the harness reports merge status | url=<PR URL>, status=<queued/merged/blocked> |
 | REFLECT | After reflection | issues_filed=<N>, lessons=<short summary> |
 
 Example:
@@ -1250,7 +1250,7 @@ Example:
   AUTO_DENT_PHASE: IMPLEMENT | case=260323-1200-k472 | branch=case/260323-1200-k472
   AUTO_DENT_PHASE: TEST | result=pass | count=15
   AUTO_DENT_PHASE: PR | url=https://github.com/Garsson-io/kaizen/pull/500
-  AUTO_DENT_PHASE: MERGE | url=https://github.com/Garsson-io/kaizen/pull/500 | status=queued
+  AUTO_DENT_PHASE: MERGE | url=https://github.com/Garsson-io/kaizen/pull/500 | status=observed
   AUTO_DENT_PHASE: REFLECT | issues_filed=1 | lessons=shared helpers reduce test boilerplate
 
 Emit these naturally as you complete each phase. Missing keys are fine — emit what you have.`;
@@ -2620,7 +2620,17 @@ async function main(): Promise<void> {
   // Post-run hygiene
   const progressIssue = ensureBatchProgressIssue(state, stateFile);
   labelArtifacts(result, 'auto-dent');
-  queueAutoMerge(result, state.host_repo || state.kaizen_repo);
+  const autoMergeDecision = decideAutoMergeSafety({
+    prCount: result.prs.length,
+    reviewRequired: !state.test_task,
+    reviewVerdict,
+    processVerdict,
+    lifecycleHealth,
+  });
+  queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);
+  if (!autoMergeDecision.allow) {
+    appendFileSync(logFile, `auto_merge_blocked=${autoMergeDecision.reasons.join('; ')}\n`);
+  }
 
   for (const pr of result.prs) {
     const status = checkMergeStatus(pr);
@@ -2640,7 +2650,8 @@ async function main(): Promise<void> {
   // full batch, so PRs continue to be driven across the trampoline without any
   // single run blocking for long. `--auto` stays queued, so GitHub may still
   // merge a "timed_out" PR server-side after the batch ends.
-  const allBatchPRs = [...new Set([...state.prs, ...result.prs])];
+  const unsafeCurrentPRs = autoMergeDecision.allow ? new Set<string>() : new Set(result.prs);
+  const allBatchPRs = [...new Set([...state.prs, ...result.prs])].filter((pr) => !unsafeCurrentPRs.has(pr));
   if (allBatchPRs.length > 0) {
     const driveResults = driveBatchToMerge(allBatchPRs, {
       maxAttempts: 6,

--- a/scripts/review-verdict-status.test.ts
+++ b/scripts/review-verdict-status.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { decideReviewVerdictStatus } from './review-verdict-status.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  decideReviewVerdictStatus,
+  getReviewVerdictStatus,
+  resolveTarget,
+} from './review-verdict-status.js';
 
 describe('decideReviewVerdictStatus', () => {
   it('fails when the latest stored review round derives FAIL', () => {
@@ -15,5 +19,65 @@ describe('decideReviewVerdictStatus', () => {
 
   it('does not fail when no stored review data exists', () => {
     expect(decideReviewVerdictStatus(0, null).outcome).toBe('no_data');
+  });
+});
+
+describe('resolveTarget', () => {
+  const originalArgv = process.argv;
+  const originalRepo = process.env.GITHUB_REPOSITORY;
+  const originalPr = process.env.PR_NUMBER;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    if (originalRepo === undefined) delete process.env.GITHUB_REPOSITORY;
+    else process.env.GITHUB_REPOSITORY = originalRepo;
+    if (originalPr === undefined) delete process.env.PR_NUMBER;
+    else process.env.PR_NUMBER = originalPr;
+  });
+
+  it('resolves a numeric PR from --repo plus --pr', () => {
+    process.argv = ['node', 'script', '--repo', 'Garsson-io/kaizen', '--pr', '1498'];
+    expect(resolveTarget()).toEqual({ repo: 'Garsson-io/kaizen', pr: '1498' });
+  });
+
+  it('resolves repo and PR from a full PR URL', () => {
+    process.argv = ['node', 'script', '--pr', 'https://github.com/Garsson-io/kaizen/pull/1498'];
+    expect(resolveTarget()).toEqual({ repo: 'Garsson-io/kaizen', pr: '1498' });
+  });
+
+  it('resolves GitHub Actions environment inputs', () => {
+    process.argv = ['node', 'script'];
+    process.env.GITHUB_REPOSITORY = 'Garsson-io/kaizen';
+    process.env.PR_NUMBER = '1498';
+    expect(resolveTarget()).toEqual({ repo: 'Garsson-io/kaizen', pr: '1498' });
+  });
+});
+
+describe('getReviewVerdictStatus', () => {
+  it('reads the latest stored review round and fails when it derives FAIL', () => {
+    const latest = vi.fn(() => 2);
+    const derive = vi.fn(() => 'FAIL' as const);
+
+    const status = getReviewVerdictStatus('Garsson-io/kaizen', '1498', {
+      latestReviewRound: latest,
+      deriveStoredRoundVerdict: derive,
+    });
+
+    expect(status.outcome).toBe('fail');
+    expect(latest).toHaveBeenCalledWith({ kind: 'pr', number: '1498', repo: 'Garsson-io/kaizen' });
+    expect(derive).toHaveBeenCalledWith({ kind: 'pr', number: '1498', repo: 'Garsson-io/kaizen' }, 2);
+  });
+
+  it('does not read a round verdict when no review rounds exist', () => {
+    const latest = vi.fn(() => 0);
+    const derive = vi.fn(() => 'FAIL' as const);
+
+    const status = getReviewVerdictStatus('Garsson-io/kaizen', '1498', {
+      latestReviewRound: latest,
+      deriveStoredRoundVerdict: derive,
+    });
+
+    expect(status.outcome).toBe('no_data');
+    expect(derive).not.toHaveBeenCalled();
   });
 });

--- a/scripts/review-verdict-status.test.ts
+++ b/scripts/review-verdict-status.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { decideReviewVerdictStatus } from './review-verdict-status.js';
+
+describe('decideReviewVerdictStatus', () => {
+  it('fails when the latest stored review round derives FAIL', () => {
+    const status = decideReviewVerdictStatus(2, 'FAIL');
+    expect(status.outcome).toBe('fail');
+    expect(status.message).toContain('r2');
+  });
+
+  it('passes PASS and PASS_WITH_PARTIALS verdicts', () => {
+    expect(decideReviewVerdictStatus(1, 'PASS').outcome).toBe('pass');
+    expect(decideReviewVerdictStatus(1, 'PASS_WITH_PARTIALS').outcome).toBe('pass');
+  });
+
+  it('does not fail when no stored review data exists', () => {
+    expect(decideReviewVerdictStatus(0, null).outcome).toBe('no_data');
+  });
+});

--- a/scripts/review-verdict-status.ts
+++ b/scripts/review-verdict-status.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env tsx
+/**
+ * CI status check for stored PR review verdicts.
+ *
+ * This is the non-Claude backstop for #1220: when branch protection requires
+ * the "Review verdict gate" check, a PR whose latest stored review round
+ * derives FAIL cannot land even outside an interactive Claude session.
+ */
+
+import { parseGithubPrUrl } from '../src/lib/github-pr.js';
+import {
+  deriveStoredRoundVerdict,
+  latestReviewRound,
+  prTarget,
+} from '../src/structured-data.js';
+import type { RoundVerdict } from '../src/review-finding-contract.js';
+
+export interface ReviewVerdictStatus {
+  outcome: 'pass' | 'fail' | 'no_data';
+  message: string;
+  round: number;
+  verdict: RoundVerdict | null;
+}
+
+export function decideReviewVerdictStatus(round: number, verdict: RoundVerdict | null): ReviewVerdictStatus {
+  if (round === 0 || verdict === null) {
+    return {
+      outcome: 'no_data',
+      message: 'No stored review rounds found; review verdict gate has no failing verdict to block.',
+      round,
+      verdict: null,
+    };
+  }
+  if (verdict === 'FAIL') {
+    return {
+      outcome: 'fail',
+      message: `Latest stored review round r${round} derives FAIL; merge is blocked.`,
+      round,
+      verdict,
+    };
+  }
+  return {
+    outcome: 'pass',
+    message: `Latest stored review round r${round} derives ${verdict}.`,
+    round,
+    verdict,
+  };
+}
+
+function readArg(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  return idx >= 0 ? process.argv[idx + 1] : undefined;
+}
+
+function usage(): never {
+  console.error('Usage: npx tsx scripts/review-verdict-status.ts --repo owner/repo --pr N|https://github.com/owner/repo/pull/N');
+  process.exit(2);
+}
+
+export function resolveTarget(): { repo: string; pr: string } {
+  const repo = readArg('--repo') ?? process.env.GITHUB_REPOSITORY;
+  const prRaw = readArg('--pr') ?? process.env.PR_NUMBER ?? process.env.GITHUB_PR_NUMBER;
+  if (!prRaw) usage();
+
+  const parsed = parseGithubPrUrl(prRaw);
+  if (parsed) return { repo: parsed.repo, pr: String(parsed.number) };
+  if (!repo || !/^\d+$/.test(prRaw)) usage();
+  return { repo, pr: prRaw };
+}
+
+export function getReviewVerdictStatus(repo: string, pr: string): ReviewVerdictStatus {
+  const target = prTarget(pr, repo);
+  const round = latestReviewRound(target);
+  const verdict = round === 0 ? null : deriveStoredRoundVerdict(target, round);
+  return decideReviewVerdictStatus(round, verdict);
+}
+
+if (process.argv[1]?.endsWith('review-verdict-status.ts') || process.argv[1]?.endsWith('review-verdict-status.js')) {
+  const target = resolveTarget();
+  const status = getReviewVerdictStatus(target.repo, target.pr);
+  console.log(status.message);
+  process.exit(status.outcome === 'fail' ? 1 : 0);
+}

--- a/scripts/review-verdict-status.ts
+++ b/scripts/review-verdict-status.ts
@@ -68,10 +68,21 @@ export function resolveTarget(): { repo: string; pr: string } {
   return { repo, pr: prRaw };
 }
 
-export function getReviewVerdictStatus(repo: string, pr: string): ReviewVerdictStatus {
+export interface ReviewVerdictReaders {
+  latestReviewRound?: typeof latestReviewRound;
+  deriveStoredRoundVerdict?: typeof deriveStoredRoundVerdict;
+}
+
+export function getReviewVerdictStatus(
+  repo: string,
+  pr: string,
+  readers: ReviewVerdictReaders = {},
+): ReviewVerdictStatus {
   const target = prTarget(pr, repo);
-  const round = latestReviewRound(target);
-  const verdict = round === 0 ? null : deriveStoredRoundVerdict(target, round);
+  const readLatestRound = readers.latestReviewRound ?? latestReviewRound;
+  const readVerdict = readers.deriveStoredRoundVerdict ?? deriveStoredRoundVerdict;
+  const round = readLatestRound(target);
+  const verdict = round === 0 ? null : readVerdict(target, round);
   return decideReviewVerdictStatus(round, verdict);
 }
 

--- a/src/hooks/enforce-merge-verdict.test.ts
+++ b/src/hooks/enforce-merge-verdict.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkMergeVerdict,
+  decideMergeGate,
+  MERGE_OVERRIDE_ENV,
+  parseMergeTarget,
+  type VerdictReader,
+} from './enforce-merge-verdict.js';
+
+describe('parseMergeTarget', () => {
+  it('parses bare PR number + --repo', () => {
+    expect(parseMergeTarget('gh pr merge 123 --repo Garsson-io/kaizen --squash')).toEqual({
+      pr: '123',
+      repo: 'Garsson-io/kaizen',
+    });
+  });
+
+  it('parses the full PR URL form', () => {
+    expect(
+      parseMergeTarget('gh pr merge https://github.com/Garsson-io/kaizen/pull/456 --squash --auto'),
+    ).toEqual({ pr: '456', repo: 'Garsson-io/kaizen' });
+  });
+
+  it('returns null when no target repo can be resolved', () => {
+    expect(parseMergeTarget('gh pr merge 123 --squash')).toBeNull();
+  });
+});
+
+describe('decideMergeGate', () => {
+  const target = { pr: '1212', repo: 'Garsson-io/kaizen' };
+
+  it('denies a merge when the latest round derives FAIL', () => {
+    const result = decideMergeGate('FAIL', { override: false, target });
+    expect(result.action).toBe('deny');
+    expect(result.message).toContain('MERGE BLOCKED');
+    expect(result.message).toContain('PR #1212');
+  });
+
+  it('allows PASS and PASS_WITH_PARTIALS', () => {
+    expect(decideMergeGate('PASS', { override: false, target }).action).toBe('allow');
+    expect(decideMergeGate('PASS_WITH_PARTIALS', { override: false, target }).action).toBe('allow');
+  });
+
+  it('warns without blocking when no review data exists', () => {
+    expect(decideMergeGate(null, { override: false, target }).action).toBe('warn');
+  });
+
+  it('allows FAIL under an explicit override and marks it bypassed', () => {
+    const result = decideMergeGate('FAIL', { override: true, target });
+    expect(result.action).toBe('allow');
+    expect(result.bypassed).toBe(true);
+    expect(result.message).toContain(MERGE_OVERRIDE_ENV);
+  });
+});
+
+describe('checkMergeVerdict', () => {
+  const failReader: VerdictReader = () => 'FAIL';
+  const passReader: VerdictReader = () => 'PASS';
+  const noDataReader: VerdictReader = () => null;
+  const throwReader: VerdictReader = () => {
+    throw new Error('gh offline');
+  };
+
+  it('blocks a real merge command when the latest round is FAIL', () => {
+    const result = checkMergeVerdict(
+      'gh pr merge https://github.com/Garsson-io/kaizen/pull/1212 --repo Garsson-io/kaizen --squash --auto',
+      { readVerdict: failReader, env: {} },
+    );
+    expect(result.action).toBe('deny');
+  });
+
+  it('allows a merge when the latest round is PASS', () => {
+    expect(checkMergeVerdict('gh pr merge 1212 --repo Garsson-io/kaizen', {
+      readVerdict: passReader,
+      env: {},
+    }).action).toBe('allow');
+  });
+
+  it('warns when there are no review rounds', () => {
+    expect(checkMergeVerdict('gh pr merge 999 --repo Garsson-io/kaizen', {
+      readVerdict: noDataReader,
+      env: {},
+    }).action).toBe('warn');
+  });
+
+  it('honours the explicit override env on FAIL', () => {
+    const result = checkMergeVerdict('gh pr merge 1212 --repo Garsson-io/kaizen', {
+      readVerdict: failReader,
+      env: { [MERGE_OVERRIDE_ENV]: '1' },
+    });
+    expect(result.action).toBe('allow');
+    expect(result.bypassed).toBe(true);
+  });
+
+  it('fails open with a warning if verdict reading throws', () => {
+    expect(checkMergeVerdict('gh pr merge 1212 --repo Garsson-io/kaizen', {
+      readVerdict: throwReader,
+      env: {},
+    }).action).toBe('warn');
+  });
+
+  it('ignores non-merge commands', () => {
+    expect(checkMergeVerdict('gh pr create --title x', { readVerdict: failReader }).action).toBe('allow');
+    expect(checkMergeVerdict('git push origin HEAD', { readVerdict: failReader }).action).toBe('allow');
+    expect(checkMergeVerdict('echo gh pr merge 1', { readVerdict: failReader }).action).toBe('allow');
+  });
+});

--- a/src/hooks/enforce-merge-verdict.test.ts
+++ b/src/hooks/enforce-merge-verdict.test.ts
@@ -2,10 +2,18 @@ import { describe, expect, it } from 'vitest';
 import {
   checkMergeVerdict,
   decideMergeGate,
+  inferGithubRepoFromCommandTarget,
   MERGE_OVERRIDE_ENV,
   parseMergeTarget,
   type VerdictReader,
 } from './enforce-merge-verdict.js';
+
+const gitRunner = (remoteUrl = 'https://github.com/Garsson-io/kaizen.git') => (args: readonly string[]) => {
+  if (args.join(' ').includes('remote get-url origin')) {
+    return { stdout: `${remoteUrl}\n`, stderr: '', exitCode: 0 };
+  }
+  return { stdout: '', stderr: '', exitCode: 1 };
+};
 
 describe('parseMergeTarget', () => {
   it('parses bare PR number + --repo', () => {
@@ -21,8 +29,34 @@ describe('parseMergeTarget', () => {
     ).toEqual({ pr: '456', repo: 'Garsson-io/kaizen' });
   });
 
-  it('returns null when no target repo can be resolved', () => {
-    expect(parseMergeTarget('gh pr merge 123 --squash')).toBeNull();
+  it('infers repo from the command target worktree for bare PR numbers', () => {
+    expect(parseMergeTarget('gh pr merge 123 --squash', {
+      cwd: '/repo',
+      git: gitRunner(),
+    })).toEqual({ pr: '123', repo: 'Garsson-io/kaizen' });
+  });
+
+  it('returns null when no target repo can be resolved from flags, URL, or remote', () => {
+    expect(parseMergeTarget('gh pr merge 123 --squash', {
+      cwd: '/repo',
+      git: gitRunner('not-github'),
+    })).toBeNull();
+  });
+});
+
+describe('inferGithubRepoFromCommandTarget', () => {
+  it('anchors repo inference to cd target before reading origin', () => {
+    const calls: string[][] = [];
+    const git = (args: readonly string[]) => {
+      calls.push([...args]);
+      return { stdout: 'git@github.com:Garsson-io/kaizen.git\n', stderr: '', exitCode: 0 };
+    };
+
+    expect(inferGithubRepoFromCommandTarget('cd /wt && gh pr merge 123 --squash', {
+      cwd: '/cwd',
+      git,
+    })).toBe('Garsson-io/kaizen');
+    expect(calls[0]).toEqual(['-C', '/wt', 'remote', 'get-url', 'origin']);
   });
 });
 
@@ -67,6 +101,18 @@ describe('checkMergeVerdict', () => {
       { readVerdict: failReader, env: {} },
     );
     expect(result.action).toBe('deny');
+  });
+
+  it('blocks a bare gh pr merge <N> command when the current repo has a FAIL verdict', () => {
+    const result = checkMergeVerdict('gh pr merge 1212 --squash', {
+      readVerdict: failReader,
+      env: {},
+      cwd: '/repo',
+      git: gitRunner(),
+    });
+    expect(result.action).toBe('deny');
+    expect(result.target).toEqual({ pr: '1212', repo: 'Garsson-io/kaizen' });
+    expect(result.verdict).toBe('FAIL');
   });
 
   it('allows a merge when the latest round is PASS', () => {

--- a/src/hooks/enforce-merge-verdict.ts
+++ b/src/hooks/enforce-merge-verdict.ts
@@ -15,12 +15,19 @@ import {
 } from '../structured-data.js';
 import { readHookInput, traceHookEvent, traceNullInput } from './hook-io.js';
 import {
+  detectGhRepo,
   extractPrNumber,
   extractPrUrl,
   extractRepoFlag,
   isGhPrCommand,
   stripHeredocBody,
 } from './parse-command.js';
+import {
+  createDefaultGitExec,
+  gitStdout,
+  resolveTargetWorktree,
+  type GitExec,
+} from './lib/git-state.js';
 
 export const MERGE_OVERRIDE_ENV = 'KAIZEN_ALLOW_MERGE_ON_FAIL';
 
@@ -36,9 +43,33 @@ export interface MergeGateResult {
   action: 'allow' | 'warn' | 'deny';
   message?: string;
   bypassed?: boolean;
+  target?: MergeTarget;
+  verdict?: MergeVerdict;
 }
 
-export function parseMergeTarget(cmdLine: string): MergeTarget | null {
+export interface ParseMergeTargetOptions {
+  cwd?: string;
+  git?: GitExec;
+}
+
+export function inferGithubRepoFromCommandTarget(
+  cmdLine: string,
+  options: ParseMergeTargetOptions = {},
+): string | null {
+  const target = resolveTargetWorktree(cmdLine, options.cwd ?? process.cwd()).dir;
+  const anchor: readonly string[] = target ? ['-C', target] : [];
+  const remoteUrl = gitStdout(
+    [...anchor, 'remote', 'get-url', 'origin'],
+    '',
+    options.git ?? createDefaultGitExec(),
+  );
+  return detectGhRepo(remoteUrl) ?? null;
+}
+
+export function parseMergeTarget(
+  cmdLine: string,
+  options: ParseMergeTargetOptions = {},
+): MergeTarget | null {
   const url = extractPrUrl(cmdLine);
   const parsedUrl = parseGithubPrUrl(url);
   if (parsedUrl) return { repo: parsedUrl.repo, pr: String(parsedUrl.number) };
@@ -46,6 +77,10 @@ export function parseMergeTarget(cmdLine: string): MergeTarget | null {
   const pr = extractPrNumber(cmdLine, 'merge');
   const repo = extractRepoFlag(cmdLine);
   if (pr && repo) return { pr, repo };
+  if (pr) {
+    const inferredRepo = inferGithubRepoFromCommandTarget(cmdLine, options);
+    if (inferredRepo) return { pr, repo: inferredRepo };
+  }
   return null;
 }
 
@@ -100,6 +135,8 @@ This gate binds the stored review verdict to the irreversible merge step.`,
 export interface CheckMergeVerdictOptions {
   readVerdict?: VerdictReader;
   env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  git?: GitExec;
 }
 
 export function checkMergeVerdict(
@@ -109,7 +146,7 @@ export function checkMergeVerdict(
   const cmdLine = stripHeredocBody(command);
   if (!isGhPrCommand(cmdLine, 'merge')) return { action: 'allow' };
 
-  const target = parseMergeTarget(cmdLine);
+  const target = parseMergeTarget(cmdLine, { cwd: options.cwd, git: options.git });
   if (!target) {
     return {
       action: 'warn',
@@ -123,7 +160,9 @@ export function checkMergeVerdict(
   const override = (options.env ?? process.env)[MERGE_OVERRIDE_ENV] === '1';
 
   try {
-    return decideMergeGate(read(target), { override, target });
+    const verdict = read(target);
+    const result = decideMergeGate(verdict, { override, target });
+    return { ...result, target, verdict };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return {
@@ -146,6 +185,9 @@ async function main(): Promise<void> {
   traceHookEvent('enforce-merge-verdict', {
     action: result.action,
     bypassed: result.bypassed ?? false,
+    pr: result.target?.pr,
+    repo: result.target?.repo,
+    verdict: result.verdict,
     reason: result.bypassed ? 'override' : result.action === 'deny' ? 'fail_verdict' : result.action,
   });
   if (result.action === 'deny') {

--- a/src/hooks/enforce-merge-verdict.ts
+++ b/src/hooks/enforce-merge-verdict.ts
@@ -1,0 +1,170 @@
+/**
+ * PreToolUse gate: bind direct `gh pr merge` commands to the stored review verdict.
+ *
+ * Auto-dent now blocks unsafe auto-merge queueing before it asks GitHub to merge.
+ * This hook covers the sibling L2 path: a direct interactive `gh pr merge` must
+ * not bypass a latest review round that derives FAIL.
+ */
+
+import { parseGithubPrUrl } from '../lib/github-pr.js';
+import type { RoundVerdict } from '../review-finding-contract.js';
+import {
+  deriveStoredRoundVerdict,
+  latestReviewRound,
+  prTarget,
+} from '../structured-data.js';
+import { readHookInput, traceHookEvent, traceNullInput } from './hook-io.js';
+import {
+  extractPrNumber,
+  extractPrUrl,
+  extractRepoFlag,
+  isGhPrCommand,
+  stripHeredocBody,
+} from './parse-command.js';
+
+export const MERGE_OVERRIDE_ENV = 'KAIZEN_ALLOW_MERGE_ON_FAIL';
+
+export interface MergeTarget {
+  pr: string;
+  repo: string;
+}
+
+export type MergeVerdict = RoundVerdict | null;
+export type VerdictReader = (target: MergeTarget) => MergeVerdict;
+
+export interface MergeGateResult {
+  action: 'allow' | 'warn' | 'deny';
+  message?: string;
+  bypassed?: boolean;
+}
+
+export function parseMergeTarget(cmdLine: string): MergeTarget | null {
+  const url = extractPrUrl(cmdLine);
+  const parsedUrl = parseGithubPrUrl(url);
+  if (parsedUrl) return { repo: parsedUrl.repo, pr: String(parsedUrl.number) };
+
+  const pr = extractPrNumber(cmdLine, 'merge');
+  const repo = extractRepoFlag(cmdLine);
+  if (pr && repo) return { pr, repo };
+  return null;
+}
+
+export const defaultVerdictReader: VerdictReader = (target) => {
+  const t = prTarget(target.pr, target.repo);
+  const round = latestReviewRound(t);
+  if (round === 0) return null;
+  return deriveStoredRoundVerdict(t, round);
+};
+
+export function decideMergeGate(
+  verdict: MergeVerdict,
+  opts: { override: boolean; target?: MergeTarget } = { override: false },
+): MergeGateResult {
+  const prRef = opts.target ? `PR #${opts.target.pr}` : 'this PR';
+
+  if (verdict === 'FAIL') {
+    if (opts.override) {
+      return {
+        action: 'allow',
+        bypassed: true,
+        message:
+          `[enforce-merge-verdict] OVERRIDE: ${MERGE_OVERRIDE_ENV} is set; ` +
+          `merging ${prRef} despite a FAIL review verdict.`,
+      };
+    }
+    return {
+      action: 'deny',
+      message: `MERGE BLOCKED: ${prRef}'s latest review round derives FAIL.
+
+Fix the findings and re-run the review until the latest round derives PASS, or
+use an explicit logged human override:
+
+  ${MERGE_OVERRIDE_ENV}=1 gh pr merge ...
+
+This gate binds the stored review verdict to the irreversible merge step.`,
+    };
+  }
+
+  if (verdict === null) {
+    return {
+      action: 'warn',
+      message:
+        `[enforce-merge-verdict] No stored review rounds found for ${prRef}; ` +
+        `merge-verdict gate is advisory for this invocation.`,
+    };
+  }
+
+  return { action: 'allow' };
+}
+
+export interface CheckMergeVerdictOptions {
+  readVerdict?: VerdictReader;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function checkMergeVerdict(
+  command: string,
+  options: CheckMergeVerdictOptions = {},
+): MergeGateResult {
+  const cmdLine = stripHeredocBody(command);
+  if (!isGhPrCommand(cmdLine, 'merge')) return { action: 'allow' };
+
+  const target = parseMergeTarget(cmdLine);
+  if (!target) {
+    return {
+      action: 'warn',
+      message:
+        `[enforce-merge-verdict] Could not resolve PR number/repo from the merge command; ` +
+        `merge-verdict gate is advisory for this invocation.`,
+    };
+  }
+
+  const read = options.readVerdict ?? defaultVerdictReader;
+  const override = (options.env ?? process.env)[MERGE_OVERRIDE_ENV] === '1';
+
+  try {
+    return decideMergeGate(read(target), { override, target });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      action: 'warn',
+      message:
+        `[enforce-merge-verdict] Could not read review verdict for PR #${target.pr} ` +
+        `(${msg}); merge-verdict gate is advisory for this invocation.`,
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  const input = await readHookInput();
+  if (!input) {
+    traceNullInput('enforce-merge-verdict');
+    process.exit(0);
+  }
+
+  const result = checkMergeVerdict(input.tool_input?.command ?? '');
+  traceHookEvent('enforce-merge-verdict', {
+    action: result.action,
+    bypassed: result.bypassed ?? false,
+    reason: result.bypassed ? 'override' : result.action === 'deny' ? 'fail_verdict' : result.action,
+  });
+  if (result.action === 'deny') {
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: result.message,
+      },
+    }));
+  } else if (result.message) {
+    process.stderr.write(`\n${result.message}\n`);
+  }
+  process.exit(0);
+}
+
+if (
+  process.argv[1]?.endsWith('enforce-merge-verdict.ts') ||
+  process.argv[1]?.endsWith('enforce-merge-verdict.js')
+) {
+  main().catch(() => process.exit(0));
+}

--- a/src/hooks/wrapper-smoke.test.ts
+++ b/src/hooks/wrapper-smoke.test.ts
@@ -229,6 +229,7 @@ describe('wrapper smoke: null stdin — all traceNullInput hooks exit 0 silently
     'kaizen-check-dirty-files-ts.sh',
     'kaizen-bump-plugin-version-ts.sh',
     'kaizen-enforce-pr-review-ts.sh',
+    'kaizen-enforce-merge-verdict-ts.sh',
     'kaizen-pr-kaizen-clear-fallback.sh',
     'kaizen-enforce-pr-reflect-ts.sh',
     'kaizen-post-merge-clear-ts.sh',

--- a/src/lib/github-pr.test.ts
+++ b/src/lib/github-pr.test.ts
@@ -4,6 +4,7 @@ import {
   findOpenPrUrlForBranch,
   parseBranchPrQueryResult,
   parseFirstPrUrl,
+  parseGithubIssueUrl,
   parseGithubPrUrl,
   parseIssueNumber,
   parseIssueState,
@@ -24,6 +25,22 @@ describe('parseGithubPrUrl', () => {
     expect(parseGithubPrUrl('https://gitlab.com/Garsson-io/kaizen/pull/997')).toBeNull();
     expect(parseGithubPrUrl('https://github.com/Garsson-io/kaizen/pull/not-a-number')).toBeNull();
     expect(parseGithubPrUrl('')).toBeNull();
+  });
+});
+
+describe('parseGithubIssueUrl', () => {
+  it('returns repo and issue number for a full GitHub issue URL', () => {
+    expect(parseGithubIssueUrl('https://github.com/Garsson-io/kaizen/issues/1220')).toEqual({
+      repo: 'Garsson-io/kaizen',
+      number: 1220,
+    });
+  });
+
+  it('returns null for non-issue, non-GitHub, and malformed numeric URLs', () => {
+    expect(parseGithubIssueUrl('https://github.com/Garsson-io/kaizen/pull/1220')).toBeNull();
+    expect(parseGithubIssueUrl('https://gitlab.com/Garsson-io/kaizen/issues/1220')).toBeNull();
+    expect(parseGithubIssueUrl('https://github.com/Garsson-io/kaizen/issues/not-a-number')).toBeNull();
+    expect(parseGithubIssueUrl('')).toBeNull();
   });
 });
 

--- a/src/lib/github-pr.ts
+++ b/src/lib/github-pr.ts
@@ -30,6 +30,11 @@ export interface GithubPrUrl {
   number: number;
 }
 
+export interface GithubIssueUrl {
+  repo: string;
+  number: number;
+}
+
 export interface QueryBranchPrStateOptions {
   repo: string;
   branch: string;
@@ -44,6 +49,15 @@ export function emptyBranchPrQueryResult(): BranchPrQueryResult {
 export function parseGithubPrUrl(prUrl: string | undefined | null): GithubPrUrl | null {
   if (!prUrl) return null;
   const match = prUrl.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)$/);
+  if (!match) return null;
+  const number = Number(match[2]);
+  if (!Number.isInteger(number) || number <= 0) return null;
+  return { repo: match[1], number };
+}
+
+export function parseGithubIssueUrl(issueUrl: string | undefined | null): GithubIssueUrl | null {
+  if (!issueUrl) return null;
+  const match = issueUrl.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)$/);
   if (!match) return null;
   const number = Number(match[2]);
   if (!Number.isInteger(number) || number <= 0) return null;


### PR DESCRIPTION
## Story

Once upon a time, auto-dent treated merge as part of the worker loop: prompts told the agent to run `gh pr merge --auto`, and the harness later called `queueAutoMerge` for every PR it saw.

Every day, that worked only when the worker environment had Claude hooks to stop unsafe terminal actions. Codex runs do not have those hooks, and direct `gh pr merge` had no verdict binding either, so the review/process verdict could be computed correctly and still not control the irreversible merge step.

One day, #1220 captured the failure mode: auto-dent could observe a red quality signal such as review skipped, review FAIL, or process-incomplete, then still allow merge to proceed.

Because of that, this PR moves auto-merge ownership back into the harness. Workers now create PRs and leave merge commands alone. The harness computes one shared merge-safety decision after review/process/lifecycle verdicts are known.

Because of that, unsafe current-run PRs now fail closed: `queueAutoMerge` refuses to queue merge, disables any already-queued auto-merge request with argv-safe `gh pr merge --disable-auto`, logs the block reason, and excludes only successfully cancelled unsafe PRs from merge babysitting.

Because of that, direct interactive `gh pr merge` is now guarded by a PreToolUse hook that reads the latest stored review round and denies merges when the derived verdict is `FAIL`, with an explicit traced override via `KAIZEN_ALLOW_MERGE_ON_FAIL=1`.

Until finally, the repo also has a `Review verdict gate` GitHub Actions check. Branch protection can require it as the non-Claude backstop: if the latest stored review round derives `FAIL`, the check fails.

And ever since, auto-dent and direct merge paths consume the same stored verdict signals instead of relying on prompt compliance or duplicated parser logic.

Fixes Garsson-io/kaizen#1220
Related: Garsson-io/kaizen#1227
Related: Garsson-io/kaizen#843

## Architecture

```text
review/process/lifecycle evidence
        |
        v
decideAutoMergeSafety()
        |
        +-- allow --> queueAutoMerge(... --auto)
        |
        +-- deny  --> queueAutoMerge blocks
                      cancelAutoMerge(... --disable-auto)
                      filter cancellable unsafe PRs out of driveBatchToMerge()

stored review findings
        |
        +-- direct gh pr merge hook --> deny on latest round FAIL
        |
        +-- Review verdict gate CI --> fail check on latest round FAIL
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Harness owns auto-merge after review | Codex has no Claude hook layer, so worker-side merge commands are not enforceable | Workers can no longer emit a MERGE marker immediately after PR create |
| Shared `auto-dent-merge-policy` helper | Keeps review/process/lifecycle merge rules in one place | Adds a small module for a compact decision table |
| Reuse `src/lib/github-pr.ts` parsers | Avoids PR/issue URL parser drift and blocks malformed URL flag injection | Strict GitHub URLs are skipped instead of loosely accepted |
| Use argv-based `ghResult` for merge/cancel | Keeps privileged merge commands out of shell-style string interpolation | Queue/cancel paths now return explicit failure lists |
| Deny review `fail`, `skipped`, missing review, `process-incomplete`, and critical lifecycle | Matches #1220's red-verdict failure modes and fails closed for PR-producing runs | Synthetic test tasks can opt out of review-required gating |
| Direct `gh pr merge` hook denies stored `FAIL` verdicts | Covers the L2 merge path outside auto-dent | Missing review data warns rather than blocking every non-kaizen merge |
| `Review verdict gate` workflow | Provides the status check branch protection can require outside Claude | Repo settings must mark the check required |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-merge-policy.ts` | Shared auto-merge allow/deny decision helper |
| `scripts/auto-dent-github.ts` | Shared PR/issue URL parsing, argv-safe auto-merge queue/cancel, explicit failure reporting |
| `scripts/auto-dent-run.ts` | Computes merge decision after verdicts and wires it into queueing/babysitting |
| `src/hooks/enforce-merge-verdict.ts` + wrapper/manifest | Blocks direct `gh pr merge` when the latest stored round derives `FAIL` |
| `scripts/review-verdict-status.ts` + workflow | CI status check that fails on latest stored review `FAIL` |
| `prompts/deep-dive-default.md`, `prompts/test-task.md`, `prompts/subtract-prune.md` | Stop telling workers to run merge commands before harness review |
| Tests | Policy, terminal-action, parser, hook, status-check, prompt, smoke, and wiring regression coverage |

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Workflow |
|---|---:|---:|---:|---:|
| Review FAIL blocks auto-merge | yes | yes | local harness wiring | prompt no longer instructs worker merge |
| Review skipped/missing blocks PR-producing auto-merge | yes | yes | local harness wiring | yes |
| Process-incomplete blocks auto-merge | yes | yes | local harness wiring | yes |
| Unsafe PR cancels queued auto-merge | yes | yes, `--disable-auto` assertion | log failure lists | yes |
| Cancel failure remains visible | yes | yes | unsafe PR not silently removed from babysitting | yes |
| Direct `gh pr merge` blocks stored FAIL | yes | wrapper smoke | PreToolUse hook registered | yes |
| CI check fails stored FAIL | yes | script target parsing | GitHub Actions workflow | branch protection can require check |
| DRY parser boundary does not drift | shared parser tests | auto-dent helper tests | source invariant | yes |

## Validation

- [x] `npx vitest run src/lib/github-pr.test.ts scripts/auto-dent-merge-policy.test.ts scripts/auto-dent-github.test.ts scripts/auto-dent-run.test.ts src/hooks/enforce-merge-verdict.test.ts scripts/review-verdict-status.test.ts` — 6 files, 457 tests passed.
- [x] `npx vitest run src/hooks/enforce-merge-verdict.test.ts scripts/review-verdict-status.test.ts scripts/auto-dent-run.test.ts` — 3 files, 339 tests passed.
- [x] `npx vitest run scripts/auto-dent*.test.ts` — 22 files, 1020 tests passed, 2 skipped.
- [x] `npx vitest run src/hooks/wrapper-smoke.test.ts src/hooks/enforce-merge-verdict.test.ts scripts/review-verdict-status.test.ts` — 3 files, 45 tests passed.
- [x] `npm run typecheck` — passed.
- [x] `bash .claude/hooks/tests/validate-hook-integrity.sh` — passed.
- [x] `git diff --check` — clean.
- [x] Structured plan updated on #1220: https://github.com/Garsson-io/kaizen/issues/1220#issuecomment-4820835943
- [x] Structured test plan updated on #1220: https://github.com/Garsson-io/kaizen/issues/1220#issuecomment-4820836211
- [ ] `npm test` — earlier full-suite run hit 2 timeouts in `src/hooks/kaizen-reflect.test.ts` under full-suite load; isolated file passed all 26 tests in ~90s.
- [ ] `npm run test:hooks` — local wrapper exits with known `test_hooks.py` drift: two PR lifecycle assertions and two `kaizen-reflect-ts.sh` timeouts. Shell hook groups and hook integrity passed.

## Branch Protection Follow-up

The code now provides the `Review verdict gate / Review verdict gate` check. To make L3 enforcement binding at GitHub, repo branch protection must require that check.