### PR TITLE
test: stabilize workflow driver cwd test

### DIFF
--- a/scripts/kaizen-workflow-driver.test.ts
+++ b/scripts/kaizen-workflow-driver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { resolve } from 'node:path';
 
 import {
@@ -11,6 +11,16 @@ import {
   renderWorkflowStatusMarkdown,
   renderAutoDentGoalContract,
 } from './kaizen-workflow-driver.js';
+
+const TSX_CLI = resolve('node_modules/tsx/dist/cli.mjs');
+const WORKFLOW_DRIVER = 'scripts/kaizen-workflow-driver.ts';
+
+function runWorkflowDriver(args: string[], options: { cwd?: string; script?: string } = {}): SpawnSyncReturns<string> {
+  return spawnSync(process.execPath, [TSX_CLI, options.script ?? WORKFLOW_DRIVER, ...args], {
+    cwd: options.cwd,
+    encoding: 'utf8',
+  });
+}
 
 describe('kaizen workflow forcing driver', () => {
   it('manual driver starts with a literal /goal and names the ticket identity', () => {
@@ -149,9 +159,7 @@ describe('kaizen workflow forcing driver', () => {
   });
 
   it('CLI exposes workflow status for operators and agents with explicit gate evidence', () => {
-    const result = spawnSync('npx', [
-      'tsx',
-      'scripts/kaizen-workflow-driver.ts',
+    const result = runWorkflowDriver([
       'status',
       '--mode',
       'exploit',
@@ -159,9 +167,7 @@ describe('kaizen workflow forcing driver', () => {
       'done: shared workflow driver reused',
       '--meet-reality',
       'done: CLI output inspected',
-    ], {
-      encoding: 'utf8',
-    });
+    ]);
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('## Kaizen Workflow Status');
@@ -174,8 +180,6 @@ describe('kaizen workflow forcing driver', () => {
 
   it('CLI status resolves repo evidence from the script location, not process cwd', () => {
     const args = [
-      'tsx',
-      'scripts/kaizen-workflow-driver.ts',
       'status',
       '--mode',
       'manual',
@@ -184,10 +188,10 @@ describe('kaizen workflow forcing driver', () => {
       '--meet-reality',
       'done: cwd invariant',
     ];
-    const fromRoot = spawnSync('npx', args, { encoding: 'utf8' });
-    const fromTmp = spawnSync('npx', ['tsx', resolve('scripts/kaizen-workflow-driver.ts'), ...args.slice(2)], {
+    const fromRoot = runWorkflowDriver(args);
+    const fromTmp = runWorkflowDriver(args, {
       cwd: '/tmp',
-      encoding: 'utf8',
+      script: resolve(WORKFLOW_DRIVER),
     });
 
     expect(fromRoot.status).toBe(0);


### PR DESCRIPTION
## Summary

Fixes #1556.

Post-merge CI for #1555 failed in TypeScript coverage shard 2/2, but the failed blob pointed at `scripts/kaizen-workflow-driver.test.ts`, not the optimized PR review loop test. The brittle assertion launched `npx tsx` from `/tmp`, which made the test depend on how `npx` discovers tooling outside the checked-out repo.

This PR keeps the cwd-invariant test, but runs the workflow driver through the repo-local `node_modules/tsx/dist/cli.mjs` with `process.execPath`. The subprocess still uses `/tmp` as cwd for the invariant check; only the tool resolution is now deterministic.

## Verification

- `npx vitest run scripts/kaizen-workflow-driver.test.ts --coverage --reporter=verbose --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0`
- `npx vitest run --coverage --reporter=default --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --shard=2/2`
- `npm run check:fast`
- `git diff --check`
