### PR TITLE
fix: allow deletion-only pre-push refs

### DIFF
--- a/docs/git-hooks-design.md
+++ b/docs/git-hooks-design.md
@@ -58,8 +58,11 @@ current checkout branch. Git sends each ref update on stdin as:
 This matters when an explicit refspec recreates a deleted remote PR branch while
 `HEAD` is on a different branch: `gh pr list --head <remote branch> --state all`
 can still find the merged PR, but querying the current checkout branch would
-miss it. Branch deletion refs (`local_sha` all zeros) are ignored because
-deleting a stale merged PR branch is the cleanup path, not new orphan work.
+miss it. Branch deletion refs (`local_sha` all zeros) and non-branch ref updates
+are ignored because deleting a stale merged PR branch or pushing a tag is not
+new branch work. When stdin contains refs but none are pushed branch targets,
+the hook allows silently with `no_push_targets` instead of falling back to the
+current branch.
 
 ### Agent-env gating
 

--- a/src/hooks/pre-push.test.ts
+++ b/src/hooks/pre-push.test.ts
@@ -188,7 +188,15 @@ describe('derivePushTargetBranches — pushed ref target contract (#1536)', () =
       'delete 0000000000000000000000000000000000000000 refs/heads/worktree-kz-1508-1502-transcripts abc123',
     );
 
-    expect(derivePushTargetBranches(refs, 'main')).toEqual(['main']);
+    expect(derivePushTargetBranches(refs, 'main')).toEqual([]);
+  });
+
+  it('does not fall back to the current branch for non-branch ref updates', () => {
+    const refs = parseStdin(
+      'refs/tags/v1.0 abc123 refs/tags/v1.0 0000000000000000000000000000000000000000',
+    );
+
+    expect(derivePushTargetBranches(refs, 'case/current')).toEqual([]);
   });
 
   it('deduplicates repeated branch targets while preserving order', () => {
@@ -718,7 +726,7 @@ describe('processPrePush — integrated flow with injected query', () => {
     expect(result.decision.context?.branch).toBe('feature/merged');
   });
 
-  it('allows a deletion-only push by evaluating the current-branch fallback, not the deleted target (#1536)', () => {
+  it('allows a deletion-only push without querying the current branch (#1536)', () => {
     const queriedBranches: string[] = [];
     const rawStdin = [
       'delete',
@@ -734,14 +742,14 @@ describe('processPrePush — integrated flow with injected query', () => {
         currentBranch: 'case/current-work',
         queryPrState: (_repo, branch) => {
           queriedBranches.push(branch);
-          return emptyQuery();
+          return mergedQuery();
         },
       },
     );
 
-    expect(queriedBranches).toEqual(['case/current-work']);
+    expect(queriedBranches).toEqual([]);
     expect(result.decision.action).toBe('allow_silent');
-    expect(result.decision.reason).toBe('no_pr_history');
+    expect(result.decision.reason).toBe('no_push_targets');
     expect(result.decision.context?.branch).toBe('case/current-work');
   });
 

--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -135,8 +135,10 @@ function branchNameFromRef(ref: string): string | null {
  *
  * Git pre-push receives the actual ref update list. That list is the authority:
  * `HEAD` can be on a different branch when an explicit refspec recreates a
- * deleted remote PR branch (#1536). Branch deletions are intentionally ignored;
- * deleting a stale merged PR branch is the cleanup path, not orphan work.
+ * deleted remote PR branch (#1536). Branch deletions and non-branch ref
+ * updates are intentionally ignored; deleting a stale merged PR branch is the
+ * cleanup path, not orphan work. Only genuinely empty stdin falls back to the
+ * current branch for manual/test invocations that lack Git's ref list.
  */
 export function derivePushTargetBranches(refs: GitPushRef[], currentBranch: string): string[] {
   const targets: string[] = [];
@@ -151,6 +153,7 @@ export function derivePushTargetBranches(refs: GitPushRef[], currentBranch: stri
   }
 
   if (targets.length > 0) return targets;
+  if (refs.length > 0) return [];
   const fallback = currentBranch.trim();
   return fallback ? [fallback] : [];
 }


### PR DESCRIPTION
## Story

Once upon a time, #1571 made the pre-push hook evaluate pushed remote branch refs, and #1579 made Codex tool-call pushes actually enter that hook under `CODEX_CI=1`.

Every day after that, branch deletion was intended to remain the cleanup path: deleting a stale merged PR branch is not new orphan work.

One day, cleanup validation exposed a remaining edge case. A deletion-only pre-push ref was correctly ignored as a pushed target, but because no target remained, the helper fell back to the current branch. If the agent was standing on a just-merged branch, the hook could deny the deletion as a merged-branch push for the current branch.

Because of that, this PR tightens the target contract: fallback to the current branch happens only when Git supplies no refs at all. If stdin contains refs but none are pushed branch targets, the hook resolves to `no_push_targets` and allows silently.

Until finally, cleanup and tag pushes do not get confused with branch work, while real branch creation/update refs still go through the merged-branch guard.

Fixes Garsson-io/kaizen#1536
Related: Garsson-io/kaizen#1571
Related: Garsson-io/kaizen#1579
Related broader lifecycle cluster: Garsson-io/kaizen#1010

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/pre-push.ts` | Returns no pushed targets when stdin has refs but none update remote branches; keeps current-branch fallback only for genuinely empty stdin |
| `src/hooks/pre-push.test.ts` | Adds/updates regression coverage for deletion-only refs, tag refs, and deletion-only process flow with a merged current branch |
| `docs/git-hooks-design.md` | Documents that deletion and non-branch refs produce `no_push_targets` instead of current-branch fallback |

## Impact (goal -> before/after -> match)

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Keep stale branch deletion as the cleanup path | Real wrapper smoke with deletion-only stdin while current branch had merged PR #1579 denied with `merged_branch_push` for the current branch | Same smoke under `CODEX_CI=1` exits `0` and traces `reason:"no_push_targets"` | Deletion cleanup no longer queries or denies based on the current branch | yes |
| Preserve merged-branch recreation protection | Pushed branch refs from #1571/#1579 still route to target-branch PR lookup | This PR only changes the no-target case after refs were parsed | Branch creation/update protection remains intact | yes |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Test File / Command | Status |
|---|---|---|---|---|---|
| 1 | Deletion refs do not fall back to current branch | code | Unit | `src/hooks/pre-push.test.ts` | tested |
| 2 | Non-branch refs, such as tags, do not fall back to current branch | code | Unit | `src/hooks/pre-push.test.ts` | tested |
| 3 | Deletion-only process flow does not query PR state even when current branch would look merged | session | Integration | `src/hooks/pre-push.test.ts` | tested |
| 4 | Real wrapper deletion-only cleanup under `CODEX_CI=1` allows silently | user/operator | System smoke | synthetic pre-push stdin against `.githooks/pre-push` | tested |
| 5 | Existing pre-push and hook suites remain green | repo | Regression | focused Vitest, `npm run check:fast`, `npm run test:hooks` | tested |

No deferred behaviors.

## Validation

- [x] `npx vitest run src/hooks/pre-push.test.ts` -> 67 tests passed
- [x] Real wrapper deletion-only smoke with `CODEX_CI=1` -> `exit_status=0`, trace `reason:"no_push_targets"`
- [x] `npm run check:fast` -> typecheck passed, changed tests passed; 3 files, 110 tests
- [x] `npm run test:hooks` -> 433 hook tests passed

## Known Limitations

- This PR is intentionally narrow. The broader worktree lifecycle cluster (#1010) remains open; this closes the deletion-only cleanup edge in the #1536 merged-branch guard path.
