### PR TITLE
feat(backlog): surface epic terminal pressure

### DIFF
--- a/.agents/skills/kaizen-audit-issues/SKILL.md
+++ b/.agents/skills/kaizen-audit-issues/SKILL.md
@@ -25,6 +25,9 @@ Before the manual drill-downs, get the aggregate health verdict. `scripts/backlo
 computes the Issue Metabolism axes from epic #953 (creation/closure ratio, inactivity-age
 distribution, horizon coverage) and prints a single verdict (`healthy`/`warning`/`pathological`).
 The verdict is bound to the exit code (pathological → exit 1) so it can gate CI or batch runs.
+It also prints `epic progress`: open epics with no tracked checklist work, checked child work that
+has gone stale, or all tracked child work complete. Treat these as required terminal-path decisions:
+decompose into child issues, replan/continue, consciously defer, or close with rationale.
 
 ```bash
 npx tsx scripts/backlog-health.ts --repo "$ISSUES_REPO" --window 30
@@ -83,6 +86,8 @@ gh issue list --repo "$ISSUES_REPO" --state closed --label "epic" --limit 50 \
 Check each epic for:
 - **Stale body:** No update in 4+ weeks — the direction may have drifted
 - **No sub-issues linked:** Epic exists but nothing is tracked under it
+- **Completed child impact with no terminal path:** checked-off child work exists, but the epic has
+  not been replanned, decomposed further, consciously deferred, or closed
 - **Prematurely closed:** Epics are infinite games; closing one requires explicit "direction abandoned" rationale
 
 ### Step 4: Incident density audit

--- a/scripts/backlog-health.test.ts
+++ b/scripts/backlog-health.test.ts
@@ -3,8 +3,10 @@ import {
   computeAgeDistribution,
   computeHorizonCoverage,
   computeCreationClosureRatio,
+  computeEpicProgress,
   buildBacklogHealthReport,
   classifyBacklogHealth,
+  formatReport,
   parseArgs,
   type OpenIssue,
   type ClosedIssue,
@@ -17,8 +19,10 @@ const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86400_000).toISOStri
 function open(partial: Partial<OpenIssue>): OpenIssue {
   return {
     number: 1,
+    title: 'Test issue',
     createdAt: daysAgo(5),
     updatedAt: daysAgo(5),
+    body: '',
     labels: [],
     ...partial,
   };
@@ -80,6 +84,86 @@ describe('computeCreationClosureRatio', () => {
   });
 });
 
