### PR TITLE
Consolidate auto-dent runtime contracts

### DIFF
--- a/scripts/auto-dent-analyze.ts
+++ b/scripts/auto-dent-analyze.ts
@@ -16,10 +16,10 @@
  */
 
 import { readdirSync, readFileSync, existsSync } from 'fs';
-import { join, basename, resolve } from 'path';
+import { basename, join, resolve } from 'path';
 import { execSync } from 'child_process';
 import { readState, type BatchState } from './auto-dent-run.js';
-import { truncateDisplay } from './auto-dent-display.js';
+import { renderToolInputSummary } from './auto-dent-display.js';
 import { parseJsonLines } from '../src/lib/json-lines.js';
 
 // Types
@@ -151,26 +151,7 @@ const DISCOVERY_TOOLS = new Set(['Read', 'Grep', 'Glob', 'Agent', 'ToolSearch'])
 const SHIPPING_TOOLS = new Set(['Bash']); // git/gh commands
 
 function formatToolInputSummary(name: string, input: Record<string, any>): string {
-  switch (name) {
-    case 'Read':
-    case 'Edit':
-    case 'Write':
-      return basename(input?.file_path || '?');
-    case 'Bash': {
-      const cmd = input?.command || input?.description || '?';
-      return truncateDisplay(cmd, 60, { ellipsis: '' });
-    }
-    case 'Grep':
-      return `"${truncateDisplay(input?.pattern || '?', 30, { ellipsis: '' })}"`;
-    case 'Glob':
-      return truncateDisplay(input?.pattern || '?', 40, { ellipsis: '' });
-    case 'Skill':
-      return `/${input?.skill_name || input?.skill || '?'}`;
-    case 'Agent':
-      return truncateDisplay(input?.description || '?', 40, { ellipsis: '' });
-    default:
-      return '';
-  }
+  return renderToolInputSummary(name, input);
 }
 
 function categorizeToolPhase(

--- a/scripts/auto-dent-display.test.ts
+++ b/scripts/auto-dent-display.test.ts
@@ -2,6 +2,13 @@ import { readFileSync } from 'fs';
 import { describe, expect, it } from 'vitest';
 import {
   collapseWhitespace,
+  prettifyPath,
+  relativizeWorktreePath,
+  renderCommandForDisplay,
+  renderPhaseMarkerSummary,
+  renderToolInputSummary,
+  renderToolUse,
+  stripCdPrefix,
   truncateAtWordBoundary,
   truncateDisplay,
 } from './auto-dent-display.js';
@@ -28,6 +35,50 @@ describe('auto-dent display text helpers (#1348)', () => {
     expect(truncateAtWordBoundary('abcdefghijklmnopqrstuvwxyz', 10)).toBe(
       'abcdefghij...',
     );
+  });
+
+  it('normalizes worktree paths while preserving non-worktree text (#1489)', () => {
+    expect(
+      relativizeWorktreePath('/home/aviad/projects/kaizen/.claude/worktrees/260628-1517-k1490-runtime-contracts/scripts/auto-dent-display.ts'),
+    ).toBe('scripts/auto-dent-display.ts');
+    expect(prettifyPath('/home/aviad/projects/kaizen/src/index.ts')).toBe('~/projects/kaizen/src/index.ts');
+    expect(prettifyPath('/tmp/not-a-worktree/file.txt')).toBe('/tmp/not-a-worktree/file.txt');
+  });
+
+  it('prettifies and line-budgets long commands through one renderer (#1489)', () => {
+    const command = 'cd /home/aviad/projects/kaizen/.claude/worktrees/260628-1517-k1490-runtime-contracts && npm run test -- scripts/auto-dent-display.test.ts --reporter verbose';
+
+    expect(stripCdPrefix(command)).toBe('npm run test -- scripts/auto-dent-display.test.ts --reporter verbose');
+    expect(renderCommandForDisplay(command, 48)).toBe('npm run test -- scripts/auto-dent-display.test.…');
+  });
+
+  it('renders tool summaries through the shared renderer contract (#1489)', () => {
+    expect(renderToolUse('Read', {
+      file_path: '/home/aviad/projects/kaizen/.claude/worktrees/260628-1517-k1490-runtime-contracts/scripts/auto-dent-stream.ts',
+    })).toBe('Read scripts/auto-dent-stream.ts');
+    expect(renderToolUse('Bash', {
+      command: 'cd /home/aviad/projects/kaizen/.claude/worktrees/260628-1517-k1490-runtime-contracts; git status --short --branch',
+    })).toBe('$ git status --short --branch');
+    expect(renderToolInputSummary('Grep', { pattern: 'AUTO_DENT_PHASE: PICK and a very long pattern' })).toBe(
+      '"AUTO_DENT_PHASE: PICK and a ve"',
+    );
+  });
+
+  it('renders phase/event summaries through the shared renderer contract (#1489)', () => {
+    expect(renderPhaseMarkerSummary({
+      phase: 'PICK',
+      fields: {
+        issue: '#1490',
+        title: 'consolidate auto-dent provider lifecycle records',
+      },
+    }, '[PICK]')).toBe('[PICK] #1490 consolidate auto-dent provider lifecycle records');
+
+    const long = renderPhaseMarkerSummary({
+      phase: 'REFLECT',
+      fields: { lessons: 'x'.repeat(160) },
+    }, '[REFLECT]');
+    expect(long).toHaveLength(120);
+    expect(long.endsWith('\u2026')).toBe(true);
   });
 });
 

