### PR TITLE
Add inside-harness auto-dent skill

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -85,6 +85,7 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 |-------|-------------|
 | `/kaizen-reflect` | Post-work reflection — classify impediments, file issues |
 | `/kaizen-do` | Goal-driven workflow driver — sets `/goal`, then drives one issue/task through the full kaizen gates |
+| `/kaizen-autodent` | inside-harness auto-dent — drives one eligible sub-issue at a time through `/kaizen-do` when hooks are unavailable or provider-specific |
 | `/kaizen-pick` | Select next issue from backlog |
 | `/kaizen-gaps` | Strategic analysis — tooling gaps, horizon concentration |
 | `/kaizen-evaluate` | Scope gate — evaluate issue before implementation |
@@ -111,6 +112,8 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 **PR bodies**: Always use `/kaizen-write-pr` when creating or editing PR descriptions. Never write a bare `gh pr create --body` with a few bullet points. The Story Spine narrative makes PRs reviewable without reading the diff.
 
 **Goal-driven workflow driver**: Use `/kaizen-do <issue|task>` when asked to work a ticket or task to completion. It starts by setting a literal `/goal` containing the ticket number/title/URL and then drives the existing kaizen gates: plan/test-plan, worktree/case, implementation/tests, related-area DRY/refactor, meet-reality proof, review/requirements/impact, reflection, PR/CI/merge/cleanup. Use `npx tsx scripts/kaizen-workflow-driver.ts status --issue <N> --repo "$ISSUES_REPO" --mode manual` for status calls instead of hand-rolling a checklist.
+
+**Inside-harness auto-dent**: Use `/kaizen-autodent <parent|sub-issue-list>` when hooks are absent, stale, provider-specific, or unavailable but a parent/umbrella issue still needs an auto-dent-style loop. It selects one eligible sub-issue at a time, delegates each selected issue to `/kaizen-do`, requires one scope-matched PR per sub-issue, and uses [`docs/workflow-gate-ledger.md`](../docs/workflow-gate-ledger.md) plus the workflow status CLI as the durable evidence contract. Do not close the parent epic from a child PR; use parent/refs linkage instead.
 
 **Structured data**: Use `npx tsx src/cli-structured-data.ts` as the primary interface for storing and retrieving structured data on PRs and issues. Key commands:
 - Reviews: `store-review-finding`, `store-review-summary`, `list-review-rounds`, `read-review-finding`

--- a/.agents/kaizen/instructions-fragment.md
+++ b/.agents/kaizen/instructions-fragment.md
@@ -10,6 +10,7 @@ Kaizen is installed at `{{KAIZEN_ROOT}}`. It provides enforcement hooks, reflect
 |-------|-------------|
 | `/kaizen-reflect` | Post-work reflection — classify impediments, file issues (Level 1→2→3) |
 | `/kaizen-do` | Goal-driven workflow driver — sets `/goal`, then drives one issue/task through the full kaizen gates |
+| `/kaizen-autodent` | inside-harness auto-dent — work one eligible sub-issue at a time through `/kaizen-do` when hooks are unavailable/provider-specific |
 | `/kaizen-pick` | Select next kaizen issue — filters claimed, balances epic momentum vs diversity |
 | `/kaizen-gaps` | Strategic analysis — tooling/testing gaps, horizon concentration, unnamed dimensions |
 | `/kaizen-deep-dive` | Autonomous deep-dive — fix root cause category behind repeated issues |
@@ -24,6 +25,7 @@ Key triggers — activate the right skill for the user's intent:
 - "gap analysis", "analyze gaps", "tooling gaps" → `/kaizen-gaps`
 - "make a dent", "hero mode", "deep dive" → `/kaizen-deep-dive`
 - "/kaizen-do <issue|task>", "work this ticket to completion" → `/kaizen-do`
+- "inside-harness auto-dent", "hook-independent auto-dent", "work this parent issue through sub-issues" → `/kaizen-autodent`
 - "what's next", "pick work", "pick a kaizen" → `/kaizen-pick`
 - "look at issue #N", "evaluate this" → `/kaizen-evaluate`
 - "lets do it", "go ahead", "build it", "ship it" → `/kaizen-implement`

