### PR TITLE
fix: anchor worktree write guard to hook event cwd

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -136,6 +136,7 @@ Memory-only retention means the next session on a different machine repeats the 
 
 ### Branch & PR hygiene
 
+- **When editing with patch-style tools from a case worktree, use absolute file paths.** Relative patch targets can resolve against the agent process checkout instead of the intended case worktree, especially in multi-worktree sessions. Anchor patch edits to the worktree path you are actually modifying (for example `.claude/worktrees/<case>/src/...`) and verify `pwd`/`git status --short --branch` in that worktree before the first source edit.
 - **Never push new commits to a branch whose most recent PR was already merged with no subsequent open PR.** Commits pushed to such a branch can get orphaned and the review-loop state file points at the merged PR, not the new work. Always create a new branch (via `EnterWorktree` or `git checkout -b`) for follow-up work.
 - **Detect merged-branch state before pushing.** Check the branch you are actually pushing. For ordinary `git push` this is usually the current branch; for explicit refspecs it is the remote target branch from `refs/heads/<branch>`. Run:
   ```bash

--- a/.claude/hooks/kaizen-enforce-worktree-writes.sh
+++ b/.claude/hooks/kaizen-enforce-worktree-writes.sh
@@ -26,6 +26,7 @@ source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
 
 read_hook_input
 get_file_path
+get_cwd
 
 # If no file path, allow (shouldn't happen for Edit/Write)
 if [ -z "$FILE_PATH" ]; then
@@ -35,21 +36,40 @@ fi
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true
 
-# Resolve the main checkout path from git
-GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
+CONTEXT_CWD="${HOOK_CWD:-$(pwd)}"
+if [ ! -d "$CONTEXT_CWD" ]; then
+  CONTEXT_CWD=$(pwd)
+fi
+CONTEXT_CWD=$(realpath -m "$CONTEXT_CWD" 2>/dev/null || echo "$CONTEXT_CWD")
+
+# Resolve the main checkout path from the hook event cwd, not the hook process
+# cwd. Edit/Write tools report their intended cwd in the hook event; anchoring
+# relative file paths there prevents cross-worktree path drift.
+GIT_COMMON=$(git -C "$CONTEXT_CWD" rev-parse --git-common-dir 2>/dev/null)
 if [ -z "$GIT_COMMON" ]; then
   exit 0
 fi
 
-# Determine main checkout root
-if [ "$GIT_COMMON" = ".git" ]; then
-  MAIN_ROOT=$(pwd)
-else
-  MAIN_ROOT=$(dirname "$GIT_COMMON")
+GIT_COMMON_ABS=$(cd "$CONTEXT_CWD" && realpath -m "$GIT_COMMON" 2>/dev/null)
+if [ -z "$GIT_COMMON_ABS" ]; then
+  exit 0
 fi
 
-# Resolve FILE_PATH to absolute
-ABS_FILE_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+# Resolve FILE_PATH to absolute, using the hook event cwd for relative paths.
+case "$FILE_PATH" in
+  /*)
+    ABS_FILE_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+    ;;
+  *)
+    ABS_FILE_PATH=$(realpath -m "$CONTEXT_CWD/$FILE_PATH" 2>/dev/null || echo "$CONTEXT_CWD/$FILE_PATH")
+    ;;
+esac
+
+if [ "$GIT_COMMON" = ".git" ]; then
+  MAIN_ROOT=$(cd "$CONTEXT_CWD" && pwd)
+else
+  MAIN_ROOT=$(dirname "$GIT_COMMON_ABS")
+fi
 
 # Only care about files inside the main checkout
 if ! echo "$ABS_FILE_PATH" | grep -q "^${MAIN_ROOT}/"; then

--- a/.claude/hooks/lib/input-utils.sh
+++ b/.claude/hooks/lib/input-utils.sh
@@ -14,6 +14,7 @@
 #   get_command              # sets COMMAND
 #   get_stdout               # sets STDOUT
 #   get_exit_code            # sets EXIT_CODE (defaults to "0")
+#   get_cwd                  # sets HOOK_CWD from the hook event cwd
 #   require_tool_bash        # exits 0 if TOOL_NAME != "Bash"
 #   require_success          # exits 0 if EXIT_CODE != "0"
 #
@@ -50,6 +51,11 @@ get_exit_code() {
 # Extract .tool_input.file_path into FILE_PATH (for Edit/Write/Read hooks).
 get_file_path() {
   FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+}
+
+# Extract .cwd into HOOK_CWD.
+get_cwd() {
+  HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 }
 
 # Exit 0 (allow) if TOOL_NAME is not "Bash".

--- a/.claude/hooks/tests/test-enforce-worktree-writes.sh
+++ b/.claude/hooks/tests/test-enforce-worktree-writes.sh
@@ -29,6 +29,16 @@ run_edit_hook_in_dir() {
   (cd "$cwd" && echo "$input" | bash "$HOOK" 2>/dev/null)
 }
 
+run_edit_hook_with_event_cwd() {
+  local process_cwd="$1"
+  local event_cwd="$2"
+  local file_path="$3"
+  local input
+  input=$(jq -n --arg cwd "$event_cwd" --arg fp "$file_path" \
+    '{"cwd":$cwd,"tool_input":{"file_path":$fp}}')
+  (cd "$process_cwd" && echo "$input" | bash "$HOOK" 2>/dev/null)
+}
+
 # Detect if we're in main checkout on main branch
 GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
@@ -107,6 +117,21 @@ git -C "$MAIN" worktree add -q -b case/260628-k1531-demo "$WT"
 
 OUTPUT=$(run_edit_hook_in_dir "$MAIN" "$MAIN/src/thing.ts")
 assert_contains "main checkout denial names active case worktree target" "$WT/src/thing.ts" "$OUTPUT"
+
+echo ""
+echo "=== Relative edit paths follow hook event cwd, not hook process cwd ==="
+
+OUTPUT=$(run_edit_hook_with_event_cwd "$WT" "$MAIN" "src/thing.ts")
+if is_denied "$OUTPUT"; then
+  echo "  PASS: event-cwd main checkout relative edit denied"
+  ((PASS++))
+else
+  echo "  FAIL: event-cwd main checkout relative edit was allowed"
+  ((FAIL++))
+fi
+
+OUTPUT=$(run_edit_hook_with_event_cwd "$MAIN" "$WT" "src/thing.ts")
+assert_eq "event-cwd worktree relative edit allowed" "" "$OUTPUT"
 
 WT2="$MAIN/.claude/worktrees/260628-k1532-demo"
 git -C "$MAIN" worktree add -q -b case/260628-k1532-demo "$WT2"


### PR DESCRIPTION
Fixes #1577

Related: #913, #28, #1536

## Story

Once upon a time, kaizen already had a main-checkout source-write guard: `kaizen-enforce-worktree-writes.sh` blocks `Edit`/`Write` source changes in the main checkout on `main` and points agents toward active case worktrees.

Every day, that guard worked when the hook process cwd, hook event cwd, and edit path all described the same checkout. The tests covered that normal path, including helpful worktree hints.

One day, #1577 recorded a different failure: a session intended to work in a case worktree, but relative patch/edit paths were resolved against the main checkout. The guard had no test for hook process cwd drifting away from hook event cwd.

Because of that, I reproduced the failure with a temporary main checkout and case worktree: run the hook process from the worktree, send a hook event whose `cwd` is main, and use relative `file_path: "src/thing.ts"`. Before this PR the output was empty, so the main-checkout source edit was allowed.

Because of that, this PR teaches the shared hook input parser to read event `cwd`, and makes `kaizen-enforce-worktree-writes.sh` anchor git context plus relative file-path resolution to that event cwd, with process cwd only as a fallback.

Until finally, the focused hook test now proves both directions: event-cwd main relative source edits are denied even from a worktree process, and event-cwd worktree relative source edits are allowed even from a main process.

And ever since, the write guard evaluates the edit context the tool reported, not the shell location where the hook happened to execute.

## Architecture

```text
PreToolUse Edit/Write event
  ├─ cwd: <tool event cwd>
  └─ tool_input.file_path: <absolute or relative path>
        ↓