+describe('computeEpicProgress', () => {
+  it('flags an impacted stale epic as needing replan/continue pressure', () => {
+    const report = computeEpicProgress([
+      open({
+        number: 10,
+        title: 'Epic with partial impact',
+        labels: ['epic'],
+        updatedAt: daysAgo(35),
+        body: '- [x] #101 shipped\n- [ ] #102 remaining',
+      }),
+    ], NOW);
+
+    expect(report.needsReplan).toBe(1);
+    expect(report.items[0]).toMatchObject({
+      number: 10,
+      checkedItems: 1,
+      uncheckedItems: 1,
+      verdict: 'needs-replan',
+    });
+    expect(report.items[0].reason).toContain('completed child work exists');
+  });
+
+  it('flags an impacted epic with no remaining checklist work as needing a terminal decision', () => {
+    const report = computeEpicProgress([
+      open({
+        number: 11,
+        title: 'Epic with all tracked work done',
+        labels: ['epic'],
+        updatedAt: daysAgo(3),
+        body: '- [x] #201 shipped\n- [x] #202 shipped',
+      }),
+    ], NOW);
+
+    expect(report.needsTerminalDecision).toBe(1);
+    expect(report.items[0]).toMatchObject({
+      number: 11,
+      checkedItems: 2,
+      uncheckedItems: 0,
+      verdict: 'needs-terminal-decision',
+    });
+  });
+
+  it('flags an epic with no checklist children as needing decomposition', () => {
+    const report = computeEpicProgress([
+      open({ number: 12, title: 'Empty epic', labels: ['epic'], body: 'Broad direction only.' }),
+    ], NOW);
+
+    expect(report.needsDecomposition).toBe(1);
+    expect(report.items[0]).toMatchObject({
+      number: 12,
+      trackedItems: 0,
+      verdict: 'needs-decomposition',
+    });
+  });
+
+  it('leaves an active epic with completed and pending work healthy while fresh', () => {
+    const report = computeEpicProgress([
+      open({
+        number: 13,
+        title: 'Fresh epic',
+        labels: ['epic'],
+        updatedAt: daysAgo(5),
+        body: '- [x] #301 shipped\n- [ ] #302 next',
+      }),
+    ], NOW);
+
+    expect(report.healthy).toBe(1);
+    expect(report.items[0].verdict).toBe('healthy');
+  });
+
+  it('ignores non-epic issues', () => {
+    const report = computeEpicProgress([
+      open({ number: 14, labels: ['kaizen'], body: '- [x] #401 done' }),
+    ], NOW);
+
+    expect(report.total).toBe(0);
+    expect(report.items).toEqual([]);
+  });
+});
+
 describe('classifyBacklogHealth', () => {
   const baseReport = buildBacklogHealthReport(
     [open({ number: 1, updatedAt: daysAgo(5), labels: ['horizon/a'] })],
@@ -121,6 +205,24 @@ describe('classifyBacklogHealth', () => {
       ratio: { created: 1, closed: 1, ratio: 1.0 },
       age: { total: 10, stale30: 0, stale60: 0, stale90: 0 },
       horizon: { byHorizon: { 'horizon/a': 8, 'horizon/b': 2 }, noHorizon: 0, distinctHorizons: 2 },
+    };
+    expect(classifyBacklogHealth(report)).toBe('warning');
+  });
+
+  it('returns warning when epics need terminal progress decisions', () => {
+    const report = {
+      ...baseReport,
+      ratio: { created: 1, closed: 1, ratio: 1.0 },
+      age: { total: 1, stale30: 0, stale60: 0, stale90: 0 },
+      horizon: { byHorizon: { 'horizon/a': 1 }, noHorizon: 0, distinctHorizons: 1 },
+      epicProgress: {
+        total: 1,
+        healthy: 0,
+        needsDecomposition: 0,
+        needsReplan: 0,
+        needsTerminalDecision: 1,
+        items: [],
+      },
     };
     expect(classifyBacklogHealth(report)).toBe('warning');
   });
@@ -172,6 +274,7 @@ describe('buildBacklogHealthReport', () => {
     expect(report.age.total).toBe(2);
     expect(report.age.stale90).toBe(1);
     expect(report.horizon.noHorizon).toBe(1);
+    expect(report.epicProgress.total).toBe(0);
     expect(typeof report.generatedAt).toBe('string');
   });
 
@@ -187,6 +290,32 @@ describe('buildBacklogHealthReport', () => {
     const report = buildBacklogHealthReport([], createdIssues, closedIssues, NOW, 30);
     expect(report.ratio.ratio).toBe(3);
     expect(classifyBacklogHealth(report)).toBe('pathological');
+  });
+});
+
+describe('formatReport', () => {
+  it('prints epic terminal-pressure details', () => {
+    const report = buildBacklogHealthReport(
+      [
+        open({
+          number: 20,
+          title: 'Partially landed epic',
+          labels: ['epic'],
+          updatedAt: daysAgo(40),
+          body: '- [x] #1 done\n- [ ] #2 next',
+        }),
+      ],
+      [],
+      [],
+      NOW,
+      30,
+      'owner/repo',
+    );
+
+    const text = formatReport(report, classifyBacklogHealth(report));
+    expect(text).toContain('epic progress');
+    expect(text).toContain('#20 needs-replan');
+    expect(text).toContain('Partially landed epic');
   });
 });
 

--- a/scripts/backlog-health.ts
+++ b/scripts/backlog-health.ts
@@ -28,8 +28,10 @@ import { gh } from '../src/lib/gh-exec.js';
 
 export interface OpenIssue {
   number: number;
+  title?: string;
   createdAt: string;
   updatedAt: string;
+  body?: string;
   labels: string[];
 }
 
@@ -66,6 +68,28 @@ export interface CreationClosureRatio {
 }
 
 export type HealthVerdict = 'healthy' | 'warning' | 'pathological';