--- a/.agents/skills/kaizen-autodent/SKILL.md
+++ b/.agents/skills/kaizen-autodent/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: kaizen-autodent
+description: Inside-harness auto-dent workflow for hook-independent kaizen runs. Use when a parent/umbrella issue or explicit sub-issue list should be driven one eligible sub-issue at a time through /kaizen-do without relying on Claude-only hooks.
+triggers:
+  - /kaizen-autodent
+  - inside-harness auto-dent
+  - hook-independent auto-dent
+  - run auto-dent inside this session
+  - work this parent issue through sub-issues
+depends_on:
+  - kaizen-do
+  - kaizen-write-plan
+  - kaizen-review-pr
+  - kaizen-write-pr
+user_invocable: true
+---
+
+# Kaizen Autodent - Inside-Harness Auto-Dent
+
+`/kaizen-autodent <parent/umbrella issue | sub-issue list | task>` packages the inside-harness auto-dent loop for providers and host repos where hooks may be absent, stale, provider-specific, or unavailable.
+
+This skill is hook-independent. Hooks are helpful feedback, not proof. Authoritative proof comes from durable artifacts: GitHub issues and PRs, stored plans/test-plans, case/worktree state, commits, test output, review attachments, CI, merge state, reflection evidence, and the workflow gate ledger.
+
+## First Action: Identify Scope
+
+Read host configuration before GitHub calls:
+
+```bash
+KAIZEN_REPO=$(jq -r '.kaizen.repo' kaizen.config.json)
+HOST_REPO=$(jq -r '.host.repo' kaizen.config.json)
+ISSUES_REPO=$(jq -r '.issues.repo // .host.repo' kaizen.config.json)
+ISSUES_LABEL=$(jq -r '.issues.label // ""' kaizen.config.json)
+```
+
+Then classify the input:
+
+| Input | Meaning | Next action |
+| --- | --- | --- |
+| parent/umbrella issue | Multi-issue campaign | Read parent body/comments and extract open sub-issues |
+| sub-issue list | Explicit queue | Verify each issue state and collision status |
+| single issue | One work item | Hand off directly to `/kaizen-do` |
+| task text | No issue yet | File or select a scope-matched issue before implementation |
+
+For every GitHub issue input, fetch identity:
+
+```bash
+gh issue view <N> --repo "$ISSUES_REPO" --json number,title,url,state,labels,body
+```
+
+## Loop Contract
+
+Work one eligible sub-issue at a time.
+
+1. Select one eligible sub-issue: open, unclaimed or intentionally taken over, not already fixed, and not blocked by dependency order.
+2. Run `/kaizen-do <sub-issue>` for that selected issue. Do not inline or fork the per-ticket workflow.
+3. Produce one scope-matched PR for that sub-issue.
+4. Use `Fixes <sub-issue>` only for the sub-issue the PR fully resolves.
+5. Do NOT close the parent epic from a child PR. Use `Parent: #<parent>` or `Refs: #<parent>` for parent linkage.
+6. After merge, update the parent issue progress/current-state/next-step if the parent tracks sub-issue progress.
+7. Continue to the next eligible sub-issue unless the parent is complete, the queue is exhausted, or the run reaches a documented blocked state.
+
+If several issues share the same small code path and one PR is clearly more efficient, stop and run `/kaizen-plan` or update the parent plan first. Do not reactively bundle issues mid-implementation.
+
+## Durable Artifact Table
+
+Use this table to verify progress. It is a view over the shared workflow contract; it is not a second gate schema.
+
+| Phase | Durable artifact |
+| --- | --- |
+| issue identity | issue number, title, URL, repo, state, labels, parent/sub-issue relationship |
+| stored plan/test-plan | `retrieve-plan` and `retrieve-testplan` output for the selected sub-issue |
+| worktree/case | branch, worktree path, case or worktree-scoped `kaizen.issue` binding |
+| commits and tests | source/test commits plus command, result, count, and output source |
+| related-area DRY/refactor | evidence that competing mechanisms/schemas/drift were reduced, or reason no refactor was warranted |
+| meet-reality output | real CLI, hook, prompt, PR, status, or workflow output showing the behavior changed |
+| review/requirements/impact | stored review findings, requirements verdict, impact proof, and fix-loop state |
+| reflection evidence | durable reflection, issue/comment, or explicit no-action reason |
+| PR/CI/merge/cleanup | PR URL, CI state, merge result, branch/worktree cleanup, issue closure |
+| hook/provider activation | hook activation evidence when hooks are expected, or schema-valid external substitute evidence when hooks are unavailable |
+
+## Shared Status
+
+Use the shared workflow driver for status. Do not hand-roll another gate checklist.
+
+```bash
+npx tsx scripts/kaizen-workflow-driver.ts status --issue <N> --repo "$ISSUES_REPO" --mode manual
+```
+
+When the inside-harness loop has evidence the CLI cannot infer, pass it explicitly:
+
+```bash
+npx tsx scripts/kaizen-workflow-driver.ts status --issue <N> --repo "$ISSUES_REPO" --mode manual \
+  --dry-refactor "done: reused /kaizen-do and workflow gate ledger" \
+  --meet-reality "done: status output inspected" \
+  --hook-provider-activation "not applicable: hook-independent run; durable external evidence used"
+```
+
+The canonical evidence contract is `docs/workflow-gate-ledger.md`. Producers and consumers must use that ledger shape instead of inventing ad hoc booleans, progress rows, or prompt-local lifecycle lists.
+
+## Stop Conditions
+
+The inside-harness loop may stop only at one of these states:
+
+- parent complete: all intended sub-issues are closed or explicitly not applicable.
+- no eligible sub-issue: all remaining issues are blocked, claimed, closed, or out of scope; update the parent with the reason.
+- current sub-issue blocked: `/kaizen-do` status shows an honest blocked gate and the blocker is recorded durably.
+- repair budget exhausted: auto-dent/ledger repair state says no further same-PR evidence repair is useful.
+
+Do not stop merely because a PR exists. The selected sub-issue is incomplete until `/kaizen-do` has driven the applicable gates or recorded an honest blocked/not-applicable state.
+
+## Related Issues Sweep
+
+Before each PR body is finalized, search for closely related issues:
+
+```bash
+gh issue list --repo "$ISSUES_REPO" --state open --search "<key terms>" --json number,title,body --limit 15
+```
+
+For each result:
+
+- Fully resolved by this PR: include `Fixes <issue>` only if it is scope-matched.
+- Parent/umbrella relationship: include `Parent: #<parent>` or `Refs: #<parent>`, never a closing keyword.
+- Partially addressed: add `Related: #<issue>` and comment on what remains.
+
+## DRY Rule
+
+This skill exists to coordinate a loop, not to redefine the kaizen lifecycle. Keep lifecycle mechanics delegated to:
+
+- `/kaizen-do` for one-ticket execution.
+- `scripts/kaizen-workflow-driver.ts status` for status output.
+- `docs/workflow-gate-ledger.md` for the workflow evidence contract.
+- `/kaizen-write-pr` for PR descriptions.
+
+If this skill needs a new phase or gate, update the workflow gate ledger first and make the new skill consume it.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A process improvement methodology implemented as a Claude Code plugin. Kaizen pr
 ## What You Get
 
 - **Enforcement hooks** — PR review loops, worktree isolation, test coverage checks, dirty file gates, kaizen reflection triggers
