### PR TITLE
test: stub gh side effects in outcome tests

### DIFF
--- a/src/hooks/pr-kaizen-clear-outcome.test.ts
+++ b/src/hooks/pr-kaizen-clear-outcome.test.ts
@@ -19,6 +19,9 @@ import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { processHookInput } from './pr-kaizen-clear.js';
 import type { RefStatus } from './lib/issue-ref-verifier.js';
+import type { HookInput } from './hook-io.js';
+
+type HookOptions = NonNullable<Parameters<typeof processHookInput>[1]>;
 
 function stateExists(stateDir: string): boolean {
   return fs
@@ -41,7 +44,26 @@ describe('processHookInput: outcome verification (kaizen #950)', () => {
     tool_name: 'Bash',
     tool_input: { command: `echo '${filed(ref)}'` },
     tool_response: { stdout: filed(ref), exit_code: 0 },
-  });
+  }) satisfies HookInput;
+
+  function processWithOutcomeOptions(
+    input: HookInput,
+    verifyRef: (ref: string) => RefStatus = () => 'exists',
+  ): string | null {
+    const options: HookOptions = {
+      stateDir,
+      verifyRef,
+      postComment: () => {},
+      getPrFiles: () => [],
+      gh: (args: string[]) => {
+        if (args.join(' ') === 'pr view 42 --repo Garsson-io/kaizen --json state --jq .state') {
+          return 'OPEN';
+        }
+        throw new Error(`unexpected gh call: ${args.join(' ')}`);
+      },
+    };
+    return processHookInput(input, options);
+  }
 
   beforeEach(() => {
     stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kz-outcome-'));
@@ -64,11 +86,7 @@ describe('processHookInput: outcome verification (kaizen #950)', () => {
 
   it('CASE 1: ref that exists → gate clears', () => {
     const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'exists');
-    const result = processHookInput(inputFor('#950'), {
-      stateDir,
-      verifyRef,
-      postComment: () => {},
-    });
+    const result = processWithOutcomeOptions(inputFor('#950'), verifyRef);
     expect(verifyRef).toHaveBeenCalledWith('#950');
     expect(result).toContain('PR kaizen gate cleared');
     expect(stateExists(stateDir)).toBe(false);
@@ -76,11 +94,7 @@ describe('processHookInput: outcome verification (kaizen #950)', () => {
 
   it('CASE 2: fabricated ref (missing) → gate stays, explains why', () => {
     const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'missing');
-    const result = processHookInput(inputFor('#99999'), {
-      stateDir,
-      verifyRef,
-      postComment: () => {},
-    });
+    const result = processWithOutcomeOptions(inputFor('#99999'), verifyRef);
     expect(result).toContain('Outcome verification failed');
     expect(result).toContain('#99999');
     // Gate must NOT have cleared.
@@ -92,24 +106,20 @@ describe('processHookInput: outcome verification (kaizen #950)', () => {
 
   it('CASE 3: unverifiable (infra/network) → fail open, gate clears', () => {
     const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'unverifiable');
-    const result = processHookInput(inputFor('#950'), {
-      stateDir,
-      verifyRef,
-      postComment: () => {},
-    });
+    const result = processWithOutcomeOptions(inputFor('#950'), verifyRef);
     expect(result).toContain('PR kaizen gate cleared');
     expect(stateExists(stateDir)).toBe(false);
   });
 
   it('CASE 4: no impediment trigger → state unchanged', () => {
     const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'missing');
-    const result = processHookInput(
+    const result = processWithOutcomeOptions(
       {
         tool_name: 'Bash',
         tool_input: { command: `echo "hello world"` },
         tool_response: { stdout: 'hello world', exit_code: 0 },
       },
-      { stateDir, verifyRef, postComment: () => {} },
+      verifyRef,
     );
     expect(result).toBeNull();
     expect(verifyRef).not.toHaveBeenCalled();
@@ -120,13 +130,13 @@ describe('processHookInput: outcome verification (kaizen #950)', () => {
     const verifyRef = vi.fn<(ref: string) => RefStatus>(() => 'missing');
     const cmd =
       'KAIZEN_IMPEDIMENTS: [{"type":"positive","impediment":"smooth run","disposition":"no-action","reason":"genuinely frictionless, well-scoped 30-line change"}]';
-    const result = processHookInput(
+    const result = processWithOutcomeOptions(
       {
         tool_name: 'Bash',
         tool_input: { command: `echo '${cmd}'` },
         tool_response: { stdout: cmd, exit_code: 0 },
       },
-      { stateDir, verifyRef, postComment: () => {} },
+      verifyRef,
     );
     expect(verifyRef).not.toHaveBeenCalled();
     expect(result).toContain('PR kaizen gate cleared');


### PR DESCRIPTION
Once upon a time, `pr-kaizen-clear-outcome.test.ts` was supposed to be a small proof of the outcome-verification contract: real refs clear, fabricated refs block, unverifiable refs fail open, and no-action findings do not require refs.

One day, #1564 showed that the suite was also paying for unrelated GitHub boundaries after the injected verifier had already decided the outcome. The test was asserting outcome behavior, but the harness still fell through to PR file lookup and auto-close metadata paths.

Because of that, this PR makes the suite inject all unrelated GitHub boundaries through one shared helper: `getPrFiles` is fixed to an empty file list, `postComment` is a no-op, and the `gh` runner only allows the cheap `pr view ... state` path needed for auto-close to return immediately as `OPEN`. Any other `gh` call now throws, so the test fails loudly if the categorical error comes back.

Because of that, all outcome cases keep their original verifier assertions while using the same no-real-`gh` harness. The touched area was DRY-swept so the side-effect contract is declared once instead of repeated case-by-case.

Until finally, the targeted suite passes in 499ms Vitest duration / 1.108s shell wall on this branch, and the full required fast checks plus coverage shard pass.

And ever since, this suite has a direct producer/consumer contract: outcome verification remains the SUT, and unrelated GitHub side effects are injected test boundaries rather than ambient work.

Fixes Garsson-io/kaizen#1564
Parent: #1532
Refs: #451

## Impact (goal -> before/after -> match)

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Keep outcome-verification coverage intact while preventing real unrelated `gh` work | Issue baseline: `time npx vitest run src/hooks/pr-kaizen-clear-outcome.test.ts --reporter=verbose` was ~3.59s Vitest / ~6.18s shell wall on main when filed | Branch run: 5/5 cases pass, 499ms Vitest / 1.108s shell wall | Suite remains behavior-complete and is below the recorded baseline | yes |
| Prevent PR file lookup / auto-close side effects from escaping the test harness | Before diff: each verifier case only injected `stateDir`, `verifyRef`, and `postComment`, leaving default PR file lookup and auto-close `gh` behavior reachable | After diff: shared helper injects `getPrFiles: () => []` and a strict `gh` stub that throws on unexpected calls | Any unrelated `gh` path now fails the test instead of silently adding latency | yes |
| DRY the touched contract | Before diff: options were repeated in individual cases | After diff: one `processWithOutcomeOptions` helper owns the outcome-test boundary | Producer/consumer test harness contract is centralized | yes |

- Acceptance signal: the same outcome cases pass, no real `gh` side effects are reachable from the suite, and required checks pass.
- Residual scan: searched open issues for `pr-kaizen-clear outcome gh latency side-effect`, `outcome verification pr-kaizen-clear`, and `gh latency hooks tests`. No additional scope-matched issue is fully addressed by this PR.

## Architecture

```text
pr-kaizen-clear-outcome.test.ts
  -> processWithOutcomeOptions(input, verifyRef)
       -> verifyRef injected per outcome case
       -> postComment no-op
       -> getPrFiles returns []
       -> gh stub returns OPEN only for PR state metadata
       -> any other gh call throws
  -> processHookInput(...)
       -> outcome verifier remains the behavior under test
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep this as a test-harness change only | #1564 asks to remove unrelated latency without changing production gate-clearing semantics | Production auto-close behavior is unchanged |
| Use one shared helper for outcome options | Makes the boundary contract explicit and prevents drift across cases | The helper has to allow the one auto-close metadata call as `OPEN` |
| Throw on unexpected `gh` calls | Proves the suite cannot silently reach real GitHub paths | Future legitimate metadata calls must be consciously added to the helper |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/pr-kaizen-clear-outcome.test.ts` | Centralizes injected hook options for the outcome-verification suite and blocks unrelated GitHub side effects |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Status | Evidence |
|---|---|---|---|
| Existing ref clears the gate | Unit | Tested | `pr-kaizen-clear-outcome.test.ts` CASE 1 |
| Missing/fabricated ref blocks clearing and audits the rejection | Unit | Tested | `pr-kaizen-clear-outcome.test.ts` CASE 2 |
| Unverifiable ref fails open and clears | Unit | Tested | `pr-kaizen-clear-outcome.test.ts` CASE 3 |
| No trigger leaves state unchanged and does not verify refs | Unit | Tested | `pr-kaizen-clear-outcome.test.ts` CASE 4 |
| No-action disposition does not require ref verification | Unit | Tested | `pr-kaizen-clear-outcome.test.ts` no-action case |
| Outcome suite does not reach unrelated real `gh` paths | Unit harness contract | Tested | strict injected `gh` stub throws on unexpected calls; `getPrFiles` returns `[]` |
| Fast local checks remain green | Local gate | Tested | `npm run check:fast` |
| Coverage shard remains green | Coverage gate | Tested | `npx vitest run --coverage --reporter=default --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --shard=1/2` |

## Validation

- [x] `time npx vitest run src/hooks/pr-kaizen-clear-outcome.test.ts --reporter=verbose` — 5 tests passed; Duration 499ms; shell wall 1.108s.
- [x] `npm run check:fast` — typecheck passed; changed Vitest suite passed.
- [x] `git diff --check`
- [x] `time npx vitest run --coverage --reporter=default --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --shard=1/2` — 83 files passed, 1846 tests passed, 3 skipped; shell wall 21.871s.
- [x] Current-main timing sample on this machine: 5 tests passed; Duration 498ms; shell wall 1.126s. This means the historical latency baseline is environment-dependent today, so the durable proof is the strict no-unexpected-`gh` contract.

## Known Limitations

- This PR does not optimize production `pr-kaizen-clear` auto-close behavior. It only removes unrelated GitHub work from the outcome-verification test harness, matching #1564 scope.
