### PR TITLE
test: compact synthetic workflow smoke path

### DIFF
--- a/src/e2e/synthetic-workflow.test.ts
+++ b/src/e2e/synthetic-workflow.test.ts
@@ -240,7 +240,7 @@ describe("Synthetic Workflow E2E", () => {
       expect(stopResult.results.some((result) => result.stdout.includes("KAIZEN REFLECTION"))).toBe(true);
     }));
 
-    it("full session completes with no timeouts", () => {
+    it("full hook registry completes with no timeouts", () => {
       expectTsxAvailable();
       withSession("full", (session) => {
         session.setHome("clean");
@@ -248,8 +248,7 @@ describe("Synthetic Workflow E2E", () => {
         session.fireSessionStart();
         session.fireBashPre("echo hello");
         session.fireWritePre("src/feature.ts");
-        session.fireBashPre("git commit -m 'add feature'");
-        session.fireBashPost("gh pr create --title test", "https://github.com/test/repo/pull/1");
+        session.fireBashPost("echo hello", "hello");
         session.fireStop();
 
         expect(session.timeoutCount).toBe(0);


### PR DESCRIPTION
## Summary

Fixes #1560.

The synthetic workflow suite had one full-session timeout smoke whose purpose was to prove the registered hook matrix can run without hanging. That test was also replaying a longer PR-style session: it fired the full Bash pre-hook group twice and used a PR-create post hook path that is already covered by adjacent successful/failed PR workflow gate tests.

This PR keeps the all-registered-hook smoke real: it still runs actual shell wrappers through `SessionSimulator`, and it still fires every registered hook group once. It just makes that smoke path compact so PR-gate behavior stays in the dedicated PR-gate tests.

## Impact (goal -> before/after -> match)

- Goal (#1560): reduce synthetic workflow E2E runtime while preserving real shell-wrapper hook coverage.
- Acceptance signal: targeted suite and shard 1/2 runtime improve; targeted suite, fast check, and coverage-shaped shard stay green.
- BEFORE: `time npx vitest run src/e2e/synthetic-workflow.test.ts --reporter=verbose` on main was ~15.66s Vitest duration / ~16.23s shell wall; shard `1/2` was ~21.44s Vitest duration / ~25.10s shell wall.
- AFTER: targeted suite is ~13.50s Vitest duration / ~14.03s shell wall; shard `1/2` is ~15.76s Vitest duration / ~18.23s shell wall.
- Delta: targeted suite saves ~2.16s Vitest duration; shard `1/2` saves ~5.68s Vitest duration and ~6.87s wall locally.
- Goal met?: yes.
- Residual scan: the compact all-hook smoke is still dominated by real wrapper startup; broader subprocess/runtime reductions remain under parent #1532.

## Test Plan (Behaviors x Levels)

| Behavior | Level | Coverage |
|---|---:|---|
| Compact full-hook synthetic smoke still runs real shell wrappers | L2 | Tested by `npx vitest run src/e2e/synthetic-workflow.test.ts --reporter=verbose` |
| Shard 1 remains green after compaction | L3 | Tested by `npx vitest run --reporter=verbose --shard=1/2` |
| CI-shaped coverage shard remains green | L3 | Tested by `npx vitest run --coverage --reporter=default --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --shard=1/2` |
| Agent fast check remains usable | L2 | Tested by `npm run check:fast` |

## Verification

- `time npx vitest run src/e2e/synthetic-workflow.test.ts --reporter=verbose`
- `time npx vitest run --reporter=verbose --shard=1/2`
- `time npx vitest run --coverage --reporter=default --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --shard=1/2`
- `npm run check:fast`
- `git diff --check`
