### PR TITLE
fix(auto-dent): classify rescue PR disposition

### DIFF
--- a/scripts/stale-pr-triage.test.ts
+++ b/scripts/stale-pr-triage.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyStalePr,
   extractClosesIssues,
+  isRescuePr,
   ageInDays,
   triageOpenPrs,
   applyTriage,
+  formatReport,
   parseCliArgs,
   runStalePrTriageMaintenance,
   type StalePrInput,
@@ -128,6 +130,49 @@ describe('classifyStalePr — #1252/#1254 verdict-binding-draft protection', () 
     const r = classifyStalePr({ ...base, linkedIssueStates: ['OPEN'], isDraft: true, mergeable: 'UNKNOWN' });
     expect(r.action).toBe('review');
     expect(r.action).not.toBe('close-superseded');
+  });
+});
+
+describe('classifyStalePr — rescue PR terminal disposition (#1483)', () => {
+  it('detects rescue PRs from title and body markers', () => {
+    expect(isRescuePr({ title: '[rescue] double-barracuda run 1', body: '' })).toBe(true);
+    expect(isRescuePr({ title: 'preserve work', body: 'FAILED-RUN RESCUE - NOT VALIDATED WORK' })).toBe(true);
+    expect(isRescuePr({ title: 'normal stale PR', body: 'Refs #123' })).toBe(false);
+  });
+
+  it('routes stale draft rescue PRs to rescue-disposition instead of generic review', () => {
+    const r = classifyStalePr({ ...base, isRescue: true, isDraft: true, mergeable: 'UNKNOWN', linkedIssueStates: ['OPEN'] });
+    expect(r.action).toBe('rescue-disposition');
+    expect(r.reason).toContain('validate/resume');
+    expect(r.reason).toContain('tracked follow-up');
+  });
+
+  it('routes conflicting stale rescue PRs to rescue-disposition instead of generic resume', () => {
+    const r = classifyStalePr({ ...base, isRescue: true, mergeable: 'CONFLICTING', linkedIssueStates: ['OPEN'] });
+    expect(r.action).toBe('rescue-disposition');
+  });
+
+  it('keeps close-superseded precedence for rescue PRs whose closing issues are all closed', () => {
+    const r = classifyStalePr({ ...base, isRescue: true, isDraft: true, linkedIssueStates: ['CLOSED'] });
+    expect(r.action).toBe('close-superseded');
+  });
+
+  it('formats rescue-disposition as its own terminal path group', () => {
+    const report = formatReport([row(44, 'rescue-disposition', [1220])]);
+    expect(report).toContain('## rescue-disposition (1)');
+    expect(report).toContain('validate/resume');
+    expect(report).toContain('tracked follow-up');
+  });
+
+  it('does not auto-close rescue-disposition rows during apply', () => {
+    let calls = 0;
+    const gh = (): string => {
+      calls++;
+      return '';
+    };
+    const result = applyTriage([row(44, 'rescue-disposition', [1220])], { gh, repo: 'o/r' });
+    expect(calls).toBe(0);
+    expect(result).toEqual({ closed: [], failed: [] });
   });
 });
 

--- a/scripts/stale-pr-triage.ts
+++ b/scripts/stale-pr-triage.ts
@@ -33,6 +33,7 @@ export type Mergeable = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
 export type StalePrAction =
   | 'skip-fresh' // younger than the staleness threshold — leave it alone
   | 'close-superseded' // linked issue already CLOSED — pure noise, close it
+  | 'rescue-disposition' // stale rescue PR — validate/resume, close superseded, or track follow-up
   | 'merge-ready' // clean, non-draft, issue still open — propose merge
   | 'resume' // conflicting — needs rebase/rework to reach a terminal state
   | 'review'; // unknown mergeability or draft — needs a human/agent look
