### PR TITLE
feat(auto-dent): make live output decision-led, not tool-call-led (#1492)

### DIFF
--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -114,6 +114,18 @@ The trampoline prints real-time progress after each run:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
+During a run the live console is **decision-led, not tool-call-led** (#1492). Every
+text source — assistant prose, tool results, and the final result — flows through one
+ingestion pipeline (`ingestRunText` in `auto-dent-stream.ts`), so parsed phase markers
+(`◉ [PICK] #1365 — …`, `[IMPLEMENT]`, `[STOP]`, …) print to the console regardless of
+whether the agent narrated them or `echo`ed them to stdout. Markers are deduplicated, so
+a decision echoed through several stream messages prints once. Control signals (stop,
+contemplation recs) are honored only from agent-authoritative text — never from tool
+output — so a `cat` of a file containing a literal `AUTO_DENT_PHASE: STOP` cannot halt
+the batch. A GitHub branch-push helper URL (`pull/new/…`, `compare/…`) renders as a
+distinct `◉ [PUSH] branch pushed — PR pending` line and a `PR | branch-pushed` work-cycle
+row, so a pushed branch is never misread as a real PR (a later `/pull/<N>` supersedes it).
+
 ### From another terminal
 
 ```bash

--- a/scripts/auto-dent-stream.test.ts
+++ b/scripts/auto-dent-stream.test.ts
@@ -569,6 +569,13 @@ describe('branch-push helper URLs vs real PRs (#1492)', () => {
     expect(prStep?.url).toBe('https://github.com/Garsson-io/kaizen/pull/new/case-x');
   });
 
+  it('classifies a compare URL end-to-end through extractArtifacts (ledger)', () => {
+    const result = makeRunResult();
+    extractArtifacts('open it: https://github.com/o/r/compare/case-x?expand=1', result);
+    expect(result.prs).toEqual([]);
+    expect(result.progressSteps?.find((s) => s.phase === 'PR')?.state).toBe('branch-pushed');
+  });
+
   it('emits a [PUSH] line to the live console', () => {
     const result = makeRunResult();
     const ctx: StreamContext = {};
@@ -582,6 +589,17 @@ describe('branch-push helper URLs vs real PRs (#1492)', () => {
     );
     expect(out).toContain('[PUSH]');
     expect(out).toContain('PR pending');
+  });
+
+  it('dedups the [PUSH] line across messages (shared ctx)', () => {
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+    const url = 'https://github.com/o/r/pull/new/case-x';
+    const out = captureConsole(() => {
+      processStreamMessage(assistantText(`pushed: ${url}`), result, Date.now(), ctx);
+      processStreamMessage(toolResult(`remote: ${url}`), result, Date.now(), ctx);
+    });
+    expect(out.match(/\[PUSH\]/g)?.length).toBe(1);
   });
 
   it('a real PR supersedes the branch-pushed step and is recorded in prs', () => {

--- a/scripts/auto-dent-stream.test.ts
+++ b/scripts/auto-dent-stream.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   extractArtifacts,
+  extractBranchPushUrl,
+  ingestRunText,
+  processStreamMessage,
   postInFlightUpdate,
   buildInFlightComment,
   relativizeWorktreePath,
@@ -433,5 +436,163 @@ describe('collapseWhitespace (#1170)', () => {
 
   it('leaves a single-line string unchanged', () => {
     expect(collapseWhitespace('sed -n 1,40p scripts/x.ts')).toBe('sed -n 1,40p scripts/x.ts');
+  });
+});
+
+// #1492 — the live console must be decision-led, not tool-call-led: phase
+// markers and artifact deltas surface from every text source, not only assistant
+// prose, and a pushed branch is distinguished from a real PR.
+
+/** Capture every console.log line emitted during `fn`, joined for substring asserts. */
+function captureConsole(fn: () => void): string {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.join(' '));
+  });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return lines.join('\n');
+}
+
+function assistantText(text: string): Record<string, any> {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } };
+}
+
+function toolResult(content: string): Record<string, any> {
+  return { type: 'user', message: { content: [{ type: 'tool_result', content }] } };
+}
+
+function resultMsg(text: string): Record<string, any> {
+  return { type: 'result', subtype: 'success', result: text };
+}
+
+describe('phase markers surface from all text sources (#1492)', () => {
+  it('surfaces a PICK marker echoed into a tool result to the console', () => {
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+    const out = captureConsole(() =>
+      processStreamMessage(
+        toolResult('AUTO_DENT_PHASE: PICK | issue=#1365 | title=wire stale-pr-triage'),
+        result,
+        Date.now(),
+        ctx,
+      ),
+    );
+    expect(out).toContain('[PICK]');
+    expect(out).toContain('#1365');
+    // Ledger still updated (pre-existing behaviour) — console now mirrors it.
+    expect(result.pickedIssue).toBe('#1365');
+  });
+
+  it('surfaces a STOP marker from the final result to the console', () => {
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+    const out = captureConsole(() =>
+      processStreamMessage(resultMsg('AUTO_DENT_PHASE: STOP | reason=backlog drained'), result, Date.now(), ctx),
+    );
+    expect(out).toContain('[STOP]');
+    expect(result.stopRequested).toBe(true); // final result is agent-authoritative
+  });
+
+  it('preserves the stop boundary: a STOP marker in a tool result does NOT halt the batch', () => {
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+    const out = captureConsole(() =>
+      // Simulates the agent `cat`ing a source/prompt file that contains a literal marker.
+      processStreamMessage(toolResult('AUTO_DENT_PHASE: STOP | reason=example in a doc'), result, Date.now(), ctx),
+    );
+    expect(out).toContain('[STOP]'); // visible for transparency
+    expect(result.stopRequested).toBe(false); // but never authoritative from tool output
+  });
+
+  it('dedups the same marker echoed across multiple stream messages', () => {
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+    const marker = 'AUTO_DENT_PHASE: PICK | issue=#1365 | title=wire stale-pr-triage';
+    const out = captureConsole(() => {
+      processStreamMessage(assistantText(`Selecting now.\n${marker}`), result, Date.now(), ctx);
+      processStreamMessage(toolResult(marker), result, Date.now(), ctx);
+    });
+    expect(out.match(/\[PICK\]/g)?.length).toBe(1);
+  });
+
+  it('still prints distinct markers (different fields)', () => {
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+    const out = captureConsole(() => {
+      processStreamMessage(assistantText('AUTO_DENT_PHASE: PICK | issue=#1 | title=a'), result, Date.now(), ctx);
+      processStreamMessage(assistantText('AUTO_DENT_PHASE: PICK | issue=#2 | title=b'), result, Date.now(), ctx);
+    });
+    expect(out.match(/\[PICK\]/g)?.length).toBe(2);
+  });
+
+  it('prints an assistant-text marker exactly once (regression)', () => {
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+    const out = captureConsole(() =>
+      processStreamMessage(assistantText('AUTO_DENT_PHASE: IMPLEMENT | case:260628-0001-x'), result, Date.now(), ctx),
+    );
+    expect(out.match(/\[IMPLEMENT\]/g)?.length).toBe(1);
+  });
+
+  it('captures contemplation recs from authoritative text but not from tool output', () => {
+    const fromText = makeRunResult();
+    ingestRunText('CONTEMPLATION_REC: pivot to observability', fromText, '0m00s', {}, { control: true });
+    expect(fromText.contemplationRecs).toEqual(['pivot to observability']);
+
+    const fromTool = makeRunResult();
+    ingestRunText('CONTEMPLATION_REC: pivot to observability', fromTool, '0m00s', {});
+    expect(fromTool.contemplationRecs).toBeUndefined();
+  });
+});
+
+describe('branch-push helper URLs vs real PRs (#1492)', () => {
+  it('extractBranchPushUrl matches pull/new and compare URLs, not a real PR', () => {
+    expect(extractBranchPushUrl('visit https://github.com/o/r/pull/new/my-branch to open')).toBe(
+      'https://github.com/o/r/pull/new/my-branch',
+    );
+    expect(extractBranchPushUrl('https://github.com/o/r/compare/feat?expand=1')).toBe(
+      'https://github.com/o/r/compare/feat?expand=1',
+    );
+    expect(extractBranchPushUrl('https://github.com/o/r/pull/123')).toBeNull();
+  });
+
+  it('classifies a pushed branch as "branch-pushed" without adding it to prs', () => {
+    const result = makeRunResult();
+    extractArtifacts('remote: https://github.com/Garsson-io/kaizen/pull/new/case-x', result);
+    expect(result.prs).toEqual([]);
+    const prStep = result.progressSteps?.find((s) => s.phase === 'PR');
+    expect(prStep?.state).toBe('branch-pushed');
+    expect(prStep?.url).toBe('https://github.com/Garsson-io/kaizen/pull/new/case-x');
+  });
+
+  it('emits a [PUSH] line to the live console', () => {
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+    const out = captureConsole(() =>
+      processStreamMessage(
+        toolResult('remote: Create a pull request:\nremote: https://github.com/o/r/pull/new/case-x'),
+        result,
+        Date.now(),
+        ctx,
+      ),
+    );
+    expect(out).toContain('[PUSH]');
+    expect(out).toContain('PR pending');
+  });
+
+  it('a real PR supersedes the branch-pushed step and is recorded in prs', () => {
+    const result = makeRunResult();
+    extractArtifacts('https://github.com/o/r/pull/new/case-x', result);
+    expect(result.progressSteps?.find((s) => s.phase === 'PR')?.state).toBe('branch-pushed');
+
+    extractArtifacts('PRs created: https://github.com/o/r/pull/123', result);
+    expect(result.prs).toContain('https://github.com/o/r/pull/123');
+    const prStep = result.progressSteps?.find((s) => s.phase === 'PR');
+    expect(prStep?.state).toBe('created');
+    expect(prStep?.url).toBe('https://github.com/o/r/pull/123');
   });
 });

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -217,6 +217,21 @@ function extractIssueRefs(value: string): string[] {
   return refs;
 }
 
+/**
+ * GitHub's post-`git push` "create a pull request" helper URL — `pull/new/<branch>`
+ * or `compare/<branch>?expand=1`. This is NOT a PR: the `pull/\d+` matcher above
+ * already excludes it (no digit follows `pull/`), so detecting it only *adds* the
+ * missing positive "branch pushed, PR pending" signal. Returns the first match, or
+ * null. Single source of truth for the pattern, reused by the ledger and the live
+ * console emitter so the two can never disagree (#1492).
+ */
+export function extractBranchPushUrl(text: string): string | null {
+  const m = text.match(
+    /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/(?:pull\/new\/[^\s)]+|compare\/[^\s)?]+(?:\?[^\s)]*)?)/,
+  );
+  return m ? m[0] : null;
+}
+
 export function extractArtifacts(text: string, result: RunResult): void {
   for (const output of parseHookOutputs(text)) {
     updateProgressFromHookOutput(output, result);
@@ -248,6 +263,21 @@ export function extractArtifacts(text: string, result: RunResult): void {
   }
   for (const m of text.matchAll(/^\s*(?:\*\*)?PRs created:\s*(?:\*\*)?\s*(https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+)/gmi)) {
     pushPr(result, m[1]);
+  }
+  // A GitHub branch-push helper URL is NOT a PR (#1492). Surface it as a
+  // distinct "branch pushed — PR pending" signal so a pushed branch is not
+  // misread as no-progress or conflated with a real PR. Only while no real PR
+  // has landed yet; a later `/pull/<N>` replaces this step via pushPr ('replace').
+  if (result.prs.length === 0) {
+    const pushUrl = extractBranchPushUrl(text);
+    if (pushUrl) {
+      upsertProgressStep(result, {
+        phase: 'PR',
+        state: 'branch-pushed',
+        detail: 'branch pushed — PR pending',
+        url: pushUrl,
+      }, 'replace');
+    }
   }
   for (const m of text.matchAll(/case[:\s]+(\d{6}-\d{4}-[\w-]+)/g)) {
     pushUnique(result.cases, m[1]);
@@ -442,6 +472,12 @@ export interface StreamContext {
   resultReceivedAt?: number;
   lastPhase?: string;
   lastActivity?: string;
+  /**
+   * Rendered run-state lines already printed to the live console, for cross-message
+   * dedup (#1492). A decision echoed through multiple stream messages — e.g. a
+   * marker the agent both narrates and `echo`es to stdout — prints exactly once.
+   */
+  printedMarkers?: Set<string>;
 }
 
 // In-flight progress update interval (10 minutes)
@@ -524,6 +560,81 @@ export function postInFlightUpdate(
   return false;
 }
 
+// Run-text ingestion — one pipeline for every text source (#1492)
+
+/**
+ * Print one derived run-state line to the live console, at most once. Dedup is
+ * keyed on the rendered line via `ctx.printedMarkers`, so the same decision
+ * echoed through several stream messages prints a single time. Returns whether
+ * the line was actually printed. With no `ctx`, prints unconditionally (callers
+ * with no cross-message state — old behaviour preserved).
+ */
+function emitOnce(line: string, elapsed: string, ctx?: StreamContext): boolean {
+  if (ctx) {
+    ctx.printedMarkers ??= new Set<string>();
+    if (ctx.printedMarkers.has(line)) return false;
+    ctx.printedMarkers.add(line);
+  }
+  console.log(`  ${color.dim(`[${elapsed}]`)}  ${line}`);
+  return true;
+}
+
+/**
+ * The single console sink for parsed phase markers. Every text source routes
+ * here, so the live console mirrors the artifact ledger instead of only showing
+ * markers the agent happened to put in assistant prose (#1492).
+ */
+export function emitPhaseMarkers(
+  text: string,
+  elapsed: string,
+  ctx?: StreamContext,
+): void {
+  for (const marker of parsePhaseMarkers(text)) {
+    const line = formatPhaseMarker(marker);
+    if (emitOnce(line, elapsed, ctx) && ctx) ctx.lastPhase = line;
+  }
+}
+
+/**
+ * One pipeline for every run-text source (assistant text, tool results, final
+ * result). Folding the three previously-divergent branches into a single helper
+ * is what keeps the artifact ledger and the live console from drifting — the
+ * exact gap behind #1492, where a phase marker echoed into a tool result fed the
+ * ledger but never reached the console.
+ *
+ * `control` gates the signals that *change run behaviour* (`checkStopSignal`,
+ * contemplation recs, reflection insights). Those are honoured only for
+ * agent-authoritative text — assistant text and the final result — never for
+ * tool results: source/prompt files contain literal `AUTO_DENT_PHASE: STOP`
+ * strings, so a `cat` of one must not be able to halt the batch. Display-only
+ * signals (the artifact ledger and console markers) run for every source.
+ */
+export function ingestRunText(
+  text: string,
+  result: RunResult,
+  elapsed: string,
+  ctx?: StreamContext,
+  opts: { control?: boolean } = {},
+): void {
+  extractArtifacts(text, result);
+  emitPhaseMarkers(text, elapsed, ctx);
+  const pushUrl = extractBranchPushUrl(text);
+  if (pushUrl) {
+    emitOnce(
+      `${color.yellow('◉ [PUSH]')} branch pushed — PR pending ${pushUrl}`,
+      elapsed,
+      ctx,
+    );
+  }
+  if (!opts.control) return;
+
+  checkStopSignal(text, result);
+  const recs = extractContemplationRecommendations(text);
+  if (recs.length > 0) (result.contemplationRecs ??= []).push(...recs);
+  const insights = extractReflectionInsights(text);
+  if (insights.length > 0) (result.reflectionInsights ??= []).push(...insights);
+}
+
 // Main stream message processor
 
 export function processStreamMessage(
@@ -553,24 +664,8 @@ export function processStreamMessage(
             if (ctx) ctx.lastActivity = toolDesc;
           }
           if (block.type === 'text' && block.text) {
-            extractArtifacts(block.text, result);
-            checkStopSignal(block.text, result);
-            // Extract contemplation recommendations (#631)
-            const recs = extractContemplationRecommendations(block.text);
-            if (recs.length > 0) {
-              if (!result.contemplationRecs) result.contemplationRecs = [];
-              result.contemplationRecs.push(...recs);
-            }
-            // Extract reflection insights (#699)
-            const insights = extractReflectionInsights(block.text);
-            if (insights.length > 0) {
-              if (!result.reflectionInsights) result.reflectionInsights = [];
-              result.reflectionInsights.push(...insights);
-            }
-            for (const marker of parsePhaseMarkers(block.text)) {
-              console.log(`  [${elapsed}]  ${formatPhaseMarker(marker)}`);
-              if (ctx) ctx.lastPhase = formatPhaseMarker(marker);
-            }
+            // Assistant prose is agent-authoritative → control signals honoured.
+            ingestRunText(block.text, result, elapsed, ctx, { control: true });
           }
         }
       }
@@ -586,7 +681,9 @@ export function processStreamMessage(
       if (msg.message?.content) {
         for (const block of msg.message.content) {
           if (block.type === 'tool_result' && typeof block.content === 'string') {
-            extractArtifacts(block.content, result);
+            // Tool output is NOT agent-authoritative (a cat'd file may contain a
+            // literal STOP marker) → ledger + console only, no control signals.
+            ingestRunText(block.content, result, elapsed, ctx);
           }
         }
       }
@@ -600,22 +697,12 @@ export function processStreamMessage(
         result.cost = msg.total_cost_usd;
       }
       if (msg.result) {
-        extractArtifacts(msg.result, result);
+        // Final result is agent-authoritative → control signals honoured.
+        ingestRunText(msg.result, result, elapsed, ctx, { control: true });
         const claimResult = parseFinalRunClaim(msg.result);
         result.finalClaimStatus = claimResult.status;
         result.finalClaim = claimResult.claim;
         result.finalClaimWarnings = claimResult.warnings;
-        checkStopSignal(msg.result, result);
-        const recs = extractContemplationRecommendations(msg.result);
-        if (recs.length > 0) {
-          if (!result.contemplationRecs) result.contemplationRecs = [];
-          result.contemplationRecs.push(...recs);
-        }
-        const insights = extractReflectionInsights(msg.result);
-        if (insights.length > 0) {
-          if (!result.reflectionInsights) result.reflectionInsights = [];
-          result.reflectionInsights.push(...insights);
-        }
       }
       {
         const statusText = msg.subtype === 'success'

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -218,6 +218,12 @@ function extractIssueRefs(value: string): string[] {
 }
 
 /**
+ * Human label for a pushed-but-PR-less branch. One constant shared by the ledger
+ * step detail and the live-console line so the two phrasings can never drift (#1492).
+ */
+export const BRANCH_PUSH_PENDING = 'branch pushed — PR pending';
+
+/**
  * GitHub's post-`git push` "create a pull request" helper URL — `pull/new/<branch>`
  * or `compare/<branch>?expand=1`. This is NOT a PR: the `pull/\d+` matcher above
  * already excludes it (no digit follows `pull/`), so detecting it only *adds* the
@@ -274,7 +280,7 @@ export function extractArtifacts(text: string, result: RunResult): void {
       upsertProgressStep(result, {
         phase: 'PR',
         state: 'branch-pushed',
-        detail: 'branch pushed — PR pending',
+        detail: BRANCH_PUSH_PENDING,
         url: pushUrl,
       }, 'replace');
     }
@@ -621,7 +627,7 @@ export function ingestRunText(
   const pushUrl = extractBranchPushUrl(text);
   if (pushUrl) {
     emitOnce(
-      `${color.yellow('◉ [PUSH]')} branch pushed — PR pending ${pushUrl}`,
+      `${color.yellow('◉ [PUSH]')} ${BRANCH_PUSH_PENDING} ${pushUrl}`,
       elapsed,
       ctx,
     );


### PR DESCRIPTION
## Problem

During the `back-cardinal` batch, the auto-dent live console was **tool-call-led, not decision-led**. The screen filled with truncated `grep`/`sed`/`echo`/`Edit` lines while the signals an operator actually needs — which issue was picked, which lifecycle phase completed, whether a real PR exists — were buried. The textbook case: the agent emitted `AUTO_DENT_PHASE: PICK | issue=#1365 | title=…` via a shell `echo`. The console rendered it as a truncated `$ echo AUTO_DENT_PHASE...` shell command instead of the rendered `◉ [PICK] #1365 — …` decision line. A `pull/new/…` branch-push URL was indistinguishable from a real PR.

## Discovery

The root cause was not a missing feature — it was **drift between two mechanisms**. `processStreamMessage` handled run text in three branches that each ran a *different subset* of the same pipeline:

| source | ledger (`extractArtifacts`) | stop / recs | **prints markers** |
|--------|:--:|:--:|:--:|
| assistant text | ✓ | ✓ | **✓** |
| tool result | ✓ | ✗ | **✗** |
| final result | ✓ | ✓ | **✗** |

A marker echoed via `echo` lands in a **tool result**, so it fed the artifact ledger but was never printed. The ledger saw markers from every source; the console saw them from one. That asymmetry *is* the bug.

## Solution

Fold all three branches into one `ingestRunText()` helper, so the ledger and the console can no longer diverge:

- **Every** text source now surfaces phase markers to the console, deduplicated across stream messages via `ctx.printedMarkers` (a marker the agent both narrates *and* echoes prints once).
- A single `control` flag gates the signals that *change run behaviour* (`checkStopSignal`, contemplation recs, reflection insights) to agent-authoritative text only — assistant text and the final result. **This preserves an intentional safety boundary**: source/prompt files contain literal `AUTO_DENT_PHASE: STOP` strings, so a `cat` of one must never halt the batch. One documented parameter replaces an accidental three-way divergence.
- Branch-push helper URLs (`pull/new/…`, `compare/…`) are classified as a distinct **"branch pushed — PR pending"** step via one shared `extractBranchPushUrl` detector — reused by both the ledger and the console emitter so the pattern can't drift. A real `/pull/<N>` later supersedes it.

## Evidence

- New unit tests in `scripts/auto-dent-stream.test.ts` (10 cases) cover: PICK from a tool result reaches the console; STOP from the final result halts but STOP from a tool result does **not** (the safety boundary); cross-message dedup; distinct markers still print; branch-push classification vs real-PR precedence; `[PUSH]` console line.
- `npx vitest run scripts/auto-dent-stream.test.ts` → 46 passed.
- `npm run build` clean; full suite green except one pre-existing load-timeout flake in `kaizen-reflect.test.ts` (passes in isolation; unrelated — this PR touches only `auto-dent-stream.ts`).

## Behaviors × Levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:--:|:--:|:--:|:--:|:--:|
| Phase markers surface from tool results / final result | ✓ | — | — | — | — |
| Cross-message dedup of echoed markers | ✓ | — | — | — | — |
| Stop signal honoured only from authoritative text (safety) | ✓ | — | — | — | — |
| Branch-push URL classified distinctly from a real PR | ✓ | — | — | — | — |

## Impact

The live console becomes a faithful mirror of the artifact ledger: operators see the selected issue, phase transitions, and a pushed-branch-vs-PR distinction without opening raw JSONL or `state.json`. This directly aids debugging of #843/#1220 without depending on them.

## Out of scope (follow-up)

Plan/test-plan comment-URL classification (named in the issue) needs a reliable signal from `store-plan`/`store-testplan`; a prose regex would violate I29 (no hand-rolled parsing for structured data). Deferred rather than shipped as a brittle heuristic.

Closes #1492
Refs #843, #1220

## Kaizen

- **Root cause:** Drift between two mechanisms — the artifact ledger saw phase markers from every text source, but the console printed them only from assistant prose. A marker `echo`ed into a tool result fed the ledger and vanished from the screen.
- **Fix level:** L2 (the stream renderer / observability layer).
- **Repeat failure?** No — first occurrence of this specific console/ledger asymmetry.
- **Escalation needed?** No. The fix is structural within the renderer: one `ingestRunText` pipeline removes the divergence so the two can't drift again.
- **Near-miss:** Consolidating the three branches nearly collapsed an *intentional* safety boundary — `checkStopSignal` is honored only from agent-authoritative text. A grep confirmed 8 source/prompt files contain literal `AUTO_DENT_PHASE: STOP`, so honoring stop from tool results would let a `cat` halt a batch. Preserved behind an explicit `control` flag rather than silently widened. Lesson: when DRYing divergent paths, each difference is either accidental drift to remove or an invariant to preserve — distinguish before collapsing.
- **Backlog issue:** #1502 filed for the deferred plan/test-plan artifact surfacing (needs a structured signal, not prose parsing per I29).