-- **Dev workflow skills** — `/kaizen-do`, `/kaizen-pick`, `/kaizen-gaps`, `/kaizen-evaluate`, `/kaizen-implement`, `/kaizen-deep-dive`, `/kaizen-reflect`, `/kaizen-audit-issues`, `/kaizen-prd`, `/kaizen-plan`, `/kaizen-review-pr`, `/kaizen-zen`
+- **Dev workflow skills** — `/kaizen-do`, `/kaizen-autodent`, `/kaizen-pick`, `/kaizen-gaps`, `/kaizen-evaluate`, `/kaizen-implement`, `/kaizen-deep-dive`, `/kaizen-reflect`, `/kaizen-audit-issues`, `/kaizen-prd`, `/kaizen-plan`, `/kaizen-review-pr`, `/kaizen-zen`
 - **Background agents** — `kaizen-bg` for post-PR reflection
 - **Philosophy and policies** — the Zen of Kaizen, escalation levels (L1/L2/L3), verification discipline, engineering practices
 - **Issue taxonomy** — labels, epics, horizons, incident recording format
@@ -85,6 +85,7 @@ Kaizen reads `kaizen.config.json` from your project root:
 
 ```
 /kaizen-do        (driver: set /goal and run one ticket/task through all gates)
+/kaizen-autodent  (inside-harness loop: one eligible sub-issue at a time through /kaizen-do)
 /kaizen-gaps      (strategic: where should we invest?)
   -> /kaizen-pick     (select: which issue next?)
     -> /kaizen-evaluate   (scope: what to build?)

--- a/src/e2e/skill-change.test.ts
+++ b/src/e2e/skill-change.test.ts
@@ -237,6 +237,55 @@ describe("kaizen-do — /goal workflow driver", () => {
 });
 
 // ---------------------------------------------------------------------------
+// kaizen-autodent — inside-harness auto-dent workflow (#1154)
+// ---------------------------------------------------------------------------
+
+describe("kaizen-autodent — inside-harness auto-dent workflow", () => {
+  it("is a user-invocable hook-independent auto-dent skill", () => {
+    const skill = loadSkill("kaizen-autodent");
+    expect(skill).toContain("inside-harness auto-dent");
+    expect(skill).toContain("hook-independent");
+    expect(skill).toContain("parent/umbrella issue");
+    expect(skill).toContain("sub-issue list");
+  });
+
+  it("requires one eligible sub-issue and one scope-matched PR at a time", () => {
+    const skill = loadSkill("kaizen-autodent");
+    expect(skill).toContain("one eligible sub-issue");
+    expect(skill).toContain("one scope-matched PR");
+    expect(skill).toContain("Do NOT close the parent epic");
+    expect(skill).toContain("Fixes <sub-issue>");
+  });
+
+  it("names durable artifacts and treats hooks as advisory feedback", () => {
+    const skill = loadSkill("kaizen-autodent");
+    for (const phrase of [
+      "issue identity",
+      "stored plan/test-plan",
+      "worktree/case",
+      "commits and tests",
+      "related-area DRY/refactor",
+      "meet-reality output",
+      "review/requirements/impact",
+      "reflection evidence",
+      "PR/CI/merge/cleanup",
+      "hook/provider activation",
+    ]) {
+      expect(skill).toContain(phrase);
+    }
+    expect(skill).toContain("Hooks are helpful feedback, not proof");
+  });
+
+  it("delegates per-sub-issue execution and status to the shared contracts", () => {
+    const skill = loadSkill("kaizen-autodent");
+    expect(skill).toContain("/kaizen-do");
+    expect(skill).toContain("scripts/kaizen-workflow-driver.ts status");
+    expect(skill).toContain("docs/workflow-gate-ledger.md");
+    expect(skill).toContain("Do not hand-roll another gate checklist");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // kaizen-evaluate — Phase 4.5: Plan Formation (kaizen #981)
 // ---------------------------------------------------------------------------
 

--- a/src/policy-docs.test.ts
+++ b/src/policy-docs.test.ts
@@ -88,6 +88,26 @@ describe('kaizen-do workflow driver docs', () => {
   });
 });
 
+describe('kaizen-autodent inside-harness workflow docs', () => {
+  const agents = read('.agents/AGENTS.md');
+  const fragment = read('.agents/kaizen/instructions-fragment.md');
+  const readme = read('README.md');
+
+  it('lists /kaizen-autodent as the hook-independent inside-harness auto-dent skill', () => {
+    expect(agents).toContain('/kaizen-autodent');
+    expect(fragment).toContain('/kaizen-autodent');
+    expect(readme).toContain('/kaizen-autodent');
+    expect(agents).toContain('inside-harness auto-dent');
+  });
+
+  it('routes parent/sub-issue execution through /kaizen-do and the workflow ledger', () => {
+    expect(agents).toContain('one eligible sub-issue');
+    expect(agents).toContain('/kaizen-do');
+    expect(agents).toContain('docs/workflow-gate-ledger.md');
+    expect(readme).toContain('one eligible sub-issue at a time through /kaizen-do');
+  });
+});
+
 // ── kaizen-write-pr SKILL — Issue linkage (B17) ────────────────────
 
 describe('kaizen-write-pr SKILL — B17: Issue linkage section', () => {


### PR DESCRIPTION
Fixes Garsson-io/kaizen#1154
Parent: #1134
Related: #1211, #1166, #1164

## Story

Once upon a time, kaizen had `/kaizen-do` for one issue at a time and auto-dent for batch execution, but no reusable inside-harness workflow for a parent issue or explicit sub-issue queue when hooks are absent, stale, provider-specific, or unavailable.

Every day, an agent could still paste an ad hoc prompt and try to run that loop manually, but the parent/sub-issue policy, one-PR-per-sub-issue rule, durable artifact proof, and hooks-as-advisory stance lived in issue text instead of an invocable skill.

One day, #1154 captured that gap directly: inside-harness auto-dent needs a skill that is hook-independent, works one eligible sub-issue at a time, and routes proof through the same `/kaizen-do` and workflow ledger contracts rather than inventing another lifecycle checklist.

Because of that, this PR adds `/kaizen-autodent` as a user-invocable skill. It identifies parent/umbrella issues or sub-issue lists, selects one eligible sub-issue, delegates the selected ticket to `/kaizen-do`, requires one scope-matched PR, forbids closing the parent epic from child PRs, names durable artifacts for each phase, and treats hooks as feedback rather than proof.

Because of that, discoverability now includes `.agents/AGENTS.md`, `.agents/kaizen/instructions-fragment.md`, and README. The regression tests pin the skill contract and the docs so future edits cannot silently drift back to `/kaizen-do` only.

Until finally, the meet-reality proof includes both deterministic checks and a real read-only provider smoke: on `origin/main`, the same synthetic request selected `/kaizen-do`; on this branch, it selected `/kaizen-autodent` and stated the one-sub-issue/no-parent-close rule.

And ever since, inside-harness auto-dent has a stable L1 entry point that is intentionally smaller than GEPA or provider-runtime integration: it coordinates the loop while preserving the shared workflow gate ledger as the source of truth.

## Architecture

```text
/kaizen-autodent <parent|sub-issue-list|task>
  -> classify parent/sub-issue/single-task input
  -> select one eligible sub-issue
  -> delegate selected issue to /kaizen-do
  -> read status from scripts/kaizen-workflow-driver.ts status
  -> use docs/workflow-gate-ledger.md as the durable evidence contract
