### PR TITLE
fix(auto-dent): feed test health into merge gate

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -577,6 +577,22 @@ describe('buildBatchReflection', () => {
     expect(consecInsight!.message).toContain('2');
   });
 
+  it('does not report no_op runs as failure root causes', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        run: 3,
+        run_history: [
+          makeRunMetrics({ run: 1, prs: ['https://github.com/Garsson-io/kaizen/pull/100'] }),
+          makeRunMetrics({ run: 2, prs: [], issues_closed: [], failure_class: 'no_op', stop_requested: true }),
+          makeRunMetrics({ run: 3, prs: [], issues_closed: [], failure_class: 'no_op', stop_requested: true }),
+        ],
+      }),
+    });
+    const reflection = buildBatchReflection(batch);
+    expect(reflection.insights.some((i) => i.message.includes('Failure root causes'))).toBe(false);
+    expect(reflection.runHistoryTable).toContain('| #2 | 5m0s | $2.50 | 0 | 0 | noop |');
+  });
+
   it('detects stop signal pattern', () => {
     const batch = makeBatchInfo({
       state: makeBatchState({

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -476,7 +476,7 @@ export function buildBatchReflection(batch: BatchInfo): BatchReflection {
 
   // Insight: failure class distribution
   const failureClasses = scores.map(s => s.failure_class);
-  const nonSuccessClasses = failureClasses.filter(fc => fc !== 'success' && fc !== 'empty_success');
+  const nonSuccessClasses = failureClasses.filter(fc => fc !== 'success' && fc !== 'empty_success' && fc !== 'no_op');
   if (nonSuccessClasses.length >= 2) {
     const dist = formatFailureDistribution(nonSuccessClasses);
     insights.push({

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -54,6 +54,7 @@ import {
   populateCrossBatchSteering,
   shouldRunCodexProvider,
 } from './auto-dent-run.js';
+import { deriveRunTestHealth } from './auto-dent-test-health.js';
 import * as github from './auto-dent-github.js';
 import { makeBatchState, makeRunResult } from './auto-dent-test-utils.js';
 import { decideAutoMergeSafety } from './auto-dent-merge-policy.js';
@@ -3582,6 +3583,18 @@ describe('auto-merge verdict binding wiring (#1220)', () => {
     expect(callSite).toContain("provider: state.provider ?? 'claude'");
   });
 
+  it('feeds observed run-level test health into the merge decision (#1527)', () => {
+    const callSite = AUTO_DENT_RUN_SOURCE.slice(
+      AUTO_DENT_RUN_SOURCE.indexOf('const autoMergeDecision = decideAutoMergeSafety({'),
+      AUTO_DENT_RUN_SOURCE.indexOf('const autoMergeQueue = queueAutoMerge('),
+    );
+    expect(callSite).toContain('testHealth');
+    const derivationIndex = AUTO_DENT_RUN_SOURCE.indexOf('const testHealth = deriveRunTestHealth({ runLog });');
+    const decisionIndex = AUTO_DENT_RUN_SOURCE.indexOf('const autoMergeDecision = decideAutoMergeSafety({');
+    expect(derivationIndex).toBeGreaterThan(-1);
+    expect(derivationIndex).toBeLessThan(decisionIndex);
+  });
+
   it('stream → verdict → gate: a degraded claude run is blocked from auto-merge end-to-end', () => {
     // Build a REAL degraded verdict by replaying a captured plugins:[] system.init
     // through the production stream processor (the same path main() uses), then feed
@@ -3632,6 +3645,37 @@ describe('auto-merge verdict binding wiring (#1220)', () => {
       provider: state.provider ?? 'claude',
     });
     expect(decision.allow).toBe(true);
+  });
+
+  it('run log → testHealth → gate: an observed unowned test failure blocks auto-merge end-to-end', () => {
+    const testHealth = deriveRunTestHealth({
+      runLog: 'FAILED FILES:\n  - test-unowned-hook\n',
+      load: () => ({ ok: true, errors: [], entries: [] }),
+    });
+    expect(testHealth).toBe('unowned-failures');
+
+    const result = makeRunResult({ prs: ['https://github.com/Garsson-io/kaizen/pull/1527'] });
+    const ctx: StreamContext = { provider: 'claude' };
+    processStreamMessage(
+      { type: 'system', subtype: 'init', session_id: 'healthyhooks1527', model: 'claude-opus-4-6', plugins: [{ name: 'kaizen' }] },
+      result,
+      Date.now(),
+      ctx,
+    );
+
+    const state = makeBatchState({ test_task: false });
+    const decision = decideAutoMergeSafety({
+      prCount: result.prs.length,
+      reviewRequired: !state.test_task,
+      reviewVerdict: 'pass',
+      processVerdict: 'pass',
+      lifecycleHealth: 'clean',
+      hookActivation: result.hookActivation,
+      provider: state.provider ?? 'claude',
+      testHealth,
+    });
+    expect(decision.allow).toBe(false);
+    expect(decision.reasons).toContain('test health unowned-failures (failing test with no owning open issue, #1518)');
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -195,6 +195,7 @@ import {
   rescueRun,
   defaultRescueDeps,
 } from './auto-dent-rescue.js';
+import { deriveRunTestHealth } from './auto-dent-test-health.js';
 import { createDefaultGitExec } from '../src/hooks/lib/git-state.js';
 import { runStalePrTriageMaintenance } from './stale-pr-triage.js';
 import { gh as ghArgs } from '../src/lib/gh-exec.js';
@@ -292,6 +293,8 @@ export interface RunMetrics {
   review_verdict?: 'pass' | 'fail' | 'skipped';
   /** Review battery cost (USD) */
   review_cost_usd?: number;
+  /** Run-level test-health verdict derived from observed failed test ids (#1527). */
+  test_health?: 'pass' | 'unowned-failures' | 'unknown';
   /**
    * Provider + billing mode used for each lifecycle phase (#1143, epic #1134).
    * Absent on older runs (treated as unknown). Defaults to Claude-under-subscription
@@ -2586,6 +2589,8 @@ async function main(): Promise<void> {
   // Post-run hygiene
   const progressIssue = ensureBatchProgressIssue(state, stateFile);
   labelArtifacts(result, 'auto-dent');
+  const runLog = existsSync(logFile) ? readFileSync(logFile, 'utf8') : undefined;
+  const testHealth = deriveRunTestHealth({ runLog });
   const autoMergeDecision = decideAutoMergeSafety({
     prCount: result.prs.length,
     reviewRequired: !state.test_task,
@@ -2598,13 +2603,10 @@ async function main(): Promise<void> {
     // Default provider to 'claude' (hook-expecting) for legacy state → fail-closed.
     hookActivation: result.hookActivation,
     provider: state.provider ?? 'claude',
-    // testHealth (#1481/#1518) is consumed by the shared SSOT and is enforced
-    // provider-agnostically at the test runner (run-all-tests.sh owned/unowned
-    // classification) and the `known-failures` CI gate. The harness does not run
-    // the suite itself, so it has no truthful run-level test signal to pass here
-    // yet — left `unknown` (non-blocking) rather than fabricated. Capturing a
-    // run-level test-failure signal for the harness is tracked as #1527,
-    // mirroring how #1220 deferred run-success consumption to #1501.
+    // Reuse the same known-failures classifier as run-all-tests.sh/CI. Absence
+    // of observed failed test ids stays `unknown`; only real run-log evidence can
+    // become pass/unowned-failures.
+    testHealth,
   });
   const autoMergeQueue = queueAutoMerge(result, state.host_repo || state.kaizen_repo, autoMergeDecision);
   if (!autoMergeDecision.allow) {
@@ -2747,13 +2749,13 @@ async function main(): Promise<void> {
       process_summary: processSummary,
       review_verdict: reviewVerdict,
       review_cost_usd: reviewCostUsd,
+      test_health: testHealth,
       phase_providers: phaseProvidersForState(state),
     },
   });
   // Classify failure: wall-clock timeout is authoritative (#686), then heuristics.
   // Feed the run log so the log-based branch (hook_rejection, infrastructure,
   // etc.) actually runs — without this argument it was dead code (#1102).
-  const runLog = existsSync(logFile) ? readFileSync(logFile, 'utf8') : undefined;
   runMetrics.failure_class = result.timedOut ? 'timeout' : classifyFailure(runMetrics, runLog);
   if (runMetrics.failure_class === 'hook_rejection' && runLog) {
     runMetrics.hook_rejection_reason = firstHookReason(runLog);

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -1215,6 +1215,27 @@ describe('classifyFailure', () => {
     expect(classifyFailure(makeRunMetrics({ exit_code: 0, prs: [], issues_filed: [], issues_closed: [] }))).toBe('empty_success');
   });
 
+  it('classifies a clean STOP/no-op run distinctly from suspicious empty_success (#1216)', () => {
+    expect(
+      classifyFailure(makeRunMetrics({
+        exit_code: 0,
+        prs: [],
+        issues_filed: [],
+        issues_closed: [],
+        stop_requested: true,
+      })),
+    ).toBe('no_op');
+  });
+
+  it('classifies claimed-work avoidance as no_op even when the process exited cleanly (#1216)', () => {
+    expect(
+      classifyFailure(
+        makeRunMetrics({ exit_code: 0, prs: [], issues_filed: [], issues_closed: [] }),
+        'Issue blocked: open PR already claims the work, stopping without duplicate implementation',
+      ),
+    ).toBe('no_op');
+  });
+
   it('classifies exit 0 with issues filed as success', () => {
     expect(classifyFailure(makeRunMetrics({ exit_code: 0, prs: [], issues_filed: ['#1'], issues_closed: [] }))).toBe('success');
   });

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -16,6 +16,7 @@ import { hasHookRejection } from './hook-signals.js';
  */
 export type FailureClass =
   | 'success'           // exit 0, produced artifacts (PRs or issues)
+  | 'no_op'             // exit 0, no artifacts, but a conscious STOP/skip/no-op
   | 'empty_success'     // exit 0 but no PRs/issues (wasted run)
   | 'hook_rejection'    // hook blocked the PR/commit
   | 'issue_blocked'     // picked an issue that couldn't be resolved
@@ -30,19 +31,33 @@ export type FailureClass =
  *
  * Classification priority:
  *   1. exit 0 + artifacts → 'success'
- *   2. exit 0 + no artifacts → 'empty_success'
- *   3. Log-based heuristics (hook_rejection, infrastructure, timeout, scope_overflow, issue_blocked)
- *   4. Fallback to 'crash' for non-zero exit, 'unknown' otherwise
+ *   2. exit 0 + no artifacts + STOP/claimed-work marker → 'no_op'
+ *   3. exit 0 + no artifacts → 'empty_success'
+ *   4. Log-based heuristics (hook_rejection, infrastructure, timeout, scope_overflow, issue_blocked)
+ *   5. Fallback to 'crash' for non-zero exit, 'unknown' otherwise
  */
 export function classifyFailure(
   metrics: RunMetrics,
   logOutput?: string,
 ): FailureClass {
   const hasArtifacts = metrics.prs.length > 0 || metrics.issues_filed.length > 0 || metrics.issues_closed.length > 0;
+  const log = logOutput?.toLowerCase() ?? '';
 
   if (metrics.exit_code === 0 && hasArtifacts) return 'success';
   // Contemplate/reflect runs are strategic — they don't produce PRs by design (#631)
   if (metrics.exit_code === 0 && !hasArtifacts && (metrics.mode === 'contemplate' || metrics.mode === 'reflect')) return 'success';
+  if (
+    metrics.exit_code === 0 &&
+    !hasArtifacts &&
+    (metrics.stop_requested ||
+      log.includes('already claimed') ||
+      log.includes('already claims the work') ||
+      log.includes('legitimate no-op') ||
+      log.includes('noop') ||
+      log.includes('no-op'))
+  ) {
+    return 'no_op';
+  }
   if (metrics.exit_code === 0 && !hasArtifacts) return 'empty_success';
 
   if (logOutput) {
@@ -52,7 +67,6 @@ export function classifyFailure(
     if (hasHookRejection(logOutput)) {
       return 'hook_rejection';
     }
-    const log = logOutput.toLowerCase();
     // Legacy fallback: pre-commit / framework hooks that don't speak the kaizen
     // structured contract still surface as English prose. Kept as a safety net.
     if (log.includes('hook rejected') || log.includes('hook blocked') || log.includes('pre-commit hook') || log.includes('hook failed')) {
@@ -93,6 +107,7 @@ export function classifyFailure(
 export function failureClassLabel(fc: FailureClass): string {
   const labels: Record<FailureClass, string> = {
     success: 'ok',
+    no_op: 'noop',
     empty_success: 'empty',
     hook_rejection: 'hook',
     issue_blocked: 'blocked',

--- a/scripts/auto-dent-test-health.test.ts
+++ b/scripts/auto-dent-test-health.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyObservedTestFailures,
+  deriveRunTestHealth,
+  extractObservedTestFailureIds,
+} from './auto-dent-test-health.js';
+import type { KnownFailuresValidation } from '../src/known-failures.js';
+
+const registry = (tests: string[]): KnownFailuresValidation => ({
+  ok: true,
+  errors: [],
+  entries: tests.map((test, i) => ({
+    test,
+    issue: 1000 + i,
+    reason: 'owned by test',
+  })),
+});
+
+describe('extractObservedTestFailureIds', () => {
+  it('extracts shell failure file names from run-all-tests output', () => {
+    const ids = extractObservedTestFailureIds(`
+FAILED FILES:
+  - test-pre-push-wrapper
+  - test_hooks.py
+
+owned-failure check (#1518)
+`);
+    expect(ids).toEqual(['test-pre-push-wrapper', 'test_hooks.py']);
+  });
+
+  it('extracts pytest nodeids from verbose pytest output', () => {
+    const ids = extractObservedTestFailureIds(`
+FAILED .claude/hooks/tests/test_hooks.py::TestHooks::test_rejects_bad_pr - AssertionError
+FAILED .claude/hooks/tests/test_hooks.py::TestHooks::test_blocks_unplanned_work - AssertionError
+`);
+    expect(ids).toEqual([
+      '.claude/hooks/tests/test_hooks.py::TestHooks::test_rejects_bad_pr',
+      '.claude/hooks/tests/test_hooks.py::TestHooks::test_blocks_unplanned_work',
+    ]);
+  });
+});
+
+describe('deriveRunTestHealth', () => {
+  it('returns unknown when the run log contains no observed failed test ids', () => {
+    expect(deriveRunTestHealth({ runLog: 'All tests passed.' })).toBe('unknown');
+  });
+
+  it('returns pass when every observed failure is owned by the shared registry', () => {
+    expect(
+      deriveRunTestHealth({
+        runLog: 'FAILED FILES:\n  - test-pre-push-wrapper\n',
+        load: () => registry(['test-pre-push-wrapper']),
+      }),
+    ).toBe('pass');
+  });
+
+  it('returns unowned-failures when any observed failure lacks an owner', () => {
+    expect(
+      deriveRunTestHealth({
+        runLog: 'FAILED FILES:\n  - test-pre-push-wrapper\n  - test-unowned-hook\n',
+        load: () => registry(['test-pre-push-wrapper']),
+      }),
+    ).toBe('unowned-failures');
+  });
+
+  it('fails closed when failures were observed but the registry cannot be loaded', () => {
+    expect(
+      deriveRunTestHealth({
+        runLog: 'FAILED FILES:\n  - test-pre-push-wrapper\n',
+        load: () => ({ ok: false, errors: ['invalid JSON'], entries: [] }),
+      }),
+    ).toBe('unowned-failures');
+  });
+
+  it('uses the same substring ownership semantics as known-failures', () => {
+    expect(
+      classifyObservedTestFailures(
+        ['.claude/hooks/tests/test_hooks.py::TestHooks::test_rejects_bad_pr'],
+        registry(['test_hooks.py::TestHooks::test_rejects_bad_pr']),
+      ),
+    ).toBe('pass');
+  });
+});

--- a/scripts/auto-dent-test-health.ts
+++ b/scripts/auto-dent-test-health.ts
@@ -1,0 +1,60 @@
+import type { KnownFailuresValidation } from '../src/known-failures.js';
+import { loadKnownFailures, unownedFailures } from '../src/known-failures.js';
+import type { TestHealthVerdict } from '../src/verdict-binding-policy.js';
+
+export interface DeriveRunTestHealthOptions {
+  runLog?: string;
+  load?: () => KnownFailuresValidation;
+}
+
+function unique(ids: string[]): string[] {
+  return [...new Set(ids.map((id) => id.trim()).filter(Boolean))];
+}
+
+export function extractObservedTestFailureIds(runLog?: string): string[] {
+  if (!runLog) return [];
+
+  const ids: string[] = [];
+  const lines = runLog.split(/\r?\n/);
+  let inFailedFiles = false;
+
+  for (const line of lines) {
+    const pytest = line.match(/^FAILED\s+(?!FILES:)(\S+)/);
+    if (pytest?.[1]) ids.push(pytest[1]);
+
+    if (/^FAILED FILES:\s*$/.test(line)) {
+      inFailedFiles = true;
+      continue;
+    }
+
+    if (inFailedFiles) {
+      const item = line.match(/^\s*-\s+(.+?)\s*$/);
+      if (item?.[1]) {
+        ids.push(item[1]);
+        continue;
+      }
+      inFailedFiles = false;
+    }
+  }
+
+  return unique(ids);
+}
+
+export function classifyObservedTestFailures(
+  failingIds: string[],
+  registry: KnownFailuresValidation,
+): TestHealthVerdict {
+  const observed = unique(failingIds);
+  if (observed.length === 0) return 'unknown';
+  if (!registry.ok) return 'unowned-failures';
+  return unownedFailures(observed, registry.entries).length > 0
+    ? 'unowned-failures'
+    : 'pass';
+}
+
+export function deriveRunTestHealth(options: DeriveRunTestHealthOptions = {}): TestHealthVerdict {
+  const failingIds = extractObservedTestFailureIds(options.runLog);
+  if (failingIds.length === 0) return 'unknown';
+  const registry = (options.load ?? loadKnownFailures)();
+  return classifyObservedTestFailures(failingIds, registry);
+}


### PR DESCRIPTION
## Story

Once upon a time, auto-dent already had a merge-readiness SSOT: `qualityVerdictBlockReasons` could block a PR when `testHealth` was `unowned-failures`.

Every day, the auto-dent harness reached the terminal merge decision with review, process, lifecycle, and hook-activation signals, but no truthful run-level test-health producer. The call site explicitly left `testHealth` unknown, so the #1518 policy was structurally wired but inert on this path.

One day, #1527 captured the gap: the shared known-failures classifier existed, but auto-dent never turned observed failed test ids from the run log into the merge gate's `TestHealthVerdict`.

Because of that, this PR adds a small `auto-dent-test-health` helper that extracts concrete failed test ids from observed run output (`FAILED FILES:` and pytest `FAILED <nodeid>` lines), runs them through the existing `loadKnownFailures`/`unownedFailures` classifier, and returns `unknown`, `pass`, or `unowned-failures`.

Because of that, `scripts/auto-dent-run.ts` now derives `testHealth` from the run log immediately before `decideAutoMergeSafety`, passes it into the existing merge policy, and stores the verdict in run history. No tests observed still means `unknown`; nothing fabricates `pass`.

Until finally, focused tests prove the full handoff: run log -> test-health derivation -> `decideAutoMergeSafety` -> existing `qualityVerdictBlockReasons` block reason.

And ever since, legitimate STOP/no-op/claimed-work avoidance also has a distinct `no_op` failure class instead of being mixed into suspicious `empty_success`, while controller failure-root-cause summaries exclude that conscious terminal bucket.

Fixes Garsson-io/kaizen#1527

Related: Garsson-io/kaizen#1216 (partial progress: STOP/no-op and claimed-work avoidance now classify as `no_op`; broader process-verdict classification remains open)
Related: Garsson-io/kaizen#1483
Related: Garsson-io/kaizen#1480

## Impact (goal -> before/after -> match)

- Goal (#1527): Auto-dent should feed truthful test-health into the terminal merge decision.
- Acceptance signal: a focused test constructs run-level failed test ids, derives `unowned-failures`, passes that verdict into `decideAutoMergeSafety`, and observes auto-merge blocked with the existing SSOT reason.
- BEFORE: `scripts/auto-dent-run.ts` had no `testHealth` field in the merge-gate call site and explicitly said the harness had no truthful signal.
- AFTER: `scripts/auto-dent-run.test.ts` includes `run log -> testHealth -> gate: an observed unowned test failure blocks auto-merge end-to-end`; `scripts/auto-dent-run.ts` passes `testHealth` into `decideAutoMergeSafety`.
- Delta: terminal merge gating now consumes observed failed-test evidence from auto-dent runs; absence of observed test evidence remains `unknown`.
- Goal met?: yes for #1527; partial for #1216.
- Residual scan: no duplicate known-failure classifier was added; rescue/stale PR terminal disposition remains in `auto-dent-rescue.ts`/`stale-pr-triage.ts`; epic checklist pressure remains in existing `syncEpicChecklists` wiring.

## Architecture

```text
auto-dent run log
  |  (real observed output only)
  v
extractObservedTestFailureIds()
  |  failed ids
  v
loadKnownFailures() + unownedFailures()
  |  TestHealthVerdict
  v
decideAutoMergeSafety()
  |  existing qualityVerdictBlockReasons()
  v
allow / block auto-merge
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Parse observed run log failure ids instead of rerunning tests | The harness must consume real run evidence without inventing `pass` | Limited to failure formats auto-dent currently surfaces |
| Reuse `loadKnownFailures`/`unownedFailures` | Keeps #1518 policy in one place | The helper depends on the registry being loadable when failures are observed |
| Missing test signal returns `unknown` | #1527 forbids proxy acceptance or fabricated pass | Auto-dent still does not require every run to execute tests |
| Add `no_op` failure class | Separates conscious stop/claimed-work avoidance from suspicious empty success (#1216) | PR productivity metrics still show no PR produced |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-test-health.ts` | New pure derivation helper for observed failed test ids -> `TestHealthVerdict` |
| `scripts/auto-dent-run.ts` | Wires derived `testHealth` into `decideAutoMergeSafety` and run history |
| `scripts/auto-dent-score.ts` | Adds `no_op` for conscious STOP/no-op/claimed-work clean exits |
| `scripts/auto-dent-ctl.ts` | Keeps `no_op` out of failure-root-cause summaries |
| `*.test.ts` updates | Red/green coverage for derivation, merge-gate handoff, scoring, and controller interpretation |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status |
|---|---|---|---|
| 1 | Derive `unknown` when auto-dent has no observed failed test ids | Unit | tested in `scripts/auto-dent-test-health.test.ts` |
| 2 | Derive `pass` when every observed failed id is owned by the known-failures registry | Unit | tested in `scripts/auto-dent-test-health.test.ts` |
| 3 | Derive `unowned-failures` when any observed failed id lacks an owner | Unit | tested in `scripts/auto-dent-test-health.test.ts` |
| 4 | Auto-dent passes the derived test-health verdict into `decideAutoMergeSafety` | Integration | tested in `scripts/auto-dent-run.test.ts` |
| 5 | `unowned-failures` blocks auto-merge through `qualityVerdictBlockReasons` | Integration | tested in `scripts/auto-dent-run.test.ts` and existing merge-policy tests |
| 6 | Legitimate STOP/no-op/claimed-work avoidance is not scored as suspicious `empty_success` | Unit | tested in `scripts/auto-dent-score.test.ts` |
| 7 | Suspicious clean exit with no artifacts remains `empty_success` | Unit | preserved in `scripts/auto-dent-score.test.ts` |
| 8 | Rescue/stale PR terminal disposition stays on existing paths | Unit/source invariant | relevant existing suites pass: `auto-dent-rescue`, `stale-pr-triage` |
| 9 | Epic checklist sync remains after issue closure reconciliation | Unit/source invariant | source sweep confirmed existing `syncEpicChecklists` path unchanged |

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run scripts/auto-dent-test-health.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-score.test.ts scripts/auto-dent-ctl.test.ts scripts/auto-dent-merge-policy.test.ts scripts/known-failures-status.test.ts src/known-failures.test.ts scripts/stale-pr-triage.test.ts scripts/auto-dent-rescue.test.ts src/verdict-binding-policy.test.ts src/verdict-binding-inventory.test.ts` -> 11 files, 664 tests passed
- [x] `npx vitest run src/emit-test-review-sentinel.test.ts --reporter=verbose` -> 2 tests passed after installing ignored worktree dependencies
- [x] `npx vitest run src/e2e/synthetic-workflow.test.ts -t 'auto-fixes on first hook; all subsequent hooks take fast path' --reporter=verbose` -> 1 test passed
- [x] `npx vitest run scripts/kaizen-doctor.test.ts -t 'returns checks in defined order' --reporter=verbose` -> 1 test passed
- [x] `npx vitest run src/hooks/kaizen-reflect.test.ts -t 'creates state file and returns reflection output' --reporter=verbose` -> 1 test passed

Full `npm test` note: under full parallel load, `scripts/kaizen-doctor.test.ts` and `src/hooks/kaizen-reflect.test.ts` each hit Vitest's 10s per-test timeout once. Both exact tests pass individually; touched-area suites are green.

## Known Limitations

- The helper recognizes the failure formats auto-dent currently surfaces (`FAILED FILES:` and pytest `FAILED <nodeid>`). If future test runners emit different formats, they should add extractor coverage here rather than creating another classifier.
- This made partial progress on #1216 by separating conscious no-op/claimed-work outcomes from `empty_success`; it does not close #1216's broader process-verdict/history taxonomy.

