### PR TITLE
test: parallelize wrapper smoke checks

### DIFF
--- a/src/hooks/wrapper-smoke.test.ts
+++ b/src/hooks/wrapper-smoke.test.ts
@@ -10,78 +10,98 @@
  * This prevents accidental kaizen gate triggers (learned from incident
  * where smoke tests with PR 99999 blocked the entire session).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { execSync } from 'node:child_process';
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
 const HOOKS_DIR = path.resolve(__dirname, '../../.claude/hooks');
 
-let tmpDir: string;
-let testPrNum: string;
+interface SmokeContext {
+  tmpDir: string;
+  testPrNum: string;
+}
 
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wrapper-smoke-'));
-  testPrNum = String(Math.floor(Math.random() * 900000) + 100000);
-});
+function createSmokeContext(): SmokeContext {
+  return {
+    tmpDir: fs.mkdtempSync(path.join(os.tmpdir(), 'wrapper-smoke-')),
+    testPrNum: String(Math.floor(Math.random() * 900000) + 100000),
+  };
+}
 
-afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+function cleanupSmokeContext(ctx: SmokeContext): void {
+  fs.rmSync(ctx.tmpDir, { recursive: true, force: true });
   // Safety cleanup: remove any state that leaked to the default dir
   const defaultDir = '/tmp/.pr-review-state';
   for (const pattern of [
-    `pr-kaizen-Garsson-io_smoke-test_${testPrNum}`,
-    `Garsson-io_smoke-test_${testPrNum}`,
-    `kaizen-done-Garsson-io_smoke-test_${testPrNum}`,
-    `post-merge-Garsson-io_smoke-test_${testPrNum}`,
+    `pr-kaizen-Garsson-io_smoke-test_${ctx.testPrNum}`,
+    `Garsson-io_smoke-test_${ctx.testPrNum}`,
+    `kaizen-done-Garsson-io_smoke-test_${ctx.testPrNum}`,
+    `post-merge-Garsson-io_smoke-test_${ctx.testPrNum}`,
   ]) {
     try {
       fs.unlinkSync(path.join(defaultDir, pattern));
     } catch {}
   }
-});
+}
 