```

`/kaizen-autodent` is a loop coordinator. It does not redefine per-ticket lifecycle gates.

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add a dedicated skill instead of expanding `/kaizen-do` | #1154 needs parent/sub-issue queue behavior; `/kaizen-do` is intentionally one ticket/task | One more skill, but clearer boundaries |
| Delegate per-sub-issue execution to `/kaizen-do` | Avoids a second lifecycle checklist and preserves existing gates | The new skill depends on `/kaizen-do` staying healthy |
| Use the workflow driver and ledger as source of truth | Keeps producers/consumers aligned across manual and auto-dent paths | This PR is L1 guidance, not a new enforcement layer |
| Treat hooks as advisory | The target workflow must work when hooks are absent or provider-specific | Stronger enforcement remains future L2/L3 work |
| Do not implement GEPA here | GEPA is tracked by #1211 as a larger reflection-to-prompt-patch mechanism | This PR only makes the inside-harness workflow invocable |

## What's In This PR

| File | Purpose |
|---|---|
| `.agents/skills/kaizen-autodent/SKILL.md` | New user-invocable inside-harness auto-dent skill |
| `.agents/AGENTS.md` | Agent-facing discoverability and policy summary |
| `.agents/kaizen/instructions-fragment.md` | Host injected instructions discoverability |
| `README.md` | Public skill list and skill-chain discoverability |
| `src/e2e/skill-change.test.ts` | Structural guard for skill contract and shared-contract delegation |
| `src/policy-docs.test.ts` | Docs drift guard for skill visibility and workflow-ledger routing |

## Behavioral Proof

Problem statement: before this PR, given the input `run hook-independent inside-harness auto-dent for a parent issue and work one eligible sub-issue at a time through the kaizen lifecycle`, the repo had no dedicated skill. A provider had to infer the loop from `/kaizen-do`, which is a one-ticket driver.

Synthetic case:

```text
Read-only. Do not edit files or run commands. A user says: "run hook-independent inside-harness auto-dent for a parent issue and work one eligible sub-issue at a time through the kaizen lifecycle." In this repo, which kaizen skill should be invoked? Answer with the skill name and one sentence explaining the parent/sub-issue rule.
```

Before evidence, run in clean `origin/main` checkout:

```text
/kaizen-do — it sets a literal /goal and drives a single issue/task through the full kaizen gate chain...
```

After evidence, run in this PR worktree:

```text
/kaizen-autodent.

