### PR TITLE
test: prefer bun for TypeScript subprocess runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      # Shard 1 contains cold-start-bound TypeScript subprocess tests. Their
+      # helper uses Bun when available and falls back to Node+tsx otherwise.
+      - uses: oven-sh/setup-bun@v2
+        if: ${{ matrix.shard == 1 }}
       - run: npm ci
       - run: npm run build
       - name: Run coverage shard

--- a/scripts/hook-gym-cli.test.ts
+++ b/scripts/hook-gym-cli.test.ts
@@ -13,32 +13,17 @@
 
 import { beforeAll, describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { resolve } from 'node:path';
+import { buildTypeScriptSubprocess } from './test-typescript-runner.js';
 
 const REPO_ROOT = resolve(__dirname, '..');
 const CLI = resolve(REPO_ROOT, 'scripts/hook-gym.ts');
-const TSX_CLI = findAncestorFile(__dirname, 'node_modules/tsx/dist/cli.mjs');
+const CLI_RUNNER = buildTypeScriptSubprocess(CLI, { startDir: __dirname });
 
 type CliResult = { stdout: string; stderr: string; status: number };
 
-function findAncestorFile(startDir: string, relativePath: string): string {
-  let dir = startDir;
-
-  while (true) {
-    const candidate = join(dir, relativePath);
-    if (existsSync(candidate)) return candidate;
-
-    const parent = dirname(dir);
-    if (parent === dir) {
-      throw new Error(`Unable to find ${relativePath} from ${startDir}`);
-    }
-    dir = parent;
-  }
-}
-
 function runCli(args: string[]): CliResult {
-  const result = spawnSync(process.execPath, [TSX_CLI, CLI, ...args], {
+  const result = spawnSync(CLI_RUNNER.command, [...CLI_RUNNER.args, ...args], {
     cwd: REPO_ROOT,
     encoding: 'utf-8',
     timeout: 30000,

--- a/scripts/test-typescript-runner.test.ts
+++ b/scripts/test-typescript-runner.test.ts
@@ -1,0 +1,99 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildTypeScriptSubprocess,
+  findAncestorFile,
+  findBunExecutable,
+  findExecutableOnPath,
+} from './test-typescript-runner.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kz-ts-runner-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('test TypeScript subprocess runner', () => {
+  it('finds executable files on PATH', () => {
+    const root = makeTempDir();
+    const binDir = join(root, 'bin');
+    mkdirSync(binDir);
+    const bun = join(binDir, 'bun');
+    writeFileSync(bun, '#!/usr/bin/env sh\n');
+    chmodSync(bun, 0o755);
+
+    expect(findExecutableOnPath('bun', binDir)).toBe(bun);
+  });
+
+  it('finds ancestor files from nested worktrees', () => {
+    const root = makeTempDir();
+    const nested = join(root, 'a', 'b', 'c');
+    const tsx = join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+    mkdirSync(nested, { recursive: true });
+    mkdirSync(join(root, 'node_modules', 'tsx', 'dist'), { recursive: true });
+    writeFileSync(tsx, '');
+
+    expect(findAncestorFile(nested, 'node_modules/tsx/dist/cli.mjs')).toBe(tsx);
+  });
+
+  it('prefers Bun when available', () => {
+    const root = makeTempDir();
+    const binDir = join(root, 'bin');
+    mkdirSync(binDir);
+    const bun = join(binDir, 'bun');
+    writeFileSync(bun, '#!/usr/bin/env sh\n');
+    chmodSync(bun, 0o755);
+
+    expect(
+      buildTypeScriptSubprocess('/repo/script.ts', {
+        env: { PATH: binDir },
+        startDir: root,
+      }),
+    ).toEqual({
+      command: bun,
+      args: ['/repo/script.ts'],
+      runtime: 'bun',
+    });
+  });
+
+  it('finds Bun from HOME when PATH has not been refreshed', () => {
+    const root = makeTempDir();
+    const bunDir = join(root, '.bun', 'bin');
+    mkdirSync(bunDir, { recursive: true });
+    const bun = join(bunDir, 'bun');
+    writeFileSync(bun, '#!/usr/bin/env sh\n');
+    chmodSync(bun, 0o755);
+
+    expect(findBunExecutable({ PATH: '', HOME: root })).toBe(bun);
+  });
+
+  it('falls back to Node plus repo-local tsx when Bun is unavailable', () => {
+    const root = makeTempDir();
+    const nested = join(root, 'scripts');
+    const tsx = join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+    mkdirSync(nested, { recursive: true });
+    mkdirSync(join(root, 'node_modules', 'tsx', 'dist'), { recursive: true });
+    writeFileSync(tsx, '');
+
+    expect(
+      buildTypeScriptSubprocess('/repo/script.ts', {
+        env: { PATH: '' },
+        startDir: nested,
+      }),
+    ).toEqual({
+      command: process.execPath,
+      args: [tsx, '/repo/script.ts'],
+      runtime: 'tsx',
+    });
+  });
+});

--- a/scripts/test-typescript-runner.ts
+++ b/scripts/test-typescript-runner.ts
@@ -1,0 +1,83 @@
+import { accessSync, constants, existsSync } from 'node:fs';
+import { delimiter, dirname, join } from 'node:path';
+
+export interface TypeScriptSubprocess {
+  command: string;
+  args: string[];
+  runtime: 'bun' | 'tsx';
+}
+
+export interface TypeScriptSubprocessOptions {
+  env?: NodeJS.ProcessEnv;
+  startDir?: string;
+}
+
+export function findAncestorFile(startDir: string, relativePath: string): string {
+  let dir = startDir;
+
+  while (true) {
+    const candidate = join(dir, relativePath);
+    if (existsSync(candidate)) return candidate;
+
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Unable to find ${relativePath} from ${startDir}`);
+    }
+    dir = parent;
+  }
+}
+
+export function findExecutableOnPath(
+  name: string,
+  pathValue: string | undefined,
+): string | null {
+  for (const dir of (pathValue ?? '').split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {}
+  }
+  return null;
+}
+
+function executableFile(path: string | undefined): string | null {
+  if (!path) return null;
+  try {
+    accessSync(path, constants.X_OK);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function findBunExecutable(env: NodeJS.ProcessEnv = process.env): string | null {
+  const bunName = process.platform === 'win32' ? 'bun.exe' : 'bun';
+  return (
+    findExecutableOnPath(bunName, env.PATH) ??
+    executableFile(env.BUN_INSTALL ? join(env.BUN_INSTALL, 'bin', bunName) : undefined) ??
+    executableFile(env.HOME ? join(env.HOME, '.bun', 'bin', bunName) : undefined)
+  );
+}
+
+export function buildTypeScriptSubprocess(
+  scriptPath: string,
+  options: TypeScriptSubprocessOptions = {},
+): TypeScriptSubprocess {
+  const env = options.env ?? process.env;
+  const bun = findBunExecutable(env);
+  if (bun) {
+    return { command: bun, args: [scriptPath], runtime: 'bun' };
+  }
+
+  const tsxCli = findAncestorFile(
+    options.startDir ?? process.cwd(),
+    'node_modules/tsx/dist/cli.mjs',
+  );
+  return {
+    command: process.execPath,
+    args: [tsxCli, scriptPath],
+    runtime: 'tsx',
+  };
+}

--- a/src/hooks/pr-kaizen-clear-fallback.test.ts
+++ b/src/hooks/pr-kaizen-clear-fallback.test.ts
@@ -15,12 +15,15 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildTypeScriptSubprocess } from '../../scripts/test-typescript-runner.js';
 
 const HOOK_PATH = path.resolve(
   __dirname,
   'pr-kaizen-clear-fallback.ts',
 );
-const TSX_CLI = findAncestorFile(__dirname, 'node_modules/tsx/dist/cli.mjs');
+const HOOK_RUNNER = buildTypeScriptSubprocess(HOOK_PATH, {
+  startDir: __dirname,
+});
 const HOOK_SOURCE = fs.readFileSync(HOOK_PATH, 'utf-8');
 
 let testStateDir: string;
@@ -29,21 +32,6 @@ let testAuditDir: string;
 const GATE_FILE = 'pr-kaizen-Garsson-io_kaizen_55';
 const PR_URL = 'https://github.com/Garsson-io/kaizen/pull/55';
 const BRANCH = 'test-branch';
-
-function findAncestorFile(startDir: string, relativePath: string): string {
-  let dir = startDir;
-
-  while (true) {
-    const candidate = path.join(dir, relativePath);
-    if (fs.existsSync(candidate)) return candidate;
-
-    const parent = path.dirname(dir);
-    if (parent === dir) {
-      throw new Error(`Unable to find ${relativePath} from ${startDir}`);
-    }
-    dir = parent;
-  }
-}
 
 beforeEach(() => {
   testStateDir = fs.mkdtempSync(
@@ -77,8 +65,8 @@ function gateStatus(filename = GATE_FILE): string | null {
 
 function runFallback(input: object): void {
   const result = spawnSync(
-    process.execPath,
-    [TSX_CLI, HOOK_PATH],
+    HOOK_RUNNER.command,
+    HOOK_RUNNER.args,
     {
       encoding: 'utf-8',
       env: {


### PR DESCRIPTION
Fixes #1567.

## Summary
- Add a test-only TypeScript subprocess runner that prefers Bun when available and falls back to Node+repo-local `tsx`.
- Update `scripts/hook-gym-cli.test.ts` and `src/hooks/pr-kaizen-clear-fallback.test.ts` to use the shared runner instead of local `tsx` resolution.
- Install Bun only on CI coverage shard 1, where these cold-start-bound subprocess suites run.

## Impact
Direct cold-start measurements on current main:
- `node node_modules/tsx/dist/cli.mjs scripts/hook-gym.ts --help`: ~0.39s wall.
- `bun scripts/hook-gym.ts --help`: ~0.08s wall.
- `node node_modules/tsx/dist/cli.mjs scripts/hook-gym.ts --run no-such-scenario`: ~0.38s wall.
- `bun scripts/hook-gym.ts --run no-such-scenario`: ~0.08s wall.

Targeted suite measurements with Bun available:
- Main baseline for `scripts/hook-gym-cli.test.ts src/hooks/pr-kaizen-clear-fallback.test.ts`: ~3.21s Vitest / ~3.86s wall.
- After: ~1.07s Vitest / ~1.68s wall.

## Compatibility
- The helper falls back to Node+`tsx` when Bun is unavailable.
- Unit tests cover PATH Bun, HOME Bun, ancestor `tsx`, and fallback behavior.
- Subprocess coverage remains real: the tests still execute the actual TypeScript CLI/hook entrypoints.

## Verification
- `time npx vitest run scripts/test-typescript-runner.test.ts --reporter=verbose`
- `time npx vitest run scripts/hook-gym-cli.test.ts src/hooks/pr-kaizen-clear-fallback.test.ts --reporter=default`
- `npm run check:fast`
- `git diff --check`
- `time npx vitest run --coverage --reporter=default --coverage.reporter=json --coverage.thresholds.lines=0 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --shard=1/2`