### PR TITLE
test: parallelize hook test runner

### DIFF
--- a/.claude/hooks/tests/run-all-tests.sh
+++ b/.claude/hooks/tests/run-all-tests.sh
@@ -6,6 +6,8 @@
 #   bash .claude/hooks/tests/run-all-tests.sh --unit     # Unit tests only
 #   bash .claude/hooks/tests/run-all-tests.sh --harness  # Integration tests only
 #   bash .claude/hooks/tests/run-all-tests.sh --quick    # Fast subset (python only)
+#   KAIZEN_HOOK_TEST_JOBS=1 bash .claude/hooks/tests/run-all-tests.sh  # Serial shell files
+#   bash .claude/hooks/tests/run-all-tests.sh --jobs 4  # Parallel shell file count
 #
 # Test files are auto-discovered by naming convention:
 #   test-integration-*.sh, test-*-e2e*.sh  → integration/harness tests
@@ -18,7 +20,59 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-MODE="${1:-all}"
+MODE="all"
+REQUESTED_JOBS="${KAIZEN_HOOK_TEST_JOBS:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --unit|--harness|--python|--quick)
+      MODE="$1"
+      shift
+      ;;
+    --jobs)
+      if [ "$#" -ge 2 ] && [[ "${2:-}" != --* ]]; then
+        REQUESTED_JOBS="$2"
+        shift 2
+      else
+        REQUESTED_JOBS=""
+        shift
+      fi
+      ;;
+    all)
+      MODE="all"
+      shift
+      ;;
+    *)
+      MODE="$1"
+      shift
+      ;;
+  esac
+done
+
+default_jobs() {
+  local cpus
+  if command -v nproc &>/dev/null; then
+    cpus=$(nproc 2>/dev/null || echo 4)
+  else
+    cpus=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
+  fi
+  case "$cpus" in
+    ''|*[!0-9]*) cpus=4 ;;
+  esac
+  if [ "$cpus" -lt 1 ]; then cpus=1; fi
+  if [ "$cpus" -gt 8 ]; then cpus=8; fi
+  echo "$cpus"
+}
+
+if [ -z "$REQUESTED_JOBS" ]; then
+  SHELL_TEST_JOBS=$(default_jobs)
+else
+  SHELL_TEST_JOBS="$REQUESTED_JOBS"
+fi
+case "$SHELL_TEST_JOBS" in
+  ''|*[!0-9]*) SHELL_TEST_JOBS=1 ;;
+esac
+if [ "$SHELL_TEST_JOBS" -lt 1 ]; then SHELL_TEST_JOBS=1; fi
 
 TOTAL_PASS=0
 TOTAL_FAIL=0
@@ -112,6 +166,107 @@ run_test_file() {
   fi
 }
 
+run_test_file_capture() {
+  local file="$1"
+  local index="$2"
+  local result_dir="$3"
+  local name
+  name=$(basename "$file" .sh)
+
+  local output_file="$result_dir/$index.output"
+  local meta_file="$result_dir/$index.meta"
+  local state_dir audit_dir exit_code pass fail
+  state_dir=$(mktemp -d "/tmp/.kaizen-test-state-$name-XXXXXX")
+  audit_dir=$(mktemp -d "/tmp/.kaizen-test-audit-$name-XXXXXX")
+
+  STATE_DIR="$state_dir" \
+    AUDIT_DIR="$audit_dir" \
+    AUDIT_LOG="$audit_dir/no-action.log" \
+    DEBUG_LOG="/dev/null" \
+    KAIZEN_TEST_RUNNER=1 \
+    bash "$file" >"$output_file" 2>&1
+  exit_code=$?
+
+  pass=$(grep -oP '(\d+) passed' "$output_file" | grep -oP '\d+' | tail -1)
+  fail=$(grep -oP '(\d+) failed' "$output_file" | grep -oP '\d+' | tail -1)
+  pass=${pass:-0}
+  fail=${fail:-0}
+
+  printf '%s\t%s\t%s\t%s\n' "$name" "$exit_code" "$pass" "$fail" >"$meta_file"
+  rm -rf "$state_dir" "$audit_dir"
+  exit "$exit_code"
+}
+
+replay_captured_test() {
+  local index="$1"
+  local result_dir="$2"
+  local meta_file="$result_dir/$index.meta"
+  local output_file="$result_dir/$index.output"
+
+  if [ ! -f "$meta_file" ]; then
+    echo ""
+    echo "━━━ unknown-$index ━━━"
+    echo "  FAIL: runner did not produce metadata"
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+    UNCLASSIFIABLE_FAIL=$((UNCLASSIFIABLE_FAIL + 1))
+    FAILED_FILES+=("unknown-$index")
+    return
+  fi
+
+  local name exit_code pass fail
+  IFS=$'\t' read -r name exit_code pass fail <"$meta_file"
+
+  echo ""
+  echo "━━━ $name ━━━"
+
+  TOTAL_PASS=$((TOTAL_PASS + pass))
+  TOTAL_FAIL=$((TOTAL_FAIL + fail))
+  TOTAL_TESTS=$((TOTAL_TESTS + pass + fail))
+
+  if [ "$exit_code" -ne 0 ] || [ "$fail" -gt 0 ]; then
+    grep -E 'FAIL:' "$output_file" || true
+    grep -E 'FAILED TESTS:' -A 100 "$output_file" || true
+    echo "  RESULT: $pass passed, $fail failed"
+    FAILED_FILES+=("$name")
+    FAILED_IDS+=("$name")
+  else
+    echo "  RESULT: $pass passed, $fail failed"
+  fi
+}
+
+run_shell_tests() {
+  if [ "$#" -eq 0 ]; then
+    return
+  fi
+
+  if [ "$SHELL_TEST_JOBS" -le 1 ]; then
+    echo "Running shell test files serially..."
+    for t in "$@"; do
+      run_test_file "$t"
+    done
+    return
+  fi
+
+  echo "Running shell test files with $SHELL_TEST_JOBS parallel jobs..."
+  local result_dir total launched idx
+  result_dir=$(mktemp -d "/tmp/.kaizen-hook-test-results-XXXXXX")
+  total=$#
+  launched=0
+  for t in "$@"; do
+    while [ "$(jobs -rp | wc -l | tr -d ' ')" -ge "$SHELL_TEST_JOBS" ]; do
+      sleep 0.1
+    done
+    launched=$((launched + 1))
+    run_test_file_capture "$t" "$launched" "$result_dir" &
+  done
+  wait || true
+
+  for idx in $(seq 1 "$total"); do
+    replay_captured_test "$idx" "$result_dir"
+  done
+  rm -rf "$result_dir"
+}
+
 # Auto-discover and classify tests
 UNIT_TESTS=()
 HARNESS_TESTS=()
