### PR TITLE
test: add fast check lane and remove accidental probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "build": "tsc",
+    "check:fast": "npm run typecheck && npm run test:fast",
     "test": "timeout --kill-after=10 120 vitest run",
+    "test:fast": "timeout --kill-after=10 60 vitest run --changed origin/main --passWithNoTests --exclude 'src/e2e/**' --exclude '**/*.e2e.test.ts'",
     "test:ci": "timeout --kill-after=10 180 vitest run --coverage --reporter=default --reporter=junit --outputFile.junit=artifacts/junit.xml",
     "test:e2e": "timeout --kill-after=10 120 vitest run src/e2e/",
     "test:e2e:live": "KAIZEN_LIVE_TEST=1 timeout --kill-after=10 120 vitest run src/e2e/",

--- a/scripts/kaizen-doctor.test.ts
+++ b/scripts/kaizen-doctor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -532,7 +532,36 @@ describe('runAllChecks + exitCodeFor', () => {
   afterEach(() => { rmSync(proj, { recursive: true, force: true }); rmSync(home, { recursive: true, force: true }); });
 
   it('returns checks in defined order', () => {
-    const results = runAllChecks({ projectRoot: proj, homeDir: home });
+    const codexRun = vi.fn((cmd: string, args: readonly string[]) => {
+      const key = `${cmd} ${args.join(' ')}`;
+      if (key === 'codex --version') return 'codex-cli 0.142.3\n';
+      if (key === 'codex doctor --json') {
+        return JSON.stringify({
+          checks: {
+            'auth.credentials': {
+              details: {
+                'stored API key': 'false',
+                'stored ChatGPT tokens': 'true',
+                'stored auth mode': 'chatgpt',
+              },
+            },
+          },
+        });
+      }
+      if (key === 'codex features list') {
+        return [
+          'shell_tool stable true',
+          'unified_exec stable true',
+          'hooks stable true',
+        ].join('\n');
+      }
+      throw new Error(`unexpected command: ${key}`);
+    });
+    const results = runAllChecks({
+      projectRoot: proj,
+      homeDir: home,
+      codexReadiness: { run: codexRun },
+    });
     expect(results.map(r => r.name)).toEqual([
       'single-registration-path',
       'plugin-double-install',
@@ -542,6 +571,7 @@ describe('runAllChecks + exitCodeFor', () => {
       'hook-exec-smoke',
       'codex-readiness',
     ]);
+    expect(codexRun).toHaveBeenCalledWith('codex', ['--version']);
   });
 
   it('exitCodeFor returns 1 when any FAIL', () => {

--- a/scripts/kaizen-doctor.ts
+++ b/scripts/kaizen-doctor.ts
@@ -47,6 +47,7 @@ export interface DoctorOpts {
   projectRoot: string;
   homeDir: string;
   pluginName?: string;
+  codexReadiness?: CodexReadinessOpts;
 }
 
 export type CommandRunner = (cmd: string, args: readonly string[]) => string;
@@ -610,7 +611,7 @@ export function runAllChecks(opts: DoctorOpts): CheckResult[] {
     checkStalePluginCache(opts),
     checkRestartNeeded(opts),
     checkHookExecSmoke(opts),
-    checkCodexReadiness(),
+    checkCodexReadiness(opts.codexReadiness),
   ];
 }
 

--- a/src/hooks/kaizen-reflect.test.ts
+++ b/src/hooks/kaizen-reflect.test.ts
@@ -49,6 +49,7 @@ const defaultOpts = {
   mainCheckout: '/home/user/projects/kaizen',
   changedFiles: 'src/hooks/kaizen-reflect.ts',
   sendNotification: vi.fn(),
+  runHookTimingSentinel: () => '',
 };
 
 describe('processHookInput', () => {
@@ -149,6 +150,23 @@ describe('processHookInput', () => {
         '--repo',
         'Garsson-io/kaizen',
       ]);
+    });
+
+    it('routes hook timing through the injected seam', () => {
+      const runHookTimingSentinel = vi.fn(() => 'TIMING REPORT');
+      const input = makeInput({
+        command: 'gh pr merge 42 --repo Garsson-io/kaizen --squash',
+        stdout: '✓ Pull request merged',
+      });
+
+      const output = processHookInput(input, {
+        ...defaultOpts,
+        changedFiles: 'src/a.ts\nsrc/b.ts',
+        runHookTimingSentinel,
+      });
+
+      expect(runHookTimingSentinel).toHaveBeenCalledWith('src/a.ts\nsrc/b.ts');
+      expect(output).toContain('TIMING REPORT');
     });
 
     it('sends Telegram notification on merge', () => {

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -160,6 +160,8 @@ function runHookTimingSentinel(changedFiles: string): string {
   }
 }
 
+type HookTimingRunner = (changedFiles: string) => string;
+
 /** Build the transcript instruction line for subagent prompts. */
 function transcriptInstruction(transcriptPath?: string): string {
   if (transcriptPath) {
@@ -298,6 +300,7 @@ export function processHookInput(
     gh?: GhRunner;
     sendNotification?: (text: string) => void;
     telemetryDir?: string;
+    runHookTimingSentinel?: HookTimingRunner;
   } = {},
 ): string | null {
   const command = input.tool_input?.command ?? '';
@@ -356,7 +359,7 @@ export function processHookInput(
   const transcriptPath = input.transcript_path;
 
   // Run hook timing sentinel (kaizen #453 — speed as a kaizen dimension)
-  const timingReport = runHookTimingSentinel(changed);
+  const timingReport = (options.runHookTimingSentinel ?? runHookTimingSentinel)(changed);
   const timingSection = timingReport
     ? `\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n${timingReport}\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`
     : '';


### PR DESCRIPTION
## Story

The kaizen repo had a broad test-speed problem, but the first baseline showed something more specific than generic slowness: tests that looked like unit/integration checks were crossing real external boundaries.

Before this PR, `npm test -- --run` failed after 91.08s. A filename-only non-E2E run still failed after 85.07s, and a focused single-worker run of the suspected files failed after 129.91s. Reading the code showed why: `processHookInput()` always ran the hook timing sentinel subprocess, and `runAllChecks()` always probed the real Codex CLI even when tests only wanted aggregate behavior.

This PR adds explicit injection seams for those two probes, keeps production defaults unchanged, and adds a changed-files fast check for agents: `npm run check:fast` runs typecheck plus changed non-E2E TS tests.

Fixes Garsson-io/kaizen#1538
Parent: Garsson-io/kaizen#1532

## Impact (goal -> before/after -> match)
- Goal (#1538): provide a reliable fast local TS check loop and remove accidental real probes from unit/integration tests.
- Acceptance signal: affected tests pass with fake/noop seams; fast, default, and CI-style TS gates pass.
- BEFORE: `npm test -- --run` failed after 91.08s; non-E2E attempt failed after 85.07s; focused three-file run failed after 129.91s; targeted hook timing test spent 5.95s on a real sentinel path.
- AFTER: `npm run check:fast` passed in 6.46s on the final branch tip; `npm test -- --run` passed in 74.88s after rebase; `npm run test:ci` passed in 77.64s with coverage above thresholds.
- Delta: default suite moved from red at 91.08s to green at 74.88s; agents now have a 6-11s changed-test check instead of reaching first for the 70s+ broad suite.
- Goal met?: yes for #1538; broader CI sharding/runtime work remains under parent #1532.
- Residual scan: `src/e2e/synthetic-workflow.test.ts` still takes ~34s under coverage and `src/hooks/pr-kaizen-clear.test.ts` still takes ~66s; these are next optimization targets under #1532.

## Architecture

```text
production hook/doctor path
  processHookInput() ── default runHookTimingSentinel() ── real hook benchmark
  runAllChecks()     ── default checkCodexReadiness()  ── real codex probes

test/fast-check path
  processHookInput({ runHookTimingSentinel: fake })
  runAllChecks({ codexReadiness: { run: fake } })
  npm run check:fast -> typecheck -> vitest --changed origin/main --exclude E2E
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add dependency seams instead of env-only skips | Tests can assert the dependency boundary directly and production defaults remain visible in code. | Small option-surface increase on two functions. |
| Add changed-test `test:fast` instead of redefining `npm test` | Agents get a quick local loop without weakening the broad default gate. | Requires agents to choose the new script for fast iteration. |
| Keep E2E/system tests in broad gates | This PR improves reliability without hiding real system coverage. | Full suite is still ~75s and needs follow-up optimization. |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/kaizen-reflect.ts` | Adds injectable hook timing runner with production default unchanged. |
| `src/hooks/kaizen-reflect.test.ts` | Uses noop timing runner in unit tests and asserts the seam routes timing output. |
| `scripts/kaizen-doctor.ts` | Passes Codex readiness options through `runAllChecks()`. |
| `scripts/kaizen-doctor.test.ts` | Uses fake Codex runner for aggregate ordering test. |
| `package.json` | Adds `test:fast` and `check:fast` scripts for agent local checks. |

## Test Plan (Behaviors × Levels)

| # | Behavior | Level | Coverage status |
|---|---|---|---|
| 1 | PR reflection tests can bypass hook timing benchmark through an injected seam while production defaults to the real sentinel. | Unit | Tested in `src/hooks/kaizen-reflect.test.ts`. |
| 2 | Doctor aggregate checks can pass Codex readiness dependencies through an injected seam while production defaults to real Codex probes. | Unit | Tested in `scripts/kaizen-doctor.test.ts`. |
| 3 | Agents have a fast package script for typecheck plus changed non-E2E TS tests. | System | Tested with timed `npm run check:fast`. |
| 4 | Existing broad gates remain available. | System | Tested with timed `npm test -- --run` and `npm run test:ci`. |

## Validation

- [x] `npm run check:fast` — passed, 6.46s real, 72 tests selected.
- [x] `npm test -- --run` — passed, 74.88s real, 161 files / 3852 tests.
- [x] `npm run test:ci` — passed, 77.64s real, coverage summary: statements 72.2%, branches 67.76%, functions 79.71%, lines 73.43%.
- [x] `git diff --check origin/main...HEAD` — passed.

## Known Limitations

This is the first PR under parent #1532, not the whole optimization program. Remaining high-value work: split/parallelize CI lanes more intelligently, evaluate Bun where measurements justify it, and reduce the slow E2E/system files that still dominate broad-suite runtime.
