### PR TITLE
feat(verdicts): enforce producer inventory coverage

### DIFF
--- a/docs/verdict-binding-inventory.md
+++ b/docs/verdict-binding-inventory.md
@@ -1,11 +1,21 @@
 # Verdict Binding Inventory
 
 Kaizen verdicts are only useful when terminal actions must consume them. This
-inventory maps every computed verdict in the #1227 category to the irreversible
-action that enforces it.
+inventory maps every computed verdict in the #1227 category to its source
+producer and to the irreversible action that enforces it.
 
 The table below is generated from `src/verdict-binding-inventory.ts`; keep the
 TypeScript inventory as the source of truth.
+
+| Computed verdict | Producer | Producer signatures | Terminal-critical |
+|---|---|---|---|
+| Stored review round verdict | src/structured-data.ts: deriveStoredRoundVerdict() from per-dimension findings | src/review-finding-contract.ts:type:RoundVerdict<br>src/structured-data.ts:function:deriveStoredRoundVerdict<br>src/structured-data.ts:field:round_verdict | yes |
+| Auto-dent review/fix-loop verdict | scripts/auto-dent-run.ts: runReviewWiring() records pass/fail/skipped | scripts/auto-dent-events.ts:field:review_verdict<br>scripts/auto-dent-run.ts:field:review_verdict | yes |
+| Durable process-evidence verdict | scripts/auto-dent-lifecycle.ts: validateProcessEvidence() | scripts/auto-dent-events.ts:field:process_verdict<br>scripts/auto-dent-lifecycle.ts:function:validateProcessEvidence<br>scripts/auto-dent-lifecycle.ts:type:ProcessVerdict<br>scripts/auto-dent-run.ts:field:process_verdict | yes |
+| Lifecycle health verdict | scripts/auto-dent-lifecycle.ts: validateRunLifecycle() | scripts/auto-dent-lifecycle.ts:function:validateRunLifecycle | yes |
+| PR merge-state verdict | scripts/auto-dent-github.ts: classifyMergeView() / checkMergeStatus() | scripts/auto-dent-github.ts:function:checkMergeStatus<br>scripts/auto-dent-github.ts:function:classifyMergeView | yes |
+| Reflection issue-ref verification verdict | src/hooks/lib/issue-ref-verifier.ts: verifyIssueRef() | src/hooks/lib/issue-ref-verifier.ts:function:verifyIssueRef | yes |
+| Batch outcome schema verdict | scripts/batch-outcome.ts: BatchOutcomeSchema.parse() | scripts/batch-outcome.ts:const:BatchOutcomeSchema | yes |
 
 | Terminal action | Computed verdicts consumed | Enforcing consumer | Failure mode blocked |
 |---|---|---|---|
@@ -19,10 +29,13 @@ TypeScript inventory as the source of truth.
 
 `findInventoryViolations()` fails when:
 
+- a source verdict producer signature is not classified in the inventory
+- a computed verdict has no producer source evidence
 - a required terminal action is missing from the inventory
 - a terminal action consumes no computed verdict
 - a terminal-critical computed verdict has no enforcing terminal consumer
-- source evidence tokens disappear from the files that are supposed to enforce a binding
+- source evidence tokens disappear from the files that are supposed to produce or enforce a binding
 
 That detector is covered by `src/verdict-binding-inventory.test.ts`, including a
-negative test with an intentionally unbound verdict.
+negative test with an intentionally unbound verdict and a producer-boundary test
+with an intentionally unclassified source signature.

--- a/src/verdict-binding-inventory.test.ts
+++ b/src/verdict-binding-inventory.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   REQUIRED_TERMINAL_ACTIONS,
   VERDICT_BINDING_INVENTORY,
+  discoverVerdictProducerSignatures,
   findInventoryViolations,
   renderVerdictBindingInventoryMarkdown,
 } from './verdict-binding-inventory.js';
@@ -34,8 +35,52 @@ describe('verdict binding inventory (#1227)', () => {
     );
   });
 
