### PR TITLE
test: speed up hook gym cli tests

### DIFF
--- a/scripts/hook-gym-cli.test.ts
+++ b/scripts/hook-gym-cli.test.ts
@@ -5,21 +5,29 @@
  *   B8 — `--list` emits formatted scenario summary with severity weights
  *   B9 — `--run <name> --dry-run` renders prompt with template vars substituted
  *
- * These are Integration level: they spawn a real `npx tsx` subprocess,
+ * These are Integration level: they spawn a real project-local `tsx` subprocess,
  * exercise the full CLI pipeline (arg parsing → scenario lookup → template
  * rendering → stdout), and assert on the composed output. Mocking stdout
  * would always pass — this is why the level is Integration not Unit.
  */
 
-import { describe, it, expect } from 'vitest';
+import { beforeAll, describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
 const REPO_ROOT = resolve(__dirname, '..');
 const CLI = resolve(REPO_ROOT, 'scripts/hook-gym.ts');
+const TSX = resolve(
+  REPO_ROOT,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
 
-function runCli(args: string[]): { stdout: string; stderr: string; status: number } {
-  const result = spawnSync('npx', ['tsx', CLI, ...args], {
+type CliResult = { stdout: string; stderr: string; status: number };
+
+function runCli(args: string[]): CliResult {
+  const result = spawnSync(TSX, [CLI, ...args], {
     cwd: REPO_ROOT,
     encoding: 'utf-8',
     timeout: 30000,
@@ -32,8 +40,14 @@ function runCli(args: string[]): { stdout: string; stderr: string; status: numbe
 }
 
 describe('hook-gym CLI — --list (B8)', () => {
+  let result: CliResult;
+
+  beforeAll(() => {
+    result = runCli(['--list']);
+  });
+
   it('exits 0 and lists all three scenarios', () => {
-    const { stdout, status } = runCli(['--list']);
+    const { stdout, status } = result;
     expect(status).toBe(0);
     expect(stdout).toContain('probe-hooks');
     expect(stdout).toContain('lifecycle-gates');
@@ -41,12 +55,12 @@ describe('hook-gym CLI — --list (B8)', () => {
   });
 
   it('shows total count', () => {
-    const { stdout } = runCli(['--list']);
+    const { stdout } = result;
     expect(stdout).toMatch(/Total: \d+ scenarios/);
   });
 
   it('includes model, budget, and timeout columns', () => {
-    const { stdout } = runCli(['--list']);
+    const { stdout } = result;
     // probe-hooks uses haiku
     expect(stdout).toMatch(/probe-hooks\s+haiku/);
     // full-clear uses sonnet
@@ -58,13 +72,13 @@ describe('hook-gym CLI — --list (B8)', () => {
   });
 
   it('includes weighted severity total per scenario', () => {
-    const { stdout } = runCli(['--list']);
+    const { stdout } = result;
     // Severity weight is printed as weight=NN
     expect(stdout).toMatch(/weight=\d+/);
   });
 
   it('shows description for each scenario', () => {
-    const { stdout } = runCli(['--list']);
+    const { stdout } = result;
     expect(stdout).toContain('Full workflow');
     expect(stdout).toContain('Gate lifecycle');
     expect(stdout).toContain('Full lifecycle');
@@ -72,13 +86,19 @@ describe('hook-gym CLI — --list (B8)', () => {
 });
 
 describe('hook-gym CLI — --run <name> --dry-run (B9)', () => {
+  let result: CliResult;
+
+  beforeAll(() => {
+    result = runCli(['--run', 'probe-hooks', '--dry-run']);
+  });
+
   it('exits 0 for a valid scenario', () => {
-    const { status } = runCli(['--run', 'probe-hooks', '--dry-run']);
+    const { status } = result;
     expect(status).toBe(0);
   });
 
   it('substitutes the {{timestamp}} template variable', () => {
-    const { stdout } = runCli(['--run', 'probe-hooks', '--dry-run']);
+    const { stdout } = result;
     // The placeholder must be gone
     expect(stdout).not.toContain('{{timestamp}}');
     // And a real timestamp (14-digit YYYYMMDDHHMMSS) should appear
@@ -86,14 +106,14 @@ describe('hook-gym CLI — --run <name> --dry-run (B9)', () => {
   });
 
   it('substitutes the {{host_repo}} template variable', () => {
-    const { stdout } = runCli(['--run', 'probe-hooks', '--dry-run']);
+    const { stdout } = result;
     expect(stdout).not.toContain('{{host_repo}}');
     // Host repo read from kaizen.config.json — kaizen self-dogfoods
     expect(stdout).toContain('Garsson-io/kaizen');
   });
 
   it('prints the scenario header block with model + budget + timeout', () => {
-    const { stdout } = runCli(['--run', 'probe-hooks', '--dry-run']);
+    const { stdout } = result;
     expect(stdout).toContain('=== Scenario: probe-hooks ===');
     expect(stdout).toContain('haiku');
     expect(stdout).toMatch(/\$\d+\.\d{2}/);
@@ -101,21 +121,21 @@ describe('hook-gym CLI — --run <name> --dry-run (B9)', () => {
   });
 
   it('prints the expected-hooks section with severity and weight', () => {
-    const { stdout } = runCli(['--run', 'probe-hooks', '--dry-run']);
+    const { stdout } = result;
     expect(stdout).toContain('--- Expected hooks ---');
     // Severity and weight annotation appears on every expected hook
     expect(stdout).toMatch(/\[sev=\d\]/);
   });
 
   it('prints the expected-gates section', () => {
-    const { stdout } = runCli(['--run', 'probe-hooks', '--dry-run']);
+    const { stdout } = result;
     expect(stdout).toContain('--- Expected gates ---');
     expect(stdout).toContain('needs_review');
     expect(stdout).toContain('needs_pr_kaizen');
   });
 
   it('prints the rendered prompt section', () => {
-    const { stdout } = runCli(['--run', 'probe-hooks', '--dry-run']);
+    const { stdout } = result;
     expect(stdout).toContain('--- Rendered prompt ---');
     // The probe-hooks scenario instructs creating hook-gym-probe.md
     expect(stdout).toContain('hook-gym-probe.md');


### PR DESCRIPTION
Fixes #1552
Parent: #1532

## Story

The Hook Gym CLI tests were preserving the right boundary: each test spawned the real `scripts/hook-gym.ts` entry point and asserted on real stdout, stderr, and exit codes. The cost was that the file spawned the same deterministic commands over and over.

On current `main`, `scripts/hook-gym-cli.test.ts` took `9.237s` wall time and `8.55s` Vitest test time for 15 assertions. Most of that was not behavior under test; it was repeated `npx tsx` process startup for identical `--list` and `--run probe-hooks --dry-run` outputs.

This PR keeps the integration boundary but amortizes the expensive setup. The repeated `--list` assertions share one CLI result, the repeated dry-run assertions share one CLI result, and the helper invokes the project-local `tsx` binary directly instead of routing every remaining subprocess through `npx`.

## Impact (goal -> before/after -> match)

| Goal | BEFORE | AFTER | Observable delta | Goal met? |
|---|---|---|---|---|
| Make this local/CI test file materially faster without weakening CLI coverage | `time npx vitest run scripts/hook-gym-cli.test.ts`: 15 passed, 8.55s test time, 9.237s wall | Same command: 15 passed, 1.71s test time, 2.400s wall | Wall time down 6.837s (about 74%); Vitest test time down 6.84s (about 80%) | yes |

- Acceptance signal: the targeted file still reports 15 passing integration tests while running materially faster.
- Residual scan: broader test/CI optimization remains tracked by #1532; this PR only targets the redundant Hook Gym CLI subprocess cost.

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Cache command results with `beforeAll` inside repeated describe blocks | Preserves all assertions while avoiding duplicate deterministic subprocesses | If a shared command fails, several assertions fail from the same root cause |
| Keep unknown-scenario and help invocations separate | They cover distinct argument paths and are not the dominant repeated cost | Still leaves five subprocesses total |
| Use `node_modules/.bin/tsx` directly | Keeps project-local TypeScript CLI execution while avoiding `npx` startup overhead | Requires dependencies to be installed, which Vitest already requires |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/hook-gym-cli.test.ts` | Shares deterministic CLI results and uses the local `tsx` binary in the test helper |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Status | Evidence |
|---|---:|---|---|
| Hook Gym CLI test still covers the real entry point | Integration | Tested | Helper still spawns `scripts/hook-gym.ts` through project-local `tsx` |
| `--list` assertions preserve behavior coverage | Integration | Tested | Existing assertions for status, scenarios, total count, model/budget/timeout, weights, and descriptions remain |
| `--run probe-hooks --dry-run` assertions preserve behavior coverage | Integration | Tested | Existing assertions for status, template substitution, host repo, header, hooks, gates, and rendered prompt remain |
| Runtime improves against baseline | Local benchmark | Tested | `9.237s` wall / `8.55s` test time -> `2.400s` wall / `1.71s` test time |
| Fast local gate remains green | Local gate | Tested | `npm run check:fast` passed |
| Diff has no whitespace errors | Static check | Tested | `git diff --check` passed |
| CI remains green | PR CI | Pending | Will verify before merge |

## Known Limitations

This does not change production Hook Gym behavior and does not optimize the larger live Hook Gym harness. It removes redundant process startup from this one hot test file.