.claude/hooks/lib/input-utils.sh
  └─ get_cwd -> HOOK_CWD
        ↓
kaizen-enforce-worktree-writes.sh
  ├─ CONTEXT_CWD = HOOK_CWD || pwd
  ├─ git -C CONTEXT_CWD rev-parse --git-common-dir
  ├─ resolve relative file_path against CONTEXT_CWD
  └─ deny if resolved target is source under main checkout on main
```

The PR also adds a canonical instruction in `.agents/AGENTS.md`: patch-style tools in case worktrees must use absolute file paths, because some patch tools are outside Claude hook enforcement.

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Anchor the existing guard to hook event `cwd` | The tool event is the policy context; process cwd can drift across worktrees | Relies on hook events providing useful `cwd`, with fallback to prior behavior |
| Add shared `get_cwd` in `input-utils.sh` | Keeps hook input parsing DRY instead of adding one-off jq parsing | Small shared API addition for shell hooks |
| Keep the fix in the existing write guard | This is already the Edit/Write source-write choke point | Does not address Bash write bypasses tracked separately in #913/#28 |
| Add an agent instruction for patch tools | The observed incident used `apply_patch`, which may not emit Claude hook events | L1 coverage only for tools outside the hook system |

## What's In This PR

| File | Purpose |
|---|---|
| `.claude/hooks/lib/input-utils.sh` | Adds shared `get_cwd` parser for hook event cwd |
| `.claude/hooks/kaizen-enforce-worktree-writes.sh` | Resolves git context and relative edit paths against event cwd |
| `.claude/hooks/tests/test-enforce-worktree-writes.sh` | Adds RED/GREEN cwd-drift shell-hook coverage |
| `.agents/AGENTS.md` | Documents absolute-path discipline for patch-style edits in worktrees |

## Test Plan (Behaviors × Levels)

| Behavior | Level | Coverage |
|---|---|---|
| Relative source edit with event `cwd` at main is denied even when hook process runs in a worktree | System | `.claude/hooks/tests/test-enforce-worktree-writes.sh`; RED failed before implementation |
| Relative source edit with event `cwd` at a case worktree is allowed even when hook process runs in main | System | `.claude/hooks/tests/test-enforce-worktree-writes.sh`; RED failed before implementation |
| Existing absolute main-checkout source edits, runtime-dir allowlist, and worktree hints remain unchanged | Regression/System | Existing focused hook test cases plus full shell hook suite |

No deferred behaviors for the hook-event guard. Bash write bypasses and broader main-checkout write policy remain tracked by #913/#28.

## Impact (goal -> before/after -> match)

- Goal (#1577): prevent relative edit-path context drift from letting worktree sessions write source files in the main checkout.
- Acceptance signal: shell-hook repro with process cwd in a case worktree, event cwd in main, and relative `src/thing.ts` must deny.
- BEFORE: the repro returned empty output, so it was allowed.
- AFTER: focused test reports `PASS: event-cwd main checkout relative edit denied` and `PASS: event-cwd worktree relative edit allowed`.
- Delta: `kaizen-enforce-worktree-writes.sh` now uses event cwd for git context and relative file-path resolution; patch-style tools also get explicit absolute-path guidance in the canonical agent instructions.
- Goal met?: yes for the Claude Edit/Write hook path; non-hook patch tools are covered by instruction, not mechanical enforcement.
- Residual scan: `rg` shows the new cwd parser is centralized in `input-utils.sh`; no duplicate local jq parsing was added.

## Validation

- [x] RED: focused hook test failed with 2 cwd-drift failures: event-cwd main relative edit was allowed, and event-cwd worktree relative edit was denied.
- [x] GREEN: `bash .claude/hooks/tests/test-enforce-worktree-writes.sh` — 13 passed, 0 failed.
- [x] Full shell hook suite: `bash .claude/hooks/tests/run-all-tests.sh` — 435 passed, 0 failed.
- [x] Fast gate: `npm run check:fast` — typecheck passed; changed Vitest set had no non-E2E tests.
- [x] Whitespace: `git diff --check` passed.
- [x] Residual scan: `rg "HOOK_CWD|get_cwd|\.cwd //|tool event cwd|process cwd" .claude/hooks src/hooks .claude/hooks/tests` showed only the shared parser/new guard references plus existing cwd-aware TypeScript hooks.

## Known Limitations

This does not close the broader Bash-write bypass class in #913/#28. It also cannot mechanically govern patch tools that do not emit Claude hook events; for that path this PR adds canonical absolute-path guidance in `.agents/AGENTS.md`.