+  it('flags source verdict producers that are not classified by the inventory', () => {
+    expect(
+      findInventoryViolations(VERDICT_BINDING_INVENTORY, () => '', {
+        discoveredProducerSignatures: ['src/new-verdict.ts:type:NewCriticalVerdict'],
+      }),
+    ).toContain(
+      'verdict producer "src/new-verdict.ts:type:NewCriticalVerdict" is not classified in the inventory',
+    );
+  });
+
+  it('flags computed verdict producer evidence drift', () => {
+    const broken = {
+      ...VERDICT_BINDING_INVENTORY,
+      computedVerdicts: VERDICT_BINDING_INVENTORY.computedVerdicts.map((verdict) =>
+        verdict.id === 'review-round-verdict'
+          ? {
+            ...verdict,
+            sourceEvidence: [
+              { file: 'src/structured-data.ts', tokens: ['missingProducerToken'] },
+            ],
+          }
+          : verdict,
+      ),
+    };
+
+    expect(
+      findInventoryViolations(broken, (path) =>
+        path === 'src/structured-data.ts' ? 'deriveStoredRoundVerdict' : '',
+      ),
+    ).toContain(
+      'computed verdict "review-round-verdict" producer evidence token missing in src/structured-data.ts: missingProducerToken',
+    );
+  });
+
   it('has no unbound computed verdicts and no source-evidence drift', () => {
     expect(findInventoryViolations(VERDICT_BINDING_INVENTORY)).toEqual([]);
+  });
+
+  it('discovers the current source verdict producer surface', () => {
+    expect(discoverVerdictProducerSignatures()).toEqual(expect.arrayContaining([
+      'src/review-finding-contract.ts:type:RoundVerdict',
+      'scripts/auto-dent-lifecycle.ts:type:ProcessVerdict',
+      'scripts/auto-dent-events.ts:field:review_verdict',
+      'scripts/auto-dent-events.ts:field:process_verdict',
+      'scripts/batch-outcome.ts:const:BatchOutcomeSchema',
+    ]));
   });
 
   it('keeps the docs table generated from the same inventory schema', () => {

--- a/src/verdict-binding-inventory.ts
+++ b/src/verdict-binding-inventory.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 
 export const REQUIRED_TERMINAL_ACTIONS = [
   'run-success-stamp',
@@ -14,6 +14,8 @@ export interface ComputedVerdict {
   id: string;
   label: string;
   producer: string;
+  producerSignatures: string[];
+  sourceEvidence: SourceEvidence[];
   terminalCritical: boolean;
 }
 
@@ -34,7 +36,18 @@ export interface TerminalActionBinding {
 
 export interface VerdictBindingInventory {
   computedVerdicts: ComputedVerdict[];
+  nonTerminalVerdictProducers: NonTerminalVerdictProducer[];
   terminalActions: TerminalActionBinding[];
+}
+
+export interface NonTerminalVerdictProducer {
+  signature: string;
+  label: string;
+  rationale: string;
+}
+
+export interface FindInventoryViolationOptions {
+  discoveredProducerSignatures?: string[];
 }
 
 export const VERDICT_BINDING_INVENTORY: VerdictBindingInventory = {
@@ -43,43 +56,212 @@ export const VERDICT_BINDING_INVENTORY: VerdictBindingInventory = {
       id: 'review-round-verdict',
       label: 'Stored review round verdict',
       producer: 'src/structured-data.ts: deriveStoredRoundVerdict() from per-dimension findings',
+      producerSignatures: [
+        'src/review-finding-contract.ts:type:RoundVerdict',
+        'src/structured-data.ts:function:deriveStoredRoundVerdict',
+        'src/structured-data.ts:field:round_verdict',
+      ],
+      sourceEvidence: [
+        { file: 'src/review-finding-contract.ts', tokens: ['export type RoundVerdict', 'deriveRoundVerdict'] },
+        { file: 'src/structured-data.ts', tokens: ['deriveStoredRoundVerdict', 'round_verdict'] },
+      ],
       terminalCritical: true,
     },
     {
       id: 'review-battery-verdict',
       label: 'Auto-dent review/fix-loop verdict',
       producer: 'scripts/auto-dent-run.ts: runReviewWiring() records pass/fail/skipped',
+      producerSignatures: [
+        'scripts/auto-dent-events.ts:field:review_verdict',
+        'scripts/auto-dent-run.ts:field:review_verdict',
+      ],
+      sourceEvidence: [
+        { file: 'scripts/auto-dent-run.ts', tokens: ['runReviewWiring', 'review_verdict'] },
+        { file: 'scripts/auto-dent-events.ts', tokens: ['review_verdict'] },
+      ],
       terminalCritical: true,
     },
     {
       id: 'process-evidence-verdict',
       label: 'Durable process-evidence verdict',
       producer: 'scripts/auto-dent-lifecycle.ts: validateProcessEvidence()',
+      producerSignatures: [
+        'scripts/auto-dent-events.ts:field:process_verdict',
+        'scripts/auto-dent-lifecycle.ts:function:validateProcessEvidence',
+        'scripts/auto-dent-lifecycle.ts:type:ProcessVerdict',
+        'scripts/auto-dent-run.ts:field:process_verdict',
+      ],
+      sourceEvidence: [
+        { file: 'scripts/auto-dent-lifecycle.ts', tokens: ['export type ProcessVerdict', 'validateProcessEvidence'] },
+        { file: 'scripts/auto-dent-events.ts', tokens: ['process_verdict'] },
+      ],
       terminalCritical: true,
     },
     {
       id: 'lifecycle-health-verdict',
       label: 'Lifecycle health verdict',
       producer: 'scripts/auto-dent-lifecycle.ts: validateRunLifecycle()',
+      producerSignatures: [
+        'scripts/auto-dent-lifecycle.ts:function:validateRunLifecycle',
+      ],
+      sourceEvidence: [
+        { file: 'scripts/auto-dent-lifecycle.ts', tokens: ['validateRunLifecycle', 'LifecycleHealth'] },
+      ],
       terminalCritical: true,
     },
     {
       id: 'pr-merge-state-verdict',
       label: 'PR merge-state verdict',
       producer: 'scripts/auto-dent-github.ts: classifyMergeView() / checkMergeStatus()',
+      producerSignatures: [
+        'scripts/auto-dent-github.ts:function:checkMergeStatus',
+        'scripts/auto-dent-github.ts:function:classifyMergeView',
+      ],
+      sourceEvidence: [
+        { file: 'scripts/auto-dent-github.ts', tokens: ['checkMergeStatus', 'classifyMergeView'] },
+      ],
       terminalCritical: true,
     },
     {
       id: 'issue-ref-verification-verdict',
       label: 'Reflection issue-ref verification verdict',
       producer: 'src/hooks/lib/issue-ref-verifier.ts: verifyIssueRef()',
+      producerSignatures: [
+        'src/hooks/lib/issue-ref-verifier.ts:function:verifyIssueRef',
+      ],
+      sourceEvidence: [
+        { file: 'src/hooks/lib/issue-ref-verifier.ts', tokens: ['verifyIssueRef', 'RefStatus'] },
+      ],
       terminalCritical: true,
     },
     {
       id: 'batch-outcome-schema-verdict',
       label: 'Batch outcome schema verdict',
       producer: 'scripts/batch-outcome.ts: BatchOutcomeSchema.parse()',
+      producerSignatures: [
+        'scripts/batch-outcome.ts:const:BatchOutcomeSchema',
+      ],
+      sourceEvidence: [
+        { file: 'scripts/batch-outcome.ts', tokens: ['BatchOutcomeSchema', 'parse'] },
+      ],
       terminalCritical: true,
+    },
+  ],
+  nonTerminalVerdictProducers: [
+    {
+      signature: 'scripts/backlog-health.ts:function:classifyBacklogHealth',
+      label: 'Backlog health report verdict',
+      rationale: 'Advisory reporting signal; it does not directly authorize an irreversible terminal action.',
+    },
+    {
+      signature: 'scripts/backlog-health.ts:type:HealthVerdict',
+      label: 'Backlog health report verdict type',
+      rationale: 'Advisory reporting signal; it does not directly authorize an irreversible terminal action.',
+    },
+    {
+      signature: 'scripts/auto-dent-final-claim.ts:type:FinalClaimProcessVerdict',
+      label: 'Final claim process verdict parser',
+      rationale: 'Input normalization for durable process evidence; terminal binding is represented by process-evidence-verdict.',
+    },
+    {
+      signature: 'scripts/auto-dent-hook-activation.ts:interface:HookActivationVerdict',
+      label: 'Hook activation verdict',
+      rationale: 'Operational observability signal tracked separately from #1227 terminal-action verdicts.',
+    },
+    {
+      signature: 'scripts/auto-dent-hook-activation.ts:function:formatHookActivationBanner',
+      label: 'Hook activation banner formatter',
+      rationale: 'Presentation helper for the hook activation signal, not a new terminal-critical producer.',
+    },
+    {
+      signature: 'scripts/auto-dent-provider-matrix.ts:function:validateProviderComparisonScenario',
+      label: 'Provider matrix validation',
+      rationale: 'Provider fitness validation used for planning/comparison, not an irreversible terminal action verdict.',
+    },
+    {
+      signature: 'scripts/auto-dent-score.ts:field:review_verdict',
+      label: 'Auto-dent score review verdict metric',
+      rationale: 'Analytics copy of the review verdict; terminal binding is represented by review-battery-verdict.',
+    },
+    {
+      signature: 'scripts/batch-summary.ts:field:process_verdict_distribution',
+      label: 'Batch summary process verdict distribution',
+      rationale: 'Aggregated reporting over process verdicts; terminal binding is represented by process-evidence-verdict.',
+    },
+    {
+      signature: 'scripts/review-verdict-status.ts:interface:ReviewVerdictReaders',
+      label: 'Review verdict status reader injection',
+      rationale: 'Dependency-injection shape for reading stored verdicts, not a new verdict producer.',
+    },
+    {
+      signature: 'scripts/review-verdict-status.ts:interface:ReviewVerdictStatus',
+      label: 'Review verdict status check',
+      rationale: 'GitHub check wrapper consuming the stored review verdict, not a new verdict producer.',
+    },
+    {
+      signature: 'src/hooks/enforce-merge-verdict.ts:function:checkMergeVerdict',
+      label: 'Merge verdict consumer check',
+      rationale: 'Consumer of the stored review verdict at merge time, not a new verdict producer.',
+    },
+    {
+      signature: 'src/hooks/enforce-merge-verdict.ts:interface:CheckMergeVerdictOptions',
+      label: 'Merge verdict consumer options',
+      rationale: 'Dependency-injection shape for the merge consumer, not a new verdict producer.',
+    },
+    {
+      signature: 'src/hooks/enforce-merge-verdict.ts:type:MergeVerdict',
+      label: 'Merge verdict consumer alias',
+      rationale: 'Consumer-side alias for the stored review verdict, not a new verdict producer.',
+    },
+    {
+      signature: 'src/hooks/enforce-merge-verdict.ts:type:VerdictReader',
+      label: 'Merge verdict reader',
+      rationale: 'Consumer-side reader for the stored review verdict, not a new verdict producer.',
+    },
+    {
+      signature: 'src/review-battery.ts:function:deriveVerdictFromFindings',
+      label: 'Review battery per-dimension verdict derivation',
+      rationale: 'Intermediate review result rolled into the review-battery-verdict terminal-critical producer.',
+    },
+    {
+      signature: 'src/review-finding-contract.ts:function:deriveVerdictFromFindings',
+      label: 'Review finding verdict derivation',
+      rationale: 'Shared derivation helper consumed by stored review round and review battery verdict producers.',
+    },
+    {
+      signature: 'src/review-finding-contract.ts:function:deriveRoundVerdict',
+      label: 'Review round derivation helper',
+      rationale: 'Helper for the stored review round verdict; terminal binding is represented by review-round-verdict.',
+    },
+    {
+      signature: 'src/review-finding-contract.ts:field:verdict',
+      label: 'Review finding payload verdict field',
+      rationale: 'Structured payload field that feeds review-round/review-battery verdicts, not a separate producer.',
+    },
+    {
+      signature: 'src/structured-data.ts:field:verdict',
+      label: 'Structured review metadata verdict field',
+      rationale: 'Stored metadata field consumed by review-round-verdict, not a separate terminal-critical producer.',
+    },
+    {
+      signature: 'src/verdict-binding-policy.ts:type:ProcessVerdict',
+      label: 'Shared process verdict policy alias',
+      rationale: 'Shared policy type for consuming the process verdict, not an independent producer.',
+    },
+    {
+      signature: 'src/verdict-binding-policy.ts:interface:QualityVerdictPolicyOptions',
+      label: 'Quality verdict policy options',
+      rationale: 'Consumer policy configuration for existing verdicts, not an independent producer.',
+    },
+    {
+      signature: 'src/verdict-binding-policy.ts:interface:QualityVerdictSignals',
+      label: 'Quality verdict policy signals',
+      rationale: 'Consumer policy input shape for existing verdicts, not an independent producer.',
+    },
+    {
+      signature: 'src/verdict-binding-policy.ts:type:ReviewVerdict',
+      label: 'Shared review verdict policy alias',
+      rationale: 'Shared policy type for consuming the review verdict, not an independent producer.',
     },
   ],
   terminalActions: [
@@ -152,11 +334,95 @@ function defaultReadFile(path: string): string {
   return readFileSync(path, 'utf8');
 }
 
+const PRODUCER_SCAN_ROOTS = ['src', 'scripts'];
+
+function listSourceFiles(dir: string): string[] {
+  let entries: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const path = `${dir}/${name}`;
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      entries = entries.concat(listSourceFiles(path));
+      continue;
+    }
+    if (path === 'src/verdict-binding-inventory.ts') continue;
+    if (!path.endsWith('.ts')) continue;
+    if (path.endsWith('.test.ts') || path.endsWith('.e2e.test.ts')) continue;
+    entries.push(path);
+  }
+  return entries;
+}
+
+export function extractVerdictProducerSignatures(file: string, content: string): string[] {
+  const signatures = new Set<string>();
+  const patterns: Array<{ kind: string; regex: RegExp }> = [
+    { kind: 'type', regex: /^\s*export\s+type\s+([A-Za-z0-9_]*Verdict[A-Za-z0-9_]*)\b/gm },
+    { kind: 'interface', regex: /^\s*export\s+interface\s+([A-Za-z0-9_]*Verdict[A-Za-z0-9_]*)\b/gm },
+    { kind: 'const', regex: /^\s*export\s+const\s+([A-Za-z0-9_]*(?:VerdictSchema|OutcomeSchema))\b/gm },
+    { kind: 'function', regex: /^\s*export\s+function\s+((?:derive|classify|validate|check|verify)[A-Za-z0-9_]*Verdict[A-Za-z0-9_]*)\b/gm },
+    { kind: 'field', regex: /^\s*([A-Za-z0-9_]*verdict[A-Za-z0-9_]*)\??:/gm },
+  ];
+
+  for (const { kind, regex } of patterns) {
+    for (const match of content.matchAll(regex)) {
+      if (kind === 'field' && match[1] === 'verdict') continue;
+      signatures.add(`${file}:${kind}:${match[1]}`);
+    }
+  }
+  return [...signatures].sort();
+}
+
+export function discoverVerdictProducerSignatures(
+  readFile: (path: string) => string = defaultReadFile,
+  files: string[] = PRODUCER_SCAN_ROOTS.flatMap(listSourceFiles),
+): string[] {
+  return files.flatMap((file) =>
+    extractVerdictProducerSignatures(file, readFile(file)),
+  ).sort();
+}
+
+function validateEvidence(
+  owner: string,
+  evidenceItems: SourceEvidence[],
+  readFile: (path: string) => string,
+): string[] {
+  const violations: string[] = [];
+  for (const evidence of evidenceItems) {
+    let content = '';
+    try {
+      content = readFile(evidence.file);
+    } catch {
+      violations.push(`${owner} evidence file missing: ${evidence.file}`);
+      continue;
+    }
+    for (const token of evidence.tokens) {
+      if (!content.includes(token)) {
+        violations.push(`${owner} evidence token missing in ${evidence.file}: ${token}`);
+      }
+    }
+  }
+  return violations;
+}
+
 export function findInventoryViolations(
   inventory: VerdictBindingInventory,
   readFile: (path: string) => string = defaultReadFile,
+  options: FindInventoryViolationOptions = {},
 ): string[] {
   const violations: string[] = [];
+  const discoveredProducerSignatures = options.discoveredProducerSignatures
+    ?? (readFile === defaultReadFile ? discoverVerdictProducerSignatures(readFile) : []);
+  const classifiedProducerSignatures = new Set([
+    ...inventory.computedVerdicts.flatMap((verdict) => verdict.producerSignatures ?? []),
+    ...(inventory.nonTerminalVerdictProducers ?? []).map((producer) => producer.signature),
+  ]);
+
+  for (const signature of discoveredProducerSignatures) {
+    if (!classifiedProducerSignatures.has(signature)) {
+      violations.push(`verdict producer "${signature}" is not classified in the inventory`);
+    }
+  }
+
   const actionIds = new Set(inventory.terminalActions.map((action) => action.id));
   for (const required of REQUIRED_TERMINAL_ACTIONS) {
     if (!actionIds.has(required)) {
@@ -168,23 +434,17 @@ export function findInventoryViolations(
     if (action.consumedVerdicts.length === 0) {
       violations.push(`terminal action "${action.id}" consumes no computed verdicts`);
     }
-    for (const evidence of action.sourceEvidence) {
-      let content = '';
-      try {
-        content = readFile(evidence.file);
-      } catch {
-        violations.push(`terminal action "${action.id}" evidence file missing: ${evidence.file}`);
-        continue;
-      }
-      for (const token of evidence.tokens) {
-        if (!content.includes(token)) {
-          violations.push(`terminal action "${action.id}" evidence token missing in ${evidence.file}: ${token}`);
-        }
-      }
-    }
+    violations.push(...validateEvidence(`terminal action "${action.id}"`, action.sourceEvidence, readFile));
   }
 
   for (const verdict of inventory.computedVerdicts) {
+    if ((verdict.producerSignatures ?? []).length === 0) {
+      violations.push(`computed verdict "${verdict.id}" has no producer signatures`);
+    }
+    if ((verdict.sourceEvidence ?? []).length === 0) {
+      violations.push(`computed verdict "${verdict.id}" has no producer source evidence`);
+    }
+    violations.push(...validateEvidence(`computed verdict "${verdict.id}" producer`, verdict.sourceEvidence ?? [], readFile));
     if (!verdict.terminalCritical) continue;
     const consumers = inventory.terminalActions.filter((action) =>
       action.consumedVerdicts.includes(verdict.id),
@@ -208,9 +468,24 @@ export function renderVerdictBindingInventoryMarkdown(
   inventory: VerdictBindingInventory,
 ): string {
   const lines = [
-    '| Terminal action | Computed verdicts consumed | Enforcing consumer | Failure mode blocked |',
+    '| Computed verdict | Producer | Producer signatures | Terminal-critical |',
     '|---|---|---|---|',
   ];
+
+  for (const verdict of inventory.computedVerdicts) {
+    lines.push([
+      verdict.label,
+      verdict.producer,
+      (verdict.producerSignatures ?? []).join('<br>'),
+      verdict.terminalCritical ? 'yes' : 'no',
+    ].map(escapeCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push(
+    '',
+    '| Terminal action | Computed verdicts consumed | Enforcing consumer | Failure mode blocked |',
+    '|---|---|---|---|',
+  );
 
   for (const action of inventory.terminalActions) {
     const verdictLabels = action.consumedVerdicts.map((id) => {


### PR DESCRIPTION
Once upon a time, kaizen had a verdict-binding inventory from #1227. It named the terminal actions that must consume known quality verdicts and tested that every declared terminal-critical verdict had an enforcing consumer.

Every day, that still left one earlier boundary unguarded: a future change could create a new computed verdict or verdict-like source surface without adding it to the inventory at all. The existing detector would only help after someone manually declared the verdict.

One day, #1514 called out that producer-side gap after PR #1510. The right fix was not a second checklist or another markdown table; it was to extend the existing TypeScript inventory so producer coverage and terminal consumer binding are checked together.

Because of that, this PR adds producer signatures and source evidence to every terminal-critical computed verdict in `src/verdict-binding-inventory.ts`. The detector now scans production `src/` and `scripts/` TypeScript surfaces for verdict producer signatures and fails when a discovered signature is not classified by the inventory.

Because of that, verdict-like surfaces that are intentionally not terminal-critical are no longer invisible drift. They are classified in the same inventory module with rationale, while terminal-critical entries still have to name their enforcing terminal action.

Until finally, `src/verdict-binding-inventory.test.ts` now proves the category: an injected unclassified producer signature fails, producer source evidence drift fails, current source has no unclassified producer signatures, and the docs remain generated from the same schema.

And ever since, adding a new producer-like verdict surface forces the maintainer to classify it immediately as either terminal-critical with an enforcing consumer or explicitly non-terminal with rationale.

Fixes Garsson-io/kaizen#1514
Related: Garsson-io/kaizen#1227, Garsson-io/kaizen#1220, Garsson-io/kaizen#519, Garsson-io/kaizen#1230

## Architecture

```
source files under src/ and scripts/
        ↓
discoverVerdictProducerSignatures()
        ↓
VERDICT_BINDING_INVENTORY
  ├─ computedVerdicts[]: terminal-critical producers + source evidence
  ├─ nonTerminalVerdictProducers[]: explicit exclusions + rationale
  └─ terminalActions[]: enforcing consumers + source evidence
        ↓
findInventoryViolations()
  ├─ unclassified producer signature => fail
  ├─ producer evidence drift => fail
  ├─ terminal action evidence drift => fail
  └─ terminal-critical verdict without consumer => fail
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Extend the existing inventory module | Keeps producer and consumer contracts in one source of truth | The inventory is larger because non-terminal verdict-like surfaces are explicit |
| Use source signatures plus evidence tokens | Catches producer-boundary drift without building a full TypeScript semantic analyzer | Detection is conservative text scanning, not whole-program type analysis |
| Classify non-terminal verdict-like surfaces | Prevents noisy false positives while making exclusions reviewable | Maintainers must add rationale for adjacent non-terminal verdict surfaces |
| Reuse one evidence validator | Avoids separate producer/consumer drift check mechanisms | Error messages identify the owner string rather than separate validator types |

## What's In This PR

| File | Purpose |
|---|---|
| `src/verdict-binding-inventory.ts` | Adds producer signatures, non-terminal classifications, source discovery, and shared producer/consumer evidence validation |
| `src/verdict-binding-inventory.test.ts` | Adds red/green tests for unclassified producers, producer evidence drift, live source discovery, and docs drift |
| `docs/verdict-binding-inventory.md` | Documents the producer table and updated detector guarantees |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Status |
|---|---|---|---|---|---|
| 1 | Undeclared source producer signature is flagged before it can remain outside the binding inventory | code | Unit | `src/verdict-binding-inventory.test.ts` | Tested |
| 2 | Terminal-critical producer classified in `computedVerdicts` must have at least one enforcing terminal action consumer | code | Unit | `src/verdict-binding-inventory.test.ts` | Tested |
| 3 | Producer source evidence tokens must continue to exist in the code they claim to describe | code | Unit | `src/verdict-binding-inventory.test.ts` | Tested |
| 4 | Current repository source has no unclassified producer signatures and no docs drift | integration | Integration | `src/verdict-binding-inventory.test.ts` | Tested |

## Validation

- [x] RED: `npx vitest run src/verdict-binding-inventory.test.ts` failed before implementation with missing producer-boundary API/tests.
- [x] `npx vitest run src/verdict-binding-inventory.test.ts` passed: 8 tests.
- [x] `npx vitest run src/verdict-binding-inventory.test.ts src/hooks/enforce-merge-verdict.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-merge-policy.test.ts` passed: 63 tests.
- [x] `npx tsc --noEmit` passed.
- [x] `git diff --check` passed.
- [x] `npx vitest run src/e2e/synthetic-workflow.test.ts -t 'auto-fixes on first hook'` passed in isolation after full-suite timeout.
- [ ] `npm test` did not pass as a whole: the repo-level 120s run timed out; a 180s rerun completed with 12 timeout failures in untouched files (`src/e2e/synthetic-workflow.test.ts` once, and 11 existing `src/hooks/kaizen-reflect.test.ts` timeouts). `src/hooks/kaizen-reflect.test.ts` reproduces the same 11 timeouts in isolation.

## Known Limitations

This is a source-level detector, not a full semantic TypeScript analyzer. It catches exported verdict-ish types/interfaces/functions, outcome schemas, and verdict-named fields, then requires every discovered signature to be classified in the inventory. A producer with no verdict/outcome-shaped source surface would still need human review, but the common producer boundary for this category is now mechanical.
