### PR TITLE
test(e2e): add shared live skill-chain runner

### DIFF
--- a/scripts/kaizen-workflow-driver.test.ts
+++ b/scripts/kaizen-workflow-driver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { resolve } from 'node:path';
 
+import { resolveTsxBin } from '../src/e2e/test-runtime.js';
 import {
   FULL_KAIZEN_GATE_LABELS,
   buildManualGoalDirective,
@@ -12,11 +13,11 @@ import {
   renderAutoDentGoalContract,
 } from './kaizen-workflow-driver.js';
 
-const TSX_CLI = resolve('node_modules/tsx/dist/cli.mjs');
+const TSX_BIN = resolveTsxBin() ?? 'tsx';
 const WORKFLOW_DRIVER = 'scripts/kaizen-workflow-driver.ts';
 
 function runWorkflowDriver(args: string[], options: { cwd?: string; script?: string } = {}): SpawnSyncReturns<string> {
-  return spawnSync(process.execPath, [TSX_CLI, options.script ?? WORKFLOW_DRIVER, ...args], {
+  return spawnSync(TSX_BIN, [options.script ?? WORKFLOW_DRIVER, ...args], {
     cwd: options.cwd,
     encoding: 'utf8',
   });

--- a/src/e2e/issue-routing.test.ts
+++ b/src/e2e/issue-routing.test.ts
@@ -15,46 +15,13 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
+import { runLiveAgent } from "./live-agent.js";
 import { SyntheticProject } from "./synthetic-project.js";
 
-const KAIZEN_ROOT = resolve(__dirname, "../..");
 const isLive = process.env.KAIZEN_LIVE_TEST === "1";
 
 const KAIZEN_REPO = "Garsson-io/kaizen";
 const HOST_FIXTURE_REPO = "Garsson-io/kaizen-test-fixture";
-
-function claude(
-  prompt: string,
-  opts: { cwd: string; maxTurns?: number; maxBudget?: number; timeout?: number },
-): { result: string; is_error: boolean; num_turns: number; total_cost_usd: number } {
-  const args = [
-    "claude", "-p",
-    "--output-format", "json",
-    "--model", "haiku",
-    "--dangerously-skip-permissions",
-    "--max-turns", String(opts.maxTurns ?? 8),
-    "--max-budget-usd", String(opts.maxBudget ?? 0.50),
-    "--plugin-dir", KAIZEN_ROOT,
-    prompt,
-  ];
-
-  const proc = spawnSync(args[0], args.slice(1), {
-    encoding: "utf-8",
-    cwd: opts.cwd,
-    timeout: opts.timeout ?? 120000,
-    env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: "cli" },
-  });
-
-  if (proc.error) throw new Error(`claude failed: ${proc.error.message}`);
-
-  try {
-    return JSON.parse(proc.stdout.trim());
-  } catch {
-    throw new Error(
-      `claude output not JSON:\nstdout: ${proc.stdout?.slice(0, 500)}\nstderr: ${proc.stderr?.slice(0, 500)}`,
-    );
-  }
-}
 
 describe("Issue Routing E2E — skill queries host repo in synthetic project", () => {
   if (!isLive) {
@@ -90,20 +57,28 @@ describe("Issue Routing E2E — skill queries host repo in synthetic project", (
   it(
     "kaizen-pick step 1 queries the host repo, not the kaizen repo",
     { timeout: 180000 },
-    () => {
+    async () => {
       // This is the real test: invoke the actual skill and check which
       // repo the agent queries. We tell it to run /kaizen-pick step 1
       // which reads kaizen.config.json and lists open issues.
-      const result = claude(
+      const result = await runLiveAgent(
         [
           "Run /kaizen-pick. Only do step 1 (gather the landscape).",
           "After listing issues, STOP. Do not continue to step 2.",
           "Show which repo you queried for issues.",
         ].join(" "),
-        { cwd: project.projectRoot, maxTurns: 15, maxBudget: 1.00, timeout: 180000 },
+        {
+          cwd: project.projectRoot,
+          maxTurns: 15,
+          maxBudgetUsd: 1.00,
+          timeoutMs: 180000,
+          artifactName: "issue-routing-kaizen-pick",
+          resultsDir: resolve(project.projectRoot, ".kaizen-live-agent-results"),
+          expectedSignals: [HOST_FIXTURE_REPO],
+        },
       );
 
-      const text = result.result ?? "";
+      const text = result.text;
       console.log("--- kaizen-pick output ---");
       console.log(text.slice(0, 1200));
       console.log("--- end ---");

--- a/src/e2e/live-agent.test.ts
+++ b/src/e2e/live-agent.test.ts
@@ -1,0 +1,173 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it, afterEach } from "vitest";
+
+import {
+  buildLiveAgentArgs,
+  runLiveAgent,
+} from "./live-agent.js";
+import type { SpawnClaudeJsonFn, SpawnClaudeJsonResult } from "../spawn-claude.js";
+
+function spawnResult(overrides: Partial<SpawnClaudeJsonResult> = {}): SpawnClaudeJsonResult {
+  return {
+    text: "ok",
+    costUsd: 0.01,
+    durationMs: 5,
+    exitCode: 0,
+    signal: null,
+    rawStdout: JSON.stringify({
+      result: "ok",
+      is_error: false,
+      total_cost_usd: 0.01,
+      num_turns: 1,
+    }),
+    rawStderr: "",
+    args: ["-p", "--plugin-dir", "/repo/kaizen"],
+    numTurns: 1,
+    ...overrides,
+  };
+}
+
+function successfulSpawn(result: Partial<SpawnClaudeJsonResult> = {}): SpawnClaudeJsonFn {
+  return async () => spawnResult(result);
+}
+
+describe("live-agent E2E runner contract", () => {
+  const tmpRoots: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpRoots.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function resultsDir(name: string): string {
+    const dir = join(tmpdir(), `kaizen-live-agent-${name}-${Date.now()}`);
+    tmpRoots.push(dir);
+    return dir;
+  }
+
+  it("builds claude -p argv with explicit local plugin source by default", () => {
+    const args = buildLiveAgentArgs({
+      prompt: "Run /kaizen-zen",
+      pluginDir: "/repo/kaizen",
+      model: "haiku",
+      maxTurns: 4,
+      maxBudgetUsd: 0.12,
+    });
+
+    expect(args).toEqual([
+      "-p",
+      "--output-format", "json",
+      "--dangerously-skip-permissions",
+      "--model", "haiku",
+      "--max-turns", "4",
+      "--max-budget-usd", "0.12",
+      "--plugin-dir", "/repo/kaizen",
+      "Run /kaizen-zen",
+    ]);
+  });
+
+  it("can explicitly run without --plugin-dir for installed-plugin tests", () => {
+    const args = buildLiveAgentArgs({
+      prompt: "Run /kaizen-zen",
+      pluginDir: null,
+    });
+
+    expect(args).not.toContain("--plugin-dir");
+    expect(args).toContain("json");
+    expect(args.at(-1)).toBe("Run /kaizen-zen");
+  });
+
+  it("persists a raw checkpoint before rejecting empty parsed output", async () => {
+    const dir = resultsDir("invalid-json");
+
+    await expect(
+      runLiveAgent("Run /kaizen-zen", {
+        resultsDir: dir,
+        artifactName: "invalid-json",
+        spawn: successfulSpawn({ text: "", rawStdout: "not json" }),
+      }),
+    ).rejects.toThrow(/raw output: .*invalid-json\.json/);
+
+    const rawPath = join(dir, "invalid-json.json");
+    expect(existsSync(rawPath)).toBe(true);
+    const checkpoint = JSON.parse(readFileSync(rawPath, "utf8"));
+    expect(checkpoint.stdout).toBe("not json");
+    expect(checkpoint.command).toBe("claude -p");
+  });
+
+  it.each([
+    ["spawn error", { error: new Error("ENOENT"), text: "" }],
+    ["nonzero exit", { text: "x", rawStderr: "bad", exitCode: 2 }],
+    ["empty result", { text: "", rawStdout: "", exitCode: 0 }],
+  ])("fails closed on %s", async (_name, result) => {
+    await expect(
+      runLiveAgent("Run /kaizen-zen", {
+        resultsDir: resultsDir(_name.replace(/\s+/g, "-")),
+        spawn: successfulSpawn(result),
+      }),
+    ).rejects.toThrow(/raw output:/);
+  });
+
+  it("fails when expected behavioral signals are missing", async () => {
+    await expect(
+      runLiveAgent("Run /kaizen-zen", {
+        resultsDir: resultsDir("missing-signal"),
+        expectedSignals: [
+          { name: "zen output", pattern: /Zen of Kaizen/ },
+        ],
+        spawn: successfulSpawn({ text: "plain output" }),
+      }),
+    ).rejects.toThrow(/missing expected signal.*zen output/);
+  });
+
+  it("returns parsed output, matched signals, and checkpoint metadata on success", async () => {
+    const dir = resultsDir("success");
+    const result = await runLiveAgent("Run /kaizen-zen", {
+      resultsDir: dir,
+      artifactName: "success",
+      expectedSignals: [
+        "kaizen",
+        { name: "zen", pattern: /Zen/i },
+      ],
+      spawn: successfulSpawn({
+        text: "The Zen of Kaizen",
+        rawStdout: JSON.stringify({
+          result: "The Zen of Kaizen",
+          is_error: false,
+          total_cost_usd: 0.01,
+          num_turns: 1,
+        }),
+      }),
+    });
+
+    expect(result.text).toBe("The Zen of Kaizen");
+    expect(result.matchedSignals).toEqual(["kaizen", "zen"]);
+    expect(result.rawPath).toBe(join(dir, "success.json"));
+    expect(existsSync(result.rawPath)).toBe(true);
+    const checkpoint = JSON.parse(readFileSync(result.rawPath, "utf8"));
+    expect(checkpoint.costUsd).toBe(0.01);
+    expect(checkpoint.durationMs).toEqual(expect.any(Number));
+  });
+
+  it("keeps skill-change live tests on the shared runner", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/e2e/skill-change.test.ts"), "utf8");
+    expect(source).toContain("runLiveAgent");
+    expect(source).not.toContain("node:child_process");
+    expect(source).not.toContain("spawnSync(");
+    expect(source).not.toContain("JSON.parse(proc.stdout");
+  });
+
+  it("keeps issue-routing and setup live agent calls out of local claude wrappers", () => {
+    const issueRouting = readFileSync(resolve(process.cwd(), "src/e2e/issue-routing.test.ts"), "utf8");
+    const setupLive = readFileSync(resolve(process.cwd(), "src/e2e/setup-live.test.ts"), "utf8");
+
+    expect(issueRouting).toContain("runLiveAgent");
+    expect(issueRouting).not.toContain("function claude(");
+    expect(issueRouting).not.toContain("JSON.parse(proc.stdout");
+
+    expect(setupLive).toContain("runInstalledPluginAgent");
+    expect(setupLive).toContain("runLiveAgent");
+    expect(setupLive).not.toContain("JSON.parse(proc.stdout");
+  });
+});

--- a/src/e2e/live-agent.ts
+++ b/src/e2e/live-agent.ts
@@ -1,0 +1,171 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import {
+  buildSpawnClaudeArgs,
+  spawnClaudeJson,
+  type SpawnClaudeJsonFn,
+  type SpawnClaudeJsonResult,
+} from "../spawn-claude.js";
+import { KAIZEN_ROOT } from "./test-runtime.js";
+
+const RAW_PREVIEW_CHARS = 300;
+
+export type ExpectedSignal = string | RegExp | {
+  name: string;
+  pattern: string | RegExp;
+};
+
+export interface LiveAgentOptions {
+  cwd?: string;
+  model?: string;
+  maxTurns?: number;
+  maxBudgetUsd?: number;
+  timeoutMs?: number;
+  /**
+   * Local plugin dir by default. Use null only for tests that explicitly verify
+   * installed-plugin behavior.
+   */
+  pluginDir?: string | null;
+  artifactName?: string;
+  resultsDir?: string;
+  expectedSignals?: ExpectedSignal[];
+  spawn?: SpawnClaudeJsonFn;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface LiveAgentRunResult {
+  text: string;
+  rawPath: string;
+  rawStdout: string;
+  rawStderr: string;
+  exitCode: number | null | undefined;
+  signal: NodeJS.Signals | null | undefined;
+  durationMs: number;
+  costUsd: number | null;
+  numTurns: number | null;
+  matchedSignals: string[];
+  args: string[];
+}
+
+export function buildLiveAgentArgs(opts: LiveAgentOptions & { prompt?: string } = {}): string[] {
+  return buildSpawnClaudeArgs({
+    outputFormat: "json",
+    verbose: false,
+    model: opts.model ?? "haiku",
+    maxTurns: opts.maxTurns ?? 5,
+    maxBudgetUsd: opts.maxBudgetUsd ?? 0.50,
+    pluginDir: opts.pluginDir === undefined ? KAIZEN_ROOT : opts.pluginDir,
+    promptArg: opts.prompt,
+  });
+}
+
+function sanitizeArtifactName(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "live-agent-run";
+}
+
+function preview(rawStdout: string, rawStderr: string): string {
+  return (rawStdout || rawStderr).slice(0, RAW_PREVIEW_CHARS);
+}
+
+function defaultResultsDir(): string {
+  return resolve(KAIZEN_ROOT, ".claude", "e2e-results", "live-agent");
+}
+
+function signalName(signal: ExpectedSignal): string {
+  if (typeof signal === "string") return signal;
+  if (signal instanceof RegExp) return signal.toString();
+  return signal.name;
+}
+
+function signalMatches(text: string, signal: ExpectedSignal): boolean {
+  if (typeof signal === "string") {
+    return text.toLowerCase().includes(signal.toLowerCase());
+  }
+  if (signal instanceof RegExp) return signal.test(text);
+  if (typeof signal.pattern === "string") {
+    return text.toLowerCase().includes(signal.pattern.toLowerCase());
+  }
+  return signal.pattern.test(text);
+}
+
+function persistCheckpoint(
+  result: SpawnClaudeJsonResult,
+  prompt: string,
+  opts: LiveAgentOptions,
+): string {
+  const rawDir = opts.resultsDir ?? defaultResultsDir();
+  mkdirSync(rawDir, { recursive: true });
+  const base = sanitizeArtifactName(opts.artifactName ?? `live-agent-${Date.now()}`);
+  const rawPath = join(rawDir, `${base}.json`);
+
+  writeFileSync(
+    rawPath,
+    JSON.stringify({
+      command: "claude -p",
+      args: result.args,
+      cwd: opts.cwd ?? KAIZEN_ROOT,
+      prompt,
+      model: opts.model ?? "haiku",
+      durationMs: result.durationMs,
+      costUsd: result.costUsd,
+      exitCode: result.exitCode,
+      signal: result.signal,
+      stdout: result.rawStdout,
+      stderr: result.rawStderr,
+    }, null, 2),
+    "utf8",
+  );
+
+  return rawPath;
+}
+
+export async function runLiveAgent(prompt: string, opts: LiveAgentOptions = {}): Promise<LiveAgentRunResult> {
+  const cwd = opts.cwd ?? KAIZEN_ROOT;
+  const spawn = opts.spawn ?? spawnClaudeJson;
+  const result = await spawn(prompt, {
+    cwd,
+    timeoutMs: opts.timeoutMs ?? 120_000,
+    model: opts.model ?? "haiku",
+    maxTurns: opts.maxTurns ?? 5,
+    maxBudgetUsd: opts.maxBudgetUsd ?? 0.50,
+    pluginDir: opts.pluginDir === undefined ? KAIZEN_ROOT : opts.pluginDir,
+    env: { ...opts.env, CLAUDE_CODE_ENTRYPOINT: "cli" },
+  });
+  const rawPath = persistCheckpoint(result, prompt, { ...opts, cwd });
+
+  if (result.error) {
+    throw new Error(`claude spawn error: ${result.error.message}; raw output: ${rawPath}\n${preview(result.rawStdout, result.rawStderr)}`);
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(`claude exited ${result.exitCode}; raw output: ${rawPath}\n${preview(result.rawStdout, result.rawStderr)}`);
+  }
+  if (!result.text.trim()) {
+    throw new Error(`claude returned empty result; raw output: ${rawPath}\n${preview(result.rawStdout, result.rawStderr)}`);
+  }
+
+  const expectedSignals = opts.expectedSignals ?? [];
+  const missing = expectedSignals.filter((signal) => !signalMatches(result.text, signal));
+  if (missing.length > 0) {
+    throw new Error(
+      `missing expected signal(s): ${missing.map(signalName).join(", ")}; raw output: ${rawPath}\n` +
+        preview(result.rawStdout, result.rawStderr),
+    );
+  }
+
+  return {
+    text: result.text,
+    rawPath,
+    rawStdout: result.rawStdout,
+    rawStderr: result.rawStderr,
+    exitCode: result.exitCode,
+    signal: result.signal,
+    durationMs: result.durationMs,
+    costUsd: result.costUsd,
+    numTurns: result.numTurns,
+    matchedSignals: expectedSignals.map(signalName),
+    args: result.args,
+  };
+}

--- a/src/e2e/setup-live.test.ts
+++ b/src/e2e/setup-live.test.ts
@@ -24,15 +24,15 @@ import {
   existsSync,
   rmSync,
 } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { tmpdir, homedir } from "node:os";
+import { runLiveAgent } from "./live-agent.js";
 
-const KAIZEN_ROOT = resolve(__dirname, "../..");
 const isLive = process.env.KAIZEN_LIVE_TEST === "1";
 
 // Run claude -p in a project directory. No --plugin-dir — uses whatever
 // plugins are installed in the user's environment (the real path).
-function claude(
+async function runInstalledPluginAgent(
   prompt: string,
   opts: {
     cwd: string;
@@ -42,43 +42,27 @@ function claude(
     pluginDir?: string;
     model?: string;
   },
-): {
+): Promise<{
   result: string;
   is_error: boolean;
   num_turns: number;
   total_cost_usd: number;
-} {
-  const args = [
-    "claude", "-p",
-    "--output-format", "json",
-    "--model", opts.model ?? "sonnet",
-    "--dangerously-skip-permissions",
-    "--max-turns", String(opts.maxTurns ?? 5),
-    "--max-budget-usd", String(opts.maxBudget ?? 0.50),
-  ];
-
-  if (opts.pluginDir) {
-    args.push("--plugin-dir", opts.pluginDir);
-  }
-
-  args.push(prompt);
-
-  const proc = spawnSync(args[0], args.slice(1), {
-    encoding: "utf-8",
+}> {
+  const result = await runLiveAgent(prompt, {
     cwd: opts.cwd,
-    timeout: opts.timeout ?? 120000,
-    env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: "cli" },
+    model: opts.model ?? "sonnet",
+    maxTurns: opts.maxTurns ?? 5,
+    maxBudgetUsd: opts.maxBudget ?? 0.50,
+    timeoutMs: opts.timeout ?? 120000,
+    pluginDir: opts.pluginDir ?? null,
+    resultsDir: join(opts.cwd, ".kaizen-live-agent-results"),
   });
-
-  if (proc.error) {
-    throw new Error(`claude failed: ${proc.error.message}`);
-  }
-
-  try {
-    return JSON.parse(proc.stdout.trim());
-  } catch {
-    throw new Error(`claude output not JSON:\nstdout: ${proc.stdout?.slice(0, 500)}\nstderr: ${proc.stderr?.slice(0, 500)}`);
-  }
+  return {
+    result: result.text,
+    is_error: false,
+    num_turns: result.numTurns ?? 0,
+    total_cost_usd: result.costUsd ?? 0,
+  };
 }
 
 // Run a claude CLI command (not -p mode)
@@ -148,9 +132,9 @@ describe("Live E2E: Full Installation Flow", () => {
       rmSync(projectDir, { recursive: true, force: true });
     });
 
-    it("kaizen-zen skill works (proves skills loaded from installed plugin)", { timeout: 60000 }, () => {
+    it("kaizen-zen skill works (proves skills loaded from installed plugin)", { timeout: 60000 }, async () => {
       // NO --plugin-dir here — uses the marketplace-installed plugin
-      const result = claude(
+      const result = await runInstalledPluginAgent(
         "Run /kaizen-zen to print the Zen of Kaizen. Just print it, nothing else.",
         { cwd: projectDir, maxTurns: 5, maxBudget: 0.30 },
       );
@@ -162,9 +146,9 @@ describe("Live E2E: Full Installation Flow", () => {
       ).toBe(true);
     });
 
-    it("kaizen-setup skill is available", { timeout: 60000 }, () => {
+    it("kaizen-setup skill is available", { timeout: 60000 }, async () => {
       // Verify /kaizen-setup is recognized (not "Unknown skill")
-      const result = claude(
+      const result = await runInstalledPluginAgent(
         'What does the /kaizen-setup skill do? Just describe it in one sentence.',
         { cwd: projectDir, maxTurns: 2, maxBudget: 0.20 },
       );
@@ -192,11 +176,11 @@ describe("Live E2E: Full Installation Flow", () => {
       rmSync(projectDir, { recursive: true, force: true });
     });
 
-    it("kaizen-setup creates config files", { timeout: 180000 }, () => {
+    it("kaizen-setup creates config files", { timeout: 180000 }, async () => {
       // The plugin is already installed (from earlier tests).
       // In a real flow the user would restart or /reload-plugins.
       // We simulate "second session" by just running /kaizen-setup directly.
-      const result = claude(
+      const result = await runInstalledPluginAgent(
         "Run /kaizen-setup to configure kaizen for this project. Use these values: name=test-python-app, repo=testorg/test-python-app, description=A test Python CLI, channel=none. Do not ask questions.",
         { cwd: projectDir, maxTurns: 15, maxBudget: 2.00 },
       );
@@ -243,9 +227,9 @@ describe("Live E2E: Full Installation Flow", () => {
       rmSync(projectDir, { recursive: true, force: true });
     });
 
-    it("blocks git rebase commands", { timeout: 30000 }, () => {
+    it("blocks git rebase commands", { timeout: 30000 }, async () => {
       // NO --plugin-dir — uses installed plugin
-      const result = claude(
+      const result = await runInstalledPluginAgent(
         "Run this exact command: git rebase -i HEAD~3",
         { cwd: projectDir, maxTurns: 3, maxBudget: 0.20 },
       );

--- a/src/e2e/skill-change.test.ts
+++ b/src/e2e/skill-change.test.ts
@@ -11,129 +11,31 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 
-const KAIZEN_ROOT = resolve(__dirname, "../..");
+import { runLiveAgent } from "./live-agent.js";
+import { KAIZEN_ROOT } from "./test-runtime.js";
+
 const isLive = process.env.KAIZEN_SKILL_TEST === "1";
-const RAW_PREVIEW_CHARS = 300;
 
 /** Read a SKILL.md file from the plugin directory. */
 function loadSkill(name: string): string {
   return readFileSync(resolve(KAIZEN_ROOT, ".claude/skills", name, "SKILL.md"), "utf-8");
 }
 
-/**
- * Run claude -p with the local plugin dir loaded.
- * Returns the text result or throws on error (including non-zero exit).
- */
-type SkillRunProcess = {
-  stdout?: string | null;
-  stderr?: string | null;
-  status?: number | null;
-  signal?: NodeJS.Signals | null;
-  error?: Error;
-};
-
-type SkillRunCheckpoint = {
-  rawPath: string;
-  rawStdout: string;
-  rawStderr: string;
-};
-
-function previewRaw(rawStdout: string, rawStderr: string): string {
-  return (rawStdout || rawStderr).slice(0, RAW_PREVIEW_CHARS);
-}
-
-function persistSkillRunCheckpoint(
-  proc: SkillRunProcess,
-  opts: { artifactName?: string; resultsDir?: string },
-  startedAt: number,
-  durationMs: number,
-): SkillRunCheckpoint {
-  const rawDir = opts.resultsDir ?? resolve(KAIZEN_ROOT, "artifacts", "skill-smoke");
-  mkdirSync(rawDir, { recursive: true });
-  const artifactBase = (opts.artifactName ?? `skill-run-${startedAt}`)
-    .replace(/[^a-zA-Z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  const rawPath = resolve(rawDir, `${artifactBase || "skill-run"}.json`);
-  const rawStdout = proc.stdout ?? "";
-  const rawStderr = proc.stderr ?? "";
-  let costUsd: number | null = null;
-  try {
-    const parsed = JSON.parse(rawStdout);
-    costUsd = typeof parsed.total_cost_usd === "number" ? parsed.total_cost_usd : null;
-  } catch {
-    costUsd = null;
-  }
-  writeFileSync(
-    rawPath,
-    JSON.stringify({
-      command: "claude -p",
-      model: "claude-haiku-4-5-20251001",
-      durationMs,
-      costUsd,
-      status: proc.status,
-      signal: proc.signal,
-      stdout: rawStdout,
-      stderr: rawStderr,
-    }, null, 2),
-    "utf-8",
-  );
-  return { rawPath, rawStdout, rawStderr };
-}
-
-function parseSkillRunResult(proc: SkillRunProcess, checkpoint: SkillRunCheckpoint): string {
-  const { rawPath, rawStdout, rawStderr } = checkpoint;
-  const preview = previewRaw(rawStdout, rawStderr);
-
-  if (proc.error) throw new Error(`claude spawn error: ${proc.error.message}; raw output: ${rawPath}\n${preview}`);
-  if (proc.status !== 0) throw new Error(`claude exited ${proc.status}; raw output: ${rawPath}\n${preview}`);
-
-  const raw = rawStdout.trim();
-  if (!raw) throw new Error(`claude produced empty output (possible timeout or silent crash); raw output: ${rawPath}\n${preview}`);
-
-  let parsed: { result?: string; is_error?: boolean };
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(`claude output not JSON; raw output: ${rawPath}\n${preview}`);
-  }
-
-  if (parsed.is_error) throw new Error(`claude returned error; raw output: ${rawPath}\n${preview}`);
-  if (!parsed.result) throw new Error(`claude returned empty result; raw output: ${rawPath}\n${preview}`);
-  return parsed.result;
-}
-
-function runSkill(
+async function runSkill(
   prompt: string,
   opts: { maxBudget?: number; timeout?: number; artifactName?: string; resultsDir?: string } = {},
-): string {
-  const startedAt = Date.now();
-  const proc = spawnSync(
-    "claude",
-    [
-      "-p",
-      "--output-format", "json",
-      "--model", "claude-haiku-4-5-20251001",
-      "--dangerously-skip-permissions",
-      "--max-turns", "3",
-      "--max-budget-usd", String(opts.maxBudget ?? 0.10),
-      "--plugin-dir", KAIZEN_ROOT,
-      prompt,
-    ],
-    {
-      encoding: "utf-8",
-      cwd: KAIZEN_ROOT,
-      timeout: opts.timeout ?? 120_000,
-      env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: "cli" },
-    },
-  );
-  const durationMs = Date.now() - startedAt;
-  const checkpoint = persistSkillRunCheckpoint(proc, opts, startedAt, durationMs);
-  return parseSkillRunResult(proc, checkpoint);
+): Promise<string> {
+  return (await runLiveAgent(prompt, {
+    model: "claude-haiku-4-5-20251001",
+    maxTurns: 3,
+    maxBudgetUsd: opts.maxBudget ?? 0.10,
+    timeoutMs: opts.timeout ?? 120_000,
+    artifactName: opts.artifactName,
+    resultsDir: opts.resultsDir ?? resolve(KAIZEN_ROOT, "artifacts", "skill-smoke"),
+  })).text;
 }
 
 
@@ -185,7 +87,7 @@ describe("kaizen-gaps — Phase 1.7: Hypothesis Validation", () => {
         "your response with a single line containing exactly [PROVEN] or [HYPOTHESIS].",
       ].join("\n");
 
-      const output = runSkill(prompt, { maxBudget: 0.05 });
+      const output = await runSkill(prompt, { maxBudget: 0.05 });
       expect(output).toMatch(/\[PROVEN\]|\[HYPOTHESIS\]/);
     },
     90_000,
@@ -230,7 +132,7 @@ describe("kaizen-evaluate — Phase 0.7: Problem Validation", () => {
         "Your response MUST include either 'Problem confirmed' or 'Problem NOT confirmed'.",
       ].join("\n");
 
-      const output = runSkill(prompt, { maxBudget: 0.10 });
+      const output = await runSkill(prompt, { maxBudget: 0.10 });
       // The plan-vs-delivery check EXISTS in kaizen-reflect at line 98.
       // Phase 0.7 MUST detect this and output "Problem NOT confirmed".
       // This assertion intentionally requires the NOT form — accepting
@@ -419,7 +321,7 @@ describe("kaizen-write-plan — test-plan discipline (#1014)", () => {
         "line: 'DEFERRAL: <acceptable|circular>'.",
       ].join("\n");
 
-      const output = runSkill(prompt, { maxBudget: 0.1 });
+      const output = await runSkill(prompt, { maxBudget: 0.1 });
       // New guidance must drive both decisions: System level, circular deferral.
       expect(output).toMatch(/LEVEL:\s*System/i);
       expect(output).toMatch(/DEFERRAL:\s*circular/i);
@@ -489,14 +391,14 @@ describe("kaizen workflow — Impact proof discipline (#1505)", () => {
 
   it.skipIf(!isLive)(
     "live smoke: planning prompt emits Impact Baseline fields",
-    () => {
+    async () => {
       const prompt = [
         "You are applying kaizen-write-plan Phase 4.5 to an issue about PRs lacking goal-impact proof.",
         "Use the new Impact Baseline discipline.",
         "Return only the Impact Baseline block with fields for Goal, Acceptance signal, BEFORE, AFTER capture method, and Residual scan.",
       ].join("\n");
 
-      const output = runSkill(prompt, {
+      const output = await runSkill(prompt, {
         maxBudget: 0.10,
         timeout: 90_000,
         artifactName: "impact-baseline-live-smoke",
@@ -507,63 +409,66 @@ describe("kaizen workflow — Impact proof discipline (#1505)", () => {
     },
   );
 
-  it("live skill smoke harness persists raw output checkpoints before parsing", () => {
-    const dir = mkdtempSync(join(tmpdir(), "skill-smoke-"));
-    try {
-      const checkpoint = persistSkillRunCheckpoint(
-        {
-          status: 0,
-          stdout: JSON.stringify({ result: "ok", total_cost_usd: 0.03 }),
-          stderr: "",
+  it("live skill smoke uses the shared live-agent checkpoint contract", async () => {
+    const result = await runLiveAgent("impact proof smoke", {
+      resultsDir: resolve(KAIZEN_ROOT, ".claude", "e2e-results", "skill-change-unit"),
+      artifactName: "impact-baseline-live-smoke",
+      spawn: async () => ({
+        text: "ok",
+        costUsd: 0.03,
+        durationMs: 250,
+        exitCode: 0,
+        signal: null,
+        rawStdout: JSON.stringify({ result: "ok", total_cost_usd: 0.03 }),
+        rawStderr: "",
+        args: ["-p", "--plugin-dir", KAIZEN_ROOT],
+        numTurns: null,
+      }),
+    });
+    const saved = JSON.parse(readFileSync(result.rawPath, "utf-8"));
+
+    expect(result.text).toBe("ok");
+    expect(saved.command).toBe("claude -p");
+    expect(saved.costUsd).toBe(0.03);
+    expect(saved.stdout).toContain('"result":"ok"');
+  });
+
+  it("live skill smoke failures include shared checkpoint path and raw preview", async () => {
+    await expect(
+      runLiveAgent("impact proof smoke", {
+        resultsDir: resolve(KAIZEN_ROOT, ".claude", "e2e-results", "skill-change-unit"),
+        artifactName: "provider-error",
+        spawn: async () => ({
+          text: "",
+          costUsd: null,
+          durationMs: 250,
+          exitCode: 1,
           signal: null,
-        },
-        { artifactName: "impact-baseline-live-smoke", resultsDir: dir },
-        1_000,
-        250,
-      );
-      const saved = JSON.parse(readFileSync(checkpoint.rawPath, "utf-8"));
+          rawStdout: "",
+          rawStderr: "monthly spend limit reached by provider",
+          args: ["-p", "--plugin-dir", KAIZEN_ROOT],
+          numTurns: null,
+        }),
+      }),
+    ).rejects.toThrow(/provider-error\.json[\s\S]*monthly spend limit reached/);
 
-      expect(saved.durationMs).toBe(250);
-      expect(saved.costUsd).toBe(0.03);
-      expect(saved.stdout).toContain('"result":"ok"');
-      expect(parseSkillRunResult({ status: 0, stdout: saved.stdout, stderr: "" }, checkpoint)).toBe("ok");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("live skill smoke failures include checkpoint path and raw preview", () => {
-    const dir = mkdtempSync(join(tmpdir(), "skill-smoke-"));
-    try {
-      const checkpoint = persistSkillRunCheckpoint(
-        { status: 1, stdout: "", stderr: "monthly spend limit reached by provider" },
-        { artifactName: "provider-error", resultsDir: dir },
-        1_000,
-        250,
-      );
-
-      expect(() => parseSkillRunResult({ status: 1, stdout: "", stderr: checkpoint.rawStderr }, checkpoint))
-        .toThrow(/provider-error\.json[\s\S]*monthly spend limit reached/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("live skill smoke malformed JSON failures include raw preview", () => {
-    const dir = mkdtempSync(join(tmpdir(), "skill-smoke-"));
-    try {
-      const checkpoint = persistSkillRunCheckpoint(
-        { status: 0, stdout: "not json from provider", stderr: "" },
-        { artifactName: "malformed-provider-json", resultsDir: dir },
-        1_000,
-        250,
-      );
-
-      expect(() => parseSkillRunResult({ status: 0, stdout: checkpoint.rawStdout, stderr: "" }, checkpoint))
-        .toThrow(/malformed-provider-json\.json[\s\S]*not json from provider/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    await expect(
+      runLiveAgent("impact proof smoke", {
+        resultsDir: resolve(KAIZEN_ROOT, ".claude", "e2e-results", "skill-change-unit"),
+        artifactName: "malformed-provider-json",
+        spawn: async () => ({
+          text: "",
+          costUsd: null,
+          durationMs: 250,
+          exitCode: 0,
+          signal: null,
+          rawStdout: "not json from provider",
+          rawStderr: "",
+          args: ["-p", "--plugin-dir", KAIZEN_ROOT],
+          numTurns: null,
+        }),
+      }),
+    ).rejects.toThrow(/malformed-provider-json\.json[\s\S]*not json from provider/);
   });
 });
 
@@ -574,7 +479,7 @@ describe("kaizen workflow — Impact proof discipline (#1505)", () => {
 describe("Behavioral: dry dimension detects copy-paste in kaizen-test-fixture#24", () => {
   it.skipIf(!isLive)(
     "INVARIANT: dry dimension returns MISSING/PARTIAL for pad() copy-paste across 3 functions",
-    () => {
+    async () => {
       // Fixture: Garsson-io/kaizen-test-fixture PR #24 contains formatters.ts
       // with pad() helper copy-pasted identically into formatDate, formatPrice,
       // and formatDuration — a classic 3-copy DRY violation.
@@ -626,7 +531,7 @@ ${fixtureDiff}
 
 Review this diff for DRY violations. Output JSON only.`;
 
-      const output = runSkill(prompt, { maxBudget: 0.15, timeout: 90_000 });
+      const output = await runSkill(prompt, { maxBudget: 0.15, timeout: 90_000 });
 
       // Parse the JSON findings block from the output
       const jsonMatch = output.match(/```json\s*([\s\S]+?)\s*```/);
@@ -643,6 +548,55 @@ Review this diff for DRY violations. Output JSON only.`;
         "dry dimension must detect the pad() copy-paste across 3 functions",
       ).toBe(true);
     },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #944 — real skill-chain behavioral smoke via claude -p + local plugin
+// ---------------------------------------------------------------------------
+
+describe("Behavioral: #944 live skill-chain proof uses local plugin + fixture PR", () => {
+  it.skipIf(!isLive)(
+    "INVARIANT: /kaizen-review-pr smoke reports the known DRY fixture signal",
+    async () => {
+      const prompt = [
+        "Run /kaizen-review-pr for https://github.com/Garsson-io/kaizen-test-fixture/pull/24.",
+        "This is a #944 behavioral smoke test. Keep it bounded: do not edit files, do not push, and do not run a fix loop.",
+        "The review skill may store its normal structured review finding marker; do not add unrelated prose comments.",
+        "You must execute the review workflow far enough to run the dry dimension against the fixture diff. Do not answer from the PR body or fixture comments alone.",
+        "It is acceptable to run only the dry dimension for this smoke test, but the answer must distinguish an actual dry-review verdict from a manual inspection.",
+        "Your final answer must include these exact labels with values:",
+        "BEHAVIORAL_PROOF:",
+        "FIXTURE_PR:",
+        "DIMENSION:",
+        "DRY_REVIEW_RAN:",
+        "DRY_VERDICT:",
+        "FINDING_SIGNAL:",
+        "STATUS:",
+      ].join("\n");
+
+      const result = await runLiveAgent(prompt, {
+        model: "claude-haiku-4-5-20251001",
+        maxTurns: 12,
+        maxBudgetUsd: 0.75,
+        timeoutMs: 180_000,
+        artifactName: "k944-review-pr-dry-fixture",
+        resultsDir: resolve(KAIZEN_ROOT, "artifacts", "skill-smoke"),
+        expectedSignals: [
+          "BEHAVIORAL_PROOF:",
+          "kaizen-test-fixture/pull/24",
+          { name: "dry dimension", pattern: /\bdry\b/i },
+          "DRY_REVIEW_RAN:",
+          { name: "dry verdict", pattern: /DRY_VERDICT:[\s\S]{0,80}\b(fail|failed)\b/i },
+          { name: "pad duplication", pattern: /\bpad\b/i },
+          { name: "gap status", pattern: /\b(MISSING|PARTIAL)\b/i },
+        ],
+      });
+
+      expect(result.args).toContain("--plugin-dir");
+      expect(result.rawPath).toContain("k944-review-pr-dry-fixture.json");
+    },
+    210_000,
   );
 });
 
@@ -704,7 +658,7 @@ describe("Behavioral: simplification-impact dimension detects additive-only work
 
   it.skipIf(!isLive)(
     "INVARIANT: simplification-impact returns MISSING/PARTIAL when a plan adds a parallel PR workflow with no related-area sweep",
-    () => {
+    async () => {
       const fixturePlan = `## Success Criteria
 GOAL: PRs must include an Architecture section.
 DONE WHEN: Agents add a new PR checklist item.
@@ -755,7 +709,7 @@ ${fixtureDiff}
 
 Review this plan and diff for simplification impact. Output JSON only.`;
 
-      const output = runSkill(prompt, { maxBudget: 0.15, timeout: 90_000 });
+      const output = await runSkill(prompt, { maxBudget: 0.15, timeout: 90_000 });
       const rawDir = resolve(KAIZEN_ROOT, "artifacts", "skill-smoke");
       mkdirSync(rawDir, { recursive: true });
       const rawPath = resolve(rawDir, "simplification-impact-additive-only-output.txt");
@@ -781,7 +735,7 @@ Review this plan and diff for simplification impact. Output JSON only.`;
 describe("Behavioral: kaizen-evaluate Phase 4.5 produces structured plan (Policy 10)", () => {
   it.skipIf(!isLive)(
     "INVARIANT: agent using Phase 4.5 steps produces GOAL: and DONE WHEN fields",
-    () => {
+    async () => {
       // Policy 10 requires behavioral proof for SKILL.md changes.
       // Before Phase 4.5: agents wrote plans as unstructured task lists with
       // no GOAL/DONE WHEN fields — the plan was a list of actions, not a
@@ -804,7 +758,7 @@ Issue: "When the CLI tool crashes, the error message shows 'undefined' instead o
 
 Complete Steps 1 and 2 (success criteria extraction and existing tools survey) and output the plan in the schema shown above.`;
 
-      const output = runSkill(prompt, { maxBudget: 0.20, timeout: 120_000 });
+      const output = await runSkill(prompt, { maxBudget: 0.20, timeout: 120_000 });
 
       // Phase 4.5 Step 1 requires GOAL: and DONE WHEN: fields in the plan output
       expect(output).toContain("GOAL:");

--- a/src/spawn-claude.test.ts
+++ b/src/spawn-claude.test.ts
@@ -1,0 +1,113 @@
+import { EventEmitter } from 'node:events';
+import { spawn } from 'node:child_process';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import { buildSpawnClaudeArgs, spawnClaude } from './spawn-claude.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, spawn: vi.fn(actual.spawn) };
+});
+
+function streamJsonPayload(text: string, costUsd: number): string {
+  const assistant = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } });
+  const result = JSON.stringify({ type: 'result', total_cost_usd: costUsd });
+  return `${assistant}\n${result}\n`;
+}
+
+function mockClaude(stdout: string, stderr = '', exitCode = 0): void {
+  vi.mocked(spawn).mockImplementation(() => {
+    const proc = new EventEmitter() as any;
+    proc.stdin = { write: vi.fn(), end: vi.fn() };
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+    setImmediate(() => {
+      if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
+      if (stderr) proc.stderr.emit('data', Buffer.from(stderr));
+      proc.emit('close', exitCode);
+    });
+    return proc;
+  });
+}
+
+describe('buildSpawnClaudeArgs', () => {
+  it('adds bounded live skill-test options without changing the stream-json contract', () => {
+    expect(buildSpawnClaudeArgs({
+      model: 'haiku',
+      maxTurns: 8,
+      maxBudgetUsd: 0.75,
+      pluginDir: '/repo/kaizen',
+    })).toEqual([
+      '-p',
+      '--output-format', 'stream-json',
+      '--verbose',
+      '--dangerously-skip-permissions',
+      '--model', 'haiku',
+      '--max-turns', '8',
+      '--max-budget-usd', '0.75',
+      '--plugin-dir', '/repo/kaizen',
+    ]);
+  });
+
+  it('omits --plugin-dir only when callers explicitly request installed-plugin behavior', () => {
+    expect(buildSpawnClaudeArgs({ model: 'haiku', pluginDir: null })).not.toContain('--plugin-dir');
+  });
+
+  it('supports JSON-mode prompt argv for live skill-chain tests', () => {
+    expect(buildSpawnClaudeArgs({
+      outputFormat: 'json',
+      verbose: false,
+      model: 'haiku',
+      maxTurns: 3,
+      maxBudgetUsd: 0.1,
+      pluginDir: '/repo/kaizen',
+      promptArg: 'Run /kaizen-zen',
+    })).toEqual([
+      '-p',
+      '--output-format', 'json',
+      '--dangerously-skip-permissions',
+      '--model', 'haiku',
+      '--max-turns', '3',
+      '--max-budget-usd', '0.1',
+      '--plugin-dir', '/repo/kaizen',
+      'Run /kaizen-zen',
+    ]);
+  });
+});
+
+describe('spawnClaude live-skill metadata', () => {
+  afterEach(() => {
+    vi.mocked(spawn).mockRestore();
+  });
+
+  it('returns raw output and constructed args for checkpointing', async () => {
+    const raw = streamJsonPayload('The Zen of Kaizen', 0.03);
+    mockClaude(raw, 'diagnostic stderr');
+
+    const result = await spawnClaude('Run /kaizen-zen', {
+      cwd: '/repo/kaizen',
+      model: 'haiku',
+      pluginDir: '/repo/kaizen',
+      maxTurns: 2,
+      maxBudgetUsd: 0.05,
+      env: { CLAUDE_CODE_ENTRYPOINT: 'cli' },
+    });
+
+    expect(result.text).toBe('The Zen of Kaizen');
+    expect(result.costUsd).toBe(0.03);
+    expect(result.rawStdout).toBe(raw);
+    expect(result.rawStderr).toBe('diagnostic stderr');
+    expect(result.args).toContain('--plugin-dir');
+    expect(result.args).toContain('/repo/kaizen');
+    expect(vi.mocked(spawn)).toHaveBeenCalledWith(
+      'claude',
+      result.args,
+      expect.objectContaining({
+        cwd: '/repo/kaizen',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: expect.objectContaining({ CLAUDE_CODE_ENTRYPOINT: 'cli' }),
+      }),
+    );
+  });
+});

--- a/src/spawn-claude.ts
+++ b/src/spawn-claude.ts
@@ -10,7 +10,7 @@
  * stream-json JSONL parsing + cost extraction + timeout live in exactly one place.
  */
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { parseJsonLines } from './lib/json-lines.js';
 
 interface StreamJsonContentBlock {
@@ -31,6 +31,9 @@ export interface SpawnClaudeResult {
   costUsd: number;
   durationMs: number;
   exitCode: number;
+  rawStdout: string;
+  rawStderr: string;
+  args: string[];
 }
 
 export interface SpawnClaudeOptions {
@@ -38,6 +41,23 @@ export interface SpawnClaudeOptions {
   timeoutMs?: number;
   /** Model override. Defaults to REVIEW_MODEL env var, then 'sonnet'. */
   model?: string;
+  /** Optional local plugin dir for live plugin/skill tests. */
+  pluginDir?: string | null;
+  /** Optional max-turn guard for bounded live skill runs. */
+  maxTurns?: number;
+  /** Optional cost guard for bounded live skill runs. */
+  maxBudgetUsd?: number;
+  /** Extra env vars for the spawned Claude process. */
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface SpawnClaudeArgsOptions extends SpawnClaudeOptions {
+  /** Defaults to stream-json for the review/judge primitive. */
+  outputFormat?: 'stream-json' | 'json';
+  /** Defaults to true for stream-json, false for json. */
+  verbose?: boolean;
+  /** Append prompt as argv instead of stdin. Used by JSON-mode live skill tests. */
+  promptArg?: string;
 }
 
 /**
@@ -49,6 +69,104 @@ export type SpawnClaudeFn = (
   opts: SpawnClaudeOptions,
 ) => Promise<SpawnClaudeResult>;
 
+export interface SpawnClaudeJsonResult {
+  text: string;
+  costUsd: number | null;
+  durationMs: number;
+  exitCode: number | null | undefined;
+  signal: NodeJS.Signals | null | undefined;
+  rawStdout: string;
+  rawStderr: string;
+  args: string[];
+  error?: Error;
+  numTurns: number | null;
+}
+
+export interface SpawnClaudeJsonOptions extends SpawnClaudeOptions {
+  promptArg?: boolean;
+}
+
+export type SpawnClaudeJsonFn = (
+  prompt: string,
+  opts: SpawnClaudeJsonOptions,
+) => Promise<SpawnClaudeJsonResult>;
+
+export function buildSpawnClaudeArgs(opts: SpawnClaudeArgsOptions = {}): string[] {
+  const model = opts.model ?? process.env.REVIEW_MODEL ?? 'sonnet';
+  const outputFormat = opts.outputFormat ?? 'stream-json';
+  const verbose = opts.verbose ?? outputFormat === 'stream-json';
+  const args = [
+    '-p',
+    '--output-format', outputFormat,
+  ];
+
+  if (verbose) args.push('--verbose');
+  args.push('--dangerously-skip-permissions', '--model', model);
+  if (opts.maxTurns !== undefined) {
+    args.push('--max-turns', String(opts.maxTurns));
+  }
+  if (opts.maxBudgetUsd !== undefined) {
+    args.push('--max-budget-usd', String(opts.maxBudgetUsd));
+  }
+  if (opts.pluginDir !== undefined && opts.pluginDir !== null) {
+    args.push('--plugin-dir', opts.pluginDir);
+  }
+  if (opts.promptArg !== undefined) args.push(opts.promptArg);
+
+  return args;
+}
+
+export const spawnClaudeJson: SpawnClaudeJsonFn = async (prompt, opts) => {
+  const startedAt = Date.now();
+  const args = buildSpawnClaudeArgs({
+    ...opts,
+    outputFormat: 'json',
+    verbose: false,
+    promptArg: opts.promptArg === false ? undefined : prompt,
+  });
+  const proc = spawnSync('claude', args, {
+    cwd: opts.cwd,
+    timeout: opts.timeoutMs ?? 120_000,
+    encoding: 'utf-8',
+    env: opts.env ? { ...process.env, ...opts.env } : process.env,
+  });
+  const durationMs = Date.now() - startedAt;
+  const rawStdout = proc.stdout ?? '';
+  const rawStderr = proc.stderr ?? '';
+
+  let text = '';
+  let costUsd: number | null = null;
+  let numTurns: number | null = null;
+  try {
+    const parsed = JSON.parse(rawStdout) as {
+      result?: unknown;
+      is_error?: unknown;
+      num_turns?: unknown;
+      total_cost_usd?: unknown;
+    };
+    if (parsed.is_error !== true && typeof parsed.result === 'string') {
+      text = parsed.result;
+    }
+    costUsd = typeof parsed.total_cost_usd === 'number' ? parsed.total_cost_usd : null;
+    numTurns = typeof parsed.num_turns === 'number' ? parsed.num_turns : null;
+  } catch {
+    // Leave parse failures to callers; raw stdout is preserved.
+  }
+
+  return {
+    text,
+    costUsd,
+    durationMs,
+    exitCode: proc.status,
+    signal: proc.signal,
+    rawStdout,
+    rawStderr,
+    args,
+    error: proc.error,
+    numTurns,
+  };
+};
+
 /**
  * Run a single `claude -p` call with the given prompt.
  * Each call is a fresh process — no shared context with the caller, by construction.
@@ -56,18 +174,13 @@ export type SpawnClaudeFn = (
  * Returns parsed text, cost, duration, and exit code.
  */
 export const spawnClaude: SpawnClaudeFn = (prompt, opts) => {
-  const model = opts.model ?? process.env.REVIEW_MODEL ?? 'sonnet';
+  const args = buildSpawnClaudeArgs(opts);
   const start = Date.now();
 
   return new Promise((resolve) => {
-    const child = spawn('claude', [
-      '-p',
-      '--output-format', 'stream-json',
-      '--verbose',
-      '--dangerously-skip-permissions',
-      '--model', model,
-    ], {
+    const child = spawn('claude', args, {
       cwd: opts.cwd,
+      env: opts.env ? { ...process.env, ...opts.env } : process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
@@ -75,8 +188,9 @@ export const spawnClaude: SpawnClaudeFn = (prompt, opts) => {
     child.stdin.end();
 
     let stdout = '';
+    let stderr = '';
     child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
-    child.stderr.on('data', () => {}); // drain to prevent blocking
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
 
     const timer = setTimeout(() => { child.kill(); }, opts.timeoutMs ?? 120_000);
 
@@ -104,7 +218,7 @@ export const spawnClaude: SpawnClaudeFn = (prompt, opts) => {
         }
       }
 
-      resolve({ text, costUsd, durationMs, exitCode: code ?? -1 });
+      resolve({ text, costUsd, durationMs, exitCode: code ?? -1, rawStdout: stdout, rawStderr: stderr, args });
     });
   });
 };


### PR DESCRIPTION
## Story

Once upon a time, kaizen had review battery tests and skill-change live tests, but the live skill tests did not exercise the user-facing skill chain. Every day, prompt-level and unit-level checks could pass while no test proved that `claude -p --plugin-dir <checkout>` could load `/kaizen-review-pr`, review a real fixture PR, and report the known flaw.

One day, #944 named the category error directly: we were testing code and prompt fragments instead of proving the behavior of the system. PR #1547 closed the hook/session gate layer, but left the `claude -p` skill-chain fixture proof open.

Because of that, this PR adds a shared live-agent runner on top of `src/spawn-claude.ts`, with one place for plugin-dir, model, budget, turns, JSON-mode output, raw stdout/stderr capture, and checkpoint persistence.

Because of that, the existing live skill tests now use that shared runner, and the new #944 smoke invokes `/kaizen-review-pr` against `Garsson-io/kaizen-test-fixture#24` through this checkout's plugin directory. The test mechanically checks that the real skill-chain output names the known DRY/pad duplication signal and reports a failing dry verdict.

Until finally, the branch has both deterministic contract tests and current live proof: the opt-in smoke ran Claude against the fixture PR, persisted the raw checkpoint, and observed the expected failing DRY result.

And ever since, future live skill-chain tests have one runner contract instead of local spawn/parsing loops, and failures preserve the raw command/output needed to debug whether the plugin, provider, or assertion failed.

Fixes Garsson-io/kaizen#944
Related: Garsson-io/kaizen#780
Related: Garsson-io/kaizen#776
Related: Garsson-io/kaizen#869
Related: Garsson-io/kaizen#868
Related: Garsson-io/kaizen#867
Related: Garsson-io/kaizen#968
Related: Garsson-io/kaizen#1230
Related: Garsson-io/kaizen#1093

## Architecture

```text
src/spawn-claude.ts
  -> buildSpawnClaudeArgs()
  -> spawnClaude()      // existing stream-json review/judge path
  -> spawnClaudeJson()  // JSON-mode live skill path
      -> src/e2e/live-agent.ts runLiveAgent()
          -> skill-change / issue-routing / setup-live
          -> raw checkpoints + expected signal assertions
```

## What's In This PR

| Area | Purpose |
|---|---|
| `src/spawn-claude.ts` | Shared argv construction plus JSON-mode `claude -p` runner with raw output, stderr, cost, duration, turns, and args metadata |
| `src/e2e/live-agent.ts` | Live test wrapper that persists raw checkpoints and fails closed on spawn errors, nonzero exits, empty result, or missing expected signals |
| `src/e2e/skill-change.test.ts` | Migrates live tests to the shared runner and adds the #944 `/kaizen-review-pr` fixture smoke |
| `src/e2e/issue-routing.test.ts`, `src/e2e/setup-live.test.ts` | Reuse the shared live runner while preserving installed-plugin versus local-plugin behavior |
| `src/e2e/live-agent.test.ts`, `src/spawn-claude.test.ts` | Deterministic contracts for args, plugin-dir behavior, checkpoint persistence, failure messages, and source invariants |
| `scripts/kaizen-workflow-driver.test.ts` | Uses the shared TSX resolver so the full suite passes from worktrees without local `node_modules` assumptions |

## Impact (goal -> before/after -> match)

- Goal (#944): prove the behavioral review workflow at the skill-chain level, not only via prompt/unit mocks.
- Acceptance signal: an opt-in live E2E test invokes Claude with `--plugin-dir` pointed at this checkout, runs `/kaizen-review-pr` for `https://github.com/Garsson-io/kaizen-test-fixture/pull/24`, and verifies the output identifies the known `pad()` DRY violation with a failing dry verdict.
- BEFORE: `src/e2e/skill-change.test.ts` directly loaded `prompts/review-dry.md` and hand-rolled its own `spawnSync("claude")`/checkpoint parser. No live test invoked `/kaizen-review-pr` against fixture PR #24 through the local plugin.
- AFTER: `KAIZEN_SKILL_TEST=1 npx vitest run src/e2e/skill-change.test.ts -t "#944"` runs the actual review skill path through this checkout's plugin directory, asserts the DRY verdict and `pad` signal, and writes `artifacts/skill-smoke/k944-review-pr-dry-fixture.json`.
- Match: the current checkpoint records `claude -p --output-format json --plugin-dir /home/aviad/projects/kaizen/.claude/worktrees/260629-0023-k944-e2e-behavioral-test-gap`, fixture PR #24, `maxTurns=12`, `maxBudgetUsd=0.75`, exit code 0, duration 67.7s, cost `$0.10027575`, and `DRY_VERDICT: FAIL` for duplicated `pad()` helpers.

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File | Coverage |
|---|---|---|---|---|---|
| 1 | Shared Claude spawn supports plugin-dir, budget, max-turns, model, stream-json review/judge calls, and JSON-mode live skill calls. | code | Unit | `src/spawn-claude.test.ts` | tested |
| 2 | Live-agent checkpoints preserve raw command, args, stdout/stderr, exit status, cost, duration, and failure context. | code | Unit | `src/e2e/live-agent.test.ts` | tested |
| 3 | Existing live skill tests route through the shared runner instead of local JSON parsing/spawn loops. | code | Unit/source invariant | `src/e2e/live-agent.test.ts` | tested |
| 4 | Issue-routing and setup-live tests reuse the shared runner while preserving local-plugin and installed-plugin modes. | code | Integration | `src/e2e/issue-routing.test.ts`, `src/e2e/setup-live.test.ts` | tested/skipped unless live env is enabled |
| 5 | `/kaizen-review-pr` loaded from this checkout detects the synthetic DRY violation in fixture PR #24. | agent | Agentic live E2E | `src/e2e/skill-change.test.ts` under `KAIZEN_SKILL_TEST=1` | tested |
| 6 | Full suite remains worktree-safe after the workflow-driver resolver fix. | user/operator | System | `npm test` | tested |

## Validation

- [x] RED proof before implementation: `npx vitest run src/e2e/live-agent.test.ts` failed because the shared live-agent module did not exist.
- [x] `npx vitest run src/spawn-claude.test.ts src/e2e/live-agent.test.ts src/e2e/skill-change.test.ts src/e2e/issue-routing.test.ts src/e2e/setup-live.test.ts` -> 3 files passed, 2 skipped; 41 passed, 10 skipped.
- [x] `KAIZEN_SKILL_TEST=1 npx vitest run src/e2e/skill-change.test.ts -t "#944"` -> 1 file passed; 1 passed, 34 skipped; duration 67.29s.
- [x] Live checkpoint: `artifacts/skill-smoke/k944-review-pr-dry-fixture.json` -> exit code 0, `--plugin-dir` pointed at this worktree, cost `$0.10027575`, `DRY_VERDICT: FAIL`, `FINDING_SIGNAL` names two MISSING findings for `pad()` duplication.
- [x] `npx tsc --noEmit` -> passed.
- [x] `git diff --check` -> passed.
- [x] `npm test` -> 167 passed files, 2 skipped; 3939 passed tests, 14 skipped. The suite still prints `Unknown option: --bogus` from an intentional CLI negative-path test and exits 0.

## Known Limitations

This closes #944's near-term `/kaizen-review-pr` skill-chain fixture proof. It does not implement the hidden full-loop oracle tracked by #867, fully enforce all skill/prompt changes from #780, prove plugin-cache precedence from #776, or cover the full review-storage-gate chain in #968. Those issues are now cheaper to address because live skill tests have one shared runner and raw checkpoint contract.