--- a/scripts/auto-dent-display.ts
+++ b/scripts/auto-dent-display.ts
@@ -5,10 +5,21 @@
  * command/path/tool text as bounded human-readable summaries (#1348).
  */
 
+import { basename } from 'node:path';
+
 export interface TruncateDisplayOptions {
   ellipsis?: string;
   collapse?: boolean;
 }
+
+export const DISPLAY_BUDGETS = {
+  path: 60,
+  command: 90,
+  grepPattern: 30,
+  globPattern: 50,
+  agentDescription: 50,
+  taskSubject: 50,
+} as const;
 
 /**
  * Collapse internal whitespace - newlines, tabs, runs of spaces - to a single
@@ -43,4 +54,129 @@ export function truncateAtWordBoundary(text: string, max: number): string {
   const lastSpace = truncated.lastIndexOf(' ');
   const cut = lastSpace > max * 0.5 ? lastSpace : max;
   return truncated.slice(0, cut).replace(/[,\s]+$/, '') + '...';
+}
+
+/** Matches a `.../.claude/worktrees/<id>` prefix; capture group 1 is the trailing slash, if any. */
+const WORKTREE_PREFIX_RE = /\S*?\/\.claude\/worktrees\/[^/\s;|&]+(\/?)/g;
+
+/**
+ * Render worktree-absolute paths repo-relative. A path *under* the worktree
+ * collapses to its remainder (`scripts/x.ts`); a bare worktree root collapses
+ * to `.`. Non-worktree paths are returned unchanged.
+ */
+export function relativizeWorktreePath(s: string): string {
+  if (!s) return s;
+  return s.replace(WORKTREE_PREFIX_RE, (_m, slash) => (slash ? '' : '.'));
+}
+
+/**
+ * Collapse noisy absolute prefixes for display: worktree paths become
+ * repo-relative, then a remaining `/home/<user>/` collapses to `~/`.
+ */
+export function prettifyPath(s: string): string {
+  if (!s) return s;
+  return relativizeWorktreePath(s).replace(/\/home\/[^/\s;|&]+\//g, '~/');
+}
+
+/**
+ * Drop a leading `cd <path>;` / `cd <path> &&` prefix from a command. The
+ * worktree is implied by the run, so the `cd` is pure boilerplate.
+ */
+export function stripCdPrefix(cmd: string): string {
+  return cmd.replace(/^\s*cd\s+\S+\s*(?:;|&&)\s*/, '');
+}
+
+export function renderPathForDisplay(path: string, max = DISPLAY_BUDGETS.path): string {
+  return truncateDisplay(prettifyPath(path || '?'), max);
+}
+
+export function renderCommandForDisplay(command: string, max = DISPLAY_BUDGETS.command): string {
+  return truncateDisplay(prettifyPath(stripCdPrefix(collapseWhitespace(command || '?'))), max);
+}
+
+export function renderToolInputSummary(name: string, input: Record<string, any>): string {
+  switch (name) {
+    case 'Read':
+    case 'Edit':
+    case 'Write':
+      return basename(input?.file_path || '?');
+    case 'Bash':
+      return truncateDisplay(
+        prettifyPath(stripCdPrefix(collapseWhitespace(input?.command || input?.description || '?'))),
+        60,
+        { ellipsis: '' },
+      );
+    case 'Grep':
+      return `"${truncateDisplay(input?.pattern || '?', DISPLAY_BUDGETS.grepPattern, { ellipsis: '' })}"`;
+    case 'Glob':
+      return truncateDisplay(input?.pattern || '?', 40, { ellipsis: '' });
+    case 'Skill':
+      return `/${input?.skill_name || input?.skill || '?'}`;
+    case 'Agent':
+      return truncateDisplay(input?.description || '?', 40, { ellipsis: '' });
+    default:
+      return '';
+  }
+}
+
+export function renderToolUse(
+  name: string,
+  input: Record<string, any>,
+): string {
+  switch (name) {
+    case 'Read':
+      return `Read ${renderPathForDisplay(input?.file_path || '?')}`;
+    case 'Edit':
+      return `Edit ${renderPathForDisplay(input?.file_path || '?')}`;
+    case 'Write':
+      return `Write ${renderPathForDisplay(input?.file_path || '?')}`;
+    case 'Bash':
+      return `$ ${renderCommandForDisplay(input?.command || input?.description || '?')}`;
+    case 'Grep':
+      return `Grep "${truncateDisplay(input?.pattern || '?', DISPLAY_BUDGETS.grepPattern)}" ${prettifyPath(input?.path || '')}`;
+    case 'Glob':
+      return `Glob ${truncateDisplay(input?.pattern || '?', DISPLAY_BUDGETS.globPattern)}`;
+    case 'Skill':
+      return `Skill /${input?.skill_name || input?.skill || '?'}`;
+    case 'Agent':
+      return `Agent: ${truncateDisplay(input?.description || '?', DISPLAY_BUDGETS.agentDescription)}`;
+    case 'TaskCreate':
+      return `Task+ ${truncateDisplay(input?.subject || '?', DISPLAY_BUDGETS.taskSubject)}`;
+    case 'TaskUpdate':
+      return `Task~ #${input?.taskId || '?'} -> ${input?.status || '?'}`;
+    case 'EnterWorktree':
+      return `EnterWorktree ${input?.name || ''}`;
+    case 'ExitWorktree':
+      return 'ExitWorktree';
+    case 'ToolSearch':
+      return 'ToolSearch';
+    default:
+      return name;
+  }
+}
+
+export interface DisplayPhaseMarker {
+  phase: string;
+  fields: Record<string, string>;
+}
+
+export function renderPhaseMarkerSummary(marker: DisplayPhaseMarker, phaseLabel: string): string {
+  const parts = [phaseLabel];
+  const { fields } = marker;
+  if (fields.issue) parts.push(fields.issue);
+  if (fields.title) parts.push(fields.title);
+  if (fields.verdict) parts.push(fields.verdict);
+  if (fields.reason) parts.push(`(${fields.reason})`);
+  if (fields.case) parts.push(`case:${fields.case}`);
+  if (fields.branch) parts.push(`branch:${fields.branch}`);
+  if (fields.result) parts.push(fields.result);
+  if (fields.count) parts.push(`${fields.count} tests`);
+  if (fields.url) parts.push(fields.url);
+  if (fields.status) parts.push(fields.status);
+  if (fields.epic) parts.push(`epic:${fields.epic}`);
+  if (fields.issues_created) parts.push(`created:${fields.issues_created}`);
+  if (fields.issues_filed) parts.push(`${fields.issues_filed} issues filed`);
+  if (fields.lessons) parts.push(fields.lessons);
+
+  return truncateDisplay(parts.join(' '), 120);
 }

--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -18,6 +18,7 @@
 import { resolve } from 'path';
 import { appendJsonLine } from '../src/lib/json-lines.js';
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
+import type { PhaseProviderRecord } from './auto-dent-provider.js';
 
 // Event type definitions
 
@@ -83,7 +84,7 @@ export interface RunCompleteEvent extends BaseEvent {
    * Provider + billing mode per lifecycle phase (#1143, epic #1134).
    * Absent on older events. Keyed by phase → { provider, billing }.
    */
-  phase_providers?: Record<string, { provider: string; billing: string }>;
+  phase_providers?: PhaseProviderRecord;
 }
 
 export interface BatchReflectEvent extends BaseEvent {

--- a/scripts/auto-dent-provider-capabilities.ts
+++ b/scripts/auto-dent-provider-capabilities.ts
@@ -7,23 +7,16 @@
  */
 
 import { escapeMarkdownTableCell } from './markdown-table.js';
-import type { Provider } from './auto-dent-provider.js';
+import { PHASES, type BillingMode, type Phase as AutoDentPhase, type Provider } from './auto-dent-provider.js';
 
-export const AUTO_DENT_PHASES = [
-  'planning',
-  'implementation',
-  'review',
-  'fix',
-  'reflection',
-  'validation',
-] as const;
+// Descriptive capability inventory phases intentionally reuse the runtime
+// provider lifecycle order; this file may add fit metadata but not a phase list.
+export const AUTO_DENT_PHASES = PHASES;
 
-export type AutoDentPhase = typeof AUTO_DENT_PHASES[number];
 // The provider union has a single definition in auto-dent-provider.ts; this
 // alias keeps the `AgentProvider` name used throughout this module while
 // guaranteeing the two can never drift apart (#843).
 export type AgentProvider = Provider;
-export type BillingMode = 'subscription-cli' | 'local-only' | 'api-token';
 export type PhaseFit = 'best' | 'supported' | 'partial' | 'avoid' | 'not-applicable';
 
 export interface ProviderCapability {

--- a/scripts/auto-dent-provider-matrix.test.ts
+++ b/scripts/auto-dent-provider-matrix.test.ts
@@ -140,6 +140,33 @@ describe('provider comparison matrix (#1152)', () => {
     );
   });
 
+  it('rejects provider comparison artifacts with impossible metric values (#1490)', () => {
+    const artifact = buildProviderComparisonArtifact({
+      batchId: 'matrix-invalid-metrics',
+      scenario: 'synthetic-lifecycle',
+      generatedAt: '2026-06-27T13:00:00.000Z',
+      results: defaultProviderComparisonResults(),
+    });
+    const invalid = {
+      ...artifact,
+      results: [
+        {
+          ...artifact.results[0],
+          metrics: {
+            ...artifact.results[0].metrics,
+            processPassRate: -1,
+            emptySuccessRate: 2,
+            hookRejections: -3,
+          },
+        },
+      ],
+    };
+
+    expect(() => parseProviderComparisonArtifact(JSON.stringify(invalid))).toThrow(
+      /metrics/,
+    );
+  });
+
   it('formats reports with provider strategy, verdict, failure class, metrics, and recommendation', () => {
     const artifact = buildProviderComparisonArtifact({
       batchId: 'matrix-1152',

--- a/scripts/auto-dent-provider-matrix.test.ts
+++ b/scripts/auto-dent-provider-matrix.test.ts
@@ -116,6 +116,30 @@ describe('provider comparison matrix (#1152)', () => {
     });
   });
 
+  it('rejects provider comparison artifacts with invalid phase provider records (#1490)', () => {
+    const artifact = buildProviderComparisonArtifact({
+      batchId: 'matrix-invalid',
+      scenario: 'synthetic-lifecycle',
+      generatedAt: '2026-06-27T13:00:00.000Z',
+      results: defaultProviderComparisonResults(),
+    });
+    const invalid = {
+      ...artifact,
+      results: [
+        {
+          ...artifact.results[0],
+          phaseProviders: {
+            planning: { provider: 'not-a-provider', billing: 'subscription-cli' },
+          },
+        },
+      ],
+    };
+
+    expect(() => parseProviderComparisonArtifact(JSON.stringify(invalid))).toThrow(
+      /phaseProviders/,
+    );
+  });
+
   it('formats reports with provider strategy, verdict, failure class, metrics, and recommendation', () => {
     const artifact = buildProviderComparisonArtifact({
       batchId: 'matrix-1152',

--- a/scripts/auto-dent-provider-matrix.ts
+++ b/scripts/auto-dent-provider-matrix.ts
@@ -9,9 +9,11 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
+import { z } from 'zod';
 import {
   CAPABILITY_INVENTORY,
   PHASES,
+  PhaseProviderRecordSchema,
   type PhaseProvider,
   type PhaseProviderRecord,
   type PlanValidation,
@@ -27,6 +29,63 @@ import { escapeMarkdownTableCell } from './markdown-table.js';
 export type ReviewQuality = 'strong' | 'adequate' | 'weak' | 'missing';
 export type CostSignal = 'available' | 'partial' | 'missing';
 export type OperatorInspectability = 'high' | 'medium' | 'low';
+
+const ReviewQualitySchema = z.enum(['strong', 'adequate', 'weak', 'missing']);
+const CostSignalSchema = z.enum(['available', 'partial', 'missing']);
+const OperatorInspectabilitySchema = z.enum(['high', 'medium', 'low']);
+const ProcessVerdictSchema = z.enum(['pass', 'process-incomplete', 'fail-open-warning']);
+
+const ProviderComparisonMetricsSchema = z.object({
+  processPassRate: z.number(),
+  emptySuccessRate: z.number(),
+  processIncompleteRate: z.number(),
+  reviewQuality: ReviewQualitySchema,
+  costSignal: CostSignalSchema,
+  hookRejections: z.number(),
+  operatorInspectability: OperatorInspectabilitySchema,
+}).strict();
+
+export const ProviderComparisonScenarioSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string().min(1),
+  phaseProviders: PhaseProviderRecordSchema,
+}).strict();
+
+export const ProviderComparisonResultSchema = z.object({
+  scenarioId: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string().min(1),
+  phaseProviders: PhaseProviderRecordSchema,
+  processVerdict: ProcessVerdictSchema,
+  failureClass: z.string().nullable(),
+  metrics: ProviderComparisonMetricsSchema,
+  validation: z.object({
+    ok: z.boolean(),
+    violations: z.array(z.object({
+      phase: z.enum(PHASES),
+      provider: z.enum(['claude', 'codex', 'provider-independent']),
+      reason: z.string(),
+    }).strict()),
+  }).strict(),
+  notes: z.array(z.string()),
+}).strict();
+
+const ProviderStrategyRecommendationSchema = z.object({
+  scenarioId: z.string().min(1),
+  label: z.string().min(1),
+  reason: z.string().min(1),
+  score: z.number(),
+}).strict();
+
+export const ProviderComparisonArtifactSchema = z.object({
+  version: z.literal(1),
+  batchId: z.string().min(1),
+  scenario: z.string().min(1),
+  generatedAt: z.string().min(1),
+  recommendation: ProviderStrategyRecommendationSchema,
+  results: z.array(ProviderComparisonResultSchema),
+}).strict();
 
 export interface ProviderComparisonScenario {
   id: string;
@@ -356,34 +415,13 @@ export function buildProviderComparisonArtifact(input: {
   };
 }
 
-function assertArtifactShape(value: unknown): asserts value is ProviderComparisonArtifact {
-  if (!value || typeof value !== 'object') throw new Error('comparison artifact must be an object');
-  const artifact = value as Partial<ProviderComparisonArtifact>;
-  if (artifact.version !== 1) throw new Error('comparison artifact version must be 1');
-  if (typeof artifact.batchId !== 'string') throw new Error('comparison artifact batchId must be a string');
-  if (typeof artifact.scenario !== 'string') throw new Error('comparison artifact scenario must be a string');
-  if (!Array.isArray(artifact.results)) throw new Error('comparison artifact results must be an array');
-  for (const result of artifact.results as Partial<ProviderComparisonResult>[]) {
-    if (typeof result.scenarioId !== 'string') throw new Error('comparison result scenarioId must be a string');
-    if (!result.phaseProviders || typeof result.phaseProviders !== 'object') {
-      throw new Error(`${result.scenarioId}: phaseProviders must be an object`);
-    }
-    if (!result.metrics || typeof result.metrics !== 'object') {
-      throw new Error(`${result.scenarioId}: metrics must be an object`);
-    }
-    if (typeof result.processVerdict !== 'string') {
-      throw new Error(`${result.scenarioId}: processVerdict must be a string`);
-    }
-    if (!('failureClass' in result)) {
-      throw new Error(`${result.scenarioId}: failureClass must be present`);
-    }
-  }
-}
-
 export function parseProviderComparisonArtifact(raw: string): ProviderComparisonArtifact {
   const parsed = JSON.parse(raw);
-  assertArtifactShape(parsed);
-  return parsed;
+  const result = ProviderComparisonArtifactSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`invalid provider comparison artifact: ${result.error.message}`);
+  }
+  return result.data;
 }
 
 export function writeProviderComparisonArtifact(

--- a/scripts/auto-dent-provider-matrix.ts
+++ b/scripts/auto-dent-provider-matrix.ts
@@ -11,13 +11,14 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import {
   CAPABILITY_INVENTORY,
-  type Phase,
+  PHASES,
   type PhaseProvider,
   type PhaseProviderRecord,
   type PlanValidation,
   type Provider,
   type ProviderCapability,
-  type ProviderPlan,
+  phaseProvider,
+  phaseProviderRecordToProviderPlan,
   validateProviderPlan,
 } from './auto-dent-provider.js';
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
@@ -72,17 +73,8 @@ export interface ProviderStrategyRecommendation {
   score: number;
 }
 
-const PHASE_ORDER: Phase[] = [
-  'planning',
-  'implementation',
-  'review',
-  'fix',
-  'reflection',
-  'validation',
-];
-
 function pp(provider: Provider, billing: PhaseProvider['billing']): PhaseProvider {
-  return { provider, billing };
+  return phaseProvider(provider, billing);
 }
 
 const CLAUDE = pp('claude', 'subscription-cli');
@@ -146,32 +138,23 @@ export function providerComparisonScenarios(): ProviderComparisonScenario[] {
   ];
 }
 
-function providerPlanFromRecord(record: PhaseProviderRecord): ProviderPlan {
-  const plan: ProviderPlan = {};
-  for (const phase of PHASE_ORDER) {
-    const provider = record[phase]?.provider;
-    if (provider) plan[phase] = provider;
-  }
-  return plan;
-}
-
 export function validateProviderComparisonScenario(
   scenario: ProviderComparisonScenario,
   inventory: readonly ProviderCapability[] = CAPABILITY_INVENTORY,
 ): PlanValidation {
-  const validation = validateProviderPlan(providerPlanFromRecord(scenario.phaseProviders), inventory);
+  const validation = validateProviderPlan(phaseProviderRecordToProviderPlan(scenario.phaseProviders), inventory);
   return {
     ...validation,
     violations: [...validation.violations].sort((a, b) => {
       const aApi = a.reason.includes('api-token') ? 0 : 1;
       const bApi = b.reason.includes('api-token') ? 0 : 1;
-      return aApi - bApi || PHASE_ORDER.indexOf(a.phase) - PHASE_ORDER.indexOf(b.phase);
+      return aApi - bApi || PHASES.indexOf(a.phase) - PHASES.indexOf(b.phase);
     }),
   };
 }
 
 function phaseSummary(record: PhaseProviderRecord): string {
-  return PHASE_ORDER
+  return PHASES
     .map((phase) => {
       const provider = record[phase];
       return provider ? `${phase}=${provider.provider} (${provider.billing})` : `${phase}=unassigned`;

--- a/scripts/auto-dent-provider-matrix.ts
+++ b/scripts/auto-dent-provider-matrix.ts
@@ -14,6 +14,7 @@ import {
   CAPABILITY_INVENTORY,
   PHASES,
   PhaseProviderRecordSchema,
+  PlanValidationSchema,
   type PhaseProvider,
   type PhaseProviderRecord,
   type PlanValidation,
@@ -26,24 +27,24 @@ import {
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
 import { escapeMarkdownTableCell } from './markdown-table.js';
 
-export type ReviewQuality = 'strong' | 'adequate' | 'weak' | 'missing';
-export type CostSignal = 'available' | 'partial' | 'missing';
-export type OperatorInspectability = 'high' | 'medium' | 'low';
-
 const ReviewQualitySchema = z.enum(['strong', 'adequate', 'weak', 'missing']);
 const CostSignalSchema = z.enum(['available', 'partial', 'missing']);
 const OperatorInspectabilitySchema = z.enum(['high', 'medium', 'low']);
 const ProcessVerdictSchema = z.enum(['pass', 'process-incomplete', 'fail-open-warning']);
+export type ReviewQuality = z.infer<typeof ReviewQualitySchema>;
+export type CostSignal = z.infer<typeof CostSignalSchema>;
+export type OperatorInspectability = z.infer<typeof OperatorInspectabilitySchema>;
 
 const ProviderComparisonMetricsSchema = z.object({
-  processPassRate: z.number(),
-  emptySuccessRate: z.number(),
-  processIncompleteRate: z.number(),
+  processPassRate: z.number().min(0).max(1),
+  emptySuccessRate: z.number().min(0).max(1),
+  processIncompleteRate: z.number().min(0).max(1),
   reviewQuality: ReviewQualitySchema,
   costSignal: CostSignalSchema,
-  hookRejections: z.number(),
+  hookRejections: z.number().int().nonnegative(),
   operatorInspectability: OperatorInspectabilitySchema,
 }).strict();
+export type ProviderComparisonMetrics = z.infer<typeof ProviderComparisonMetricsSchema>;
 
 export const ProviderComparisonScenarioSchema = z.object({
   id: z.string().min(1),
@@ -51,6 +52,7 @@ export const ProviderComparisonScenarioSchema = z.object({
   description: z.string().min(1),
   phaseProviders: PhaseProviderRecordSchema,
 }).strict();
+export type ProviderComparisonScenario = z.infer<typeof ProviderComparisonScenarioSchema>;
 
 export const ProviderComparisonResultSchema = z.object({
   scenarioId: z.string().min(1),
@@ -60,16 +62,10 @@ export const ProviderComparisonResultSchema = z.object({
   processVerdict: ProcessVerdictSchema,
   failureClass: z.string().nullable(),
   metrics: ProviderComparisonMetricsSchema,
-  validation: z.object({
-    ok: z.boolean(),
-    violations: z.array(z.object({
-      phase: z.enum(PHASES),
-      provider: z.enum(['claude', 'codex', 'provider-independent']),
-      reason: z.string(),
-    }).strict()),
-  }).strict(),
+  validation: PlanValidationSchema,
   notes: z.array(z.string()),
 }).strict();
+export type ProviderComparisonResult = z.infer<typeof ProviderComparisonResultSchema>;
 
 const ProviderStrategyRecommendationSchema = z.object({
   scenarioId: z.string().min(1),
@@ -77,6 +73,7 @@ const ProviderStrategyRecommendationSchema = z.object({
   reason: z.string().min(1),
   score: z.number(),
 }).strict();
+export type ProviderStrategyRecommendation = z.infer<typeof ProviderStrategyRecommendationSchema>;
 
 export const ProviderComparisonArtifactSchema = z.object({
   version: z.literal(1),
@@ -86,51 +83,7 @@ export const ProviderComparisonArtifactSchema = z.object({
   recommendation: ProviderStrategyRecommendationSchema,
   results: z.array(ProviderComparisonResultSchema),
 }).strict();
-
-export interface ProviderComparisonScenario {
-  id: string;
-  label: string;
-  description: string;
-  phaseProviders: PhaseProviderRecord;
-}
-
-export interface ProviderComparisonMetrics {
-  processPassRate: number;
-  emptySuccessRate: number;
-  processIncompleteRate: number;
-  reviewQuality: ReviewQuality;
-  costSignal: CostSignal;
-  hookRejections: number;
-  operatorInspectability: OperatorInspectability;
-}
-
-export interface ProviderComparisonResult {
-  scenarioId: string;
-  label: string;
-  description: string;
-  phaseProviders: PhaseProviderRecord;
-  processVerdict: ProcessVerdict;
-  failureClass: string | null;
-  metrics: ProviderComparisonMetrics;
-  validation: PlanValidation;
-  notes: string[];
-}
-
-export interface ProviderComparisonArtifact {
-  version: 1;
-  batchId: string;
-  scenario: string;
-  generatedAt: string;
-  recommendation: ProviderStrategyRecommendation;
-  results: ProviderComparisonResult[];
-}
-
-export interface ProviderStrategyRecommendation {
-  scenarioId: string;
-  label: string;
-  reason: string;
-  score: number;
-}
+export type ProviderComparisonArtifact = z.infer<typeof ProviderComparisonArtifactSchema>;
 
 function pp(provider: Provider, billing: PhaseProvider['billing']): PhaseProvider {
   return phaseProvider(provider, billing);

--- a/scripts/auto-dent-provider.test.ts
+++ b/scripts/auto-dent-provider.test.ts
@@ -1,27 +1,54 @@
 import { describe, it, expect } from 'vitest';
 import {
   CAPABILITY_INVENTORY,
+  BillingModeSchema,
   PHASES,
-  PROVIDERS,
+  PhaseProviderRecordSchema,
+  PhaseProviderSchema,
+  PhaseSchema,
+  ProviderCapabilitySchema,
   SUBSCRIPTION_COMPATIBLE_BILLING,
+  phaseProviderRecordToProviderPlan,
   renderCapabilityMatrix,
   validateProviderPlan,
   defaultPhaseProviders,
+  phaseProvidersForAgentProvider,
+  parsePhaseProviderRecord,
+  ProviderSchema,
   type ProviderCapability,
   type ProviderPlan,
 } from './auto-dent-provider.js';
 
 describe('capability inventory (#1141)', () => {
+  it('exports runtime schemas for provider lifecycle records (#1490)', () => {
+    expect(ProviderSchema.parse('claude')).toBe('claude');
+    expect(PhaseSchema.parse('planning')).toBe('planning');
+    expect(BillingModeSchema.parse('subscription-cli')).toBe('subscription-cli');
+    expect(PhaseProviderSchema.parse({ provider: 'codex', billing: 'subscription-cli' })).toEqual({
+      provider: 'codex',
+      billing: 'subscription-cli',
+    });
+
+    expect(() => ProviderSchema.parse('gpt-five')).toThrow();
+    expect(() => PhaseSchema.parse('deploy')).toThrow();
+    expect(() => BillingModeSchema.parse('credit-card')).toThrow();
+    expect(() => PhaseProviderSchema.parse({ provider: 'claude', billing: 'credit-card' })).toThrow();
+    expect(() => PhaseProviderRecordSchema.parse({
+      deploy: { provider: 'claude', billing: 'subscription-cli' },
+    })).toThrow();
+    expect(() => ProviderCapabilitySchema.parse({
+      provider: 'claude',
+      phase: 'planning',
+      billingMode: 'subscription-cli',
+      fit: 'best',
+      acceptedForUnattended: true,
+      rationale: '',
+    })).toThrow();
+  });
+
   it('validates inventory shape — every entry is well-formed', () => {
-    const fits = new Set(['best', 'works', 'avoid']);
-    const billings = new Set(['subscription-cli', 'local-only', 'api-token']);
     for (const c of CAPABILITY_INVENTORY) {
-      expect(PROVIDERS).toContain(c.provider);
-      expect(PHASES).toContain(c.phase);
-      expect(billings.has(c.billingMode)).toBe(true);
-      expect(fits.has(c.fit)).toBe(true);
-      expect(typeof c.acceptedForUnattended).toBe('boolean');
-      expect(c.rationale.length).toBeGreaterThan(0);
+      expect(ProviderCapabilitySchema.parse(c)).toEqual(c);
     }
   });
 
@@ -119,10 +146,18 @@ describe('defaultPhaseProviders (#1143)', () => {
   });
 
   it('produces a plan that passes validateProviderPlan', () => {
-    const plan: ProviderPlan = {};
-    for (const [phase, pp] of Object.entries(defaultPhaseProviders())) {
-      plan[phase as keyof ProviderPlan] = pp!.provider;
-    }
+    const plan = phaseProviderRecordToProviderPlan(defaultPhaseProviders());
     expect(validateProviderPlan(plan).ok).toBe(true);
+  });
+
+  it('parses and serializes existing default Claude and Codex records through one contract (#1490)', () => {
+    const claude = parsePhaseProviderRecord(defaultPhaseProviders());
+    const codex = parsePhaseProviderRecord(phaseProvidersForAgentProvider('codex'));
+
+    expect(claude).toEqual(defaultPhaseProviders());
+    expect(codex.implementation).toEqual({ provider: 'codex', billing: 'subscription-cli' });
+    expect(codex.review).toEqual({ provider: 'claude', billing: 'subscription-cli' });
+    expect(codex.validation).toEqual({ provider: 'provider-independent', billing: 'local-only' });
+    expect(validateProviderPlan(phaseProviderRecordToProviderPlan(codex)).ok).toBe(true);
   });
 });

--- a/scripts/auto-dent-provider.ts
+++ b/scripts/auto-dent-provider.ts
@@ -123,17 +123,19 @@ export const CAPABILITY_INVENTORY: readonly ProviderCapability[] = [
 ];
 
 /** A single reason a provider plan was rejected. */
-export interface PlanViolation {
-  phase: Phase;
-  provider: Provider;
-  reason: string;
-}
+export const PlanViolationSchema = z.object({
+  phase: PhaseSchema,
+  provider: ProviderSchema,
+  reason: z.string(),
+}).strict();
+export type PlanViolation = z.infer<typeof PlanViolationSchema>;
 
 /** Result of validating a provider plan against the capability inventory. */
-export interface PlanValidation {
-  ok: boolean;
-  violations: PlanViolation[];
-}
+export const PlanValidationSchema = z.object({
+  ok: z.boolean(),
+  violations: z.array(PlanViolationSchema),
+}).strict();
+export type PlanValidation = z.infer<typeof PlanValidationSchema>;
 
 /**
  * Is this (phase, provider) runnable under the subscription-only constraint?
@@ -204,13 +206,6 @@ export function phaseProviderRecordToProviderPlan(record: PhaseProviderRecord): 
     if (provider) plan[phase] = provider;
   }
   return plan;
-}
-
-export function orderedPhaseProviderEntries(record: PhaseProviderRecord): Array<[Phase, PhaseProvider]> {
-  return PHASES.flatMap((phase) => {
-    const provider = record[phase];
-    return provider ? [[phase, provider] as [Phase, PhaseProvider]] : [];
-  });
 }
 
 export function phaseProvider(provider: Provider, billing: BillingMode): PhaseProvider {

--- a/scripts/auto-dent-provider.ts
+++ b/scripts/auto-dent-provider.ts
@@ -7,7 +7,7 @@
  * combination is accepted for unattended batches.
  *
  * It deliberately holds NO orchestration logic and changes NO run behavior. It
- * exposes a typed inventory plus two consumers:
+ * exposes a schema-backed runtime contract plus consumers:
  *   - #1141 renderCapabilityMatrix() — print the provider × phase × billing matrix.
  *   - #1142 validateProviderPlan()   — reject API-token-only (subscription-
  *           incompatible) provider plans with a clear reason.
@@ -21,26 +21,20 @@
  * acceptedForUnattended=false and rejected by validateProviderPlan.
  */
 
+import { z } from 'zod';
+
 /** Agent providers auto-dent can reason about. */
-export type Provider = 'claude' | 'codex' | 'provider-independent';
+export const PROVIDERS = ['claude', 'codex', 'provider-independent'] as const;
+export const ProviderSchema = z.enum(PROVIDERS);
+export type Provider = z.infer<typeof ProviderSchema>;
+
+/** Providers that can run the agent-facing lifecycle phases. */
+export const AGENT_PROVIDERS = ['claude', 'codex'] as const;
+export const AgentProviderSchema = z.enum(AGENT_PROVIDERS);
+export type AgentProvider = z.infer<typeof AgentProviderSchema>;
 
 /** Lifecycle phases where a provider choice is meaningful (epic #1134 vocabulary). */
-export type Phase =
-  | 'planning'
-  | 'implementation'
-  | 'review'
-  | 'fix'
-  | 'reflection'
-  | 'validation';
-
-/** How a capability is billed. Only subscription-compatible modes are accepted. */
-export type BillingMode = 'subscription-cli' | 'local-only' | 'api-token';
-
-/** How well a provider fits a phase. */
-export type Fit = 'best' | 'works' | 'avoid';
-
-/** Canonical phase order — drives matrix layout and ensures every phase is named. */
-export const PHASES: readonly Phase[] = [
+export const PHASES = [
   'planning',
   'implementation',
   'review',
@@ -48,9 +42,18 @@ export const PHASES: readonly Phase[] = [
   'reflection',
   'validation',
 ] as const;
+export const PhaseSchema = z.enum(PHASES);
+export type Phase = z.infer<typeof PhaseSchema>;
 
-/** Providers in canonical display order. */
-export const PROVIDERS: readonly Provider[] = ['claude', 'codex', 'provider-independent'] as const;
+/** How a capability is billed. Only subscription-compatible modes are accepted. */
+export const BILLING_MODES = ['subscription-cli', 'local-only', 'api-token'] as const;
+export const BillingModeSchema = z.enum(BILLING_MODES);
+export type BillingMode = z.infer<typeof BillingModeSchema>;
+
+/** How well a provider fits a phase. */
+export const FITS = ['best', 'works', 'avoid'] as const;
+export const FitSchema = z.enum(FITS);
+export type Fit = z.infer<typeof FitSchema>;
 
 /**
  * Billing modes that are compatible with the hard subscription-only constraint.
@@ -61,17 +64,33 @@ export const SUBSCRIPTION_COMPATIBLE_BILLING: readonly BillingMode[] = [
   'local-only',
 ] as const;
 
+/** Provider + billing recorded for a single phase of a run (#1143). */
+export const PhaseProviderSchema = z.object({
+  provider: ProviderSchema,
+  billing: BillingModeSchema,
+}).strict();
+export type PhaseProvider = z.infer<typeof PhaseProviderSchema>;
+
+/** Per-phase provider/billing record stored on run metrics (#1143). */
+export const PhaseProviderRecordSchema = z.partialRecord(PhaseSchema, PhaseProviderSchema);
+export type PhaseProviderRecord = z.infer<typeof PhaseProviderRecordSchema>;
+
+/** Provider plan schema: which provider runs each phase (phases may be omitted). */
+export const ProviderPlanSchema = z.partialRecord(PhaseSchema, ProviderSchema);
+export type ProviderPlan = z.infer<typeof ProviderPlanSchema>;
+
 /** One row of the capability matrix: a (provider, phase) cell with its properties. */
-export interface ProviderCapability {
-  provider: Provider;
-  phase: Phase;
-  billingMode: BillingMode;
-  fit: Fit;
-  /** Whether this capability is accepted for unattended auto-dent batches. */
-  acceptedForUnattended: boolean;
-  /** One-line human rationale for the fit/accepted decision. */
-  rationale: string;
-}
+export const ProviderCapabilitySchema = z.object({
+  provider: ProviderSchema,
+  phase: PhaseSchema,
+  billingMode: BillingModeSchema,
+  fit: FitSchema,
+  acceptedForUnattended: z.boolean(),
+  rationale: z.string().min(1),
+}).strict();
+
+/** One row of the capability matrix: a (provider, phase) cell with its properties. */
+export type ProviderCapability = z.infer<typeof ProviderCapabilitySchema>;
 
 /**
  * Hand-authored capability inventory. Reflects today's reality plus the Codex
@@ -102,9 +121,6 @@ export const CAPABILITY_INVENTORY: readonly ProviderCapability[] = [
   { provider: 'claude', phase: 'review', billingMode: 'api-token', fit: 'avoid', acceptedForUnattended: false, rationale: 'API-token review works but violates the subscription-only constraint.' },
   { provider: 'codex', phase: 'implementation', billingMode: 'api-token', fit: 'avoid', acceptedForUnattended: false, rationale: 'API-token implementation is an optional future path, not required.' },
 ];
-
-/** A provider plan: which provider runs each phase (phases may be omitted). */
-export type ProviderPlan = Partial<Record<Phase, Provider>>;
 
 /** A single reason a provider plan was rejected. */
 export interface PlanViolation {
@@ -172,14 +188,34 @@ export function validateProviderPlan(
   return { ok: violations.length === 0, violations };
 }
 
-/** Provider + billing recorded for a single phase of a run (#1143). */
-export interface PhaseProvider {
-  provider: Provider;
-  billing: BillingMode;
+export function parsePhaseProviderRecord(input: unknown): PhaseProviderRecord {
+  return PhaseProviderRecordSchema.parse(input);
 }
 
-/** Per-phase provider/billing record stored on run metrics (#1143). */
-export type PhaseProviderRecord = Partial<Record<Phase, PhaseProvider>>;
+export function safeParsePhaseProviderRecord(input: unknown): PhaseProviderRecord | null {
+  const parsed = PhaseProviderRecordSchema.safeParse(input);
+  return parsed.success ? parsed.data : null;
+}
+
+export function phaseProviderRecordToProviderPlan(record: PhaseProviderRecord): ProviderPlan {
+  const plan: ProviderPlan = {};
+  for (const phase of PHASES) {
+    const provider = record[phase]?.provider;
+    if (provider) plan[phase] = provider;
+  }
+  return plan;
+}
+
+export function orderedPhaseProviderEntries(record: PhaseProviderRecord): Array<[Phase, PhaseProvider]> {
+  return PHASES.flatMap((phase) => {
+    const provider = record[phase];
+    return provider ? [[phase, provider] as [Phase, PhaseProvider]] : [];
+  });
+}
+
+export function phaseProvider(provider: Provider, billing: BillingMode): PhaseProvider {
+  return PhaseProviderSchema.parse({ provider, billing });
+}
 
 /**
  * #1143 — The provider/billing reality of an auto-dent run today.
@@ -189,15 +225,28 @@ export type PhaseProviderRecord = Partial<Record<Phase, PhaseProvider>>;
  * run auditable for provider usage and billing mode without changing behavior.
  */
 export function defaultPhaseProviders(): PhaseProviderRecord {
-  const claude: PhaseProvider = { provider: 'claude', billing: 'subscription-cli' };
-  return {
+  const claude = phaseProvider('claude', 'subscription-cli');
+  return parsePhaseProviderRecord({
     planning: claude,
     implementation: claude,
     review: claude,
     fix: claude,
     reflection: claude,
-    validation: { provider: 'provider-independent', billing: 'local-only' },
-  };
+    validation: phaseProvider('provider-independent', 'local-only'),
+  });
+}
+
+export function phaseProvidersForAgentProvider(provider: AgentProvider): PhaseProviderRecord {
+  if (provider !== 'codex') return defaultPhaseProviders();
+  const codex = phaseProvider('codex', 'subscription-cli');
+  return parsePhaseProviderRecord({
+    planning: codex,
+    implementation: codex,
+    review: phaseProvider('claude', 'subscription-cli'),
+    fix: codex,
+    reflection: codex,
+    validation: phaseProvider('provider-independent', 'local-only'),
+  });
 }
 
 /**

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -19,7 +19,6 @@ import {
   formatToolUse,
   formatHeartbeat,
   processStreamMessage,
-  truncateAtWord,
   cleanGuidanceForTitle,
   buildInFlightComment,
   extractLinkedIssue,
@@ -1657,35 +1656,6 @@ describe('BatchState provider field (#1144)', () => {
     expect(shouldRunCodexProvider(makeBatchState({ provider: 'codex', test_task: true }))).toBe(true);
     expect(shouldRunCodexProvider(makeBatchState({ provider: 'claude', test_task: false }))).toBe(false);
     expect(shouldRunCodexProvider(makeBatchState({ provider: undefined, test_task: false }))).toBe(false);
-  });
-});
-
-describe('truncateAtWord', () => {
-  it('returns short text unchanged', () => {
-    expect(truncateAtWord('hello world', 50)).toBe('hello world');
-  });
-
-  it('truncates at word boundary with ellipsis', () => {
-    const result = truncateAtWord('improve the auto dent harness and reflection', 30);
-    expect(result.length).toBeLessThanOrEqual(33); // 30 + "..."
-    expect(result).toContain('...');
-    expect(result).not.toContain(' ...');
-  });
-
-  it('truncates exactly at max when no good word boundary', () => {
-    const result = truncateAtWord('abcdefghijklmnopqrstuvwxyz', 10);
-    expect(result).toBe('abcdefghij...');
-  });
-
-  it('strips trailing commas and spaces before ellipsis', () => {
-    const result = truncateAtWord('improve hooks, testing, and more stuff here', 25);
-    expect(result).not.toMatch(/[,\s]\.\.\.$/);
-    expect(result).toContain('...');
-  });
-
-  it('handles text exactly at max length', () => {
-    const text = 'exactly ten';
-    expect(truncateAtWord(text, 11)).toBe('exactly ten');
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -46,7 +46,7 @@ import {
   readBatchOutcomesFromGithub,
   computeSteeringRecommendations,
 } from './batch-outcome.js';
-import { defaultPhaseProviders, type PhaseProviderRecord } from './auto-dent-provider.js';
+import { phaseProvidersForAgentProvider, type PhaseProviderRecord } from './auto-dent-provider.js';
 import {
   buildKaizenCycleSteps,
   formatIssueForDisplay,
@@ -1265,10 +1265,6 @@ Emit these naturally as you complete each phase. Missing keys are fine — emit 
   return prompt;
 }
 
-// Text utilities
-
-export const truncateAtWord = truncateAtWordBoundary;
-
 /**
  * Clean raw guidance into a readable title.
  * Fixes obvious typos, normalizes whitespace, sentence-cases.
@@ -1319,7 +1315,7 @@ export function ensureBatchProgressIssue(
   }
 
   const cleanGuidance = cleanGuidanceForTitle(state.guidance);
-  const title = `[Auto-Dent] ${truncateAtWord(cleanGuidance, 70)} (${state.batch_id})`;
+  const title = `[Auto-Dent] ${truncateAtWordBoundary(cleanGuidance, 70)} (${state.batch_id})`;
   const startedAt = new Date(state.batch_start * 1000).toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
   const body = [
     `## Auto-Dent Batch`,
@@ -2024,16 +2020,7 @@ function printRunSummary(
 }
 
 function phaseProvidersForState(state: BatchState): PhaseProviderRecord {
-  if (state.provider !== 'codex') return defaultPhaseProviders();
-  const codex = { provider: 'codex' as const, billing: 'subscription-cli' as const };
-  return {
-    planning: codex,
-    implementation: codex,
-    review: { provider: 'claude', billing: 'subscription-cli' },
-    fix: codex,
-    reflection: codex,
-    validation: { provider: 'provider-independent', billing: 'local-only' },
-  };
+  return phaseProvidersForAgentProvider(state.provider);
 }
 
 export function shouldRunCodexProvider(state: Pick<BatchState, 'provider'>): boolean {

--- a/scripts/auto-dent-runtime-contract-invariant.test.ts
+++ b/scripts/auto-dent-runtime-contract-invariant.test.ts
@@ -17,12 +17,13 @@ function stripComments(content: string): string {
 describe('auto-dent runtime contract source invariants (#1490, #1489)', () => {
   it('keeps provider lifecycle files from defining local phase-order arrays (#1490)', () => {
     const providerLifecycleFiles = [
+      'scripts/auto-dent-provider-capabilities.ts',
       'scripts/auto-dent-provider-matrix.ts',
       'scripts/auto-dent-run.ts',
       'scripts/auto-dent-events.ts',
       'scripts/batch-summary.ts',
     ];
-    const localPhaseOrder = /\b(?:const|export\s+const)\s+\w*PHASE\w*(?:ORDER|DISPLAY_ORDER)\s*=\s*\[/;
+    const localPhaseOrder = /\b(?:const|export\s+const)\s+(?:\w*PHASE\w*|PHASES)\s*=\s*\[/;
 
     const offenders = providerLifecycleFiles.filter((file) => localPhaseOrder.test(stripComments(readRepoFile(file))));
 
@@ -43,11 +44,14 @@ describe('auto-dent runtime contract source invariants (#1490, #1489)', () => {
   });
 
   it('fails synthetic local phase-order and truncate-helper fixtures', () => {
-    const localPhaseOrder = /\b(?:const|export\s+const)\s+\w*PHASE\w*(?:ORDER|DISPLAY_ORDER)\s*=\s*\[/;
+    const localPhaseOrder = /\b(?:const|export\s+const)\s+(?:\w*PHASE\w*|PHASES)\s*=\s*\[/;
     const localTruncateHelper = /\b(?:function|const|let|var)\s+truncate[A-Z]\w*\s*(?:[:=(]|=)/;
 
     expect(localPhaseOrder.test('const PHASE_ORDER = ["planning"];')).toBe(true);
     expect(localPhaseOrder.test('const PHASE_DISPLAY_ORDER = ["planning"];')).toBe(true);
+    expect(localPhaseOrder.test('const PHASES = ["planning"];')).toBe(true);
+    expect(localPhaseOrder.test('const PROVIDER_PHASES = ["planning"];')).toBe(true);
+    expect(localPhaseOrder.test('export const LIFECYCLE_PHASES = ["planning"];')).toBe(true);
     expect(localTruncateHelper.test('function truncateCommand(input: string) { return input; }')).toBe(true);
     expect(localTruncateHelper.test('const truncatePath = (input: string) => input;')).toBe(true);
   });

--- a/scripts/auto-dent-runtime-contract-invariant.test.ts
+++ b/scripts/auto-dent-runtime-contract-invariant.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(__dirname, '..');
+
+function readRepoFile(file: string): string {
+  return readFileSync(join(REPO_ROOT, file), 'utf8');
+}
+
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+}
+
+describe('auto-dent runtime contract source invariants (#1490, #1489)', () => {
+  it('keeps provider lifecycle files from defining local phase-order arrays (#1490)', () => {
+    const providerLifecycleFiles = [
+      'scripts/auto-dent-provider-matrix.ts',
+      'scripts/auto-dent-run.ts',
+      'scripts/auto-dent-events.ts',
+      'scripts/batch-summary.ts',
+    ];
+    const localPhaseOrder = /\b(?:const|export\s+const)\s+\w*PHASE\w*(?:ORDER|DISPLAY_ORDER)\s*=\s*\[/;
+
+    const offenders = providerLifecycleFiles.filter((file) => localPhaseOrder.test(stripComments(readRepoFile(file))));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps auto-dent display runtime files from defining local truncate helpers (#1489)', () => {
+    const displayRuntimeFiles = [
+      'scripts/auto-dent-stream.ts',
+      'scripts/auto-dent-run.ts',
+      'scripts/auto-dent-analyze.ts',
+    ];
+    const localTruncateHelper = /\b(?:function|const|let|var)\s+truncate[A-Z]\w*\s*(?:[:=(]|=)/;
+
+    const offenders = displayRuntimeFiles.filter((file) => localTruncateHelper.test(stripComments(readRepoFile(file))));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('fails synthetic local phase-order and truncate-helper fixtures', () => {
+    const localPhaseOrder = /\b(?:const|export\s+const)\s+\w*PHASE\w*(?:ORDER|DISPLAY_ORDER)\s*=\s*\[/;
+    const localTruncateHelper = /\b(?:function|const|let|var)\s+truncate[A-Z]\w*\s*(?:[:=(]|=)/;
+
+    expect(localPhaseOrder.test('const PHASE_ORDER = ["planning"];')).toBe(true);
+    expect(localPhaseOrder.test('const PHASE_DISPLAY_ORDER = ["planning"];')).toBe(true);
+    expect(localTruncateHelper.test('function truncateCommand(input: string) { return input; }')).toBe(true);
+    expect(localTruncateHelper.test('const truncatePath = (input: string) => input;')).toBe(true);
+  });
+
+  it('canonical homes own the shared contracts', () => {
+    expect(readRepoFile('scripts/auto-dent-provider.ts')).toContain('export const PHASES');
+    expect(readRepoFile('scripts/auto-dent-display.ts')).toContain('export function truncateDisplay');
+  });
+});

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -19,8 +19,8 @@ import {
   type RunProgressStep,
 } from './auto-dent-progress.js';
 import {
-  collapseWhitespace,
-  truncateDisplay,
+  renderPhaseMarkerSummary,
+  renderToolUse,
 } from './auto-dent-display.js';
 import { parseHookOutputs, type HookOutput } from '../src/hooks/lib/gate-signal.js';
 import type { Provider } from './auto-dent-provider.js';
@@ -71,46 +71,12 @@ function formatElapsed(startMs: number): string {
   return `${m}m${s.toString().padStart(2, '0')}s`;
 }
 
-export { collapseWhitespace } from './auto-dent-display.js';
-
-// Semantic line budget (#1157)
-//
-// In an auto-dent run worktree every command is prefixed with
-// `cd /home/.../.claude/worktrees/<id>; ...` and every path is absolute under
-// that worktree. That low-signal prefix consumes the truncation budget, pushing
-// the high-value tail (the real command / file) past the cutoff. These pure
-// helpers reclaim the budget for the meaningful part. Display-only: they never
-// touch the machine-readable logs.
-
-/** Matches a `.../.claude/worktrees/<id>` prefix; capture group 1 is the trailing slash, if any. */
-const WORKTREE_PREFIX_RE = /\S*?\/\.claude\/worktrees\/[^/\s;|&]+(\/?)/g;
-
-/**
- * Render worktree-absolute paths repo-relative. A path *under* the worktree
- * (trailing slash present) collapses to its remainder (`scripts/x.ts`); a bare
- * worktree root collapses to `.`. Non-worktree paths are returned unchanged.
- */
-export function relativizeWorktreePath(s: string): string {
-  if (!s) return s;
-  return s.replace(WORKTREE_PREFIX_RE, (_m, slash) => (slash ? '' : '.'));
-}
-
-/**
- * Collapse noisy absolute prefixes for display: worktree paths become
- * repo-relative, then a remaining `/home/<user>/` collapses to `~/`.
- */
-export function prettifyPath(s: string): string {
-  if (!s) return s;
-  return relativizeWorktreePath(s).replace(/\/home\/[^/\s;|&]+\//g, '~/');
-}
-
-/**
- * Drop a leading `cd <path>;` / `cd <path> &&` prefix from a command. The
- * worktree is implied by the run, so the `cd` is pure boilerplate.
- */
-export function stripCdPrefix(cmd: string): string {
-  return cmd.replace(/^\s*cd\s+\S+\s*(?:;|&&)\s*/, '');
-}
+export {
+  collapseWhitespace,
+  prettifyPath,
+  relativizeWorktreePath,
+  stripCdPrefix,
+} from './auto-dent-display.js';
 
 // Tool use formatting
 
@@ -118,36 +84,7 @@ export function formatToolUse(
   name: string,
   input: Record<string, any>,
 ): string {
-  switch (name) {
-    case 'Read':
-      return `Read ${truncateDisplay(prettifyPath(input?.file_path || '?'), 60)}`;
-    case 'Edit':
-      return `Edit ${truncateDisplay(prettifyPath(input?.file_path || '?'), 60)}`;
-    case 'Write':
-      return `Write ${truncateDisplay(prettifyPath(input?.file_path || '?'), 60)}`;
-    case 'Bash':
-      return `$ ${truncateDisplay(prettifyPath(stripCdPrefix(collapseWhitespace(input?.command || input?.description || '?'))), 90)}`;
-    case 'Grep':
-      return `Grep "${truncateDisplay(input?.pattern || '?', 30)}" ${prettifyPath(input?.path || '')}`;
-    case 'Glob':
-      return `Glob ${truncateDisplay(input?.pattern || '?', 50)}`;
-    case 'Skill':
-      return `Skill /${input?.skill_name || input?.skill || '?'}`;
-    case 'Agent':
-      return `Agent: ${truncateDisplay(input?.description || '?', 50)}`;
-    case 'TaskCreate':
-      return `Task+ ${truncateDisplay(input?.subject || '?', 50)}`;
-    case 'TaskUpdate':
-      return `Task~ #${input?.taskId || '?'} -> ${input?.status || '?'}`;
-    case 'EnterWorktree':
-      return `EnterWorktree ${input?.name || ''}`;
-    case 'ExitWorktree':
-      return `ExitWorktree`;
-    case 'ToolSearch':
-      return `ToolSearch`;
-    default:
-      return name;
-  }
+  return renderToolUse(name, input);
 }
 
 // Structured phase marker parsing
@@ -185,26 +122,7 @@ export function parsePhaseMarkers(text: string): PhaseMarker[] {
 export function formatPhaseMarker(marker: PhaseMarker): string {
   const styleFn = PHASE_STYLE[marker.phase] || color.dim;
   const icon = marker.phase === 'STOP' ? '\u25cf' : '\u25c9';
-  const parts = [styleFn(`${icon} [${marker.phase}]`)];
-
-  // Show the most informative fields for each phase
-  const { fields } = marker;
-  if (fields.issue) parts.push(fields.issue);
-  if (fields.title) parts.push(fields.title);
-  if (fields.verdict) parts.push(fields.verdict);
-  if (fields.reason) parts.push(`(${fields.reason})`);
-  if (fields.case) parts.push(`case:${fields.case}`);
-  if (fields.branch) parts.push(`branch:${fields.branch}`);
-  if (fields.result) parts.push(fields.result);
-  if (fields.count) parts.push(`${fields.count} tests`);
-  if (fields.url) parts.push(fields.url);
-  if (fields.status) parts.push(fields.status);
-  if (fields.epic) parts.push(`epic:${fields.epic}`);
-  if (fields.issues_created) parts.push(`created:${fields.issues_created}`);
-  if (fields.issues_filed) parts.push(`${fields.issues_filed} issues filed`);
-  if (fields.lessons) parts.push(fields.lessons);
-
-  return truncateDisplay(parts.join(' '), 120);
+  return renderPhaseMarkerSummary(marker, styleFn(`${icon} [${marker.phase}]`));
 }
 
 // Artifact extraction from agent output

--- a/scripts/batch-summary.test.ts
+++ b/scripts/batch-summary.test.ts
@@ -466,6 +466,25 @@ describe('provider-per-phase distribution (#1143)', () => {
     expect(text).toContain('**planning:** claude (subscription-cli): 1');
   });
 
+  it('skips malformed provider metadata without dropping valid run aggregation (#1490)', () => {
+    const summary = summarizeEvents([
+      makeCompleteEvent({
+        run_num: 1,
+        phase_providers: {
+          planning: { provider: 'not-a-provider', billing: 'subscription-cli' },
+        } as any,
+      }),
+      makeCompleteEvent({ run_num: 2, phase_providers: claudePhases }),
+    ]);
+
+    expect(summary.total_runs).toBe(2);
+    expect(summary.phase_provider_distribution).toEqual({
+      planning: { 'claude (subscription-cli)': 1 },
+      implementation: { 'claude (subscription-cli)': 1 },
+      validation: { 'provider-independent (local-only)': 1 },
+    });
+  });
+
   it('aggregates a hybrid Claude/Codex/provider-independent batch', () => {
     const summary = summarizeEvents([
       makeCompleteEvent({ run_num: 1, phase_providers: {

--- a/scripts/batch-summary.ts
+++ b/scripts/batch-summary.ts
@@ -18,6 +18,7 @@ import { resolve } from 'path';
 import { parseJsonLines } from '../src/lib/json-lines.js';
 import type { EventEnvelope, RunCompleteEvent, RunIssuePickedEvent, RunPrCreatedEvent } from './auto-dent-events.js';
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
+import { PHASES, safeParsePhaseProviderRecord } from './auto-dent-provider.js';
 
 export interface BatchSummary {
   batch_id: string;
@@ -163,7 +164,7 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
   // phase_providers (legacy events) contribute nothing — the map stays sparse.
   const phaseProviderDistribution: Record<string, Record<string, number>> = {};
   for (const e of completeEvents) {
-    const phaseProviders = e.event.phase_providers;
+    const phaseProviders = safeParsePhaseProviderRecord(e.event.phase_providers);
     if (!phaseProviders) continue;
     for (const [phase, pp] of Object.entries(phaseProviders)) {
       if (!pp) continue;
@@ -212,16 +213,6 @@ export function summarizeEvents(envelopes: EventEnvelope[]): BatchSummary {
     process_verdict_distribution: processVerdictDistribution,
   };
 }
-
-/** Lifecycle phase display order for the provider-per-phase summary block (#1143). */
-const PHASE_DISPLAY_ORDER = [
-  'planning',
-  'implementation',
-  'review',
-  'fix',
-  'reflection',
-  'validation',
-];
 
 /**
  * Format a BatchSummary as plain-language text suitable for posting
@@ -317,9 +308,10 @@ export function formatPlainLanguage(summary: BatchSummary): string {
   if (providerPhases.length > 0) {
     lines.push('');
     lines.push('### Provider per Phase');
+    const knownProviderPhases = new Set<string>(PHASES);
     const ordered = [
-      ...PHASE_DISPLAY_ORDER.filter((p) => providerPhases.includes(p)),
-      ...providerPhases.filter((p) => !PHASE_DISPLAY_ORDER.includes(p)).sort(),
+      ...PHASES.filter((p) => providerPhases.includes(p)),
+      ...providerPhases.filter((p) => !knownProviderPhases.has(p)).sort(),
     ];
     for (const phase of ordered) {
       const byProvider = summary.phase_provider_distribution[phase];

--- a/src/hooks/transcript-analysis.test.ts
+++ b/src/hooks/transcript-analysis.test.ts
@@ -84,6 +84,15 @@ describe('truncation ownership (#1351)', () => {
     const source = readFileSync('src/hooks/transcript-analysis.ts', 'utf8');
     expect(source).not.toMatch(/function\s+truncate\s*\(/);
   });
+
+  it('documents why transcript evidence keeps prefix-preserving truncation outside auto-dent display (#1489)', () => {
+    const hookSource = readFileSync('src/hooks/transcript-analysis.ts', 'utf8');
+    const utilSource = readFileSync('src/analysis/util.ts', 'utf8');
+
+    expect(hookSource).toContain("import { truncateAfterPrefix } from '../analysis/util.js'");
+    expect(utilSource).toContain('preserves the transcript-analysis evidence contract');
+    expect(utilSource).toContain('choose how many source characters remain visible');
+  });
 });
 
 describe('analyzeTranscript', () => {


### PR DESCRIPTION
## Story

Auto-dent had two adjacent runtime surfaces that looked consolidated at first glance but still had competing contracts in the files that actually run batches.

Every day, provider lifecycle data flowed through capability rows, provider comparison scenarios, run-complete events, run history, and batch summaries. Display text flowed through `auto-dent-display.ts`, `auto-dent-stream.ts`, `auto-dent-analyze.ts`, and a legacy alias in `auto-dent-run.ts`. Each path was reasonable locally, but phase order, validation, path normalization, command rendering, and truncation policy could drift.

One day, #1490 and #1489 named those as one failure mode: the provider/runtime display contracts were not explicit enough to prevent future local arrays and helper variants from returning.

Because of that, this PR makes `scripts/auto-dent-provider.ts` the schema-backed provider lifecycle boundary: providers, agent providers, phases, billing modes, capability rows, phase-provider records, provider plans, parsing, plan derivation, ordered phase entries, and Claude/Codex default records now live there.

Because of that, this PR also makes `scripts/auto-dent-display.ts` the shared display renderer: worktree path normalization, home-path prettification, command cleanup, line budgets, tool summaries, analyze summaries, and phase/event summaries route through one module. `auto-dent-stream.ts` keeps parsing and color; it no longer owns display policy.

Until finally, the old drift points are guarded by source invariants: provider lifecycle files cannot define local phase-order arrays, and runtime display files cannot define local `truncate*` helpers outside the shared renderer.

And ever since, future provider/display changes have one place to extend and focused tests that fail if the duplicate mechanisms return.

Fixes Garsson-io/kaizen#1490
Fixes Garsson-io/kaizen#1489
Parent: Garsson-io/kaizen#1482
Related: Garsson-io/kaizen#1164

## Architecture

```text
auto-dent-provider.ts
  schemas: Provider / Phase / Billing / Capability / PhaseProviderRecord
  helpers: parse record -> derive plan -> ordered phase entries -> defaults
      |
      +-- auto-dent-provider-matrix.ts
      +-- auto-dent-run.ts
      +-- auto-dent-events.ts
      +-- batch-summary.ts

auto-dent-display.ts
  renderer: truncate / path / command / tool summary / phase summary
      |
      +-- auto-dent-stream.ts
      +-- auto-dent-analyze.ts
      +-- auto-dent-run.ts uses canonical word-boundary helper directly
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Extend `auto-dent-provider.ts` instead of adding a new contracts file | It was already the closest canonical provider owner; a new module would create another import choice | The module grows, but stays coherent: provider lifecycle only |
| Use Zod schemas already in the repo | #1490 asked for a schema-backed runtime boundary; `zod` is already a dependency | Runtime parsing adds small overhead only at record boundaries |
| Move display helpers into `auto-dent-display.ts` | It already owned truncation; stream/analyze were duplicating policy | Stream keeps compatibility re-exports for existing tests/importers |
| Remove `auto-dent-run.ts`’s `truncateAtWord` alias | It was a local display helper competing with the canonical word-boundary helper | Tests moved to the canonical display helper rather than preserving the alias |
| Skip invalid `phase_providers` in batch summaries | Legacy/noisy telemetry should not crash summaries | Bad records are rejected by schema tests and ignored in legacy aggregation |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-provider.ts` | Adds provider lifecycle schemas and shared phase-provider helpers |
| `scripts/auto-dent-provider-matrix.ts` | Removes local phase order and provider-plan conversion |
| `scripts/auto-dent-run.ts` | Uses shared provider record selection and removes local truncate alias |
| `scripts/auto-dent-events.ts` | Types `phase_providers` as the shared provider record |
| `scripts/batch-summary.ts` | Parses provider records through the schema and orders phases through `PHASES` |
| `scripts/auto-dent-display.ts` | Owns path, command, tool, and phase/event summary rendering |
| `scripts/auto-dent-stream.ts` | Delegates display rendering while retaining parser/color responsibilities |
| `scripts/auto-dent-analyze.ts` | Delegates tool input summaries to the shared renderer |
| `scripts/auto-dent-runtime-contract-invariant.test.ts` | Adds source invariants for duplicate phase arrays and local truncate helpers |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Coverage |
|---|---|---|
| 1 | Invalid provider, phase, billing, capability, and phase-provider records are rejected by exported schemas | Unit | Tested in `scripts/auto-dent-provider.test.ts` |
| 2 | Existing Claude defaults and Codex/hybrid provider records remain valid | Unit | Tested in `scripts/auto-dent-provider.test.ts` and `scripts/auto-dent-provider-matrix.test.ts` |
| 3 | Provider matrix, run metrics, event serialization, and batch summary display derive from one phase/provider contract | Integration | Tested in provider matrix, batch summary, run, and source invariant tests |
| 4 | Long command/path rendering strips worktree boilerplate, preserves non-worktree text, and applies one line budget | Unit | Tested in `scripts/auto-dent-display.test.ts` |
| 5 | Runtime display call sites route through the shared renderer | Integration | Tested in `scripts/auto-dent-stream.test.ts`, `scripts/auto-dent-analyze.test.ts`, and source invariant tests |
| 6 | Transcript prefix-visible evidence remains intentionally separate | Unit | Not changed; transcript helper is not an auto-dent runtime display helper and remains covered by existing transcript tests |
| 7 | Source invariants fail for duplicate local phase-order arrays or local `truncate*` runtime helpers | Unit | Tested in `scripts/auto-dent-runtime-contract-invariant.test.ts` |

## Validation

- RED confirmed before implementation: focused contract tests failed for missing schema/display exports and existing duplicate local mechanisms.
- `npx vitest run scripts/auto-dent-display.test.ts scripts/auto-dent-stream.test.ts scripts/auto-dent-provider.test.ts scripts/auto-dent-provider-matrix.test.ts scripts/batch-summary.test.ts scripts/auto-dent-analyze.test.ts scripts/auto-dent-runtime-contract-invariant.test.ts scripts/auto-dent-run.test.ts`  
  Passed: 8 files, 489 tests.
- `npm run typecheck`  
  Passed.
- Source sweep for duplicate provider phase-order arrays in provider lifecycle files: no matches.
- Source sweep for local `truncate*` helpers in auto-dent runtime display files: no matches.
- `npx tsx scripts/auto-dent-provider-matrix.ts --dry-run`  
  Shows all provider scenarios as subscription-compatible.
- `timeout --kill-after=10 180 npx vitest run --testTimeout=30000`  
  Passed: 148 files, 3621 tests, 12 skipped.
- `npm test` with the repo default 10s per-test timeout still times out under full-suite load in unrelated hook/e2e tests (`src/e2e/synthetic-workflow.test.ts`, `src/hooks/kaizen-reflect.test.ts`). Both files pass when run individually.

## Known Limitations

- This PR does not move `src/hooks/transcript-analysis.ts` onto `scripts/auto-dent-display.ts`; `src` should not depend on `scripts`, and its prefix-preserving evidence helper is an intentional non-runtime display contract.