@@ -55,11 +56,20 @@ export interface StalePrInput {
   mergeable: Mergeable;
   /** Whether the PR is a draft. */
   isDraft: boolean;
+  /** Whether the PR is a gate-skipped rescue PR preserving stranded work. */
+  isRescue?: boolean;
 }
 
 export interface StalePrTriage {
   action: StalePrAction;
   reason: string;
+}
+
+export function isRescuePr(input: { title?: string | null; body?: string | null }): boolean {
+  const title = input.title ?? '';
+  const body = input.body ?? '';
+  return /^\s*\[rescue\]/i.test(title) ||
+    /\b(?:FAILED-RUN RESCUE|Rescue Notice|Rescue Context|NOT VALIDATED WORK)\b/i.test(body);
 }
 
 /**
@@ -68,9 +78,10 @@ export interface StalePrTriage {
  * Precedence (most authoritative terminal signal first):
  *  1. fresh (ageDays < staleDays)            -> skip-fresh
  *  2. ALL linked issues CLOSED                -> close-superseded
- *  3. CONFLICTING                             -> resume
- *  4. MERGEABLE && !draft                     -> merge-ready
- *  5. otherwise (UNKNOWN / draft)             -> review
+ *  3. rescue PR                               -> rescue-disposition
+ *  4. CONFLICTING                             -> resume
+ *  5. MERGEABLE && !draft                     -> merge-ready
+ *  6. otherwise (UNKNOWN / draft)             -> review
  *
  * The closed-issue signal wins over mergeability because a PR whose closing
  * issues are all resolved is pure noise regardless of whether it would merge
@@ -90,6 +101,13 @@ export function classifyStalePr(input: StalePrInput): StalePrTriage {
     return {
       action: 'close-superseded',
       reason: 'every linked Closes-issue is already CLOSED — the work it closes is resolved; pure noise',
+    };
+  }
+
+  if (input.isRescue) {
+    return {
+      action: 'rescue-disposition',
+      reason: 'rescue PR with unvalidated preserved work — terminal path required: validate/resume, close as superseded, or convert to tracked follow-up',
     };
   }
 
@@ -221,6 +239,7 @@ export function triageOpenPrs(deps: TriageDeps): TriageRow[] {
       linkedIssueStates,
       mergeable: normalizeMergeable(pr.mergeable),
       isDraft: pr.isDraft,
+      isRescue: isRescuePr({ title: pr.title, body: pr.body }),
     });
     rows.push({ number: pr.number, title: pr.title, url: pr.url, ageDays, closesIssues, triage });
   }
@@ -251,6 +270,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
 
 const ACTION_ORDER: StalePrAction[] = [
   'close-superseded',
+  'rescue-disposition',
   'resume',
   'merge-ready',
   'review',
@@ -267,6 +287,9 @@ export function formatReport(rows: TriageRow[]): string {
       const closes = r.closesIssues.length > 0 ? ` closes ${r.closesIssues.map((n) => `#${n}`).join(', ')}` : '';
       lines.push(`  #${r.number} (${r.ageDays}d${closes}) — ${r.title}`);
       lines.push(`    ${r.triage.reason}`);
+      if (action === 'rescue-disposition') {
+        lines.push('    terminal path: validate/resume, close as superseded, or convert to tracked follow-up');
+      }
       lines.push(`    ${r.url}`);
     }
   }


### PR DESCRIPTION
## Story

Once upon a time, auto-dent rescue preserved stranded work by opening draft `[rescue]` PRs that were clearly marked as not validated.

Every day, stale PR maintenance could find old PRs and classify them as `close-superseded`, `resume`, `merge-ready`, or `review`. That worked for normal PRs, but rescue PRs are not normal stale drafts: they are raw gate-skipped preserved work.

One day, #1483 captured the next failure mode: preservation without terminal disposition creates a new limbo state. The concrete rescue examples from that issue are now closed, but the classifier still had no way to distinguish future rescue PRs from generic stale review work.

Because of that, this PR teaches stale-pr triage to detect rescue PRs by title/body markers such as `[rescue]`, `Rescue Notice`, `Rescue Context`, `FAILED-RUN RESCUE`, and `NOT VALIDATED WORK`.

Because of that, stale rescue PRs now route to a dedicated `rescue-disposition` action unless the existing high-confidence `close-superseded` rule already applies. The report spells out the bounded terminal path: validate/resume, close as superseded, or convert to a tracked follow-up.

Until finally, the automatic close path remains exactly as conservative as before: `applyTriage` still closes only `close-superseded` rows. Ambiguous rescue PRs are surfaced for disposition, not discarded.

Fixes Garsson-io/kaizen#1483

## Impact (goal -> before/after -> match)

- Goal (#1483): Rescue PRs should not become a second limbo state after preserving stranded work.
- Acceptance signal: a stale draft rescue PR with still-open refs is classified as `rescue-disposition`, not generic `review`/`resume`; a rescue PR whose closing issues are all closed still uses `close-superseded`.
- BEFORE: `classifyStalePr()` had no rescue-specific input/action and routed stale draft rescue PRs to `review` or conflicting rescue PRs to `resume`.
- AFTER: `scripts/stale-pr-triage.test.ts` proves rescue marker detection, `rescue-disposition` classification, close-superseded precedence, report formatting, and non-auto-close apply behavior.
- Delta: future rescue PRs show up in a dedicated terminal-disposition report group with explicit choices.
- Goal met?: yes.
- Residual scan: no second PR scanner, issue-state lookup, or auto-close mechanism was added; current-run rescue finalizer remains separate.

## Architecture

```text
open PR list
  |
  v
isRescuePr(title/body)
  |
  v
classifyStalePr()
  |-- fresh ------------------> skip-fresh
  |-- all closing refs closed -> close-superseded
  |-- rescue marker ----------> rescue-disposition
  |-- conflicting ------------> resume
  |-- mergeable non-draft ----> merge-ready
  `-- otherwise -------------> review
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add rescue detection to stale-pr triage | That module already owns pre-existing open PR graveyard maintenance | Adds one field/action to the existing classifier |
| Keep `close-superseded` precedence over rescue-specific classification | A PR whose closing issues are all closed is still safely terminal | Rescue-specific reporting is skipped for that high-confidence close case |
| Keep apply auto-closing only `close-superseded` | Rescue PRs may contain unique work; ambiguous rescue output should not be discarded | `rescue-disposition` creates pressure via report, not automatic closure |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/stale-pr-triage.ts` | Adds `isRescuePr`, `isRescue` classification input, `rescue-disposition` action, and report guidance |
| `scripts/stale-pr-triage.test.ts` | Adds tests for detection, precedence, report output, and apply safety |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status |
|---|---|---|---|
| 1 | Detect rescue PRs from `[rescue]` title/body rescue markers | Unit | tested |
| 2 | Stale rescue PR with open refs routes to terminal-disposition action | Unit | tested |
| 3 | Stale rescue PR with all closed closing refs still uses `close-superseded` | Unit | tested |
| 4 | Report output contains a rescue-disposition group with validate/resume, close superseded, or follow-up wording | Unit | tested |
| 5 | Apply closes only close-superseded and never auto-closes rescue-disposition | Unit | tested |

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run scripts/stale-pr-triage.test.ts scripts/auto-dent-rescue.test.ts scripts/auto-dent-run.test.ts` -> 3 files, 415 tests passed
- [x] `git diff --check`

## Known Limitations

- This creates terminal-disposition pressure in the maintenance report; it does not automatically decide whether ambiguous rescue PR content should be resumed, superseded, or converted to follow-up. That decision still requires a human/agent pass.
- The concrete rescue PRs named in #1483 were already closed before this PR; this is recurrence prevention for future rescue PRs.