-function testPrUrl(): string {
+async function withSmokeContext<T>(fn: (ctx: SmokeContext) => T | Promise<T>): Promise<T> {
+  const ctx = createSmokeContext();
+  try {
+    return await fn(ctx);
+  } finally {
+    cleanupSmokeContext(ctx);
+  }
+}
+
+function testPrUrl(ctx: SmokeContext): string {
   // Use a fake repo name "smoke-test" that doesn't match any real repo
-  return `https://github.com/Garsson-io/smoke-test/pull/${testPrNum}`;
+  return `https://github.com/Garsson-io/smoke-test/pull/${ctx.testPrNum}`;
 }
 
 /** Run a bash wrapper with optional stdin, return { stdout, exitCode }.
  *  Pass `input` as an object to send JSON, or omit/null for empty stdin. */
 function runWrapper(
+  ctx: SmokeContext,
   wrapperName: string,
   input: object | null,
   extraEnv?: Record<string, string>,
-): { stdout: string; exitCode: number } {
+): Promise<{ stdout: string; exitCode: number }> {
   const wrapperPath = path.join(HOOKS_DIR, wrapperName);
   if (!fs.existsSync(wrapperPath)) {
     throw new Error(`Wrapper not found: ${wrapperPath}`);
   }
 
   const stdinData = input != null ? JSON.stringify(input) : '';
-  try {
-    const stdout = execSync(`bash "${wrapperPath}"`, {
-      encoding: 'utf-8',
-      input: stdinData,
+  return new Promise((resolve) => {
+    const child = spawn('bash', [wrapperPath], {
       env: {
         ...process.env,
-        STATE_DIR: tmpDir,
-        AUDIT_DIR: path.join(tmpDir, 'audit'),
-        IPC_DIR: path.join(tmpDir, 'ipc'),
+        STATE_DIR: ctx.tmpDir,
+        AUDIT_DIR: path.join(ctx.tmpDir, 'audit'),
+        IPC_DIR: path.join(ctx.tmpDir, 'ipc'),
         HOOK_TIMING_SENTINEL_DISABLED: 'true',
         ...extraEnv,
       },
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 15000,
-    }).trim();
-    return { stdout, exitCode: 0 };
-  } catch (err: any) {
-    return {
-      stdout: err.stdout?.trim?.() ?? '',
-      exitCode: err.status ?? 1,
-    };
-  }
+    });
+    let stdout = '';
+    const timeout = setTimeout(() => child.kill('SIGTERM'), 15_000);
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.on('error', () => {
+      clearTimeout(timeout);
+      resolve({ stdout: stdout.trim(), exitCode: 1 });
+    });
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      resolve({ stdout: stdout.trim(), exitCode: code ?? 1 });
+    });
+    child.stdin.end(stdinData);
+  });
 }
 
 const NOOP_INPUT = {
@@ -121,7 +141,7 @@ describe('wrapper smoke: bash wrappers exist and are executable', () => {
     'pr-kaizen-clear-ts.sh',
     'kaizen-reflect-ts.sh',
   ]) {
-    it(`${wrapper} exists and is executable`, () => {
+    it.concurrent(`${wrapper} exists and is executable`, () => {
       const wrapperPath = path.join(HOOKS_DIR, wrapper);
       expect(fs.existsSync(wrapperPath)).toBe(true);
       const stats = fs.statSync(wrapperPath);
@@ -131,39 +151,39 @@ describe('wrapper smoke: bash wrappers exist and are executable', () => {
 });
 
 describe('wrapper smoke: pr-review-loop-ts.sh', () => {
-  it('exits 0 with no output on non-matching command', () => {
-    const { stdout, exitCode } = runWrapper('pr-review-loop-ts.sh', NOOP_INPUT);
+  it.concurrent('exits 0 with no output on non-matching command', async () => withSmokeContext(async (ctx) => {
+    const { stdout, exitCode } = await runWrapper(ctx, 'pr-review-loop-ts.sh', NOOP_INPUT);
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
-  });
+  }));
 
-  it('produces review prompt on PR create', () => {
-    const { stdout, exitCode } = runWrapper('pr-review-loop-ts.sh', {
+  it.concurrent('produces review prompt on PR create', async () => withSmokeContext(async (ctx) => {
+    const { stdout, exitCode } = await runWrapper(ctx, 'pr-review-loop-ts.sh', {
       tool_input: { command: 'gh pr create --title "smoke test"' },
       tool_response: {
-        stdout: testPrUrl(),
+        stdout: testPrUrl(ctx),
         stderr: '',
         exit_code: '0',
       },
     });
     expect(exitCode).toBe(0);
     expect(stdout).toContain('MANDATORY SELF-REVIEW');
-    expect(stdout).toContain(`pull/${testPrNum}`);
-  });
+    expect(stdout).toContain(`pull/${ctx.testPrNum}`);
+  }));
 });
 
 describe('wrapper smoke: kaizen-reflect-ts.sh', () => {
-  it('exits 0 with no output on non-matching command', () => {
-    const { stdout, exitCode } = runWrapper('kaizen-reflect-ts.sh', NOOP_INPUT);
+  it.concurrent('exits 0 with no output on non-matching command', async () => withSmokeContext(async (ctx) => {
+    const { stdout, exitCode } = await runWrapper(ctx, 'kaizen-reflect-ts.sh', NOOP_INPUT);
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
-  });
+  }));
 
-  it('produces reflection prompt on PR create', () => {
-    const { stdout, exitCode } = runWrapper('kaizen-reflect-ts.sh', {
+  it.concurrent('produces reflection prompt on PR create', async () => withSmokeContext(async (ctx) => {
+    const { stdout, exitCode } = await runWrapper(ctx, 'kaizen-reflect-ts.sh', {
       tool_input: { command: 'gh pr create --title "smoke test"' },
       tool_response: {
-        stdout: testPrUrl(),
+        stdout: testPrUrl(ctx),
         stderr: '',
         exit_code: '0',
       },
@@ -171,12 +191,12 @@ describe('wrapper smoke: kaizen-reflect-ts.sh', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain('KAIZEN REFLECTION');
     expect(stdout).toContain('kaizen-bg');
-  });
+  }));
 });
 
 describe('wrapper smoke: pr-kaizen-clear-ts.sh', () => {
-  it('exits 0 silently when no gate is active', () => {
-    const { stdout, exitCode } = runWrapper('pr-kaizen-clear-ts.sh', {
+  it.concurrent('exits 0 silently when no gate is active', async () => withSmokeContext(async (ctx) => {
+    const { stdout, exitCode } = await runWrapper(ctx, 'pr-kaizen-clear-ts.sh', {
       tool_name: 'Bash',
       tool_input: {
         command: "echo 'KAIZEN_NO_ACTION [test-only]: smoke test'",
@@ -189,20 +209,20 @@ describe('wrapper smoke: pr-kaizen-clear-ts.sh', () => {
     });
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
-  });
+  }));
 
-  it('clears gate when valid KAIZEN_NO_ACTION submitted', () => {
+  it.concurrent('clears gate when valid KAIZEN_NO_ACTION submitted', async () => withSmokeContext(async (ctx) => {
     // Create a gate state file in tmpDir
-    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
       encoding: 'utf-8',
     }).trim();
-    const key = `Garsson-io_smoke-test_${testPrNum}`;
+    const key = `Garsson-io_smoke-test_${ctx.testPrNum}`;
     fs.writeFileSync(
-      path.join(tmpDir, `pr-kaizen-${key}`),
-      `PR_URL=${testPrUrl()}\nSTATUS=needs_pr_kaizen\nBRANCH=${branch}\n`,
+      path.join(ctx.tmpDir, `pr-kaizen-${key}`),
+      `PR_URL=${testPrUrl(ctx)}\nSTATUS=needs_pr_kaizen\nBRANCH=${branch}\n`,
     );
 
-    const { stdout, exitCode } = runWrapper('pr-kaizen-clear-ts.sh', {
+    const { stdout, exitCode } = await runWrapper(ctx, 'pr-kaizen-clear-ts.sh', {
       tool_name: 'Bash',
       tool_input: {
         command: "echo 'KAIZEN_NO_ACTION [test-only]: smoke test'",
@@ -215,7 +235,7 @@ describe('wrapper smoke: pr-kaizen-clear-ts.sh', () => {
     });
     expect(exitCode).toBe(0);
     expect(stdout).toContain('PR kaizen gate cleared');
-  });
+  }));
 });
 
 describe('wrapper smoke: null stdin — all traceNullInput hooks exit 0 silently', () => {
@@ -237,10 +257,10 @@ describe('wrapper smoke: null stdin — all traceNullInput hooks exit 0 silently
   ];
 
   for (const wrapper of traceNullInputWrappers) {
-    it(`${wrapper} exits 0 silently on empty stdin`, () => {
-      const { stdout, exitCode } = runWrapper(wrapper, null, { KAIZEN_HOOK_TRACE: '0' });
+    it.concurrent(`${wrapper} exits 0 silently on empty stdin`, async () => withSmokeContext(async (ctx) => {
+      const { stdout, exitCode } = await runWrapper(ctx, wrapper, null, { KAIZEN_HOOK_TRACE: '0' });
       expect(exitCode).toBe(0);
       expect(stdout).toBe('');
-    });
+    }));
   }
 });


### PR DESCRIPTION
## Summary

Fixes #1558.

`src/hooks/wrapper-smoke.test.ts` was still spending most of its time serially waiting on independent bash wrapper subprocesses. This keeps the real wrapper -> tsx -> hook smoke coverage, but removes the shared global test state and runs independent subprocess checks asynchronously/concurrently with a fresh temp state context per test.

## Runtime

Baseline on `main`:

- `time npx vitest run src/hooks/wrapper-smoke.test.ts --reporter=verbose`
- Vitest duration: ~7.14s
- Shell wall: ~9.587s

After this change:

- `time npx vitest run src/hooks/wrapper-smoke.test.ts --reporter=verbose`
- Vitest duration: ~4.33s
- Shell wall: ~7.343s

`npm run check:fast` ran the changed file in ~3.62s.

## Verification

- `time npx vitest run src/hooks/wrapper-smoke.test.ts --reporter=verbose`
- `npm run check:fast`
- `git diff --check`
