### PR TITLE
test: scope plugin lifecycle hook setup

### DIFF
--- a/src/e2e/plugin-lifecycle.test.ts
+++ b/src/e2e/plugin-lifecycle.test.ts
@@ -52,8 +52,8 @@ const PLUGIN_JSON_PATH = join(KAIZEN_ROOT, ".claude-plugin", "plugin.json");
 // ── Shared Test State ──
 
 let hostProject: string;
-let mockDir: MockDir;
-let stateDir: StateDir;
+let mockDir: MockDir | undefined;
+let stateDir: StateDir | undefined;
 
 // Parse plugin.json for hook registration verification
 const pluginJson = JSON.parse(readFileSync(PLUGIN_JSON_PATH, "utf-8"));
@@ -64,7 +64,10 @@ function hookPath(name: string): string {
   return join(HOOKS_DIR, name);
 }
 
-function hookEnv(opts?: { branch?: string; isWorktree?: boolean }): Record<string, string> {
+function hookEnv(): Record<string, string> {
+  if (!mockDir || !stateDir) {
+    throw new Error("hookEnv requires workflow hook test setup");
+  }
   return {
     STATE_DIR: stateDir.path,
     AUDIT_DIR: join(stateDir.path, "audit"),
@@ -94,18 +97,6 @@ beforeAll(() => {
 
 afterAll(() => {
   rmSync(hostProject, { recursive: true, force: true });
-});
-
-beforeEach(() => {
-  mockDir = createMockDir();
-  addGitMock(mockDir, { branch: "wt/test-branch", isWorktree: true });
-  addGhMock(mockDir);
-  stateDir = createStateDir();
-});
-
-afterEach(() => {
-  mockDir?.cleanup();
-  stateDir?.cleanup();
 });
 
 // ════════════════════════════════════════════════════════════════════
@@ -276,6 +267,20 @@ describe("Part 4: Dev workflow simulation through hooks", () => {
   // through individual hooks. This is the trigger-to-outcome test:
   // given a sequence of Claude Code events, do hooks produce the
   // correct enforcement decisions?
+
+  beforeEach(() => {
+    mockDir = createMockDir();
+    addGitMock(mockDir, { branch: "wt/test-branch", isWorktree: true });
+    addGhMock(mockDir);
+    stateDir = createStateDir();
+  });
+
+  afterEach(() => {
+    mockDir?.cleanup();
+    stateDir?.cleanup();
+    mockDir = undefined;
+    stateDir = undefined;
+  });
 
   describe("4a: Write enforcement (enforce-worktree-writes)", () => {
     it("blocks source code writes in main checkout on main branch", () => {


### PR DESCRIPTION
Once upon a time, `plugin-lifecycle.test.ts` was the broad trigger-to-outcome proof for the kaizen plugin: setup, hook inventory, skill inventory, and a real shell-hook workflow simulation all lived in one file.

One day, while continuing the #1532 runtime sweep, the targeted suite still took 17.64s Vitest / 21.754s wall. Code reading showed a simple category error: every structural test paid `createMockDir`, git/gh mock setup, and state-dir setup even though only the Part 4 workflow simulation calls shell hooks.

Because of that, this PR moves hook-runner setup/cleanup into the Part 4 workflow block. The structural setup/config, hook inventory, and skill inventory sections now run without workflow-only mocks, while Part 4 still executes real shell wrappers with isolated state per test.

Because of that, `runKaizenHook()` remains guarded by `hookEnv()`: if a future structural test accidentally reaches for hook execution without setup, it fails clearly instead of inheriting hidden global state.

Until finally, the targeted suite keeps the same pass/skip count and drops to 10.54s Vitest / 11.313s wall locally.

Fixes Garsson-io/kaizen#1568
Parent: #1532

## Impact (goal -> before/after -> match)

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Remove workflow-only hook setup from structural plugin lifecycle tests | `time npx vitest run src/e2e/plugin-lifecycle.test.ts --reporter=verbose` on main: 104 passed, 2 skipped, 17.64s Vitest / 21.754s wall | Same command on this branch: 104 passed, 2 skipped, 10.54s Vitest / 11.313s wall | -7.10s Vitest duration and -10.441s shell wall; structural tests now run in 0-7ms instead of paying mock setup | yes |
| Preserve real shell-wrapper lifecycle coverage | Part 4 used `runHook()`/`runKaizenHook()` with global setup | Part 4 owns `beforeEach`/`afterEach` setup and still calls the same hook subprocess runner | Workflow assertions still execute real hooks with isolated git/gh mocks and state | yes |
| Avoid new runner surface | Existing helpers were globally initialized | Existing helpers are reused with narrower ownership; `hookEnv()` now guards setup | No parallel runner abstraction added | yes |

- Residual scan: searched open/closed issues for `plugin-lifecycle test slow subprocess`; no duplicate scope-matched issue exists. Open #962 is a different hook/session failure-capture problem.

## Architecture

```text
plugin-lifecycle.test.ts
  Part 1-3 structural tests
    -> read config/plugin/skill files directly
    -> no mockDir/stateDir setup

  Part 4 workflow simulation
    beforeEach -> createMockDir + git/gh mocks + createStateDir
    runKaizenHook -> hookEnv guard -> runHook(real shell wrapper)
    afterEach -> cleanup + clear globals
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Scope setup to Part 4 | Only workflow tests need hook subprocess state and mock commands | Part 4 now owns the lifecycle setup explicitly |
| Keep structural tests granular | Preserves specific failure names for missing hooks/skills | Leaves many tiny tests, but they are now cheap |
| Guard `hookEnv()` | Prevents hidden setup coupling from returning | Misplaced future hook tests fail fast and need to live in the workflow block or create their own setup |

## What's In This PR

| File | Purpose |
|---|---|
| `src/e2e/plugin-lifecycle.test.ts` | Moves hook mock/state setup from file-global hooks into Part 4 workflow simulation and guards hook env access |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Status | Evidence |
|---|---|---|---|
| Structural setup/config checks avoid hook-runner setup | Unit | Tested | Part 1 tests pass in 1-7ms without file-global setup |
| Hook and skill inventory checks remain granular | Unit | Tested | Part 2/3 tests retain per-hook/per-skill names and pass |
| Workflow simulation still executes shell hooks with isolated state | System | Tested | Part 4 tests pass through `runHook()`/`runKaizenHook()` |
| Targeted suite is materially faster with same pass/skip count | System | Tested | targeted timing command: 104 passed, 2 skipped, 10.54s / 11.313s |
| Fast and coverage gates remain green | System | Tested | `npm run check:fast`; coverage shard 1/2 |

## Validation

- [x] `time npx vitest run src/e2e/plugin-lifecycle.test.ts --reporter=verbose` — 104 passed, 2 skipped; 10.54s Vitest / 11.313s wall.
- [x] `npm run check:fast` — typecheck passed; changed non-E2E test lane had no files and exited 0.
- [x] `git diff --check`
- [x] `time npx vitest run --coverage --reporter=default --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --shard=1/2` — 83 files passed, 1846 tests passed, 3 skipped; 20.464s wall.

## Known Limitations

- Coverage mode is still dominated by real Part 4 workflow subprocesses plus `synthetic-workflow.test.ts`; this PR intentionally preserves that system coverage instead of replacing it with direct TypeScript calls.
