### PR TITLE
feat(auto-dent): surface backlog health in batch finalizer

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -191,6 +191,18 @@ describe('buildPrompt', () => {
   });
 });
 
+describe('closeBatchProgressIssue maintenance wiring', () => {
+  it('runs backlog-health maintenance during batch finalize', () => {
+    const closeSection = AUTO_DENT_RUN_SOURCE.slice(
+      AUTO_DENT_RUN_SOURCE.indexOf('export function closeBatchProgressIssue'),
+      AUTO_DENT_RUN_SOURCE.indexOf('// Execute Claude'),
+    );
+
+    expect(closeSection).toContain('runBacklogHealthMaintenance');
+    expect(closeSection).toContain('[backlog-health]');
+  });
+});
+
 describe('buildTemplateVars', () => {
   it('builds all expected template variables', () => {
     const state = makeBatchState({

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -201,6 +201,7 @@ import {
 import { deriveRunTestHealth } from './auto-dent-test-health.js';
 import { createDefaultGitExec } from '../src/hooks/lib/git-state.js';
 import { runStalePrTriageMaintenance } from './stale-pr-triage.js';
+import { runBacklogHealthMaintenance } from './backlog-health.js';
 import { gh as ghArgs } from '../src/lib/gh-exec.js';
 
 // Types
@@ -1611,6 +1612,31 @@ export function closeBatchProgressIssue(
     } catch (err) {
       console.log(`  [intelligence] batch-artifacts upload skipped: ${(err as Error).message}`);
     }
+  }
+
+  // Backlog-health maintenance (#1497, PRD #951 DoD item 4): surface the
+  // issue-metabolism verdict at the once-per-batch finalize choke point. This
+  // mirrors stale-PR maintenance: best-effort and self-guarding, never blocking
+  // progress issue closure.
+  try {
+    const windowRaw = parseInt(process.env.KAIZEN_BACKLOG_HEALTH_WINDOW_DAYS ?? '', 10);
+    const windowDays = Number.isFinite(windowRaw) && windowRaw > 0 ? windowRaw : 30;
+    const result = runBacklogHealthMaintenance({
+      gh: ghArgs,
+      repo: kaizenRepo,
+      progressIssue: m[1],
+      windowDays,
+      log: (msg) => console.log(`  [backlog-health] ${msg}`),
+      err: (msg) => console.log(`  [backlog-health] ${msg}`),
+    });
+    if (result.verdict) {
+      console.log(
+        `  [backlog-health] verdict ${result.verdict}` +
+          (result.commentPosted ? ' posted' : ' (report-only)'),
+      );
+    }
+  } catch (err) {
+    console.log(`  [backlog-health] maintenance skipped: ${(err as Error).message}`);
   }
 
   // Pre-existing-PR graveyard maintenance (#1365, follow-up to #1159/PR #1363):

--- a/scripts/backlog-health.test.ts
+++ b/scripts/backlog-health.test.ts
@@ -6,8 +6,10 @@ import {
   computeEpicProgress,
   buildBacklogHealthReport,
   classifyBacklogHealth,
+  formatBacklogHealthSection,
   formatReport,
   parseArgs,
+  runBacklogHealthMaintenance,
   type OpenIssue,
   type ClosedIssue,
   type CreatedIssue,
@@ -316,6 +318,105 @@ describe('formatReport', () => {
     expect(text).toContain('epic progress');
     expect(text).toContain('#20 needs-replan');
     expect(text).toContain('Partially landed epic');
+  });
+});
+
+describe('formatBacklogHealthSection', () => {
+  function reportForSection(): ReturnType<typeof buildBacklogHealthReport> {
+    return buildBacklogHealthReport(
+      [
+        open({ number: 1, updatedAt: daysAgo(5), labels: ['horizon/a'] }),
+        open({ number: 2, updatedAt: daysAgo(100), labels: [] }),
+      ],
+      [
+        { number: 1, createdAt: daysAgo(5) },
+        { number: 2, createdAt: daysAgo(6) },
+      ],
+      [{ number: 3, closedAt: daysAgo(7) }],
+      NOW,
+      30,
+      'owner/repo',
+    );
+  }
+
+  it.each(['healthy', 'warning', 'pathological'] as const)(
+    'renders a compact markdown section for %s verdicts',
+    (verdict) => {
+      const text = formatBacklogHealthSection(reportForSection(), verdict);
+
+      expect(text).toContain('### Backlog Health');
+      expect(text).toContain(verdict.toUpperCase());
+      expect(text).toContain('2 created / 1 closed = 2.00:1');
+      expect(text).toContain('>30d 1');
+      expect(text).toContain('1 distinct');
+      expect(text).toContain('1 unlabeled');
+    },
+  );
+});
+
+describe('runBacklogHealthMaintenance', () => {
+  it('fetches, classifies, formats, and posts the backlog-health section', () => {
+    const calls: string[][] = [];
+    const res = runBacklogHealthMaintenance({
+      repo: 'owner/repo',
+      progressIssue: '999',
+      windowDays: 30,
+      now: NOW,
+      fetchOpenIssues: () => [
+        open({ number: 1, updatedAt: daysAgo(5), labels: ['horizon/a'] }),
+      ],
+      fetchCreatedInWindow: () => [{ number: 1, createdAt: daysAgo(5) }],
+      fetchClosedInWindow: () => [{ number: 2, closedAt: daysAgo(5) }],
+      gh: (args) => {
+        calls.push(args);
+        return '';
+      },
+    });
+
+    expect(res.commentPosted).toBe(true);
+    expect(res.verdict).toBe('healthy');
+    expect(res.section).toContain('### Backlog Health');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(expect.arrayContaining(['issue', 'comment', '999', '--repo', 'owner/repo', '--body']));
+    expect(calls[0].join('\n')).toContain('Backlog Health');
+  });
+
+  it('never throws when the fetch path fails', () => {
+    const errors: string[] = [];
+
+    const res = runBacklogHealthMaintenance({
+      repo: 'owner/repo',
+      progressIssue: '999',
+      fetchOpenIssues: () => {
+        throw new Error('fetch failed');
+      },
+      err: (message) => errors.push(message),
+    });
+
+    expect(res).toEqual({ report: null, verdict: null, section: '', commentPosted: false });
+    expect(errors.join('\n')).toContain('backlog-health scan failed');
+  });
+
+  it('never throws when posting the comment fails', () => {
+    const errors: string[] = [];
+
+    const res = runBacklogHealthMaintenance({
+      repo: 'owner/repo',
+      progressIssue: '999',
+      windowDays: 30,
+      now: NOW,
+      fetchOpenIssues: () => [open({ number: 1, updatedAt: daysAgo(5), labels: ['horizon/a'] })],
+      fetchCreatedInWindow: () => [{ number: 1, createdAt: daysAgo(5) }],
+      fetchClosedInWindow: () => [{ number: 2, closedAt: daysAgo(5) }],
+      gh: () => {
+        throw new Error('comment failed');
+      },
+      err: (message) => errors.push(message),
+    });
+
+    expect(res.commentPosted).toBe(false);
+    expect(res.section).toContain('### Backlog Health');
+    expect(errors.join('\n')).toContain('failed to post backlog-health report');
   });
 });
 

--- a/scripts/backlog-health.ts
+++ b/scripts/backlog-health.ts
@@ -24,6 +24,8 @@
 
 import { gh } from '../src/lib/gh-exec.js';
 
+type GhRunner = (args: string[], timeoutMs?: number) => string;
+
 // Types
 
 export interface OpenIssue {
@@ -325,8 +327,8 @@ function warnIfTruncated(label: string, count: number): void {
   }
 }
 
-export function fetchOpenIssues(repo: string): OpenIssue[] {
-  const raw = gh(
+export function fetchOpenIssues(repo: string, ghRun: GhRunner = gh): OpenIssue[] {
+  const raw = ghRun(
     ['issue', 'list', '--repo', repo, '--state', 'open', '--limit', String(FETCH_LIMIT),
       '--json', 'number,title,createdAt,updatedAt,labels'],
     60_000,
@@ -338,14 +340,14 @@ export function fetchOpenIssues(repo: string): OpenIssue[] {
     title: i.title,
     createdAt: i.createdAt,
     updatedAt: i.updatedAt,
-    body: i.labels.some((label) => label.name === 'epic') ? fetchIssueBody(repo, i.number) : '',
+    body: i.labels.some((label) => label.name === 'epic') ? fetchIssueBody(repo, i.number, ghRun) : '',
     labels: i.labels.map((l) => l.name),
   }));
 }
 
-export function fetchIssueBody(repo: string, number: number): string {
+export function fetchIssueBody(repo: string, number: number, ghRun: GhRunner = gh): string {
   try {
-    const raw = gh(['issue', 'view', String(number), '--repo', repo, '--json', 'body'], 30_000);
+    const raw = ghRun(['issue', 'view', String(number), '--repo', repo, '--json', 'body'], 30_000);
     const issue: GhIssueBody = JSON.parse(raw);
     return issue.body ?? '';
   } catch {
@@ -353,9 +355,14 @@ export function fetchIssueBody(repo: string, number: number): string {
   }
 }
 
-export function fetchCreatedInWindow(repo: string, windowDays: number, now: Date): CreatedIssue[] {
+export function fetchCreatedInWindow(
+  repo: string,
+  windowDays: number,
+  now: Date,
+  ghRun: GhRunner = gh,
+): CreatedIssue[] {
   const since = windowSince(windowDays, now);
-  const raw = gh(
+  const raw = ghRun(
     ['issue', 'list', '--repo', repo, '--state', 'all', '--limit', String(FETCH_LIMIT),
       '--search', `created:>=${since}`, '--json', 'number,createdAt'],
     60_000,
@@ -365,9 +372,14 @@ export function fetchCreatedInWindow(repo: string, windowDays: number, now: Date
   return issues.map((i) => ({ number: i.number, createdAt: i.createdAt }));
 }
 
-export function fetchClosedInWindow(repo: string, windowDays: number, now: Date): ClosedIssue[] {
+export function fetchClosedInWindow(
+  repo: string,
+  windowDays: number,
+  now: Date,
+  ghRun: GhRunner = gh,
+): ClosedIssue[] {
   const since = windowSince(windowDays, now);
-  const raw = gh(
+  const raw = ghRun(
     ['issue', 'list', '--repo', repo, '--state', 'closed', '--limit', String(FETCH_LIMIT),
       '--search', `closed:>=${since}`, '--json', 'number,closedAt'],
     60_000,
@@ -390,10 +402,7 @@ export function formatReport(report: BacklogHealthReport, verdict: HealthVerdict
   lines.push(
     `  inactivity: >30d ${report.age.stale30}  >60d ${report.age.stale60}  >90d ${report.age.stale90}`,
   );
-  const horizons = Object.entries(report.horizon.byHorizon)
-    .sort((a, b) => b[1] - a[1])
-    .map(([h, n]) => `${h}=${n}`)
-    .join('  ');
+  const horizons = formatHorizonCounts(report.horizon, { separator: '  ' });
   lines.push(`  horizons (${report.horizon.distinctHorizons} distinct, ${report.horizon.noHorizon} unlabeled): ${horizons || '(none)'}`);
   lines.push(
     `  epic progress: ${report.epicProgress.healthy}/${report.epicProgress.total} healthy  ` +
@@ -408,6 +417,100 @@ export function formatReport(report: BacklogHealthReport, verdict: HealthVerdict
     );
   }
   return lines.join('\n');
+}
+
+function formatHorizonCounts(
+  horizon: HorizonCoverage,
+  opts: { separator: string; limit?: number },
+): string {
+  return Object.entries(horizon.byHorizon)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, opts.limit)
+    .map(([h, n]) => `${h}=${n}`)
+    .join(opts.separator);
+}
+
+export function formatBacklogHealthSection(report: BacklogHealthReport, verdict: HealthVerdict): string {
+  const horizons = formatHorizonCounts(report.horizon, { separator: ', ', limit: 5 });
+  const epic = report.epicProgress;
+  return [
+    '### Backlog Health',
+    '',
+    '| Metric | Value |',
+    '|--------|-------|',
+    `| **Verdict** | ${verdict.toUpperCase()} |`,
+    `| **Open issues** | ${report.totalOpen} |`,
+    `| **Creation/closure** | ${report.ratio.created} created / ${report.ratio.closed} closed = ${report.ratio.ratio.toFixed(2)}:1 |`,
+    `| **Inactivity** | >30d ${report.age.stale30} · >60d ${report.age.stale60} · >90d ${report.age.stale90} |`,
+    `| **Horizons** | ${report.horizon.distinctHorizons} distinct, ${report.horizon.noHorizon} unlabeled${horizons ? ` · ${horizons}` : ''} |`,
+    `| **Epic pressure** | ${epic.healthy}/${epic.total} healthy · decompose ${epic.needsDecomposition} · replan ${epic.needsReplan} · terminal-decision ${epic.needsTerminalDecision} |`,
+  ].join('\n');
+}
+
+export interface BacklogHealthMaintenanceResult {
+  report: BacklogHealthReport | null;
+  verdict: HealthVerdict | null;
+  section: string;
+  commentPosted: boolean;
+}
+
+export interface BacklogHealthMaintenanceDeps {
+  repo: string;
+  progressIssue?: string;
+  windowDays?: number;
+  now?: Date;
+  gh?: GhRunner;
+  fetchOpenIssues?: (repo: string) => OpenIssue[];
+  fetchCreatedInWindow?: (repo: string, windowDays: number, now: Date) => CreatedIssue[];
+  fetchClosedInWindow?: (repo: string, windowDays: number, now: Date) => ClosedIssue[];
+  log?: (message: string) => void;
+  err?: (message: string) => void;
+}
+
+export function runBacklogHealthMaintenance(
+  deps: BacklogHealthMaintenanceDeps,
+): BacklogHealthMaintenanceResult {
+  const err = deps.err ?? (() => {});
+  const log = deps.log ?? (() => {});
+  const ghRun = deps.gh ?? gh;
+  const now = deps.now ?? new Date();
+  const windowDays = deps.windowDays ?? 30;
+
+  let report: BacklogHealthReport;
+  let verdict: HealthVerdict;
+  let section: string;
+  try {
+    const open = (deps.fetchOpenIssues ?? ((repo) => fetchOpenIssues(repo, ghRun)))(deps.repo);
+    const created = (deps.fetchCreatedInWindow ?? ((repo, window, at) => fetchCreatedInWindow(repo, window, at, ghRun)))(
+      deps.repo,
+      windowDays,
+      now,
+    );
+    const closed = (deps.fetchClosedInWindow ?? ((repo, window, at) => fetchClosedInWindow(repo, window, at, ghRun)))(
+      deps.repo,
+      windowDays,
+      now,
+    );
+    report = buildBacklogHealthReport(open, created, closed, now, windowDays, deps.repo);
+    verdict = classifyBacklogHealth(report);
+    section = formatBacklogHealthSection(report, verdict);
+  } catch (e) {
+    err(`backlog-health scan failed: ${(e as Error).message}`);
+    return { report: null, verdict: null, section: '', commentPosted: false };
+  }
+
+  let commentPosted = false;
+  if (deps.progressIssue) {
+    try {
+      ghRun(['issue', 'comment', deps.progressIssue, '--repo', deps.repo, '--body', section]);
+      commentPosted = true;
+      log(`posted backlog-health report to #${deps.progressIssue}`);
+    } catch (e) {
+      err(`failed to post backlog-health report: ${(e as Error).message}`);
+    }
+  }
+
+  return { report, verdict, section, commentPosted };
 }
 
 // CLI


### PR DESCRIPTION
## Once upon a time...

`backlog-health.ts` could classify the issue backlog as `healthy`, `warning`, or `pathological`, but the signal lived behind a manual command. Auto-dent batch finalization already posts the durable batch summary, raw artifacts, and stale-PR triage, but it did not surface issue-metabolism health where operators actually review batch outcomes.

## Every day...

A batch could close successfully while the backlog remained pathological. The final progress issue captured PR counts and run outcomes, but omitted the backlog-health verdict and its basic counts, so #953/#951 stayed an L1 manual-inspection signal rather than an L2 batch-level signal.

## One day...

#1497 asked for the backlog-health verdict to appear in the auto-dent batch summary path. I added a small maintenance seam around the existing backlog-health pure functions, then invoked it from `closeBatchProgressIssue` beside stale-PR maintenance.

## Because of that...

- `scripts/backlog-health.ts` now exposes `runBacklogHealthMaintenance`, with injected fetchers/`gh` runner for tests and best-effort behavior for production.
- `formatBacklogHealthSection` renders a compact markdown table with verdict, open issue count, creation/closure ratio, inactivity buckets, horizon coverage, and epic pressure.
- `scripts/auto-dent-run.ts` runs the maintenance at the once-per-batch finalizer choke point, posts the section to the batch progress issue, logs `[backlog-health]` status, and never blocks batch closure on scan/comment failures.
- The fetch layer keeps its existing `gh` timeouts while becoming injectable.

## Until finally...

Every closed auto-dent batch can carry the backlog-health verdict and counts in the same operator-visible issue thread as other finalization artifacts.

Fixes #1497
Refs #951
Refs #953
Refs #728

## Plan / Test Plan

- Plan: https://github.com/Garsson-io/kaizen/issues/1497#issuecomment-4827558239
- Test plan: https://github.com/Garsson-io/kaizen/issues/1497#issuecomment-4827558340

## Verification

- RED: `npx vitest run scripts/backlog-health.test.ts scripts/auto-dent-run.test.ts --reporter=verbose` failed before implementation on missing `formatBacklogHealthSection`, missing `runBacklogHealthMaintenance`, and missing finalizer wiring.
- GREEN: `npx vitest run scripts/backlog-health.test.ts scripts/auto-dent-run.test.ts --reporter=verbose` passed: 363 tests.
- `npm run check:fast` passed after rebase: typecheck plus 662 changed tests, 2 skipped.
- `git diff --check` passed.
- `npm run test:ci:shard -- --shard=1/2` passed and wrote blob report.
- `npm run test:ci:shard -- --shard=2/2` passed and wrote blob report; stderr included the existing parser-test `Unknown option: --bogus` line.
- Live no-post scan: `npx tsx scripts/backlog-health.ts --repo Garsson-io/kaizen --window 30 || true` reported `PATHOLOGICAL` with 375 open issues, 256 created / 261 closed = 0.98:1, >90d stale 287, 13 horizons, 299 unlabeled, and 18/60 healthy epics.