The parent/sub-issue rule: it selects one eligible sub-issue at a time and delegates each through /kaizen-do, requiring one scope-matched PR per sub-issue — and it never closes the parent epic from a child PR (use Parent:/Refs: linkage instead).
```

Smoke test command: the exact read-only `claude -p --output-format json` command above was run once against `origin/main` and once against this branch. The deterministic CI smoke is `npx vitest run src/e2e/skill-change.test.ts src/policy-docs.test.ts`, which asserts the new skill text, delegation policy, durable artifact table, hooks-advisory language, and docs discoverability.

## Impact (goal -> before/after -> match)

- Goal (#1154): make hook-independent, inside-harness auto-dent reusable for parent/umbrella issues or sub-issue lists while preserving durable kaizen gates.
- Acceptance signal: new user-invocable skill, one eligible sub-issue policy, one scope-matched PR policy, no parent epic closure, artifact phase table, hooks-as-advisory language, `/kaizen-do` + workflow-driver + ledger reuse, docs/tests discoverability.
- BEFORE: `/kaizen-do` existed for one issue/task, but no `kaizen-autodent` skill existed and docs listed only `/kaizen-do` for this workflow family. The provider smoke on `origin/main` selected `/kaizen-do` for the synthetic inside-harness auto-dent request.
- AFTER: `.agents/skills/kaizen-autodent/SKILL.md` exists; docs list `/kaizen-autodent`; tests assert the parent/sub-issue, artifact, advisory-hook, and shared-contract requirements; the same provider smoke on this branch selected `/kaizen-autodent`.
- Delta: one new skill plus doc/test ratchets; no new lifecycle schema or competing gate checklist.
- Goal met?: yes.
- Residual scan: GEPA prompt evolution is related but separate and remains tracked by #1211; provider-agnostic enforcement and DRY sweep modes remain related follow-ups (#1166, #1164).

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Inside-harness auto-dent skill exists and is user-invocable for parent issue or sub-issue list | Tested: `src/e2e/skill-change.test.ts` | Not needed for structural skill text | Not needed | Provider smoke selects `/kaizen-autodent` | Not needed |
| Skill requires one eligible sub-issue and one scope-matched PR per sub-issue | Tested: `src/e2e/skill-change.test.ts` | Not needed | Not needed | Provider smoke states the rule | Not needed |
| Skill phases name durable artifacts instead of relying on hooks | Tested: `src/e2e/skill-change.test.ts` | Not needed | Not needed | Not needed | Not needed |
| Skill reuses `/kaizen-do`, workflow status CLI, and workflow gate ledger | Tested: `src/e2e/skill-change.test.ts` | Not needed | Status CLI smoke run manually | Not needed | Tested by workflow status CLI output for #1154 |
| Docs make the skill discoverable | Tested: `src/policy-docs.test.ts` | Not needed | Not needed | Provider smoke observes the new skill | Not needed |
| Related-area DRY sweep avoids competing lifecycle text | Tested structurally by shared-contract assertions | Not needed | Manual `rg` residual scan | Not needed | Workflow status CLI shows the canonical gates |

## Validation

- [x] RED first: `npx vitest run src/e2e/skill-change.test.ts src/policy-docs.test.ts --reporter=verbose` failed before implementation because `/kaizen-autodent` and docs discoverability did not exist.
- [x] `npx vitest run src/e2e/skill-change.test.ts src/policy-docs.test.ts scripts/kaizen-workflow-driver.test.ts --reporter=verbose` — passed.
- [x] `npm run typecheck` — passed.
- [x] `npm run test:fast` — 1 file passed, 50 tests passed.
- [x] `npm test` — 168 files passed, 3973 tests passed, 14 skipped.
- [x] `npx tsx scripts/kaizen-workflow-driver.ts status --issue 1154 --repo Garsson-io/kaizen --mode manual ...` — rendered canonical gates; DRY/refactor and meet-reality marked done via explicit evidence; hook/provider activation marked not applicable for hook-independent skill.
- [x] Read-only provider smoke on `origin/main` and this branch showed `/kaizen-do` -> `/kaizen-autodent` selection change for the synthetic inside-harness auto-dent request.
- [x] Related issue sweep found #1211 GEPA, #1166 provider-agnostic enforcement, and #1164 cross-PR DRY mode as related follow-ups, not scope-matched closures.

## Known Limitations

This is the L1 skill codification requested by #1154. It does not implement the GEPA optimizer from #1211, provider-agnostic enforcement from #1166, or cross-PR DRY sweep mode from #1164.
