### PR TITLE
fix(auto-dent): treat clean STOP no-ops as process-complete

### DIFF
--- a/scripts/auto-dent-lifecycle.test.ts
+++ b/scripts/auto-dent-lifecycle.test.ts
@@ -472,6 +472,44 @@ describe('validateProcessEvidence — durable kaizen evidence verdict (#1149)', 
     expect(result.checks.filter((check) => check.status === 'fail')).toEqual([]);
   });
 
+  it('treats an intentional STOP/no-op before implementation as process-complete', () => {
+    const result = validateProcessEvidence(
+      validationWith(['PICK', 'EVALUATE', 'STOP']),
+      fullEvidence({
+        planEvidence: false,
+        implementationEvidence: false,
+        prEvidence: false,
+        testEvidence: false,
+        reviewEvidence: false,
+        reflectionEvidence: false,
+        mergeReadiness: 'not-applicable',
+        intentionalNoOp: true,
+      }),
+    );
+    expect(result.verdict).toBe('pass');
+    expect(result.checks.filter((check) => check.status === 'fail')).toEqual([]);
+  });
+
+  it('does not let a no-op hint mask a claimed implementation without evidence', () => {
+    const result = validateProcessEvidence(
+      validationWith(['PICK', 'EVALUATE', 'IMPLEMENT', 'STOP']),
+      fullEvidence({
+        implementationEvidence: false,
+        prEvidence: false,
+        testEvidence: false,
+        reviewEvidence: false,
+        reflectionEvidence: false,
+        mergeReadiness: 'not-applicable',
+        intentionalNoOp: true,
+      }),
+    );
+    expect(result.verdict).toBe('process-incomplete');
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      id: 'implementation',
+      status: 'fail',
+    }));
+  });
+
   it('treats provider review fail as completed review evidence, not missing evidence', () => {
     const result = validateProcessEvidence(
       validationWith(['IMPLEMENT', 'TEST', 'PR']),

--- a/scripts/auto-dent-lifecycle.ts
+++ b/scripts/auto-dent-lifecycle.ts
@@ -171,6 +171,8 @@ export type MergeReadinessEvidence = 'ready' | 'not-ready' | 'unknown' | 'not-ap
 export type ProviderReviewEvidenceStatus = 'pass' | 'fail' | 'skipped' | 'missing' | 'pending';
 
 export interface ProcessEvidence {
+  /** The run intentionally stopped/skipped before producing work artifacts. */
+  intentionalNoOp?: boolean;
   /** Durable plan or claimed-plan assignment evidence exists. */
   planEvidence?: boolean;
   /** Durable implementation evidence exists (case/worktree or equivalent). */
@@ -252,15 +254,26 @@ export function validateProcessEvidence(
 ): ProcessValidation {
   const present = new Set(validation.phasesPresent);
   const checks: ProcessCheck[] = [];
-  const hasWorkClaim =
-    present.has('EVALUATE') ||
+  const hasProducingClaim =
     present.has('IMPLEMENT') ||
     present.has('TEST') ||
     present.has('PR') ||
     present.has('MERGE') ||
-    present.has('REFLECT') ||
+    present.has('REFLECT');
+  const hasDurableArtifact =
     evidence.implementationEvidence === true ||
-    evidence.prEvidence === true;
+    evidence.prEvidence === true ||
+    evidence.reflectionEvidence === true;
+  const intentionalNoOp =
+    evidence.intentionalNoOp === true &&
+    !hasProducingClaim &&
+    !hasDurableArtifact;
+  const hasWorkClaim =
+    !intentionalNoOp &&
+    (present.has('EVALUATE') ||
+      hasProducingClaim ||
+      evidence.implementationEvidence === true ||
+      evidence.prEvidence === true);
 
   const needsImplementation =
     present.has('IMPLEMENT') || present.has('TEST') || present.has('PR') || present.has('MERGE') || evidence.prEvidence === true;

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -3541,6 +3541,17 @@ describe('test-task lifecycle evidence regression guard', () => {
   it('does not treat skipped review as process-incomplete for synthetic test tasks', () => {
     expect(source).toContain("reviewVerdict: state.test_task ? 'pass' : result.reviewVerdict");
   });
+
+  it('passes clean artifactless STOP runs as intentional no-ops to process validation (#1216)', () => {
+    expect(source).toContain('const intentionalNoOp =');
+    expect(source).toContain('exitCode === 0');
+    expect(source).toContain('result.stopRequested');
+    expect(source).toContain('result.prs.length === 0');
+    expect(source).toContain('result.issuesFiled.length === 0');
+    expect(source).toContain('result.issuesClosed.length === 0');
+    expect(source).toContain('result.cases.length === 0');
+    expect(source).toContain('intentionalNoOp,');
+  });
 });
 
 describe('auto-merge verdict binding wiring (#1220)', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2420,7 +2420,15 @@ async function main(): Promise<void> {
           : mergeStatuses.some((status) => status === 'closed') ? 'not-ready'
             : mergeStatuses.every((status) => status === 'merged' || status === 'auto_queued') ? 'ready'
               : 'unknown';
+    const intentionalNoOp =
+      exitCode === 0 &&
+      result.stopRequested &&
+      result.prs.length === 0 &&
+      result.issuesFiled.length === 0 &&
+      result.issuesClosed.length === 0 &&
+      result.cases.length === 0;
     const processEvidence: ProcessEvidence = {
+      intentionalNoOp,
       planEvidence: Boolean(state.test_task) || Boolean(promptMeta.claimedPlanIssue),
       implementationEvidence: Boolean(state.test_task) ? result.prs.length > 0 : result.cases.length > 0,
       prEvidence: result.prs.length > 0,


### PR DESCRIPTION
## Summary

Fixes Garsson-io/kaizen#1216.

Clean artifactless STOP/no-op auto-dent runs now carry an explicit `intentionalNoOp` process-evidence signal, so the durable process verdict agrees with the already-landed `failure_class: no_op` taxonomy from #1534.

The validator only honors the no-op signal when there are no producing phase claims (`IMPLEMENT`/`TEST`/`PR`/`MERGE`/`REFLECT`) and no durable implementation, PR, or reflection artifacts. Claimed work still requires the normal plan, implementation, PR, test, review, reflection, and merge-readiness evidence.

## Tests

- `npx vitest run scripts/auto-dent-lifecycle.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-score.test.ts scripts/auto-dent-merge-policy.test.ts`
- `npm run typecheck`
- `npx vitest run scripts/auto-dent-lifecycle.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-score.test.ts scripts/auto-dent-ctl.test.ts scripts/batch-summary.test.ts scripts/auto-dent-merge-policy.test.ts scripts/auto-dent-rescue.test.ts`
