### PR TITLE
test: use direct tsx subprocesses in hook tests

### DIFF
--- a/scripts/hook-gym-cli.test.ts
+++ b/scripts/hook-gym-cli.test.ts
@@ -13,21 +13,32 @@
 
 import { beforeAll, describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 
 const REPO_ROOT = resolve(__dirname, '..');
 const CLI = resolve(REPO_ROOT, 'scripts/hook-gym.ts');
-const TSX = resolve(
-  REPO_ROOT,
-  'node_modules',
-  '.bin',
-  process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
-);
+const TSX_CLI = findAncestorFile(__dirname, 'node_modules/tsx/dist/cli.mjs');
 
 type CliResult = { stdout: string; stderr: string; status: number };
 
+function findAncestorFile(startDir: string, relativePath: string): string {
+  let dir = startDir;
+
+  while (true) {
+    const candidate = join(dir, relativePath);
+    if (existsSync(candidate)) return candidate;
+
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Unable to find ${relativePath} from ${startDir}`);
+    }
+    dir = parent;
+  }
+}
+
 function runCli(args: string[]): CliResult {
-  const result = spawnSync(TSX, [CLI, ...args], {
+  const result = spawnSync(process.execPath, [TSX_CLI, CLI, ...args], {
     cwd: REPO_ROOT,
     encoding: 'utf-8',
     timeout: 30000,

--- a/src/hooks/pr-kaizen-clear-fallback.test.ts
+++ b/src/hooks/pr-kaizen-clear-fallback.test.ts
@@ -10,7 +10,7 @@
  *
  * Previously untested (kaizen #928 — fallback hook test desert).
  */
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -20,6 +20,7 @@ const HOOK_PATH = path.resolve(
   __dirname,
   'pr-kaizen-clear-fallback.ts',
 );
+const TSX_CLI = findAncestorFile(__dirname, 'node_modules/tsx/dist/cli.mjs');
 const HOOK_SOURCE = fs.readFileSync(HOOK_PATH, 'utf-8');
 
 let testStateDir: string;
@@ -28,6 +29,21 @@ let testAuditDir: string;
 const GATE_FILE = 'pr-kaizen-Garsson-io_kaizen_55';
 const PR_URL = 'https://github.com/Garsson-io/kaizen/pull/55';
 const BRANCH = 'test-branch';
+
+function findAncestorFile(startDir: string, relativePath: string): string {
+  let dir = startDir;
+
+  while (true) {
+    const candidate = path.join(dir, relativePath);
+    if (fs.existsSync(candidate)) return candidate;
+
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Unable to find ${relativePath} from ${startDir}`);
+    }
+    dir = parent;
+  }
+}
 
 beforeEach(() => {
   testStateDir = fs.mkdtempSync(
@@ -60,9 +76,9 @@ function gateStatus(filename = GATE_FILE): string | null {
 }
 
 function runFallback(input: object): void {
-  const json = JSON.stringify(input);
-  execSync(
-    `echo '${json.replace(/'/g, "'\\''")}' | npx tsx "${HOOK_PATH}"`,
+  const result = spawnSync(
+    process.execPath,
+    [TSX_CLI, HOOK_PATH],
     {
       encoding: 'utf-8',
       env: {
@@ -70,10 +86,12 @@ function runFallback(input: object): void {
         STATE_DIR: testStateDir,
         AUDIT_DIR: testAuditDir,
       },
-      stdio: ['pipe', 'pipe', 'pipe'],
+      input: JSON.stringify(input),
       timeout: 15000,
     },
   );
+
+  expect(result.status, result.stderr || result.stdout).toBe(0);
 }
 
 function bashInput(command: string, stdout: string): object {


### PR DESCRIPTION
Fixes #1562.

## Summary
- Replace the fallback hook test helper's `echo ... | npx tsx` shell pipeline with `spawnSync(process.execPath, [tsx cli, hook])` and stdin input.
- Resolve the nearest ancestor `node_modules/tsx/dist/cli.mjs` so nested local worktrees and normal CI checkouts both work.
- Apply the same resolver to `scripts/hook-gym-cli.test.ts`, which otherwise blocked coverage shard verification in the nested worktree.

## Impact
- `src/hooks/pr-kaizen-clear-fallback.test.ts` baseline: ~4.80s Vitest / ~5.38s wall.
- After: ~2.86-2.95s Vitest / ~3.40-3.52s wall.
- Removes shell quoting from JSON hook input while keeping real subprocess coverage of the hook entrypoint.

## Verification
- `time npx vitest run src/hooks/pr-kaizen-clear-fallback.test.ts --reporter=verbose`
- `time npx vitest run scripts/hook-gym-cli.test.ts --reporter=verbose`
- `npm run check:fast`
- `git diff --check`
- `time npx vitest run --coverage --reporter=default --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --shard=1/2`