+export type EpicProgressVerdict = 'healthy' | 'needs-decomposition' | 'needs-replan' | 'needs-terminal-decision';
+
+export interface EpicProgressItem {
+  number: number;
+  title: string;
+  updatedAt: string;
+  inactiveDays: number;
+  trackedItems: number;
+  checkedItems: number;
+  uncheckedItems: number;
+  verdict: EpicProgressVerdict;
+  reason: string;
+}
+
+export interface EpicProgressReport {
+  total: number;
+  healthy: number;
+  needsDecomposition: number;
+  needsReplan: number;
+  needsTerminalDecision: number;
+  items: EpicProgressItem[];
+}
 
 export interface BacklogHealthReport {
   repo?: string;
@@ -74,6 +98,7 @@ export interface BacklogHealthReport {
   ratio: CreationClosureRatio;
   age: AgeDistribution;
   horizon: HorizonCoverage;
+  epicProgress: EpicProgressReport;
   generatedAt: string;
 }
 
@@ -87,6 +112,25 @@ function inactivityDays(iso: string, now: Date): number {
 
 function isHorizonLabel(label: string): boolean {
   return label.startsWith('horizon/') || label.startsWith('horizon:');
+}
+
+function isEpic(issue: OpenIssue): boolean {
+  return issue.labels.includes('epic');
+}
+
+interface ChecklistItem {
+  checked: boolean;
+}
+
+function parseChecklistItems(body: string | undefined): ChecklistItem[] {
+  if (!body) return [];
+  const items: ChecklistItem[] = [];
+  const pattern = /^- \[([ xX])\]\s+.+$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(body)) !== null) {
+    items.push({ checked: match[1].toLowerCase() === 'x' });
+  }
+  return items;
 }
 
 /**
@@ -127,6 +171,55 @@ export function computeCreationClosureRatio(created: number, closed: number): Cr
   return { created, closed, ratio: created / Math.max(closed, 1) };
 }
 
+const EPIC_REPLAN_DAYS = 28;
+
+/** Progress pressure for open epics with landed/checked child work. */
+export function computeEpicProgress(issues: OpenIssue[], now: Date): EpicProgressReport {
+  const items: EpicProgressItem[] = issues
+    .filter(isEpic)
+    .map((issue) => {
+      const checklist = parseChecklistItems(issue.body);
+      const checkedItems = checklist.filter((item) => item.checked).length;
+      const trackedItems = checklist.length;
+      const uncheckedItems = trackedItems - checkedItems;
+      const inactiveDays = Math.floor(inactivityDays(issue.updatedAt, now));
+      let verdict: EpicProgressVerdict = 'healthy';
+      let reason = 'epic has active tracked work';
+
+      if (trackedItems === 0) {
+        verdict = 'needs-decomposition';
+        reason = 'open epic has no tracked checklist items';
+      } else if (checkedItems > 0 && uncheckedItems === 0) {
+        verdict = 'needs-terminal-decision';
+        reason = 'all tracked child work is checked; close, defer, or add next scoped child work';
+      } else if (checkedItems > 0 && inactiveDays > EPIC_REPLAN_DAYS) {
+        verdict = 'needs-replan';
+        reason = `completed child work exists but epic has not been updated in ${inactiveDays} days`;
+      }
+
+      return {
+        number: issue.number,
+        title: issue.title ?? '',
+        updatedAt: issue.updatedAt,
+        inactiveDays,
+        trackedItems,
+        checkedItems,
+        uncheckedItems,
+        verdict,
+        reason,
+      };
+    });
+
+  return {
+    total: items.length,
+    healthy: items.filter((item) => item.verdict === 'healthy').length,
+    needsDecomposition: items.filter((item) => item.verdict === 'needs-decomposition').length,
+    needsReplan: items.filter((item) => item.verdict === 'needs-replan').length,
+    needsTerminalDecision: items.filter((item) => item.verdict === 'needs-terminal-decision').length,
+    items,
+  };
+}
+
 /**
  * Assemble every axis into a single report for a window ending at `now`.
  *
@@ -152,6 +245,7 @@ export function buildBacklogHealthReport(
     ratio: computeCreationClosureRatio(createdInWindow, closedInWindow),
     age: computeAgeDistribution(open, now),
     horizon: computeHorizonCoverage(open),
+    epicProgress: computeEpicProgress(open, now),
     generatedAt: now.toISOString(),
   };
 }
@@ -175,6 +269,11 @@ function horizonConcentration(horizon: HorizonCoverage): number {
   return max / labeled;
 }
 
+function epicPressureCount(epicProgress: EpicProgressReport | undefined): number {
+  if (!epicProgress) return 0;
+  return epicProgress.needsDecomposition + epicProgress.needsReplan + epicProgress.needsTerminalDecision;
+}
+
 /** Classify a report into a single health verdict. Pathological wins over warning. */
 export function classifyBacklogHealth(report: BacklogHealthReport): HealthVerdict {
   const share90 = stale90Share(report.age);
@@ -184,7 +283,8 @@ export function classifyBacklogHealth(report: BacklogHealthReport): HealthVerdic
   if (
     report.ratio.ratio >= RATIO_WARNING ||
     share90 >= STALE90_SHARE_WARNING ||
-    horizonConcentration(report.horizon) >= HORIZON_CONCENTRATION_WARNING
+    horizonConcentration(report.horizon) >= HORIZON_CONCENTRATION_WARNING ||
+    epicPressureCount(report.epicProgress) > 0
   ) {
     return 'warning';
   }
@@ -195,9 +295,14 @@ export function classifyBacklogHealth(report: BacklogHealthReport): HealthVerdic
 
 interface GhOpenIssue {
   number: number;
+  title: string;
   createdAt: string;
   updatedAt: string;
   labels: { name: string }[];
+}
+
+interface GhIssueBody {
+  body: string;
 }
 
 const FETCH_LIMIT = 500;
@@ -223,17 +328,29 @@ function warnIfTruncated(label: string, count: number): void {
 export function fetchOpenIssues(repo: string): OpenIssue[] {
   const raw = gh(
     ['issue', 'list', '--repo', repo, '--state', 'open', '--limit', String(FETCH_LIMIT),
-      '--json', 'number,createdAt,updatedAt,labels'],
+      '--json', 'number,title,createdAt,updatedAt,labels'],
     60_000,
   );
   const issues: GhOpenIssue[] = JSON.parse(raw);
   warnIfTruncated('open issues', issues.length);
   return issues.map((i) => ({
     number: i.number,
+    title: i.title,
     createdAt: i.createdAt,
     updatedAt: i.updatedAt,
+    body: i.labels.some((label) => label.name === 'epic') ? fetchIssueBody(repo, i.number) : '',
     labels: i.labels.map((l) => l.name),
   }));
+}
+
+export function fetchIssueBody(repo: string, number: number): string {
+  try {
+    const raw = gh(['issue', 'view', String(number), '--repo', repo, '--json', 'body'], 30_000);
+    const issue: GhIssueBody = JSON.parse(raw);
+    return issue.body ?? '';
+  } catch {
+    return '';
+  }
 }
 
 export function fetchCreatedInWindow(repo: string, windowDays: number, now: Date): CreatedIssue[] {
@@ -278,6 +395,18 @@ export function formatReport(report: BacklogHealthReport, verdict: HealthVerdict
     .map(([h, n]) => `${h}=${n}`)
     .join('  ');
   lines.push(`  horizons (${report.horizon.distinctHorizons} distinct, ${report.horizon.noHorizon} unlabeled): ${horizons || '(none)'}`);
+  lines.push(
+    `  epic progress: ${report.epicProgress.healthy}/${report.epicProgress.total} healthy  ` +
+    `decompose ${report.epicProgress.needsDecomposition}  replan ${report.epicProgress.needsReplan}  ` +
+    `terminal-decision ${report.epicProgress.needsTerminalDecision}`,
+  );
+  const pressuredEpics = report.epicProgress.items.filter((item) => item.verdict !== 'healthy');
+  for (const item of pressuredEpics) {
+    lines.push(
+      `    #${item.number} ${item.verdict}: ${item.title} ` +
+      `(${item.checkedItems}/${item.trackedItems} checked, ${item.inactiveDays}d inactive) — ${item.reason}`,
+    );
+  }
   return lines.join('\n');
 }
 

--- a/src/verdict-binding-inventory.ts
+++ b/src/verdict-binding-inventory.ts
@@ -186,6 +186,11 @@ export const VERDICT_BINDING_INVENTORY: VerdictBindingInventory = {
       rationale: 'Advisory reporting signal; it does not directly authorize an irreversible terminal action.',
     },
     {
+      signature: 'scripts/backlog-health.ts:type:EpicProgressVerdict',
+      label: 'Epic progress pressure verdict type',
+      rationale: 'Advisory reporting signal for backlog/epic hygiene; it requires human replan, decomposition, deferral, or closure decisions rather than authorizing an irreversible terminal action.',
+    },
+    {
       signature: 'scripts/auto-dent-final-claim.ts:type:FinalClaimProcessVerdict',
       label: 'Final claim process verdict parser',
       rationale: 'Input normalization for durable process evidence; terminal binding is represented by process-evidence-verdict.',


### PR DESCRIPTION
## Summary

Fixes Garsson-io/kaizen#1480.

Adds an `epicProgress` axis to `scripts/backlog-health.ts` so epics with impact-bearing child/checklist work no longer drift as inert long-lived issues. The report now surfaces open epics that need one of the explicit terminal paths: decompose into child issues, replan/continue, consciously defer, or close with rationale.

This is report-only; it does not auto-close or rewrite epics. It rolls up to at least a `warning` backlog-health verdict and is documented in `/kaizen-audit-issues` so future audits consume the new signal.

## Live proof

`npx tsx scripts/backlog-health.ts --repo Garsson-io/kaizen --window 30 || true` now prints an `epic progress` section. Current live output included:

- `epic progress: 18/62 healthy  decompose 36  replan 7  terminal-decision 1`
- `#506 needs-terminal-decision ... (5/5 checked, 97d inactive)`
- stale partial-impact epics such as `#982 needs-replan` and `#275 needs-replan`

## Tests

- `npx vitest run scripts/backlog-health.test.ts scripts/staleness-audit.test.ts scripts/auto-dent-github.test.ts src/verdict-binding-inventory.test.ts`
- `npm run typecheck`
- `git diff --check`
- live `npx tsx scripts/backlog-health.ts --repo Garsson-io/kaizen --window 30 || true`
