### PR TITLE
Add GEPA prompt-evolution bundle for auto-dent

### DIFF
--- a/scripts/auto-dent-gepa.test.ts
+++ b/scripts/auto-dent-gepa.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+import {
+  buildGepaPromptEvolutionBundle,
+  type GepaBundleInput,
+} from './auto-dent-gepa.js';
+import type { RunMetrics } from './auto-dent-run.js';
+
+function run(overrides: Partial<RunMetrics>): RunMetrics {
+  return {
+    run: 1,
+    start_epoch: 1,
+    duration_seconds: 60,
+    exit_code: 0,
+    cost_usd: 1,
+    tool_calls: 10,
+    prs: [],
+    issues_filed: [],
+    issues_closed: [],
+    cases: [],
+    stop_requested: false,
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<GepaBundleInput> = {}): GepaBundleInput {
+  return {
+    batchId: 'batch-gepa',
+    generatedAt: '2026-06-29T01:09:00.000Z',
+    promptTarget: {
+      id: 'explore-gaps',
+      path: 'prompts/explore-gaps.md',
+      text: 'Explore prompt',
+    },
+    textualFeedback: [
+      'Explore should emit durable candidate-task manifests, not only file issues.',
+      'Reward should not collapse to a single issues_filed scalar.',
+    ],
+    runs: [
+      run({
+        run: 1,
+        mode: 'explore',
+        issues_filed: ['#1196', '#1211'],
+        prompt_template: 'explore-gaps.md',
+        prompt_hash: 'abc123',
+        process_verdict: 'pass',
+        review_verdict: 'skipped',
+      }),
+      run({
+        run: 2,
+        mode: 'exploit',
+        prs: ['https://github.com/Garsson-io/kaizen/pull/1581'],
+        review_verdict: 'pass',
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+describe('auto-dent GEPA bundle (#1211)', () => {
+  it('builds a dry-run GEPA-ready bundle from prompt, feedback, and run traces', () => {
+    const bundle = buildGepaPromptEvolutionBundle(input());
+
+    expect(bundle).toMatchObject({
+      version: 1,
+      optimizer: 'GEPA',
+      runtime: { mode: 'dry-run', externalDependency: 'optional' },
+      batchId: 'batch-gepa',
+      promptTarget: {
+        id: 'explore-gaps',
+        path: 'prompts/explore-gaps.md',
+        text: 'Explore prompt',
+      },
+    });
+    expect(bundle.textualFeedback).toContain('Reward should not collapse to a single issues_filed scalar.');
+    expect(bundle.traceExamples).toHaveLength(2);
+    expect(bundle.traceExamples[0]).toMatchObject({
+      run: 1,
+      mode: 'explore',
+      promptHash: 'abc123',
+      promptTemplate: 'explore-gaps.md',
+      reward: 2,
+      artifacts: { prs: [], issuesFiled: ['#1196', '#1211'], issuesClosed: [] },
+      qualitySignals: { processVerdict: 'pass', reviewVerdict: 'skipped' },
+    });
+    expect(bundle.traceExamples[1].reward).toBe(1);
+  });
+
+  it('names Pareto objectives instead of a single scalar reward', () => {
+    const bundle = buildGepaPromptEvolutionBundle(input());
+
+    expect(bundle.paretoObjectives.map((objective) => objective.id)).toEqual([
+      'mode_reward',
+      'process_completeness',
+      'review_pass_rate',
+      'cost_usd',
+    ]);
+    expect(bundle.paretoObjectives.find((objective) => objective.id === 'mode_reward')).toMatchObject({
+      direction: 'maximize',
+      source: 'scripts/auto-dent-run.ts:modeSuccess',
+    });
+    expect(bundle.paretoObjectives.find((objective) => objective.id === 'cost_usd')).toMatchObject({
+      direction: 'minimize',
+    });
+  });
+
+  it('CLI emits inspectable JSON without requiring live GEPA, Python, or API keys', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'auto-dent-gepa-'));
+    const inputPath = join(tmp, 'input.json');
+    const promptPath = join(tmp, 'explore-gaps.md');
+    writeFileSync(inputPath, JSON.stringify(input({ promptTarget: { id: 'explore-gaps', path: promptPath } }), null, 2));
+    writeFileSync(promptPath, 'Prompt from disk');
+
+    const result = spawnSync('npx', ['tsx', 'scripts/auto-dent-gepa.ts', '--input', inputPath, '--prompt-file', promptPath], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.runtime).toEqual({ mode: 'dry-run', externalDependency: 'optional' });
+    expect(parsed.promptTarget.text).toBe('Prompt from disk');
+    expect(parsed.traceExamples[0].mode).toBe('explore');
+
+    const source = readFileSync('scripts/auto-dent-gepa.ts', 'utf8');
+    expect(source).not.toContain('child_process');
+    expect(source).not.toContain('pip install');
+    expect(source).not.toContain('OPENAI_API_KEY');
+  });
+});

--- a/scripts/auto-dent-gepa.ts
+++ b/scripts/auto-dent-gepa.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env npx tsx
+/**
+ * auto-dent-gepa — deterministic GEPA-ready prompt-evolution bundle.
+ *
+ * This does not run GEPA. It creates the local contract a later GEPA runner can
+ * consume: prompt target, trajectory examples, textual feedback, and Pareto
+ * objectives. The dry-run path has no Python, API-key, or live LLM dependency.
+ */
+
+import { readFileSync } from 'fs';
+import { modeSuccess, type RunMetrics } from './auto-dent-run.js';
+
+export interface GepaPromptTarget {
+  id: string;
+  path: string;
+  text?: string;
+}
+
+export interface GepaBundleInput {
+  batchId: string;
+  promptTarget: GepaPromptTarget;
+  runs: RunMetrics[];
+  textualFeedback?: string[];
+  generatedAt?: string;
+}
+
+export interface GepaTraceExample {
+  run: number;
+  mode: string;
+  promptHash?: string;
+  promptTemplate?: string;
+  reward: number;
+  artifacts: {
+    prs: string[];
+    issuesFiled: string[];
+    issuesClosed: string[];
+  };
+  qualitySignals: {
+    reviewVerdict?: RunMetrics['review_verdict'];
+    processVerdict?: RunMetrics['process_verdict'];
+    lifecycleHealth?: RunMetrics['lifecycle_health'];
+    failureClass?: string;
+  };
+}
+
+export interface GepaParetoObjective {
+  id: string;
+  direction: 'maximize' | 'minimize';
+  source: string;
+  rationale: string;
+}
+
+export interface GepaPromptEvolutionBundle {
+  version: 1;
+  optimizer: 'GEPA';
+  runtime: {
+    mode: 'dry-run';
+    externalDependency: 'optional';
+  };
+  batchId: string;
+  generatedAt: string;
+  promptTarget: GepaPromptTarget;
+  textualFeedback: string[];
+  traceExamples: GepaTraceExample[];
+  paretoObjectives: GepaParetoObjective[];
+}
+
+export const DEFAULT_GEPA_OBJECTIVES: GepaParetoObjective[] = [
+  {
+    id: 'mode_reward',
+    direction: 'maximize',
+    source: 'scripts/auto-dent-run.ts:modeSuccess',
+    rationale: 'Preserve the mode-aware reward signal auto-dent already records.',
+  },
+  {
+    id: 'process_completeness',
+    direction: 'maximize',
+    source: 'RunMetrics.process_verdict',
+    rationale: 'A prompt candidate that increases artifacts while skipping kaizen evidence is worse, not better.',
+  },
+  {
+    id: 'review_pass_rate',
+    direction: 'maximize',
+    source: 'RunMetrics.review_verdict',
+    rationale: 'GEPA candidates should improve reviewable work, not just raw output count.',
+  },
+  {
+    id: 'cost_usd',
+    direction: 'minimize',
+    source: 'RunMetrics.cost_usd',
+    rationale: 'GEPA is valuable to kaizen partly because it promises fewer rollouts for prompt improvement.',
+  },
+];
+
+export function buildGepaPromptEvolutionBundle(input: GepaBundleInput): GepaPromptEvolutionBundle {
+  return {
+    version: 1,
+    optimizer: 'GEPA',
+    runtime: {
+      mode: 'dry-run',
+      externalDependency: 'optional',
+    },
+    batchId: input.batchId,
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    promptTarget: input.promptTarget,
+    textualFeedback: input.textualFeedback ?? [],
+    traceExamples: input.runs.map((run) => {
+      const mode = run.mode ?? 'exploit';
+      return {
+        run: run.run,
+        mode,
+        promptHash: run.prompt_hash,
+        promptTemplate: run.prompt_template,
+        reward: modeSuccess(mode, run),
+        artifacts: {
+          prs: run.prs,
+          issuesFiled: run.issues_filed,
+          issuesClosed: run.issues_closed,
+        },
+        qualitySignals: {
+          reviewVerdict: run.review_verdict,
+          processVerdict: run.process_verdict,
+          lifecycleHealth: run.lifecycle_health,
+          failureClass: run.failure_class,
+        },
+      };
+    }),
+    paretoObjectives: DEFAULT_GEPA_OBJECTIVES,
+  };
+}
+
+function parseArgs(argv: string[]): Record<string, string | true> {
+  const args: Record<string, string | true> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    i++;
+  }
+  return args;
+}
+
+function usage(): never {
+  console.error('Usage: npx tsx scripts/auto-dent-gepa.ts --input bundle-input.json [--prompt-file prompts/explore-gaps.md]');
+  process.exit(1);
+}
+
+function readJson(path: string): GepaBundleInput {
+  return JSON.parse(readFileSync(path, 'utf8')) as GepaBundleInput;
+}
+
+if (process.argv[1]?.endsWith('auto-dent-gepa.ts') || process.argv[1]?.endsWith('auto-dent-gepa.js')) {
+  const args = parseArgs(process.argv.slice(2));
+  const inputPath = typeof args.input === 'string' ? args.input : '';
+  if (!inputPath) usage();
+
+  const input = readJson(inputPath);
+  const promptFile = typeof args['prompt-file'] === 'string' ? args['prompt-file'] : '';
+  if (promptFile) {
+    input.promptTarget = {
+      ...input.promptTarget,
+      path: input.promptTarget.path || promptFile,
+      text: readFileSync(promptFile, 'utf8'),
+    };
+  }
+
+  process.stdout.write(`${JSON.stringify(buildGepaPromptEvolutionBundle(input), null, 2)}\n`);
+}


### PR DESCRIPTION
## Story

Once upon a time, auto-dent had run metrics, reflection insights, prompt templates, and UCB1 mode selection, but GEPA existed only as an ecosystem-research issue. The system could talk about reflective prompt evolution, but it had no local handoff artifact that a GEPA runner could consume.

Every day, reflection text and batch outcomes stayed human-readable. A maintainer could read them and patch prompts by hand, but auto-dent could not package prompt targets, traces, textual feedback, and objectives into a stable prompt-evolution contract.

One day, #1211 named GEPA as the missing mechanism for #1158's reflection-to-prompt-patch loop. Current GEPA sources describe exactly the pieces kaizen already has nearby: execution traces, natural-language feedback, candidate prompt targets, and Pareto-style objectives.

Because of that, this PR adds `scripts/auto-dent-gepa.ts`: a deterministic dry-run bundle builder for GEPA-ready prompt evolution. It maps existing `RunMetrics` into trace examples, preserves textual feedback, names the prompt target, and exposes multiple Pareto objectives instead of collapsing optimization to a single reward scalar.

Because of that, the first integration step is dependency-safe: no Python, no `pip install gepa`, no API keys, and no live LLM optimizer are required to produce or test the contract.

Until finally, the CLI smoke emits inspectable JSON from `prompts/explore-gaps.md`, and tests prove the bundle includes prompt target text, feedback, trace rewards, quality signals, and Pareto objectives.

And ever since, the next GEPA runner does not need to invent kaizen's data model. It can consume a stable local bundle and focus on live optimization policy.

Fixes Garsson-io/kaizen#1211
Related: #1158, #1196, #555, #1167

## Architecture

```text
auto-dent run metrics + reflection text + prompt target
  -> buildGepaPromptEvolutionBundle()
  -> GEPA-ready dry-run JSON
       - promptTarget
       - textualFeedback
       - traceExamples
       - paretoObjectives
       - runtime: dry-run / externalDependency optional
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add a dry-run GEPA bundle before a live optimizer | Gives kaizen a deterministic contract and tests before adding Python/API/runtime variability | Does not execute GEPA yet |
| Reuse `RunMetrics` and `modeSuccess` | Keeps reward inputs tied to existing auto-dent telemetry | Current reward still includes known #1196 limitations, so Pareto objectives also include quality/cost signals |
| Use multiple objectives | GEPA is Pareto-oriented; single-scalar `issues_filed` is the known bad proxy | Later scoring still needs real optimizer experiments |
| Keep external dependency optional | Preserves subscription-safe operation and deterministic CI | Live GEPA runner remains future work |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-gepa.ts` | GEPA-ready prompt-evolution bundle builder and dry-run CLI |
| `scripts/auto-dent-gepa.test.ts` | Unit/system tests for bundle shape, Pareto objectives, and CLI JSON output |

## Impact (goal -> before/after -> match)

- Goal (#1211): make GEPA actionable as the mechanism for kaizen's reflection-to-prompt-patch loop.
- Acceptance signal: deterministic GEPA-ready bundle from existing prompt/run/reflection data, with prompt target, trace examples, textual feedback, Pareto objectives, and no required live dependency.
- BEFORE: repo search found no `GEPA`/`gepa` implementation; reflections and run metrics existed but had no prompt-evolution handoff artifact.
- AFTER: `scripts/auto-dent-gepa.ts` emits GEPA-ready dry-run JSON and tests prove the contract.
- Delta: first concrete GEPA integration point exists; live optimizer execution can now consume a stable bundle instead of inventing data shape.
- Goal met?: yes for first adoption mechanism; live optimization remains a follow-up extension, not required for this deterministic contract.
- Residual scan: #1196 still tracks explore manifest/reward proxy; #1158 remains broader RSI loop; #1167 remains event-sourced state input.

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Bundle contains prompt target, textual feedback, traces, objectives, runtime mode | Tested: `scripts/auto-dent-gepa.test.ts` | Not needed | Not needed | Not needed | Not needed |
| Bundle reuses existing mode reward signal | Tested via `modeSuccess` reward expectations | Not needed | Not needed | Not needed | Not needed |
| CLI dry-run emits inspectable JSON from fixture input and prompt file | Covered by subprocess test | Not needed | Tested: subprocess spawn of CLI | Not needed | Not needed |
| External GEPA dependency is optional | Source invariant in test | Not needed | CLI test runs without Python/API keys | Not needed | Not needed |

## Validation

- [x] `npx vitest run scripts/auto-dent-gepa.test.ts` — 1 file passed, 3 tests passed.
- [x] `npx tsx scripts/auto-dent-gepa.ts --input <fixture> --prompt-file prompts/explore-gaps.md` — emitted GEPA dry-run JSON with prompt text, feedback, trace example, reward, quality signals, and Pareto objectives.
- [x] `npm run typecheck` — passed.
- [x] `npm run test:fast` — 1 file passed, 3 tests passed.
- [x] `npx vitest run scripts/auto-dent-gepa.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-score.test.ts` — 3 files passed, 454 tests passed before rebase.
- [x] `npm test` — 169 files passed, 3996 tests passed, 14 skipped on final base.

## Known Limitations

This PR creates the GEPA-ready local contract and dry-run CLI. It intentionally does not install or execute the external GEPA optimizer, run live LLM prompt evolution, or patch prompts automatically.
