### PR TITLE
test: reduce synthetic workflow hook matrix runtime

### DIFF
--- a/src/e2e/synthetic-workflow.test.ts
+++ b/src/e2e/synthetic-workflow.test.ts
@@ -1,9 +1,10 @@
 /**
  * synthetic-workflow.test.ts — E2E session lifecycle tests.
  *
- * Uses SessionSimulator to model realistic Claude Code sessions, firing
- * ALL registered hooks for each event type. Tests that:
- *   1. scope-guard auto-fix propagates across all hooks in a session
+ * Uses SessionSimulator to model realistic Claude Code sessions. A dedicated
+ * smoke test fires ALL registered hooks; repeated behavior tests use narrower
+ * representative hook profiles. Tests that:
+ *   1. scope-guard auto-fix propagates across a session
  *   2. Hooks compose correctly across event types (SessionStart → PreToolUse → Stop)
  *   3. No hook hangs or crashes in expected environments
  *
@@ -11,19 +12,74 @@
  * timeouts across the full session, not just individual hook behavior.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { SessionSimulator } from "./session-simulator.js";
 
-describe("Synthetic Workflow E2E", () => {
-  let session: SessionSimulator;
+type HookRegistry = SessionSimulator["hooks"];
+type HookProfile = "full" | "scope-guard" | "representative";
 
-  afterEach(() => {
-    session?.cleanup();
+function hookCount(hooks: HookRegistry): number {
+  return Object.values(hooks).reduce((sum, names) => sum + names.length, 0);
+}
+
+function profileHooks(profile: HookProfile, hooks: HookRegistry): HookRegistry {
+  if (profile === "full") return hooks;
+
+  if (profile === "scope-guard") {
+    return {
+      SessionStart: ["kaizen-session-cleanup-ts.sh"],
+      PreToolUseBash: ["kaizen-block-git-rebase.sh"],
+      PreToolUseWrite: ["kaizen-enforce-worktree-writes.sh"],
+      PostToolUseBash: ["kaizen-capture-worktree-context.sh"],
+      Stop: ["kaizen-verify-before-stop.sh"],
+    };
+  }
+
+  return {
+    SessionStart: ["kaizen-session-cleanup-ts.sh"],
+    PreToolUseBash: ["kaizen-block-git-rebase.sh"],
+    PreToolUseWrite: ["kaizen-enforce-worktree-writes.sh"],
+    PostToolUseBash: ["kaizen-pr-kaizen-clear-fallback.sh"],
+    Stop: ["kaizen-verify-before-stop.sh"],
+  };
+}
+
+function createSession(profile: HookProfile = "full"): SessionSimulator {
+  const session = new SessionSimulator();
+  session.hooks = profileHooks(profile, session.hooks);
+  return session;
+}
+
+function withSession<T>(profile: HookProfile, fn: (session: SessionSimulator) => T): T {
+  const session = createSession(profile);
+  try {
+    return fn(session);
+  } finally {
+    session.cleanup();
+  }
+}
+
+describe("Synthetic Workflow E2E", () => {
+  describe("runtime profile invariant", () => {
+    it("keeps repeated behavior profiles narrower than the full wrapper matrix", () => {
+      const full = createSession("full");
+      const scopeGuard = createSession("scope-guard");
+      const representative = createSession("representative");
+      try {
+        expect(hookCount(full.hooks)).toBeGreaterThan(15);
+        expect(hookCount(scopeGuard.hooks)).toBeLessThan(hookCount(full.hooks));
+        expect(hookCount(representative.hooks)).toBeLessThan(hookCount(full.hooks));
+        expect(scopeGuard.hooks.SessionStart).toEqual(["kaizen-session-cleanup-ts.sh"]);
+      } finally {
+        full.cleanup();
+        scopeGuard.cleanup();
+        representative.cleanup();
+      }
+    });
   });
 
   describe("scope-guard propagation", () => {
-    it("auto-fixes on first hook; all subsequent hooks take fast path", () => {
-      session = new SessionSimulator();
+    it.concurrent("auto-fixes on first hook; subsequent representative hooks take fast path", () => withSession("scope-guard", (session) => {
       session.setHome("bad_kaizen_install");
 
       session.fireSessionStart();
@@ -37,10 +93,9 @@ describe("Synthetic Workflow E2E", () => {
       expect(session.settingsJson()).toContain("other-plugin@1.0");
       expect(session.counterExists()).toBe(false);
       expect(session.timeoutCount).toBe(0);
-    });
+    }));
 
-    it("clean HOME produces zero warnings", () => {
-      session = new SessionSimulator();
+    it.concurrent("clean HOME produces zero warnings", () => withSession("scope-guard", (session) => {
       session.setHome("clean");
 
       session.fireSessionStart();
@@ -49,10 +104,9 @@ describe("Synthetic Workflow E2E", () => {
 
       expect(session.warningCount).toBe(0);
       expect(session.timeoutCount).toBe(0);
-    });
+    }));
 
-    it("counter cap shows manual instructions without auto-fix", () => {
-      session = new SessionSimulator();
+    it.concurrent("counter cap shows manual instructions without auto-fix", () => withSession("scope-guard", (session) => {
       session.setHome("bad_kaizen_install");
       session.setCounter(3);
 
@@ -60,10 +114,9 @@ describe("Synthetic Workflow E2E", () => {
 
       expect(session.allStderr).toContain("Manual fix");
       expect(session.homeHasKaizen()).toBe(true);
-    });
+    }));
 
-    it("no settings.json is a graceful noop", () => {
-      session = new SessionSimulator();
+    it.concurrent("no settings.json is a graceful noop", () => withSession("scope-guard", (session) => {
       session.setHome("no_settings");
 
       session.fireSessionStart();
@@ -72,10 +125,9 @@ describe("Synthetic Workflow E2E", () => {
 
       expect(session.warningCount).toBe(0);
       expect(session.timeoutCount).toBe(0);
-    });
+    }));
 
-    it("malformed settings.json doesn't crash any hook", () => {
-      session = new SessionSimulator();
+    it.concurrent("malformed settings.json doesn't crash any representative hook", () => withSession("scope-guard", (session) => {
       // Has "kaizen@kaizen" as a string but enabledPlugins is not an object
       session.setHomeRaw('{"enabledPlugins": "not_an_object_but_has_kaizen@kaizen"}');
 
@@ -84,10 +136,9 @@ describe("Synthetic Workflow E2E", () => {
       session.fireStop();
 
       expect(session.timeoutCount).toBe(0);
-    });
+    }));
 
-    it("other plugins preserved after auto-fix", () => {
-      session = new SessionSimulator();
+    it.concurrent("other plugins preserved after auto-fix", () => withSession("scope-guard", (session) => {
       session.setHome("bad_kaizen_install");
 
       session.fireSessionStart();
@@ -95,44 +146,45 @@ describe("Synthetic Workflow E2E", () => {
       const settings = JSON.parse(session.settingsJson());
       expect(settings.enabledPlugins["other-plugin@1.0"]).toBe(true);
       expect(settings.enabledPlugins).not.toHaveProperty("kaizen@kaizen");
-    });
+    }));
   });
 
   describe("session lifecycle composition", () => {
     it("full session completes with no timeouts", () => {
-      session = new SessionSimulator();
-      session.setHome("clean");
+      withSession("full", (session) => {
+        session.setHome("clean");
 
-      session.fireSessionStart();
-      session.fireBashPre("echo hello");
-      session.fireWritePre("src/feature.ts");
-      session.fireBashPre("git commit -m 'add feature'");
-      session.fireBashPost("gh pr create --title test", "https://github.com/test/repo/pull/1");
-      session.fireStop();
+        session.fireSessionStart();
+        session.fireBashPre("echo hello");
+        session.fireWritePre("src/feature.ts");
+        session.fireBashPre("git commit -m 'add feature'");
+        session.fireBashPost("gh pr create --title test", "https://github.com/test/repo/pull/1");
+        session.fireStop();
 
-      expect(session.timeoutCount).toBe(0);
-      expect(session.totalHooksRun).toBeGreaterThan(0);
+        expect(session.timeoutCount).toBe(0);
+        expect(session.totalHooksRun).toBeGreaterThan(0);
+        expect(hookCount(session.hooks)).toBeGreaterThan(15);
+      });
     });
 
-    it("different event types fire different hook sets", () => {
-      session = new SessionSimulator();
+    it.concurrent("different event types fire representative hook sets", () => withSession("representative", (session) => {
       session.setHome("clean");
 
       const startResult = session.fireSessionStart();
       const bashResult = session.fireBashPre("echo hello");
       const writeResult = session.fireWritePre("src/test.ts");
+      const postResult = session.fireBashPost("echo hello", "hello");
       const stopResult = session.fireStop();
 
-      // Each event type fires a different number of hooks
-      // (exact counts depend on which hooks exist on disk)
+      // Each event type still fires at least one real shell hook.
       expect(startResult.results.length).toBeGreaterThan(0);
       expect(bashResult.results.length).toBeGreaterThan(0);
       expect(writeResult.results.length).toBeGreaterThan(0);
+      expect(postResult.results.length).toBeGreaterThan(0);
       expect(stopResult.results.length).toBeGreaterThan(0);
-    });
+    }));
 
-    it("hook registry can be customized per test", () => {
-      session = new SessionSimulator();
+    it.concurrent("hook registry can be customized per test", () => withSession("representative", (session) => {
       session.setHome("clean");
 
       // Only fire block-git-rebase for PreToolUse Bash
@@ -141,6 +193,6 @@ describe("Synthetic Workflow E2E", () => {
       const result = session.fireBashPre("echo hello");
       expect(result.results.length).toBe(1);
       expect(result.results[0].exitCode).toBe(0);
-    });
+    }));
   });
 });


### PR DESCRIPTION
## Summary

Fixes Garsson-io/kaizen#1545

Parent: Garsson-io/kaizen#1532

`src/e2e/synthetic-workflow.test.ts` was replaying the complete shell hook wrapper matrix for nearly every behavior assertion. This PR keeps one full-wrapper lifecycle smoke, then moves repeated scope-guard and event-composition checks onto explicit narrower hook profiles with per-test cleanup.

## Impact

Before:
- `npx vitest run src/e2e/synthetic-workflow.test.ts --reporter=verbose`: 31.023s real, 9 tests
- In the prior full coverage run, `src/e2e/synthetic-workflow.test.ts` reported ~34.7s inside the suite

After:
- `npx vitest run src/e2e/synthetic-workflow.test.ts --reporter=verbose`: 8.850s real, 10 tests
- `npm test -- --run`: 32.499s real, 163 files / 3898 tests / 13 skipped
- `npm run test:ci`: 32.350s real, coverage thresholds pass
- In the full coverage run, `src/e2e/synthetic-workflow.test.ts` reports 13.512s while preserving a full-matrix smoke

## B x L

| Risk | B | L | Why |
| --- | ---: | ---: | --- |
| Full hook lifecycle regression hidden by narrower repeated tests | 4 | 1 | A dedicated full-session smoke still runs the complete default registry and asserts no timeouts. |
| Narrow profiles accidentally become the new default for all coverage | 3 | 1 | Added a runtime profile invariant comparing full vs repeated profiles and asserting SessionStart scope-guard coverage. |
| Concurrent repeated tests interfere through shared state | 3 | 1 | Removed shared `afterEach` state; each test creates and cleans up its own simulator, temp HOME, state dir, audit dir, and mock bin. |

## Validation

- `npx vitest run src/e2e/synthetic-workflow.test.ts --reporter=verbose` passed in 8.850s real
- `npx vitest run src/emit-test-review-sentinel.test.ts` passed after worktree-local `npm ci`
- `npm test -- --run` passed in 32.499s real
- `npm run test:ci` passed in 32.350s real; coverage summary: 72.22% statements / 67.44% branches / 79.70% functions / 73.45% lines
- `npm run typecheck` passed
- `npm run check:fast` passed
- `git diff --check` passed

## Follow-up

This keeps the parent optimization track open. Remaining high-value directions include CI coverage sharding/merge handling and further shell-wrapper-heavy files such as `pr-review-loop`, `hook-gym-cli`, wrapper smoke, and plugin lifecycle tests.
