### PR TITLE
test(hooks): pin extractCaseIssueFromBranch contract (#1193)

### DIFF
--- a/src/hooks/lib/case-branch.test.ts
+++ b/src/hooks/lib/case-branch.test.ts
@@ -1,0 +1,68 @@
+/**
+ * case-branch.test.ts — direct contract test for `extractCaseIssueFromBranch` (#1193).
+ *
+ * This parser is the load-bearing cross-check for the #1106 plan-gate fix:
+ * `enforce-plan-stored.ts` uses it to verify the declared `kaizen.issue` matches
+ * the canonical case-branch token and FAILS CLOSED on mismatch. It is also the
+ * basis of the per-worktree binding self-heal in `issue-binding.ts` (#1111).
+ *
+ * Before this file the function was covered only INDIRECTLY (via the binding
+ * suite), so a regex regression could silently weaken the gate (false-null →
+ * over-block) or break it (false-match → gate passes the wrong issue) while the
+ * suite stayed green. The cases below pin every documented edge the regex
+ * `^case\/\d{6,}-k(\d+)(?:-|$)` decides.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { extractCaseIssueFromBranch } from './case-branch.js';
+
+describe('extractCaseIssueFromBranch', () => {
+  describe('matches and extracts the issue number', () => {
+    const matches: Array<[string, string]> = [
+      // Happy path: canonical `case/<date>-k<N>-<slug>`.
+      ['case/260626-k950-outcome-verification', '950'],
+      // Slug-less branch terminated by `$` (the `(?:-|$)` alternative).
+      ['case/260626-k950', '950'],
+      // Multi-digit issue numbers.
+      ['case/260626-k12345-x', '12345'],
+      ['case/260626-k12345', '12345'],
+      // Single-digit issue number at the `\d{6,}` date lower bound.
+      ['case/123456-k7-z', '7'],
+      // Longer (timestamped) date prefixes still satisfy `\d{6,}`.
+      ['case/2606261200-k950-x', '950'],
+    ];
+
+    it.each(matches)('%s -> %s', (branch, expected) => {
+      expect(extractCaseIssueFromBranch(branch)).toBe(expected);
+    });
+  });
+
+  describe('returns null for any other branch shape', () => {
+    const nonMatches: Array<[string, string]> = [
+      // `\d{6,}` lower boundary: a 5-digit date must NOT match.
+      ['case/26-k950-x', '5-digit date below the \\d{6,} bound'],
+      ['case/12345-k7', '5-digit date below the \\d{6,} bound (no slug)'],
+      // `^` anchor: the token must not be matched as a substring.
+      ['feature/case/260626-k950-x', 'not anchored at start (prefixed)'],
+      [' case/260626-k950', 'leading whitespace defeats the ^ anchor'],
+      // Missing / non-numeric issue token after `-k`.
+      ['case/260626-kfoo', 'non-numeric issue token'],
+      ['case/260626-k', 'no issue number at all'],
+      ['case/260626-k-slug', 'dash where the number should be'],
+      // Separator discipline: the number must be followed by `-` or end.
+      ['case/260626-k950x', 'number not terminated by - or end of string'],
+      // Date present but `-k` segment missing entirely.
+      ['case/260626-outcome', 'no -k segment'],
+      // Non-case branch shapes the case system never produces.
+      ['k950-slug', 'bare k<N> branch'],
+      ['worktree-2606281815-7b6c', 'auto-dent worktree branch'],
+      ['main', 'default branch'],
+      ['', 'empty string'],
+    ];
+
+    it.each(nonMatches)('%s -> null (%s)', (branch) => {
+      expect(extractCaseIssueFromBranch(branch)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`src/hooks/lib/case-branch.ts` exports `extractCaseIssueFromBranch(branch)` — a one-line regex parser (`^case\/\d{6,}-k(\d+)(?:-|$)`) whose docstring makes strong safety claims ("Returns null for ANY other branch shape… so it never misfires"). Nothing pinned those claims.

This is not a cosmetic gap: the function is the **load-bearing cross-check** for the #1106 plan-gate fix. `enforce-plan-stored.ts` calls it to verify the declared `kaizen.issue` matches the canonical case-branch token and **fails closed on mismatch**, and `issue-binding.ts` (#1111) uses it to self-heal the per-worktree binding. A regex regression could silently **weaken** the gate (false-null → over-block) or **break** it (false-match → the gate passes the *wrong* issue) — and the existing suite, which only covered the function *indirectly* via `issue-binding.test.ts`, would stay green.

## Discovery

Surfaced by auto-dent explore run `powerful-capybara/run-24` (testing-gaps sweep, batch #1133) and filed as #1193. The interesting cases are the boundary decisions baked into the regex: the `\d{6,}` date lower bound, the `^` anchor, the `(?:-|$)` separator discipline, and the `(\d+)` issue token.

## Solution

Add `src/hooks/lib/case-branch.test.ts` — a direct, table-driven vitest test (matching the existing `current-branch.test.ts` `it.each` idiom in the same directory). No production change: this is a pure characterization/contract test of an already-shipped pure function. It pins every edge the regex decides:

- **Matches:** happy path, slug-less `$`-termination, multi-digit numbers, single-digit number at the date bound, timestamped (longer) date prefixes.
- **Null:** 5-digit date (below `\d{6,}`), non-anchored/leading-space (defeats `^`), missing/non-numeric issue token, number not terminated by `-`/end (separator), and non-case shapes (bare `k<N>`, `worktree-*`, `main`, empty string).

## Evidence

- `npx vitest run src/hooks/lib/case-branch.test.ts` → **19 passed**.
- Full lib suite green: **172 passed (9 files)** — no collateral breakage.
- **Mutation / meet-reality:** relaxing the regex `\d{6,}` → `\d+` fails 2 cases (the date-bound nulls); dropping the `^` anchor fails 2 cases (the prefixed/whitespace nulls). The test genuinely guards the contract — it is not tautological. Reverted; clean.

### Behaviors × levels

| Behavior | Unit | Integration | System | Agentic | Workflow |
|----------|:----:|:-----------:|:------:|:-------:|:--------:|
| Extract issue from canonical case branch | ✅ | — | — | — | — |
| `\d{6,}` date lower-bound enforcement | ✅ | — | — | — | — |
| `^` anchor (no substring match) | ✅ | — | — | — | — |
| Separator discipline after issue number | ✅ | — | — | — | — |
| Null for missing/non-numeric / non-case shapes | ✅ | — | — | — | — |

The function is pure (`string -> string | null`, no I/O), so Unit is the complete and correct level. The integration path through `enforce-plan-stored.ts` / `issue-binding.ts` is already exercised by those modules' own suites; this PR pins the parser's *own* contract.

## Impact (goal -> before/after -> match)

- **Goal:** make a regression in the #1106 fail-closed plan-gate parser *impossible to merge green*.
- **Before:** `extractCaseIssueFromBranch` had **zero direct tests**; its documented safety contract was unpinned. A bad edit to the regex passes CI silently.
- **After:** **19 direct, mutation-verified assertions** lock the contract. The mutation check proves a weakened regex turns the suite red.
- **Match:** the goal exactly matches — this is the small, high-leverage test the issue asked for, and the deferred adjacent gaps (#1183, auto-dent.ts helpers) are left to the PRs touching those modules, as #1193 specifies.

Closes #1193
Refs #1106, #1111

Run tag: missing-crayfish/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
