### PR TITLE
fix(health): unambiguous hook-lifecycle health + owned-failure merge gate (#1481, #1518)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -206,8 +206,23 @@ HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
 npm install          # Install deps
 npm run build        # Compile TypeScript
 npm test             # Run TS tests
-npm run test:hooks   # Run shell hook tests
+npm run test:hooks   # Run shell + Python hook lifecycle tests (test_hooks.py)
 ```
+
+> **`npm run test:hooks` is part of the real health path, not optional.** It runs
+> the Python hook lifecycle suite (`test_hooks.py`); CI installs pytest and runs
+> it (a missing runner is now a hard failure, not a silent skip — #1481), so green
+> CI can no longer hide a red local hook suite.
+
+**Known-failure ownership (#1481 / #1518).** Never merge as if the tree is healthy
+while a relevant test is red. A failing test is either *part of your change* (fix
+it before merge) or a *separate, pre-existing incident* — and the latter must have
+an **owning OPEN issue** in `.agents/kaizen/known-failures.json` (`{ test, issue,
+reason }`). Unowned failures fail `run-all-tests.sh`, the `known-failures` CI job
+fails on a closed/missing owner, and `qualityVerdictBlockReasons` (the merge SSOT)
+blocks merge on `testHealth: unowned-failures`. Under parallelism, exactly one
+agent owns driving a known failure to resolution. See
+`.agents/kaizen/policies-local.md`.
 
 ## Testing — Behavioral vs Structural
 

--- a/.agents/kaizen/known-failures.json
+++ b/.agents/kaizen/known-failures.json
@@ -1,0 +1,4 @@
+{
+  "_doc": "Registry of known-failing tests that are allowed to NOT block merge/CI because each failure has an OWNED, OPEN tracking issue (#1518). A failing test is either fixed before merge, or it is a tracked incident with a single owner — never invisible background noise. Each entry: { test: a substring matched against the failing test id (pytest nodeid, vitest name, or shell test file), issue: the owning OPEN GitHub issue number, reason: why it is tolerated for now }. The `known-failures` CI gate FAILS if any entry's owning issue is closed or missing, forcing a fix or a re-filed owner. An empty list means the tree must be fully green.",
+  "knownFailures": []
+}

--- a/.agents/kaizen/local/policies-local.md
+++ b/.agents/kaizen/local/policies-local.md
@@ -25,10 +25,12 @@ A failing test is **never** invisible background noise. Before you merge:
      and tolerated; otherwise the suite fails.
    - The `known-failures` CI job fails if any registry entry's owning issue is
      closed or missing (fix the test or re-file an owner).
-   - The merge-readiness SSOT (`qualityVerdictBlockReasons`, consumed by both
-     `enforce-merge-verdict` and `decideAutoMergeSafety`) blocks merge on a
+   - The merge-readiness SSOT (`qualityVerdictBlockReasons`, consumed by
+     `decideAutoMergeSafety` for auto-dent auto-merge) blocks merge on a
      `testHealth: unowned-failures` signal; `test-health-verdict` is a
-     terminal-critical entry in `docs/verdict-binding-inventory.md`.
+     terminal-critical entry in `docs/verdict-binding-inventory.md`. (The direct
+     `enforce-merge-verdict` PreToolUse gate consumes the stored review-round
+     verdict, not test health.)
 
 <!-- Example:
 10. Never install system packages on the host. System deps go in Dockerfiles.

--- a/.agents/kaizen/local/policies-local.md
+++ b/.agents/kaizen/local/policies-local.md
@@ -3,6 +3,33 @@
 These policies extend the generic kaizen policies for this project.
 Add project-specific enforcement rules here.
 
+## Known-failure ownership (#1481 / #1518)
+
+A failing test is **never** invisible background noise. Before you merge:
+
+1. **Run the real health path.** `npm run typecheck`, `npm test`, and
+   `npm run test:hooks` (the last includes the Python hook lifecycle suite,
+   `test_hooks.py`, which CI now runs with pytest installed — green CI no longer
+   hides a red local hook suite).
+2. **A failing test is one of two things, never a third.**
+   - *Part of your change* → fix it before merge.
+   - *A separate, pre-existing incident you believe is unrelated* → it must have
+     an **owning OPEN issue** recorded in `.agents/kaizen/known-failures.json`
+     (`{ test, issue, reason }`). Record the exact failing command/nodeid and the
+     issue. "Probably unrelated / pre-existing noise" is not a disposition.
+3. **Single owner under parallelism.** When multiple agents run at once, exactly
+   **one** claims ownership of driving a known failure to resolution or explicit
+   disposition. Do not assume another agent owns it.
+4. **Enforcement is mechanical, not honor-system.**
+   - `run-all-tests.sh` classifies every failure: owned-by-open-issue → logged
+     and tolerated; otherwise the suite fails.
+   - The `known-failures` CI job fails if any registry entry's owning issue is
+     closed or missing (fix the test or re-file an owner).
+   - The merge-readiness SSOT (`qualityVerdictBlockReasons`, consumed by both
+     `enforce-merge-verdict` and `decideAutoMergeSafety`) blocks merge on a
+     `testHealth: unowned-failures` signal; `test-health-verdict` is a
+     terminal-critical entry in `docs/verdict-binding-inventory.md`.
+
 <!-- Example:
 10. Never install system packages on the host. System deps go in Dockerfiles.
 11. All dev work must be in a case with its own worktree.

--- a/.agents/kaizen/zen.md
+++ b/.agents/kaizen/zen.md
@@ -40,6 +40,9 @@ When they conflict, trust the data.
 Every failure is a gift — if you file the issue.
 An incident without a kaizen issue is just suffering.
 
+A red test is never someone else's problem.
+Fix it before merge, or give it an owner and an open issue — never call it noise.
+
 The fix isn't done until the outcome is verified.
 "It should work" is not a test.
 

--- a/.claude/hooks/tests/harness.py
+++ b/.claude/hooks/tests/harness.py
@@ -29,6 +29,8 @@ from typing import Optional
 
 HOOKS_DIR = Path(__file__).parent.parent
 SETTINGS_PATH = HOOKS_DIR.parent / "settings.json"
+# Repo root: .claude/hooks -> .claude -> <root>
+REPO_ROOT = HOOKS_DIR.parent.parent
 
 
 # Input builders — construct schema-compliant event JSON
@@ -353,13 +355,38 @@ class PRReviewState:
         return len(list(self.state_dir.iterdir()))
 
     def create_review_sentinel(self, pr_url: str, round_num: int | str):
-        """Create the review sentinel written by store-review-summary/store-review-batch.
+        """Create a VALID signed review sentinel via the product SSOT (#1481).
 
-        Format: <STATE_DIR>/<owner_repo_pr>.reviewed-r<round>
+        Shells out to the `KAIZEN_TEST_RUNNER`-gated `emit-test-review-sentinel`
+        command, which builds the sentinel with the same `buildReviewSentinelRecord`
+        + `expectedPrReviewDimensions()` the gate validates against. The harness
+        therefore carries zero knowledge of the signed sentinel format, so the
+        format drift that caused #1481 (stale `reviewed_at=test` fixture) cannot
+        recur. Writes to <STATE_DIR>/<owner_repo_pr>.reviewed-r<round>.
         """
-        state_key = pr_url.replace("https://github.com/", "").replace("/pull/", "_").replace("/", "_")
-        sentinel = self.state_dir / f"{state_key}.reviewed-r{round_num}"
-        sentinel.write_text("reviewed_at=test\n")
+        m = re.match(r"https://github\.com/([^/]+/[^/]+)/pull/(\d+)", pr_url)
+        if not m:
+            raise ValueError(f"create_review_sentinel: cannot parse PR URL: {pr_url}")
+        repo, pr = m.group(1), m.group(2)
+
+        cli = REPO_ROOT / "src" / "cli-structured-data.ts"
+        local_tsx = REPO_ROOT / "node_modules" / ".bin" / "tsx"
+        cmd = [str(local_tsx)] if local_tsx.exists() else ["npx", "tsx"]
+        cmd += [
+            str(cli), "emit-test-review-sentinel",
+            "--repo", repo, "--pr", pr, "--round", str(round_num),
+        ]
+
+        env = os.environ.copy()
+        env["STATE_DIR"] = str(self.state_dir)
+        env["KAIZEN_TEST_RUNNER"] = "1"
+
+        proc = subprocess.run(cmd, capture_output=True, text=True, env=env,
+                              cwd=str(REPO_ROOT), timeout=30)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "emit-test-review-sentinel failed "
+                f"({proc.returncode}): {proc.stdout}{proc.stderr}")
 
 
 # Mock git/gh helpers

--- a/.claude/hooks/tests/run-all-tests.sh
+++ b/.claude/hooks/tests/run-all-tests.sh
@@ -24,6 +24,15 @@ TOTAL_PASS=0
 TOTAL_FAIL=0
 TOTAL_TESTS=0
 FAILED_FILES=()
+# Failing test identifiers collected for the #1518 owned-failure classifier
+# (pytest nodeids; shell test file names). A failure is only tolerated if it is
+# owned by an OPEN issue in .agents/kaizen/known-failures.json.
+FAILED_IDS=()
+# Failures we could NOT turn into a classifiable test id — a missing test runner,
+# or a test process that failed without emitting parseable test ids. These are
+# infrastructure failures, never registry-ownable, so they are ALWAYS fatal and
+# can never be "tolerated" by the owned-failure classifier.
+UNCLASSIFIABLE_FAIL=0
 
 # Global test isolation: all hooks write state to temp dirs by default.
 # This prevents tests from polluting production state directories
@@ -96,6 +105,8 @@ run_test_file() {
     echo "$output" | grep -E 'FAILED TESTS:' -A 100 || true
     echo "  RESULT: $pass passed, $fail failed"
     FAILED_FILES+=("$name")
+    # Shell suites report file-level granularity; register entries by file name.
+    FAILED_IDS+=("$name")
   else
     echo "  RESULT: $pass passed, $fail failed"
   fi
@@ -122,15 +133,32 @@ echo "Hook Test Suite"
 echo "==============="
 echo "Discovered ${#UNIT_TESTS[@]} unit tests, ${#HARNESS_TESTS[@]} integration tests"
 
+# Missing python3/pytest normally means a local "soft skip" — but in the
+# required CI path that silent skip is exactly the #1481 ambiguity (green CI
+# while the local hook lifecycle suite is red). Set KAIZEN_REQUIRE_PYTHON_TESTS=1
+# (CI does) to make the absence of the runner a HARD failure instead.
+python_runner_missing() {
+  local reason="$1"
+  if [ "${KAIZEN_REQUIRE_PYTHON_TESTS:-0}" = "1" ]; then
+    echo "  FAIL: $reason — required in this path (KAIZEN_REQUIRE_PYTHON_TESTS=1). Install pytest (pip install pytest)."
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+    FAILED_FILES+=("test_hooks.py (runner unavailable: $reason)")
+    # Infrastructure failure — not a registry-ownable test, so never tolerable.
+    UNCLASSIFIABLE_FAIL=$((UNCLASSIFIABLE_FAIL + 1))
+  else
+    echo "  SKIP: $reason"
+  fi
+}
+
 run_python_tests() {
   echo ""
   echo "━━━ test_hooks.py (pytest) ━━━"
   if ! command -v python3 &>/dev/null; then
-    echo "  SKIP: python3 not available"
+    python_runner_missing "python3 not available"
     return
   fi
   if ! python3 -c "import pytest" 2>/dev/null; then
-    echo "  SKIP: pytest not installed (pip3 install pytest)"
+    python_runner_missing "pytest not installed (pip install pytest)"
     return
   fi
 
@@ -152,6 +180,16 @@ run_python_tests() {
     echo "$output" | grep -E '(PASSED|FAILED)' | head -20
     echo "  RESULT: $pass passed, $fail failed"
     FAILED_FILES+=("test_hooks.py")
+    # Collect pytest nodeids ("FAILED <nodeid> - ...") for the #1518 classifier.
+    local nodeids_before=${#FAILED_IDS[@]}
+    while IFS= read -r nodeid; do
+      [ -n "$nodeid" ] && FAILED_IDS+=("$nodeid")
+    done < <(echo "$output" | grep -oP '^FAILED \K\S+' || true)
+    # A pytest failure with no parseable nodeids (e.g. a collection/import error)
+    # cannot be attributed to a registry entry — treat as unclassifiable (fatal).
+    if [ "${#FAILED_IDS[@]}" -eq "$nodeids_before" ]; then
+      UNCLASSIFIABLE_FAIL=$((UNCLASSIFIABLE_FAIL + 1))
+    fi
   else
     echo "  RESULT: $pass passed, $fail failed"
   fi
@@ -195,6 +233,22 @@ echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "TOTAL: $TOTAL_TESTS tests, $TOTAL_PASS passed, $TOTAL_FAIL failed"
 
+# #1518: a failure is forbidden from blocking only if it is OWNED by an OPEN
+# tracking issue in .agents/kaizen/known-failures.json. Route every failure
+# through the single classifier; unowned failures (or an unavailable classifier)
+# fail the suite. The registry ships empty, so today any failure is fatal.
+classify_failures() {
+  [ ${#FAILED_IDS[@]} -eq 0 ] && return 0
+  local root="$SCRIPT_DIR/../../.."
+  local tsx="$root/node_modules/.bin/tsx"
+  local cli="$root/scripts/known-failures-status.ts"
+  if [ ! -x "$tsx" ] || [ ! -f "$cli" ]; then
+    echo "  (known-failures classifier unavailable — treating failures as unowned)"
+    return 1
+  fi
+  printf '%s\n' "${FAILED_IDS[@]}" | "$tsx" "$cli" --classify
+}
+
 if [ ${#FAILED_FILES[@]} -gt 0 ]; then
   echo ""
   echo "FAILED FILES:"
@@ -202,6 +256,13 @@ if [ ${#FAILED_FILES[@]} -gt 0 ]; then
     echo "  - $f"
   done
   echo ""
+  echo "━━━ owned-failure check (#1518) ━━━"
+  if [ "$UNCLASSIFIABLE_FAIL" -gt 0 ]; then
+    echo "  $UNCLASSIFIABLE_FAIL infrastructure failure(s) (missing runner / unattributable) — never tolerable."
+  elif classify_failures; then
+    echo "All failures are owned by tracked OPEN issues (#1518) — tolerated, not blocking."
+    exit 0
+  fi
   exit 1
 fi
 

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -283,7 +283,10 @@ class TestPRLifecycle:
         r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "needs_review"
-        assert "No review findings stored" in r.stdout
+        # The gate now reports the structured sentinel reason (#920); the old
+        # "No review findings stored" wording was replaced by the sentinel-aware
+        # "no valid review sentinel stored" message.
+        assert "no valid review sentinel stored" in r.stdout
 
         # Sentinel present -> clears
         state.create_review_sentinel(self.PR_URL, 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,19 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # The Python hook lifecycle suite (test_hooks.py) MUST gate in CI — a
+      # missing runner used to silently skip it, producing green CI while the
+      # local suite was red (#1481). Install pytest and require it.
+      - name: Install pytest
+        run: python -m pip install --upgrade pytest
       - run: npm ci
       - run: npm run build
       - name: Run shell hook tests
+        env:
+          KAIZEN_REQUIRE_PYTHON_TESTS: '1'
         run: bash .claude/hooks/tests/run-all-tests.sh
       - name: Verify no test side-effects on repo files
         run: |
@@ -54,6 +64,24 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate hook file integrity
         run: bash .claude/hooks/tests/validate-hook-integrity.sh
+
+  known-failures:
+    name: Known-failure ownership
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # #1518: the known-failures registry must be schema-valid and every entry's
+      # owning issue must still be OPEN. A closed/missing owner fails CI, forcing
+      # the failure to be fixed or re-filed — it can't become invisible noise.
+      - name: Validate known-failure ownership
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: npx tsx scripts/known-failures-status.ts --validate --repo "$GITHUB_REPOSITORY"
 
   ts-tests:
     name: TypeScript tests + coverage

--- a/docs/verdict-binding-inventory.md
+++ b/docs/verdict-binding-inventory.md
@@ -17,6 +17,7 @@ TypeScript inventory as the source of truth.
 | Reflection issue-ref verification verdict | src/hooks/lib/issue-ref-verifier.ts: verifyIssueRef() | src/hooks/lib/issue-ref-verifier.ts:function:verifyIssueRef | yes |
 | Batch outcome schema verdict | scripts/batch-outcome.ts: BatchOutcomeSchema.parse() | scripts/batch-outcome.ts:const:BatchOutcomeSchema | yes |
 | Hook-activation verdict | scripts/auto-dent-hook-activation.ts: evaluateHookActivation() from the session system.init event | scripts/auto-dent-hook-activation.ts:function:evaluateHookActivation<br>scripts/auto-dent-hook-activation.ts:interface:HookActivationVerdict | yes |
+| Test-health verdict | src/known-failures.ts: unownedFailures() over the known-failures registry, surfaced as the testHealth signal (#1481/#1518) | src/known-failures.ts:function:unownedFailures<br>scripts/known-failures-status.ts:function:runClassify | yes |
 
 | Terminal action | Computed verdicts consumed | Enforcing consumer | Failure mode blocked |
 |---|---|---|---|
@@ -24,7 +25,7 @@ TypeScript inventory as the source of truth.
 | Issue close | PR merge-state verdict<br>Auto-dent review/fix-loop verdict<br>Durable process-evidence verdict<br>Lifecycle health verdict | verifyIssuesClosed()/autoCloseKaizenIssues() require merged PR state and route closure through the configured issues repo; merge itself is gated by quality verdicts | Issue closure only follows a merged PR, auto-merge is denied when quality verdicts are red, and host-mode closures cannot silently target the kaizen repo. |
 | Batch finalize | Batch outcome schema verdict<br>PR merge-state verdict | closeBatchProgressIssue() reconciles merged PR outcomes, then buildBatchOutcome()/BatchOutcomeSchema validate the durable record | Final batch metrics do not rely only on scraped narration; malformed outcome records are rejected on read. |
 | Gate clear | Reflection issue-ref verification verdict | processHookInput() validates filed/incident refs before clearing the gate state | A fabricated filed issue/incident ref cannot clear the reflection gate. |
-| Merge | Stored review round verdict<br>Auto-dent review/fix-loop verdict<br>Durable process-evidence verdict<br>Lifecycle health verdict<br>Hook-activation verdict | enforce-merge-verdict blocks direct FAIL merges; decideAutoMergeSafety blocks unsafe auto-merge queueing, including degraded/unknown hook-activation (#1220) | A PR with FAIL review/process/lifecycle verdicts — or a degraded run where kaizen hooks did not load (or no system.init was seen on a hook-expecting provider) — cannot be merged or queued by the normal paths. |
+| Merge | Stored review round verdict<br>Auto-dent review/fix-loop verdict<br>Durable process-evidence verdict<br>Lifecycle health verdict<br>Hook-activation verdict<br>Test-health verdict | enforce-merge-verdict blocks direct FAIL merges; decideAutoMergeSafety blocks unsafe auto-merge queueing, including degraded/unknown hook-activation (#1220) and unowned test failures (#1518) | A PR with FAIL review/process/lifecycle verdicts — a degraded run where kaizen hooks did not load (or no system.init was seen on a hook-expecting provider) — or a run that observed a failing test owned by no open issue — cannot be merged or queued by the normal paths. |
 
 ## Detector
 

--- a/scripts/auto-dent-merge-policy.test.ts
+++ b/scripts/auto-dent-merge-policy.test.ts
@@ -178,3 +178,42 @@ describe('auto-dent merge policy — hook_activation binding (#1220 completion /
     ).toEqual({ allow: true, reasons: [] });
   });
 });
+
+describe('auto-dent merge policy — test-health binding (#1481/#1518)', () => {
+  const ready = {
+    prCount: 1,
+    reviewRequired: true,
+    reviewVerdict: 'pass' as const,
+    processVerdict: 'pass' as const,
+    lifecycleHealth: 'clean' as const,
+    hookActivation: HOOK_ACTIVE_CLAUDE,
+    provider: 'claude' as const,
+  };
+
+  it('blocks a PR whose run observed an unowned test failure', () => {
+    const d = decideAutoMergeSafety({ ...ready, testHealth: 'unowned-failures' });
+    expect(d.allow).toBe(false);
+    expect(d.reasons.some(r => r.includes('test health unowned-failures'))).toBe(true);
+  });
+
+  it('blocks regardless of reviewRequired (test health is provider-agnostic, not review-gated)', () => {
+    const d = decideAutoMergeSafety({ ...ready, reviewRequired: false, testHealth: 'unowned-failures' });
+    expect(d.allow).toBe(false);
+  });
+
+  it('does not block on pass / unknown / absent test-health', () => {
+    expect(decideAutoMergeSafety({ ...ready, testHealth: 'pass' }).allow).toBe(true);
+    expect(decideAutoMergeSafety({ ...ready, testHealth: 'unknown' }).allow).toBe(true);
+    expect(decideAutoMergeSafety({ ...ready }).allow).toBe(true);
+  });
+
+  it('does not block an unowned-failure run that is not producing a PR', () => {
+    expect(decideAutoMergeSafety({ ...ready, prCount: 0, testHealth: 'unowned-failures' }).allow).toBe(true);
+  });
+
+  it('surfaces test-health alongside other red verdicts', () => {
+    const reasons = autoMergeBlockReasons({ ...ready, reviewVerdict: 'fail', testHealth: 'unowned-failures' });
+    expect(reasons).toContain('review verdict fail');
+    expect(reasons.some(r => r.includes('test health unowned-failures'))).toBe(true);
+  });
+});

--- a/scripts/auto-dent-merge-policy.ts
+++ b/scripts/auto-dent-merge-policy.ts
@@ -3,6 +3,7 @@ import {
   type LifecycleHealth,
   type ProcessVerdict,
   type ReviewVerdict,
+  type TestHealthVerdict,
 } from '../src/verdict-binding-policy.js';
 import { providerClaimsHookSupport, type HookActivationVerdict } from './auto-dent-hook-activation.js';
 import type { Provider } from './auto-dent-provider.js';
@@ -15,6 +16,12 @@ export interface AutoMergeSafetySignals {
   reviewVerdict?: ReviewVerdict;
   processVerdict?: ProcessVerdict;
   lifecycleHealth?: LifecycleHealth;
+  /**
+   * Test-health verdict for the run (#1481/#1518). `unowned-failures` blocks the
+   * merge; `pass`/`unknown`/absent do not. Consumed via the shared
+   * `qualityVerdictBlockReasons` SSOT — no separate rule here.
+   */
+  testHealth?: TestHealthVerdict;
   /**
    * Hook-activation verdict for the run (#843/#1500). `undefined` means no
    * `system.init` event was observed this run, so hook state is unknown.

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2644,6 +2644,13 @@ async function main(): Promise<void> {
     // Default provider to 'claude' (hook-expecting) for legacy state → fail-closed.
     hookActivation: result.hookActivation,
     provider: state.provider ?? 'claude',
+    // testHealth (#1481/#1518) is consumed by the shared SSOT and is enforced
+    // provider-agnostically at the test runner (run-all-tests.sh owned/unowned
+    // classification) and the `known-failures` CI gate. The harness does not run
+    // the suite itself, so it has no truthful run-level test signal to pass here
+    // yet — left `unknown` (non-blocking) rather than fabricated. Capturing a
+    // run-level test-failure signal for the harness is a deferred follow-up,
+    // mirroring how #1220 deferred run-success consumption to #1501.
   });
   const autoMergeQueue = queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);
   if (!autoMergeDecision.allow) {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2649,7 +2649,7 @@ async function main(): Promise<void> {
     // classification) and the `known-failures` CI gate. The harness does not run
     // the suite itself, so it has no truthful run-level test signal to pass here
     // yet — left `unknown` (non-blocking) rather than fabricated. Capturing a
-    // run-level test-failure signal for the harness is a deferred follow-up,
+    // run-level test-failure signal for the harness is tracked as #1527,
     // mirroring how #1220 deferred run-success consumption to #1501.
   });
   const autoMergeQueue = queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);

--- a/scripts/known-failures-status.test.ts
+++ b/scripts/known-failures-status.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { runClassify } from './known-failures-status.js';
+import type { KnownFailure } from '../src/known-failures.js';
+
+// runValidate reads the on-disk registry (empty in this repo), so we assert the
+// classifier boundary here and rely on src/known-failures.test.ts for the
+// ownership/issue-state logic (findOwnershipProblems).
+
+describe('runClassify (CLI boundary)', () => {
+  const entries: KnownFailure[] = [
+    { test: 'flaky_suite.py', issue: 1200, reason: 'tracked flake' },
+  ];
+
+  it('exits 0 when there are no failures', () => {
+    expect(runClassify([], entries)).toBe(0);
+  });
+
+  it('exits 0 when every failure is owned', () => {
+    expect(runClassify(['flaky_suite.py::TestX::test_y'], entries)).toBe(0);
+  });
+
+  it('exits 1 when any failure is unowned', () => {
+    expect(runClassify(['flaky_suite.py::test_y', 'new_breakage.py::test_z'], entries)).toBe(1);
+  });
+
+  it('treats an empty registry as: every failure is unowned', () => {
+    expect(runClassify(['anything.py::test_a'], [])).toBe(1);
+  });
+});

--- a/scripts/known-failures-status.test.ts
+++ b/scripts/known-failures-status.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { runClassify } from './known-failures-status.js';
-import type { KnownFailure } from '../src/known-failures.js';
+import { runClassify, runValidate, parseIssueState, ghIssueState } from './known-failures-status.js';
+import type { KnownFailure, KnownFailuresValidation } from '../src/known-failures.js';
+import type { GhResult } from '../src/lib/gh-exec.js';
+
+const gh = (status: number, stdout = '', stderr = ''): GhResult => ({ status, stdout, stderr });
 
 // runValidate reads the on-disk registry (empty in this repo), so we assert the
 // classifier boundary here and rely on src/known-failures.test.ts for the
@@ -25,5 +28,50 @@ describe('runClassify (CLI boundary)', () => {
 
   it('treats an empty registry as: every failure is unowned', () => {
     expect(runClassify(['anything.py::test_a'], [])).toBe(1);
+  });
+});
+
+describe('parseIssueState', () => {
+  it('maps gh state to open/closed/missing', () => {
+    expect(parseIssueState(gh(0, '{"state":"OPEN"}'))).toBe('open');
+    expect(parseIssueState(gh(0, '{"state":"CLOSED"}'))).toBe('closed');
+    expect(parseIssueState(gh(1, '', 'not found'))).toBe('missing'); // non-zero exit
+    expect(parseIssueState(gh(0, 'not json'))).toBe('missing');       // malformed
+    expect(parseIssueState(gh(0, '{}'))).toBe('missing');             // no state field
+  });
+});
+
+describe('ghIssueState (injected runner)', () => {
+  it('queries gh and parses the result', () => {
+    const calls: string[][] = [];
+    const stateOf = ghIssueState('owner/repo', (args) => { calls.push(args); return gh(0, '{"state":"open"}'); });
+    expect(stateOf(42)).toBe('open');
+    expect(calls[0]).toEqual(['issue', 'view', '42', '--json', 'state', '--repo', 'owner/repo']);
+  });
+});
+
+describe('runValidate (closed-issue gate)', () => {
+  const load = (entries: KnownFailure[]): (() => KnownFailuresValidation) =>
+    () => ({ ok: true, errors: [], entries });
+
+  it('passes an empty registry', () => {
+    expect(runValidate('r', () => 'open', load([]))).toBe(0);
+  });
+
+  it('passes when every owning issue is open', () => {
+    expect(runValidate('r', () => 'open', load([{ test: 'a.py::x', issue: 1, reason: 'r' }]))).toBe(0);
+  });
+
+  it('FAILS when an owning issue is closed', () => {
+    expect(runValidate('r', () => 'closed', load([{ test: 'a.py::x', issue: 1, reason: 'r' }]))).toBe(1);
+  });
+
+  it('FAILS when an owning issue is missing', () => {
+    expect(runValidate('r', () => 'missing', load([{ test: 'a.py::x', issue: 1, reason: 'r' }]))).toBe(1);
+  });
+
+  it('FAILS on an invalid registry', () => {
+    const badLoad = (): KnownFailuresValidation => ({ ok: false, errors: ['bad'], entries: [] });
+    expect(runValidate('r', () => 'open', badLoad)).toBe(1);
   });
 });

--- a/scripts/known-failures-status.ts
+++ b/scripts/known-failures-status.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env tsx
+/**
+ * known-failures-status.ts — the provider-agnostic enforcement of #1518.
+ *
+ * Two modes (one classifier, `src/known-failures.ts`, shared by both):
+ *
+ *   --validate (default): the `known-failures` CI gate. The registry must be
+ *     schema-valid AND every entry's owning issue must be OPEN. A closed/missing
+ *     owner means the failure is no longer tracked — exit 1 to force a fix or a
+ *     re-filed owner. This is the L3, non-Claude backstop: it holds even outside
+ *     an interactive session and for providers (e.g. Codex) with no hook runtime.
+ *
+ *   --classify: read failing test ids (from --failures-file <path> or stdin, one
+ *     per line) and split them into owned (logged, tolerated) vs unowned. Exit 1
+ *     iff any failure is unowned. `run-all-tests.sh` calls this so the test
+ *     runner — the single choke point both providers share — refuses to report
+ *     green while an unowned failure exists.
+ */
+import { readFileSync } from 'node:fs';
+import { ghResult } from '../src/lib/gh-exec.js';
+import {
+  loadKnownFailures,
+  findOwnershipProblems,
+  unownedFailures,
+  isKnownFailure,
+  type IssueState,
+  type KnownFailure,
+} from '../src/known-failures.js';
+
+function readArg(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  return idx >= 0 ? process.argv[idx + 1] : undefined;
+}
+
+/** Resolve a GitHub issue's state via `gh`, mapping a not-found to `missing`. */
+export function ghIssueState(repo: string | undefined): (issue: number) => IssueState {
+  return (issue: number): IssueState => {
+    const args = ['issue', 'view', String(issue), '--json', 'state'];
+    if (repo) args.push('--repo', repo);
+    const res = ghResult(args);
+    if (res.status !== 0) return 'missing';
+    try {
+      const state = String((JSON.parse(res.stdout) as { state?: string }).state ?? '').toLowerCase();
+      return state === 'open' ? 'open' : state === 'closed' ? 'closed' : 'missing';
+    } catch {
+      return 'missing';
+    }
+  };
+}
+
+export function runValidate(repo: string | undefined, stateOf: (issue: number) => IssueState): number {
+  const reg = loadKnownFailures();
+  if (!reg.ok) {
+    console.error('known-failures: registry is invalid:');
+    reg.errors.forEach(e => console.error(`  - ${e}`));
+    return 1;
+  }
+  if (reg.entries.length === 0) {
+    console.log('known-failures: registry is empty — the tree must be fully green. OK.');
+    return 0;
+  }
+  const problems = findOwnershipProblems(reg.entries, stateOf);
+  if (problems.length > 0) {
+    console.error('known-failures: these entries no longer have an OPEN owning issue (fix the test or re-file an owner):');
+    for (const p of problems) {
+      console.error(`  - issue #${p.issue} is ${p.state}; owns: ${p.tests.join(', ')}`);
+    }
+    return 1;
+  }
+  console.log(`known-failures: ${reg.entries.length} entr${reg.entries.length === 1 ? 'y' : 'ies'}, all owned by OPEN issues. OK.`);
+  return 0;
+}
+
+function readFailingIds(): string[] {
+  const file = readArg('--failures-file');
+  const raw = file ? readFileSync(file, 'utf8') : (() => {
+    try { return readFileSync(0, 'utf8'); } catch { return ''; }
+  })();
+  return raw.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+export function runClassify(failingIds: string[], entries: KnownFailure[]): number {
+  if (failingIds.length === 0) {
+    console.log('known-failures: no failing tests reported. OK.');
+    return 0;
+  }
+  for (const id of failingIds) {
+    const owner = isKnownFailure(id, entries);
+    if (owner) console.log(`  KNOWN-OWNED (#${owner.issue}): ${id}`);
+  }
+  const unowned = unownedFailures(failingIds, entries);
+  if (unowned.length > 0) {
+    console.error('known-failures: UNOWNED failing tests (fix before merge, or register with an owning open issue per #1518):');
+    unowned.forEach(id => console.error(`  - ${id}`));
+    return 1;
+  }
+  console.log(`known-failures: all ${failingIds.length} failing test(s) are owned by tracked issues. Tolerated.`);
+  return 0;
+}
+
+function main(): void {
+  const repo = readArg('--repo') ?? process.env.GITHUB_REPOSITORY ?? 'Garsson-io/kaizen';
+  const mode = process.argv.includes('--classify') ? 'classify' : 'validate';
+  if (mode === 'classify') {
+    const reg = loadKnownFailures();
+    if (!reg.ok) {
+      console.error('known-failures: registry is invalid; cannot classify failures:');
+      reg.errors.forEach(e => console.error(`  - ${e}`));
+      process.exit(1);
+    }
+    process.exit(runClassify(readFailingIds(), reg.entries));
+  }
+  process.exit(runValidate(repo, ghIssueState(repo)));
+}
+
+if (process.argv[1]?.endsWith('known-failures-status.ts') || process.argv[1]?.endsWith('known-failures-status.js')) {
+  main();
+}

--- a/scripts/known-failures-status.ts
+++ b/scripts/known-failures-status.ts
@@ -17,7 +17,7 @@
  *     green while an unowned failure exists.
  */
 import { readFileSync } from 'node:fs';
-import { ghResult } from '../src/lib/gh-exec.js';
+import { ghResult, type GhResult } from '../src/lib/gh-exec.js';
 import {
   loadKnownFailures,
   findOwnershipProblems,
@@ -25,6 +25,7 @@ import {
   isKnownFailure,
   type IssueState,
   type KnownFailure,
+  type KnownFailuresValidation,
 } from '../src/known-failures.js';
 
 function readArg(name: string): string | undefined {
@@ -32,24 +33,35 @@ function readArg(name: string): string | undefined {
   return idx >= 0 ? process.argv[idx + 1] : undefined;
 }
 
+/** Map a `gh issue view --json state` result to an IssueState (pure, testable). */
+export function parseIssueState(res: GhResult): IssueState {
+  if (res.status !== 0) return 'missing';
+  try {
+    const state = String((JSON.parse(res.stdout) as { state?: string }).state ?? '').toLowerCase();
+    return state === 'open' ? 'open' : state === 'closed' ? 'closed' : 'missing';
+  } catch {
+    return 'missing';
+  }
+}
+
 /** Resolve a GitHub issue's state via `gh`, mapping a not-found to `missing`. */
-export function ghIssueState(repo: string | undefined): (issue: number) => IssueState {
+export function ghIssueState(
+  repo: string | undefined,
+  run: (args: string[]) => GhResult = ghResult,
+): (issue: number) => IssueState {
   return (issue: number): IssueState => {
     const args = ['issue', 'view', String(issue), '--json', 'state'];
     if (repo) args.push('--repo', repo);
-    const res = ghResult(args);
-    if (res.status !== 0) return 'missing';
-    try {
-      const state = String((JSON.parse(res.stdout) as { state?: string }).state ?? '').toLowerCase();
-      return state === 'open' ? 'open' : state === 'closed' ? 'closed' : 'missing';
-    } catch {
-      return 'missing';
-    }
+    return parseIssueState(run(args));
   };
 }
 
-export function runValidate(repo: string | undefined, stateOf: (issue: number) => IssueState): number {
-  const reg = loadKnownFailures();
+export function runValidate(
+  repo: string | undefined,
+  stateOf: (issue: number) => IssueState,
+  load: () => KnownFailuresValidation = loadKnownFailures,
+): number {
+  const reg = load();
   if (!reg.ok) {
     console.error('known-failures: registry is invalid:');
     reg.errors.forEach(e => console.error(`  - ${e}`));

--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -73,6 +73,7 @@ describe('handler registry', () => {
       'store-metadata', 'retrieve-metadata', 'query-connected', 'query-pr',
       'update-pr-section',
       'store-iteration', 'retrieve-iteration',
+      'emit-test-review-sentinel',
     ];
     for (const cmd of expectedCommands) {
       expect(handlers[cmd], `missing handler for '${cmd}'`).toBeDefined();
@@ -85,8 +86,8 @@ describe('handler registry', () => {
     }
   });
 
-  it('has exactly 20 handlers (no stale entries)', () => {
-    expect(Object.keys(handlers).length).toBe(20);
+  it('has exactly 21 handlers (no stale entries)', () => {
+    expect(Object.keys(handlers).length).toBe(21);
   });
 });
 

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -63,6 +63,8 @@ import {
 import {
   buildReviewSentinelRecord,
   serializeReviewSentinel,
+  expectedPrReviewDimensions,
+  reviewSentinelPath,
 } from './review-sentinel.js';
 import {
   normalizeReviewFindingData,
@@ -133,14 +135,47 @@ export function resolveRound(a: CliArgs): number {
   return 1;
 }
 
+interface SentinelTotals {
+  findingCount: number;
+  totalDone: number;
+  totalPartial: number;
+  totalMissing: number;
+}
+
+/**
+ * Single low-level sentinel writer — the SSOT shared by the production
+ * `store-review-*` path and the test-only emitter. Builds the signed record
+ * via `buildReviewSentinelRecord` and writes it to the state dir. Returns the
+ * path. Throws on failure (callers that want best-effort wrap it in try/catch).
+ */
+function writeSentinelRecord(
+  repo: string,
+  pr: string,
+  round: number,
+  dimensionsReviewed: string[],
+  totals: SentinelTotals,
+): string {
+  const stateDir = process.env.STATE_DIR ?? '/tmp/.pr-review-state';
+  const prUrl = `https://github.com/${repo}/pull/${pr}`;
+  const record = buildReviewSentinelRecord({
+    prUrl,
+    round,
+    dimensionsReviewed,
+    ...totals,
+  });
+  mkdirSync(stateDir, { recursive: true });
+  // Shared path SSOT so the writer can never drift from the hook reader (#1481).
+  const path = reviewSentinelPath(stateDir, prUrl, round);
+  writeFileSync(path, serializeReviewSentinel(record));
+  return path;
+}
+
 function writeReviewSentinel(repo: string, pr: string | undefined, round: number): void {
   if (!pr) return;
   try {
-    const stateDir = process.env.STATE_DIR ?? '/tmp/.pr-review-state';
-    const stateKey = `${repo.replace('/', '_')}_${pr}`;
     const target = prTarget(pr, repo);
     const dimensionsReviewed = listReviewDimensions(target, round);
-    const totals = dimensionsReviewed.reduce(
+    const totals = dimensionsReviewed.reduce<SentinelTotals>(
       (acc, dim) => {
         const content = readReviewFinding(target, round, dim);
         const meta = content ? extractReviewFindingMeta(content) : null;
@@ -153,14 +188,7 @@ function writeReviewSentinel(repo: string, pr: string | undefined, round: number
       },
       { findingCount: 0, totalDone: 0, totalPartial: 0, totalMissing: 0 },
     );
-    const record = buildReviewSentinelRecord({
-      prUrl: `https://github.com/${repo}/pull/${pr}`,
-      round,
-      dimensionsReviewed,
-      ...totals,
-    });
-    mkdirSync(stateDir, { recursive: true });
-    writeFileSync(`${stateDir}/${stateKey}.reviewed-r${round}`, serializeReviewSentinel(record));
+    writeSentinelRecord(repo, pr, round, dimensionsReviewed, totals);
   } catch {
     // best effort — sentinel is advisory
   }
@@ -362,6 +390,36 @@ async function handleStoreIteration(a: CliArgs): Promise<void> {
   console.log(`Iteration state stored: ${url}`);
 }
 
+/**
+ * Test-only: emit a VALID signed review sentinel for the hook lifecycle suite.
+ *
+ * Refuses unless `KAIZEN_TEST_RUNNER=1`, so this can never be a production
+ * fabrication bypass of the review gate (#1019/#1212 class). It reuses the same
+ * `writeSentinelRecord` SSOT and `expectedPrReviewDimensions()` the validator
+ * uses, so the Python harness carries zero knowledge of the sentinel format —
+ * the drift that caused #1481 cannot recur.
+ */
+async function handleEmitTestReviewSentinel(a: CliArgs): Promise<void> {
+  if (process.env.KAIZEN_TEST_RUNNER !== '1') {
+    console.error(
+      'emit-test-review-sentinel: refused — test-only command, requires KAIZEN_TEST_RUNNER=1.',
+    );
+    process.exit(1);
+  }
+  if (!a.pr) {
+    console.error('emit-test-review-sentinel: --pr required');
+    process.exit(1);
+  }
+  const round = resolveRound(a);
+  const path = writeSentinelRecord(a.repo, a.pr, round, expectedPrReviewDimensions(), {
+    findingCount: 1,
+    totalDone: 1,
+    totalPartial: 0,
+    totalMissing: 0,
+  });
+  console.log(`Test review sentinel written (round ${round}): ${path}`);
+}
+
 async function handleRetrieveIteration(a: CliArgs): Promise<void> {
   const state = retrieveIterationState(
     a.pr ? prTarget(a.pr, a.repo) : issueTarget(a.issue, a.repo),
@@ -393,6 +451,7 @@ export const handlers: Record<string, Handler> = {
   'update-pr-section': handleUpdatePrSection,
   'store-iteration': handleStoreIteration,
   'retrieve-iteration': handleRetrieveIteration,
+  'emit-test-review-sentinel': handleEmitTestReviewSentinel,
 };
 
 async function main(): Promise<void> {

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -163,10 +163,14 @@ function writeSentinelRecord(
     dimensionsReviewed,
     ...totals,
   });
-  mkdirSync(stateDir, { recursive: true });
+  // Owner-only dir + file (0o700/0o600): the sentinel gates merges, so it must
+  // not be readable/tamperable by other users of a shared /tmp — matching the
+  // hook path's `ensureStateDir` posture and closing CWE-377/378 (insecure temp
+  // file). The deterministic name is required by the reader/writer contract.
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   // Shared path SSOT so the writer can never drift from the hook reader (#1481).
   const path = reviewSentinelPath(stateDir, prUrl, round);
-  writeFileSync(path, serializeReviewSentinel(record));
+  writeFileSync(path, serializeReviewSentinel(record), { mode: 0o600 });
   return path;
 }
 

--- a/src/emit-test-review-sentinel.test.ts
+++ b/src/emit-test-review-sentinel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { validateReviewSentinel } from './review-sentinel.js';

--- a/src/emit-test-review-sentinel.test.ts
+++ b/src/emit-test-review-sentinel.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { validateReviewSentinel } from './review-sentinel.js';
+
+// The `emit-test-review-sentinel` command can write a sentinel that PASSES the
+// review gate. That is exactly the fabrication a malicious/confused caller could
+// use to bypass review (#1019/#1212). Its only protection is the
+// KAIZEN_TEST_RUNNER guard — so prove, end-to-end, that the guard holds.
+const CLI = resolve(__dirname, 'cli-structured-data.ts');
+const TSX = resolve(__dirname, '..', 'node_modules', '.bin', 'tsx');
+const PR_URL = 'https://github.com/Garsson-io/kaizen/pull/55';
+
+function run(stateDir: string, env: Record<string, string>) {
+  return spawnSync(TSX, [CLI, 'emit-test-review-sentinel', '--repo', 'Garsson-io/kaizen', '--pr', '55', '--round', '1'], {
+    encoding: 'utf8',
+    env: { ...process.env, STATE_DIR: stateDir, ...env },
+  });
+}
+
+describe('emit-test-review-sentinel guard (#1481/#1518 anti-bypass)', () => {
+  let stateDir: string;
+  beforeEach(() => { stateDir = mkdtempSync(join(tmpdir(), 'kf-sentinel-')); });
+  afterEach(() => { rmSync(stateDir, { recursive: true, force: true }); });
+
+  it('REFUSES (nonzero, writes nothing) without KAIZEN_TEST_RUNNER', () => {
+    const r = run(stateDir, { KAIZEN_TEST_RUNNER: '' });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/refused/i);
+    expect(readdirSync(stateDir)).toHaveLength(0); // no sentinel fabricated
+  });
+
+  it('writes a VALID signed sentinel WITH KAIZEN_TEST_RUNNER=1', () => {
+    const r = run(stateDir, { KAIZEN_TEST_RUNNER: '1' });
+    expect(r.status).toBe(0);
+    const files = readdirSync(stateDir).filter(f => f.endsWith('.reviewed-r1'));
+    expect(files).toHaveLength(1);
+    const content = readFileSync(join(stateDir, files[0]), 'utf8');
+    expect(validateReviewSentinel(content, { prUrl: PR_URL, round: 1 }).ok).toBe(true);
+  });
+  // Generous timeout: each case cold-starts tsx, which can be slow under the
+  // full suite's parallel load. (#1481 spirit: no flaky tests.)
+}, 60_000);

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -26,6 +26,7 @@ import {
   buildReviewSentinelRecord,
   serializeReviewSentinel,
   validateReviewSentinel,
+  reviewSentinelPath,
   type ReviewSentinelInput,
   type ReviewSentinelValidation,
 } from '../review-sentinel.js';
@@ -111,7 +112,7 @@ function isValidPrUrl(url: string): boolean {
  * Format: <stateDir>/<stateKey>.reviewed-r<round>
  */
 function defaultCheckReviewSentinel(prUrl: string, round: string, stateDir: string): ReviewSentinelValidation {
-  const sentinel = join(stateDir, `${prUrlToStateKey(prUrl)}.reviewed-r${round}`);
+  const sentinel = reviewSentinelPath(stateDir, prUrl, round);
   try {
     statSync(sentinel);
     return validateReviewSentinel(readFileSync(sentinel, 'utf-8'), { prUrl, round });
@@ -131,7 +132,7 @@ export function writeReviewSentinel(
   options: Partial<ReviewSentinelInput> = {},
 ): void {
   ensureStateDir(stateDir);
-  const sentinel = join(stateDir, `${prUrlToStateKey(prUrl)}.reviewed-r${round}`);
+  const sentinel = reviewSentinelPath(stateDir, prUrl, round);
   const record = buildReviewSentinelRecord({ ...options, prUrl, round });
   writeFileSync(sentinel, serializeReviewSentinel(record));
 }

--- a/src/known-failures.test.ts
+++ b/src/known-failures.test.ts
@@ -17,11 +17,20 @@ const ok = (entries: Partial<KnownFailure>[]) =>
 describe('parseKnownFailures', () => {
   it('accepts a valid entry and ignores unknown top-level keys', () => {
     const r = parseKnownFailures(
-      JSON.stringify({ _doc: 'note', knownFailures: [{ test: 'a::b', issue: 1481, reason: 'tracked' }] }),
+      JSON.stringify({ _doc: 'note', knownFailures: [{ test: 'mod.py::test_x', issue: 1481, reason: 'tracked' }] }),
     );
     expect(r.ok).toBe(true);
     expect(r.errors).toEqual([]);
-    expect(r.entries).toEqual([{ test: 'a::b', issue: 1481, reason: 'tracked' }]);
+    expect(r.entries).toEqual([{ test: 'mod.py::test_x', issue: 1481, reason: 'tracked' }]);
+  });
+
+  it('rejects a catch-all / too-generic test id (no delimiter or < 5 chars)', () => {
+    expect(parseKnownFailures(ok([{ test: 'test_', issue: 1, reason: 'x' }])).ok).toBe(false);
+    expect(parseKnownFailures(ok([{ test: 'tests', issue: 1, reason: 'x' }])).ok).toBe(false); // no delimiter
+    expect(parseKnownFailures(ok([{ test: 'a.b', issue: 1, reason: 'x' }])).ok).toBe(false);   // too short
+    // but real test ids pass:
+    expect(parseKnownFailures(ok([{ test: 'foo.py', issue: 1, reason: 'x' }])).ok).toBe(true);
+    expect(parseKnownFailures(ok([{ test: 'test-foo-bar', issue: 1, reason: 'x' }])).ok).toBe(true);
   });
 
   it('accepts an empty registry', () => {

--- a/src/known-failures.test.ts
+++ b/src/known-failures.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  parseKnownFailures,
+  loadKnownFailures,
+  isKnownFailure,
+  unownedFailures,
+  findOwnershipProblems,
+  knownFailuresPath,
+  type KnownFailure,
+  type IssueState,
+} from './known-failures.js';
+
+const ok = (entries: Partial<KnownFailure>[]) =>
+  JSON.stringify({ knownFailures: entries });
+
+describe('parseKnownFailures', () => {
+  it('accepts a valid entry and ignores unknown top-level keys', () => {
+    const r = parseKnownFailures(
+      JSON.stringify({ _doc: 'note', knownFailures: [{ test: 'a::b', issue: 1481, reason: 'tracked' }] }),
+    );
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.entries).toEqual([{ test: 'a::b', issue: 1481, reason: 'tracked' }]);
+  });
+
+  it('accepts an empty registry', () => {
+    const r = parseKnownFailures(ok([]));
+    expect(r.ok).toBe(true);
+    expect(r.entries).toEqual([]);
+  });
+
+  it('rejects malformed JSON', () => {
+    const r = parseKnownFailures('{ not json');
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/invalid JSON/);
+  });
+
+  it('rejects a missing knownFailures array', () => {
+    const r = parseKnownFailures(JSON.stringify({ items: [] }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/knownFailures/);
+  });
+
+  it('rejects a missing/invalid issue', () => {
+    expect(parseKnownFailures(ok([{ test: 'a', reason: 'x' }])).ok).toBe(false);
+    expect(parseKnownFailures(ok([{ test: 'a', issue: 0, reason: 'x' }])).ok).toBe(false);
+    expect(parseKnownFailures(ok([{ test: 'a', issue: 1.5, reason: 'x' }])).ok).toBe(false);
+  });
+
+  it('rejects an empty test or reason', () => {
+    expect(parseKnownFailures(ok([{ test: '', issue: 1, reason: 'x' }])).ok).toBe(false);
+    expect(parseKnownFailures(ok([{ test: 'a', issue: 1, reason: '  ' }])).ok).toBe(false);
+  });
+
+  it('reports per-entry errors with their index', () => {
+    const r = parseKnownFailures(ok([{ test: 'a', issue: 1, reason: 'ok' }, { test: 'b' }]));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.includes('knownFailures[1]'))).toBe(true);
+  });
+});
+
+describe('isKnownFailure / unownedFailures', () => {
+  const entries: KnownFailure[] = [
+    { test: 'test_hooks.py::TestPRLifecycle::test_full_lifecycle', issue: 1481, reason: 'tracked' },
+    { test: 'flaky_suite.py', issue: 1200, reason: 'whole-file flake' },
+  ];
+
+  it('matches an exact nodeid', () => {
+    expect(isKnownFailure('x/test_hooks.py::TestPRLifecycle::test_full_lifecycle', entries)?.issue).toBe(1481);
+  });
+
+  it('matches any failure in a file-scoped entry', () => {
+    expect(isKnownFailure('a/flaky_suite.py::TestX::test_y', entries)?.issue).toBe(1200);
+  });
+
+  it('does not match an unrelated failure', () => {
+    expect(isKnownFailure('test_other.py::test_z', entries)).toBeUndefined();
+  });
+
+  it('returns only the unowned failures', () => {
+    const failing = [
+      'flaky_suite.py::TestX::test_y',
+      'test_other.py::test_z',
+      'test_hooks.py::TestPRLifecycle::test_full_lifecycle',
+    ];
+    expect(unownedFailures(failing, entries)).toEqual(['test_other.py::test_z']);
+  });
+
+  it('treats an empty registry as: everything is unowned', () => {
+    expect(unownedFailures(['a', 'b'], [])).toEqual(['a', 'b']);
+  });
+});
+
+describe('findOwnershipProblems', () => {
+  const entries: KnownFailure[] = [
+    { test: 'a', issue: 10, reason: 'r' },
+    { test: 'b', issue: 10, reason: 'r' },
+    { test: 'c', issue: 20, reason: 'r' },
+  ];
+
+  it('flags entries whose owning issue is closed or missing, grouped by issue', () => {
+    const states: Record<number, IssueState> = { 10: 'open', 20: 'closed' };
+    const problems = findOwnershipProblems(entries, n => states[n] ?? 'missing');
+    expect(problems).toEqual([{ issue: 20, state: 'closed', tests: ['c'] }]);
+  });
+
+  it('returns no problems when every owning issue is open', () => {
+    expect(findOwnershipProblems(entries, () => 'open')).toEqual([]);
+  });
+});
+
+describe('shipped registry', () => {
+  it('parses and validates the checked-in .agents/kaizen/known-failures.json', () => {
+    const path = knownFailuresPath();
+    const r = parseKnownFailures(readFileSync(path, 'utf8'));
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('loadKnownFailures returns the same validated entries', () => {
+    expect(loadKnownFailures().ok).toBe(true);
+  });
+});

--- a/src/known-failures.ts
+++ b/src/known-failures.ts
@@ -1,0 +1,144 @@
+/**
+ * known-failures.ts — the single source of truth for "known failing test ->
+ * owned open issue" (#1518).
+ *
+ * A failing test is either part of the current change and must be fixed before
+ * merge, or it is a separate, tracked incident with exactly one owning OPEN
+ * issue. It can never be invisible background noise. This module loads and
+ * validates the registry (`.agents/kaizen/known-failures.json`) and provides
+ * the classification primitives reused by:
+ *   - `run-all-tests.sh` (via `scripts/known-failures-status.ts --classify`):
+ *     unowned failures fail the suite; owned ones are logged and tolerated.
+ *   - the `known-failures` CI gate (`--validate`): every entry's owning issue
+ *     must be OPEN, or CI fails.
+ *   - the merge-readiness SSOT (`qualityVerdictBlockReasons`, via a `testHealth`
+ *     signal): a run that observed unowned failures is not merge-ready.
+ *
+ * Keeping one classifier here (rather than re-deriving ownership in bash, in CI,
+ * and at the merge gate) is the DRY/consolidation requirement of this work.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveProjectRoot } from './lib/resolve-project-root.js';
+
+/** Registry location, relative to the project root. */
+export const KNOWN_FAILURES_PATH = '.agents/kaizen/known-failures.json';
+
+export interface KnownFailure {
+  /**
+   * Substring matched against a failing test id — a pytest nodeid
+   * (`test_hooks.py::Class::test_x`), a vitest test name, or a shell test file.
+   * Coarser strings (a file name) intentionally cover every failure in that
+   * file; use the full nodeid to scope to a single case.
+   */
+  test: string;
+  /** Owning GitHub issue number. Must reference an OPEN issue. */
+  issue: number;
+  /** Why this failure is tolerated for now (human context). */
+  reason: string;
+  /** Optional: who registered the entry. */
+  addedBy?: string;
+}
+
+export interface KnownFailuresValidation {
+  ok: boolean;
+  errors: string[];
+  entries: KnownFailure[];
+}
+
+export type IssueState = 'open' | 'closed' | 'missing';
+
+export interface OwnershipProblem {
+  issue: number;
+  state: IssueState;
+  tests: string[];
+}
+
+/** Absolute path to the registry for the given (or detected) project root. */
+export function knownFailuresPath(root: string = resolveProjectRoot(process.cwd())): string {
+  return join(root, KNOWN_FAILURES_PATH);
+}
+
+/** Parse + validate registry content. Unknown top-level keys (e.g. `_doc`) are ignored. */
+export function parseKnownFailures(content: string): KnownFailuresValidation {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (e) {
+    return { ok: false, errors: [`invalid JSON: ${(e as Error).message}`], entries: [] };
+  }
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray((parsed as { knownFailures?: unknown }).knownFailures)) {
+    return { ok: false, errors: ['expected an object with a "knownFailures" array'], entries: [] };
+  }
+
+  const raw = (parsed as { knownFailures: unknown[] }).knownFailures;
+  const errors: string[] = [];
+  const entries: KnownFailure[] = [];
+
+  raw.forEach((entry, i) => {
+    const where = `knownFailures[${i}]`;
+    if (!entry || typeof entry !== 'object') {
+      errors.push(`${where}: must be an object`);
+      return;
+    }
+    const { test, issue, reason, addedBy } = entry as Partial<KnownFailure>;
+    const testOk = typeof test === 'string' && test.trim().length > 0;
+    const issueOk = typeof issue === 'number' && Number.isInteger(issue) && issue > 0;
+    const reasonOk = typeof reason === 'string' && reason.trim().length > 0;
+    if (!testOk) errors.push(`${where}.test: must be a non-empty string`);
+    if (!issueOk) errors.push(`${where}.issue: must be a positive integer (the owning open issue)`);
+    if (!reasonOk) errors.push(`${where}.reason: must be a non-empty string (why it is tolerated)`);
+    if (testOk && issueOk && reasonOk) {
+      entries.push({
+        test: test!.trim(),
+        issue: issue!,
+        reason: reason!.trim(),
+        ...(typeof addedBy === 'string' && addedBy.trim() ? { addedBy: addedBy.trim() } : {}),
+      });
+    }
+  });
+
+  return { ok: errors.length === 0, errors, entries };
+}
+
+/** Load the registry from disk. A missing file is treated as an empty registry. */
+export function loadKnownFailures(root?: string): KnownFailuresValidation {
+  const path = knownFailuresPath(root);
+  if (!existsSync(path)) return { ok: true, errors: [], entries: [] };
+  return parseKnownFailures(readFileSync(path, 'utf8'));
+}
+
+/** The registry entry that owns a failing test id, if any (substring match). */
+export function isKnownFailure(testId: string, entries: KnownFailure[]): KnownFailure | undefined {
+  const id = testId.trim();
+  if (!id) return undefined;
+  return entries.find(e => id.includes(e.test));
+}
+
+/** The failing ids NOT covered by any registry entry — these must block. */
+export function unownedFailures(failingIds: string[], entries: KnownFailure[]): string[] {
+  return failingIds.map(s => s.trim()).filter(Boolean).filter(id => !isKnownFailure(id, entries));
+}
+
+/**
+ * Registry entries whose owning issue is not OPEN — a closed/missing owner means
+ * the failure is no longer tracked, so the entry must be removed (fix the test)
+ * or re-filed. Pure: the issue-state lookup is injected for testability.
+ */
+export function findOwnershipProblems(
+  entries: KnownFailure[],
+  stateOf: (issue: number) => IssueState,
+): OwnershipProblem[] {
+  const byIssue = new Map<number, string[]>();
+  for (const e of entries) {
+    const tests = byIssue.get(e.issue) ?? [];
+    tests.push(e.test);
+    byIssue.set(e.issue, tests);
+  }
+  const problems: OwnershipProblem[] = [];
+  for (const [issue, tests] of byIssue) {
+    const state = stateOf(issue);
+    if (state !== 'open') problems.push({ issue, state, tests });
+  }
+  return problems;
+}

--- a/src/known-failures.ts
+++ b/src/known-failures.ts
@@ -82,15 +82,21 @@ export function parseKnownFailures(content: string): KnownFailuresValidation {
       return;
     }
     const { test, issue, reason, addedBy } = entry as Partial<KnownFailure>;
-    const testOk = typeof test === 'string' && test.trim().length > 0;
+    // A `test` must look like a real test identifier, not a catch-all. Naive
+    // `id.includes(test)` matching means an over-broad entry (e.g. "test" or
+    // "py") would silently tolerate unrelated failures — so require a recognizable
+    // delimiter (`.`/`/`/`:`/`-`, present in every pytest nodeid, vitest name, or
+    // shell test file) and a minimum length. Use the full nodeid to be safe.
+    const testStr = typeof test === 'string' ? test.trim() : '';
+    const testOk = testStr.length >= 5 && /[.:/\\-]/.test(testStr);
     const issueOk = typeof issue === 'number' && Number.isInteger(issue) && issue > 0;
     const reasonOk = typeof reason === 'string' && reason.trim().length > 0;
-    if (!testOk) errors.push(`${where}.test: must be a non-empty string`);
+    if (!testOk) errors.push(`${where}.test: must be a specific test id (≥5 chars and contain one of . / : -), not a catch-all`);
     if (!issueOk) errors.push(`${where}.issue: must be a positive integer (the owning open issue)`);
     if (!reasonOk) errors.push(`${where}.reason: must be a non-empty string (why it is tolerated)`);
     if (testOk && issueOk && reasonOk) {
       entries.push({
-        test: test!.trim(),
+        test: testStr,
         issue: issue!,
         reason: reason!.trim(),
         ...(typeof addedBy === 'string' && addedBy.trim() ? { addedBy: addedBy.trim() } : {}),

--- a/src/review-sentinel.test.ts
+++ b/src/review-sentinel.test.ts
@@ -5,9 +5,36 @@ import {
   expectedPrReviewDimensions,
   serializeReviewSentinel,
   validateReviewSentinel,
+  reviewSentinelPath,
+  reviewSentinelStateKey,
 } from './review-sentinel.js';
+import { prUrlToStateKey } from './hooks/state-utils.js';
 
 const PR_URL = 'https://github.com/Garsson-io/kaizen/pull/997';
+
+describe('review sentinel path SSOT (#1481 anti-drift)', () => {
+  it('derives the same state key as the legacy prUrlToStateKey (behavior-preserving)', () => {
+    for (const url of [
+      'https://github.com/Garsson-io/kaizen/pull/55',
+      'https://github.com/Garsson-io/kaizen/pull/997',
+      'https://github.com/owner/repo-name/pull/12345',
+    ]) {
+      expect(reviewSentinelStateKey(url)).toBe(prUrlToStateKey(url));
+    }
+  });
+
+  it('writer and reader resolve to one identical path', () => {
+    expect(reviewSentinelPath('/state', PR_URL, 3)).toBe(
+      `/state/${prUrlToStateKey(PR_URL)}.reviewed-r3`,
+    );
+    // round may be passed as string or number — both must agree.
+    expect(reviewSentinelPath('/state', PR_URL, '3')).toBe(reviewSentinelPath('/state', PR_URL, 3));
+  });
+
+  it('throws on an invalid PR URL', () => {
+    expect(() => reviewSentinelStateKey('not-a-url')).toThrow('invalid PR URL');
+  });
+});
 
 describe('review sentinel contract', () => {
   it('uses the shared YAML frontmatter parser for expected review dimensions', () => {

--- a/src/review-sentinel.ts
+++ b/src/review-sentinel.ts
@@ -1,11 +1,30 @@
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { readYamlFrontmatter } from './lib/frontmatter.js';
 import { parseGithubPrUrl } from './lib/github-pr.js';
 import { resolveProjectRoot } from './lib/resolve-project-root.js';
 
 export const REVIEW_SENTINEL_SCHEMA_VERSION = 1;
+
+/**
+ * The single source of truth for where a review sentinel lives on disk.
+ * Both the writer (`cli-structured-data.ts` / `pr-review-loop.writeReviewSentinel`)
+ * and the reader (`pr-review-loop.defaultCheckReviewSentinel`) derive the path
+ * here, so the path format can never drift between them — drift between a writer
+ * and a reader is exactly the failure class behind #1481.
+ */
+export function reviewSentinelStateKey(prUrl: string): string {
+  const parsed = parseGithubPrUrl(prUrl);
+  if (!parsed) {
+    throw new Error(`invalid PR URL for review sentinel: ${prUrl}`);
+  }
+  return `${parsed.repo.replace('/', '_')}_${parsed.number}`;
+}
+
+export function reviewSentinelPath(stateDir: string, prUrl: string, round: string | number): string {
+  return join(stateDir, `${reviewSentinelStateKey(prUrl)}.reviewed-r${round}`);
+}
 
 export const DEFAULT_PR_REVIEW_DIMENSIONS = [
   'correctness',

--- a/src/verdict-binding-inventory.ts
+++ b/src/verdict-binding-inventory.ts
@@ -159,6 +159,20 @@ export const VERDICT_BINDING_INVENTORY: VerdictBindingInventory = {
       ],
       terminalCritical: true,
     },
+    {
+      id: 'test-health-verdict',
+      label: 'Test-health verdict',
+      producer: 'src/known-failures.ts: unownedFailures() over the known-failures registry, surfaced as the testHealth signal (#1481/#1518)',
+      producerSignatures: [
+        'src/known-failures.ts:function:unownedFailures',
+        'scripts/known-failures-status.ts:function:runClassify',
+      ],
+      sourceEvidence: [
+        { file: 'src/known-failures.ts', tokens: ['unownedFailures', 'findOwnershipProblems'] },
+        { file: 'scripts/known-failures-status.ts', tokens: ['runClassify', 'known-failures'] },
+      ],
+      terminalCritical: true,
+    },
   ],
   nonTerminalVerdictProducers: [
     {
@@ -276,6 +290,11 @@ export const VERDICT_BINDING_INVENTORY: VerdictBindingInventory = {
       label: 'Shared review verdict policy alias',
       rationale: 'Shared policy type for consuming the review verdict, not an independent producer.',
     },
+    {
+      signature: 'src/verdict-binding-policy.ts:type:TestHealthVerdict',
+      label: 'Shared test-health verdict policy alias',
+      rationale: 'Shared policy type for consuming the test-health verdict; terminal binding is represented by test-health-verdict (produced by src/known-failures.ts).',
+    },
   ],
   terminalActions: [
     {
@@ -331,12 +350,13 @@ export const VERDICT_BINDING_INVENTORY: VerdictBindingInventory = {
       id: 'merge',
       label: 'Merge',
       terminalAction: 'Direct gh pr merge and auto-dent auto-merge queueing',
-      consumedVerdicts: ['review-round-verdict', 'review-battery-verdict', 'process-evidence-verdict', 'lifecycle-health-verdict', 'hook-activation-verdict'],
-      enforcingConsumer: 'enforce-merge-verdict blocks direct FAIL merges; decideAutoMergeSafety blocks unsafe auto-merge queueing, including degraded/unknown hook-activation (#1220)',
-      failureModeBlocked: 'A PR with FAIL review/process/lifecycle verdicts — or a degraded run where kaizen hooks did not load (or no system.init was seen on a hook-expecting provider) — cannot be merged or queued by the normal paths.',
+      consumedVerdicts: ['review-round-verdict', 'review-battery-verdict', 'process-evidence-verdict', 'lifecycle-health-verdict', 'hook-activation-verdict', 'test-health-verdict'],
+      enforcingConsumer: 'enforce-merge-verdict blocks direct FAIL merges; decideAutoMergeSafety blocks unsafe auto-merge queueing, including degraded/unknown hook-activation (#1220) and unowned test failures (#1518)',
+      failureModeBlocked: 'A PR with FAIL review/process/lifecycle verdicts — a degraded run where kaizen hooks did not load (or no system.init was seen on a hook-expecting provider) — or a run that observed a failing test owned by no open issue — cannot be merged or queued by the normal paths.',
       sourceEvidence: [
         { file: 'src/hooks/enforce-merge-verdict.ts', tokens: ['deriveStoredRoundVerdict', "verdict === 'FAIL'", 'MERGE BLOCKED'] },
-        { file: 'scripts/auto-dent-merge-policy.ts', tokens: ['qualityVerdictBlockReasons', 'decideAutoMergeSafety', 'hookActivationBlockReasons'] },
+        { file: 'scripts/auto-dent-merge-policy.ts', tokens: ['qualityVerdictBlockReasons', 'decideAutoMergeSafety', 'hookActivationBlockReasons', 'testHealth'] },
+        { file: 'src/verdict-binding-policy.ts', tokens: ['testHealth', 'unowned-failures'] },
         { file: '.claude-plugin/plugin.json', tokens: ['kaizen-enforce-merge-verdict-ts.sh'] },
       ],
     },

--- a/src/verdict-binding-policy.test.ts
+++ b/src/verdict-binding-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { qualityVerdictBlockReasons, hasHardQualityFailure } from './verdict-binding-policy.js';
+
+describe('qualityVerdictBlockReasons — test-health (#1481/#1518)', () => {
+  it('blocks on unowned-failures', () => {
+    const reasons = qualityVerdictBlockReasons({ reviewVerdict: 'pass', testHealth: 'unowned-failures' });
+    expect(reasons.some(r => r.includes('test health unowned-failures'))).toBe(true);
+    expect(hasHardQualityFailure({ testHealth: 'unowned-failures' })).toBe(true);
+  });
+
+  it('does not block on pass / unknown / absent (absence-of-evidence is not failure)', () => {
+    expect(qualityVerdictBlockReasons({ reviewVerdict: 'pass', testHealth: 'pass' })).toEqual([]);
+    expect(qualityVerdictBlockReasons({ reviewVerdict: 'pass', testHealth: 'unknown' })).toEqual([]);
+    expect(qualityVerdictBlockReasons({ reviewVerdict: 'pass' })).toEqual([]);
+  });
+
+  it('is provider-agnostic: blocks even when review is not required', () => {
+    expect(
+      qualityVerdictBlockReasons({ testHealth: 'unowned-failures' }, { requireReview: false }),
+    ).toHaveLength(1);
+  });
+
+  it('regression: existing review/process/lifecycle rules are unchanged', () => {
+    expect(qualityVerdictBlockReasons({ reviewVerdict: 'fail' })).toContain('review verdict fail');
+    expect(qualityVerdictBlockReasons({ processVerdict: 'process-incomplete' })).toContain('process verdict process-incomplete');
+    expect(qualityVerdictBlockReasons({ lifecycleHealth: 'critical' })).toContain('lifecycle health critical');
+    expect(qualityVerdictBlockReasons({ reviewVerdict: 'pass' })).toEqual([]);
+  });
+});

--- a/src/verdict-binding-policy.ts
+++ b/src/verdict-binding-policy.ts
@@ -1,11 +1,20 @@
 export type ReviewVerdict = 'pass' | 'fail' | 'skipped';
 export type ProcessVerdict = 'pass' | 'process-incomplete' | 'fail-open-warning';
 export type LifecycleHealth = 'clean' | 'degraded' | 'critical';
+/**
+ * Test-health verdict (#1481/#1518). `unowned-failures` means the run observed a
+ * failing test that is NOT owned by an OPEN tracking issue in the known-failures
+ * registry — that PR is not merge-ready. `unknown` (no test signal observed) and
+ * absence are non-blocking: absence-of-evidence is not a failure here, mirroring
+ * how the review verdict is only required at terminal actions.
+ */
+export type TestHealthVerdict = 'pass' | 'unowned-failures' | 'unknown';
 
 export interface QualityVerdictSignals {
   reviewVerdict?: ReviewVerdict;
   processVerdict?: ProcessVerdict;
   lifecycleHealth?: LifecycleHealth;
+  testHealth?: TestHealthVerdict;
 }
 
 export interface QualityVerdictPolicyOptions {
@@ -37,6 +46,13 @@ export function qualityVerdictBlockReasons(
 
   if (signals.lifecycleHealth === 'critical') {
     reasons.push('lifecycle health critical');
+  }
+
+  // #1518: an observed test failure that no OPEN issue owns blocks merge. This
+  // is provider-agnostic (not gated behind requireReview): unlike review, test
+  // health is a hard signal for both Claude and Codex runs.
+  if (signals.testHealth === 'unowned-failures') {
+    reasons.push('test health unowned-failures (failing test with no owning open issue, #1518)');
   }
 
   return reasons;


### PR DESCRIPTION
## Problem

Mainline could present as **healthy while it wasn't**. During the June 28 review, `npm run typecheck` passed, the full Vitest suite passed, and GitHub Actions on `main` were green — yet `npm run test:hooks` was **red locally**: two `test_hooks.py` PR-lifecycle cases failing. An agent or human trusting green CI would merge straight past a broken hook-workflow contract (#1481). And in discussion, the failure was waved off as "probably unrelated / pre-existing" — exposing a second gap: there's no rule forbidding merge while a known test is red unless someone *owns* that failure (#1518).

## Discovery

Two root causes, both verified against source — not guessed:

1. **The two red tests are stale fixtures, not a product regression.** `harness.py::create_review_sentinel` wrote the ancient `reviewed_at=test` format, but the product correctly requires a **signed JSON sentinel** (`buildReviewSentinelRecord` + sha256 integrity + full dimension coverage, #920). The gate rightly rejected the stale fixture (`missing_sentinel`) → stayed `needs_review`, and the old `"No review findings stored"` string had been renamed. Re-implementing the digest in Python would re-introduce the exact drift that caused this — rejected.
2. **CI silently skipped the Python suite.** The `shell-tests` job ran `run-all-tests.sh` but installed only Node; `run_python_tests()` hit `if ! python3 -c "import pytest"` → printed `SKIP` and returned 0. So `test_hooks.py` **never gated in CI**. The silent skip *is* the ambiguity.
3. **No owned-failure mechanism existed** — no registry, no "failing test → owning open issue", no enforcement.

## Solution

**#1481 — make the tree truly green and the signal unambiguous**
- A `KAIZEN_TEST_RUNNER`-gated `emit-test-review-sentinel` CLI command builds a valid sentinel via the real SSOT (`buildReviewSentinelRecord` + `expectedPrReviewDimensions()`). It **refuses outside the test runner**, so it can never be a production fabrication bypass (#1019/#1212 class). The Python harness shells out to it and carries **zero** knowledge of the sentinel format — the drift can't recur.
- CI installs pytest and sets `KAIZEN_REQUIRE_PYTHON_TESTS=1`, which turns a **missing runner into a hard failure** instead of a silent skip.

**#1518 — forbid merging with unowned failing tests**
- `src/known-failures.ts` (SSOT) + `.agents/kaizen/known-failures.json` registry (`{ test, issue, reason }`, ships empty).
- `run-all-tests.sh` classifies every failure: owned-by-open-issue → logged & tolerated; **unowned or unattributable (missing runner / no parseable id) → fatal.**
- A new `known-failures` CI job fails if any entry's owning issue is **closed/missing** (forces fix-or-refile) — provider-agnostic, works for Codex too.
- A `testHealth` signal is bound into the merge SSOT `qualityVerdictBlockReasons` (consumed by `decideAutoMergeSafety` for auto-dent auto-merge; the direct `enforce-merge-verdict` PreToolUse gate consumes the review-round verdict, not test health); `test-health-verdict` is registered **terminal-critical** in `docs/verdict-binding-inventory.md` so `findInventoryViolations` (CI) fails if it's ever un-bound — an **L3 ratchet**.
- Rule codified in `zen.md`, `policies-local.md`, and `AGENTS.md`/CLAUDE.md.

**DRY / consolidation** (a first-class goal of this work)
- One sentinel **writer** (`writeSentinelRecord`) shared by the prod `store-review-*` path and the test emitter.
- One sentinel **path** SSOT (`reviewSentinelPath`) shared by the hook *reader* and all *writers* — collapsing three independent derivations into one, since writer/reader path drift is literally the #1481 failure class (anti-drift test proves it equals the legacy `prUrlToStateKey`).
- One failure **classifier** reused by the runner, the CI gate, and the merge signal.

## Evidence

**BEFORE**
```
test_hooks.py::TestPRLifecycle → 2 failed, 3 passed
ci.yml shell-tests: setup-python steps = 0  → run_python_tests() silently SKIPs in CI
.agents/kaizen/known-failures.* → (none);  src/known-failures.ts → (none)
```

**AFTER**
```
test_hooks.py::TestPRLifecycle → 5 passed            (full file: 38 passed)
ci.yml: setup-python = 1, KAIZEN_REQUIRE_PYTHON_TESTS = 1
  missing pytest + required  → run-all-tests.sh exits 1  (was a silent pass)
known-failures classifier: unowned failure → exit 1 (blocks)
                            owned-by-open-issue → tolerated, logged
                            missing runner / unattributable → fatal (never tolerable)
merge SSOT: qualityVerdictBlockReasons blocks on testHealth: 'unowned-failures'
L3 ratchet: test-health-verdict bound terminal-critical → merge (inventory test enforces)
```

**Validation:** `npm run typecheck` clean · `vitest` **3719 passed / 0 failed** · `test:hooks` **424 passed** (incl. `test_hooks.py` 38) · `known-failures --validate` OK · hook-integrity OK · no #448 side-effects.

## Impact

Green CI can no longer hide a red local hook suite, and a failing test can no longer be invisible background noise: it is either fixed before merge or has a single owner and an open issue, enforced at the test runner (provider-agnostic), in CI, and at the merge gate.

## Notes
- `enforce-merge-verdict` stays review-verdict-only and the auto-dent harness does not yet populate a run-level `testHealth` (left `unknown`/non-blocking rather than fabricated) — the same principled boundary #1220 used when deferring run-success consumption to #1501. Enforcement is live at the runner + CI + SSOT; harness population of the run-level signal is tracked as **#1527** (filed so the deferred producer is owned, per this PR's own #1518 rule).

## Review

Adversarial dimension battery — **3 rounds, all 14 dimensions PASS, 0 MISSING**:
- **R1** (all PASS): PARTIALs fixed in `8ade676` — corrected a docs inaccuracy about which gate consumes the SSOT; added a specificity guard against catch-all registry entries; added tests for the `KAIZEN_TEST_RUNNER` anti-fabrication guard and the closed/missing-owner CI gate; filed **#1527** for the deferred harness `testHealth` signal.
- **R2** (all PASS): every R1 finding verified resolved.
- **R3** (all PASS): CI's CodeQL surfaced 2 alerts in changed code — a trivial unused import (mine) and a high `js/insecure-temporary-file` that is a **pre-existing repo-wide pattern** (the `/tmp/.pr-review-state` state-dir convention, already alerted on `main` at `pr-review-loop.ts:136` and `cli-structured-data.ts`; my DRY refactor only moved the line into a changed hunk). Fixed the import; hardened the merge-gating sentinel write to owner-only (`0o700`/`0o600`) so **CodeQL now reports no new alerts**; filed **#1528** to own the repo-wide remediation (dogfooding this PR's own #1518 rule).

## Validation

All required CI checks green on HEAD: TypeScript typecheck · TypeScript tests + coverage · Shell hook tests (**now running pytest** — the #1481 fix proven on real CI) · Hook integrity · **Known-failure ownership** (the new #1518 CI gate) · Review verdict gate · CodeQL (no new alerts). Local: `vitest` 3729 passed/0 failed, `test:hooks` 424 passed (incl. `test_hooks.py` 38), no #448 side-effects.
- E2E (I23): no hook `*.sh` enforcement logic or skill behavior changed beyond the Python runner, which the hook-test suite covers.

Closes #1481
Closes #1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