@@ -198,15 +353,11 @@ run_python_tests() {
 case "$MODE" in
   --unit)
     echo "Running unit tests only..."
-    for t in "${UNIT_TESTS[@]}"; do
-      run_test_file "$t"
-    done
+    run_shell_tests "${UNIT_TESTS[@]}"
     ;;
   --harness)
     echo "Running harness tests only..."
-    for t in "${HARNESS_TESTS[@]}"; do
-      run_test_file "$t"
-    done
+    run_shell_tests "${HARNESS_TESTS[@]}"
     run_python_tests
     ;;
   --python)
@@ -219,12 +370,7 @@ case "$MODE" in
     ;;
   all|*)
     echo "Running all tests..."
-    for t in "${UNIT_TESTS[@]}"; do
-      run_test_file "$t"
-    done
-    for t in "${HARNESS_TESTS[@]}"; do
-      run_test_file "$t"
-    done
+    run_shell_tests "${UNIT_TESTS[@]}" "${HARNESS_TESTS[@]}"
     run_python_tests
     ;;
 esac


### PR DESCRIPTION
## Summary

Fixes Garsson-io/kaizen#1548

Parent: Garsson-io/kaizen#1532

The shell hook test runner discovered 27 shell files and then executed them one by one before running pytest. This PR keeps the existing reporting and owned-failure classifier contract, but runs shell test files in parallel by default with per-file temp `STATE_DIR` / `AUDIT_DIR` isolation. Output is captured and replayed in discovery order so logs stay readable.

It also adds:
- `KAIZEN_HOOK_TEST_JOBS=1` serial escape hatch
- `--jobs N` CLI override
- a bounded default job count capped at 8

## Impact

Before:
- `bash .claude/hooks/tests/run-all-tests.sh` on main checkout: 58.112s real, 435 tests
- Same worktree serial escape path after the change: 57.806s real, 430 tests
- Post-#1545 main CI shell hook job: 1m02s

After:
- `npm run test:hooks`: 35.642s real, 430 tests
- `KAIZEN_REQUIRE_PYTHON_TESTS=1 npm run test:hooks`: 35.542s real, 430 tests
- Default direct runner also passed with the new parallel path: 44.603s real in one run

The 430-vs-435 local count difference is environmental, not introduced by parallelism: in this case worktree, `KAIZEN_HOOK_TEST_JOBS=1` reports the same 430 total as the parallel path.

## B x L

| Risk | B | L | Why |
| --- | ---: | ---: | --- |
| Parallel shell files race through shared state | 4 | 1 | Each shell file runs with its own temp `STATE_DIR`, `AUDIT_DIR`, `AUDIT_LOG`, and `DEBUG_LOG`. |
| Failure attribution gets lost across child processes | 4 | 1 | Workers write metadata; parent replays output and appends failed shell file names to `FAILED_IDS`, preserving the classifier contract. |
| Over-aggressive parallelism flakes slower integration tests | 3 | 2 | Default is capped at 8. A `--jobs 16` probe failed `test-worktree-context-integration`, so the cap is intentionally conservative and `KAIZEN_HOOK_TEST_JOBS=1` remains available. |

## Validation

- `bash .claude/hooks/tests/run-all-tests.sh` passed, 430 tests, 44.603s real
- `KAIZEN_HOOK_TEST_JOBS=1 bash .claude/hooks/tests/run-all-tests.sh` passed, 430 tests, 57.806s real
- `KAIZEN_HOOK_TEST_JOBS=1 bash .claude/hooks/tests/run-all-tests.sh --unit` passed, 352 tests
- `KAIZEN_REQUIRE_PYTHON_TESTS=1 bash .claude/hooks/tests/run-all-tests.sh --python` passed, 38 tests
- `bash .claude/hooks/tests/run-all-tests.sh --jobs --python` passed, proving `--jobs` no longer swallows the next flag
- `npm run test:hooks` passed, 35.642s real
- `KAIZEN_REQUIRE_PYTHON_TESTS=1 npm run test:hooks` passed, 35.542s real
- `npm run check:fast` passed
- `bash -n .claude/hooks/tests/run-all-tests.sh` passed
- `git diff --check` passed

## Follow-up

Parent #1532 remains open. After this, the next likely CI-level lever is TypeScript coverage sharding/report merge, while local runtime work can keep targeting wrapper-heavy TypeScript files.
