### PR TITLE
feat(auto-dent): add cross-PR DRY sweep

### DIFF
--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -168,6 +168,33 @@ row, so a pushed branch is never misread as a real PR (a later `/pull/<N>` super
 npx tsx scripts/auto-dent-ctl.ts status
 ```
 
+### Cross-PR DRY sweep
+
+Use the dry-sweep control command when a batch has accumulated several adjacent
+Auto-Dent PRs and you want cleanup candidates before adding more mechanisms:
+
+```bash
+npx tsx scripts/auto-dent-ctl.ts dry-sweep --repo Garsson-io/kaizen --limit 20
+```
+
+The report scans production `scripts/` and `src/` code for known drift families
+such as GitHub execution wrappers, direct progress comments versus marker
+attachments, telemetry envelopes, display formatting, and markdown table helpers.
+When `--repo` is provided it also annotates candidates with recent merged PRs
+whose changed files overlap the candidate files.
+
+To persist the result on a batch progress issue as an idempotent marker-comment
+attachment:
+
+```bash
+npx tsx scripts/auto-dent-ctl.ts dry-sweep --repo Garsson-io/kaizen --post <progress-issue>
+```
+
+`auto-dent-ctl.ts reflect` runs the same sweep on its normal cadence and surfaces
+the candidate count in reflection insights. Treat those insights as advisory
+steering: convert high-confidence findings into small cleanup issues or PRs
+before adding another parallel mechanism.
+
 ### From GitHub
 
 Each batch creates a progress issue (labeled `auto-dent`). Per-run results are posted as comments with PRs created, issues filed, and run metrics.
@@ -335,7 +362,8 @@ Add to the batch loop in `auto-dent.ts` (between runs) or to `auto-dent-run.ts` 
 | `scripts/auto-dent.sh` | Compatibility wrapper for the TS batch runner |
 | `scripts/auto-dent.ts` | TypeScript batch runner (outer loop, self-update, stop conditions, summaries) |
 | `scripts/auto-dent-run.ts` | Single-run TypeScript runner (prompt building, stream-json parsing, state updates) |
-| `scripts/auto-dent-ctl.ts` | Control plane (status, halt) |
+| `scripts/auto-dent-ctl.ts` | Control plane (status, halt, reflect, dry-sweep) |
+| `scripts/auto-dent-dry-sweep.ts` | Cross-PR/codebase DRY drift candidate collector |
 | `scripts/auto-dent-score.ts` | Run and batch quality scoring |
 | `scripts/auto-dent-provider-matrix.ts` | Synthetic Claude/Codex/hybrid provider comparison matrix |
 | `scripts/auto-dent-harness.ts` | Harness utilities (auto-merge, labeling) |

--- a/prompts/review-cross-pr-dry.md
+++ b/prompts/review-cross-pr-dry.md
@@ -1,0 +1,59 @@
+---
+name: cross-pr-dry
+description: History-aware DRY/refactor/simplify review for mechanism drift across merged PRs and adjacent codebase paths.
+applies_to: reflection
+needs: [multiple_prs, git-history, codebase]
+high_when:
+  - "Recent merged PRs repeatedly touched the same mechanism family"
+  - "A shared helper exists but adjacent code still writes a local wrapper or direct shell/comment path"
+  - "Multiple telemetry, formatter, parser, or GitHub I/O contracts coexist without an owner"
+low_when:
+  - "Only one concrete evidence location exists"
+  - "The apparent duplication is deliberately separate and documented"
+---
+
+Your task: Review cross-PR/codebase DRY drift for {{repo}}.
+
+This review runs in reflection context. It is not a normal PR diff review. Use the deterministic dry-sweep context as evidence, then decide whether the candidates represent actionable duplication/drift or acceptable separation.
+
+## Dry-Sweep Context
+
+{{dry_sweep_context}}
+
+## Review Dimension: Cross-PR DRY
+
+Find mechanism drift that single-PR review misses:
+
+- repeated wrappers around GitHub CLI, subprocesses, comments, parsers, validators, formatters, or telemetry envelopes
+- direct comments competing with marker-comment attachments
+- local schema or event envelope variants that should share one contract
+- cleanup candidates where deletion/unification is better than another additive feature
+
+## Instructions
+
+1. Treat every finding as a candidate unless it has concrete file/line evidence.
+2. Prefer existing shared mechanisms over new abstractions.
+3. Name the unification target when one exists.
+4. Distinguish true drift from acceptable specialized helpers.
+5. Do not prescribe a broad rewrite. Recommend the smallest cleanup issue or PR that would reduce future drift.
+
+## Output Format
+
+```json
+{
+  "dimension": "cross-pr-dry",
+  "summary": "<one-line assessment>",
+  "findings": [
+    {
+      "requirement": "<mechanism family or candidate>",
+      "status": "DONE | PARTIAL | MISSING",
+      "detail": "<evidence, judgment, suggested unification target, and smallest next cleanup>"
+    }
+  ]
+}
+```
+
+Rules for status:
+- DONE: No actionable cross-PR DRY drift. Existing separation is justified.
+- PARTIAL: Candidate drift exists but should be tracked/advisory until more evidence appears.
+- MISSING: Clear duplicated mechanism or competing source of truth exists and should be consolidated.

--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -27,6 +27,7 @@ import {
   type WatchdogResult,
   type AggregateBatchRecord,
 } from './auto-dent-ctl.js';
+import type { DrySweepReport } from './auto-dent-dry-sweep.js';
 import type { RunMetrics } from './auto-dent-run.js';
 import { makeBatchState } from './auto-dent-test-utils.js';
 
@@ -645,6 +646,57 @@ describe('buildBatchReflection', () => {
     const reflection = buildBatchReflection(batch);
     const stopInsight = reflection.insights.find((i) => i.message.includes('stop signals'));
     expect(stopInsight).toBeDefined();
+  });
+
+  it('surfaces dry-sweep findings as advisory reflection insight', () => {
+    const drySweepReport: DrySweepReport = {
+      generatedAt: '2026-06-29T00:00:00.000Z',
+      repo: 'Garsson-io/kaizen',
+      recentPrLimit: 20,
+      candidates: [
+        {
+          kind: 'progress_comments',
+          summary: 'Direct progress comments compete with marker attachments',
+          confidence: 85,
+          evidence: [
+            { path: 'scripts/auto-dent-run.ts', line: 10, symbol: 'gh issue comment', detail: 'direct comment' },
+            { path: 'src/section-editor.ts', line: 338, symbol: 'writeAttachment', detail: 'shared attachment primitive' },
+          ],
+          files: ['scripts/auto-dent-run.ts', 'src/section-editor.ts'],
+          recentPrs: [
+            {
+              number: 100,
+              title: 'refactor(auto-dent): progress comments',
+              mergedAt: '2026-06-28T10:00:00Z',
+              changedFiles: ['scripts/auto-dent-run.ts'],
+              url: 'https://github.com/Garsson-io/kaizen/pull/100',
+            },
+          ],
+          suggestedUnificationTarget: 'src/section-editor.ts writeAttachment',
+        },
+      ],
+    };
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        run: 3,
+        run_history: [
+          makeRunMetrics({ run: 1, prs: ['https://github.com/Garsson-io/kaizen/pull/1'] }),
+          makeRunMetrics({ run: 2, prs: ['https://github.com/Garsson-io/kaizen/pull/2'] }),
+          makeRunMetrics({ run: 3, prs: ['https://github.com/Garsson-io/kaizen/pull/3'] }),
+        ],
+      }),
+    });
+
+    const reflection = buildBatchReflection(batch, { drySweepReport });
+
+    expect(reflection.insights).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'recommendation',
+        message: expect.stringContaining('DRY sweep found 1 candidate'),
+      }),
+    ]));
+    expect(formatBatchReflection(reflection)).toContain('progress_comments');
+    expect(formatBatchReflectionComment(reflection)).toContain('DRY sweep found 1 candidate');
   });
 
   it('builds run history table', () => {

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -8,6 +8,7 @@
  *   score [batch-id]    Score batches — efficiency, success rate, cost-per-PR, hook activation health
  *   score --post-hoc    Include live merge status checks
  *   cleanup [batch-id]  Close superseded PRs whose issues are already resolved from GitHub
+ *   dry-sweep [--repo R]  Cross-PR DRY/refactor/simplify drift scan (#1164)
  *   reflect [batch-id]  Cross-run pattern analysis (#551)
  *   reflect --post [batch-id]  Post reflection summary to progress issue (#571)
  *   watchdog [--threshold N]  Check active batches for stale heartbeats, halt if stuck
@@ -16,6 +17,7 @@
  *   npx tsx scripts/auto-dent-ctl.ts status
  *   npx tsx scripts/auto-dent-ctl.ts halt
  *   npx tsx scripts/auto-dent-ctl.ts halt batch-260321-0136-a1b2
+ *   npx tsx scripts/auto-dent-ctl.ts dry-sweep --repo Garsson-io/kaizen
  *   npx tsx scripts/auto-dent-ctl.ts watchdog --threshold 600
  */
 
@@ -43,6 +45,13 @@ import {
 import { truncateDisplay } from './auto-dent-display.js';
 import { appendJsonLine, parseJsonLines } from '../src/lib/json-lines.js';
 import { readJsonValueFile, writeJsonValueFile } from '../src/lib/json-file.js';
+import { writeAttachment } from '../src/section-editor.js';
+import {
+  buildDrySweepReport,
+  formatDrySweepReport,
+  summarizeDrySweepReport,
+  type DrySweepReport,
+} from './auto-dent-dry-sweep.js';
 
 function getRepoRoot(): string {
   try {
@@ -388,11 +397,18 @@ export interface BatchReflection {
   runHistoryTable: string;
 }
 
+export interface BuildBatchReflectionOptions {
+  drySweepReport?: DrySweepReport | null;
+}
+
 /**
  * Build a batch reflection from state data.
  * Analyzes run history to find patterns, efficiency anomalies, and recommendations.
  */
-export function buildBatchReflection(batch: BatchInfo): BatchReflection {
+export function buildBatchReflection(
+  batch: BatchInfo,
+  opts: BuildBatchReflectionOptions = {},
+): BatchReflection {
   const s = batch.state;
   const history = s.run_history || [];
   const insights: ReflectionInsight[] = [];
@@ -507,6 +523,13 @@ export function buildBatchReflection(batch: BatchInfo): BatchReflection {
         message: `Expensive: $${avgCostPerPr.toFixed(2)}/PR is above the $3.00 threshold — consider simpler issues`,
       });
     }
+  }
+
+  if (opts.drySweepReport && opts.drySweepReport.candidates.length > 0) {
+    insights.push({
+      type: 'recommendation',
+      message: summarizeDrySweepReport(opts.drySweepReport),
+    });
   }
 
   // Build run history table
@@ -998,6 +1021,7 @@ Usage:
   auto-dent-ctl.ts score [batch-id]    Score batch(es) — efficiency, success rate, cost
   auto-dent-ctl.ts score --post-hoc [batch-id]  Include live PR merge status checks
   auto-dent-ctl.ts cleanup [batch-id]  Close superseded PRs whose issues are already resolved
+  auto-dent-ctl.ts dry-sweep [--repo R] [--limit N] [--json] [--post ISSUE]  Cross-PR DRY drift scan
   auto-dent-ctl.ts reflect [batch-id]  Cross-run pattern analysis and learning (#551)
   auto-dent-ctl.ts reflect --post [batch-id]  Post reflection summary to progress issue (#571)
   auto-dent-ctl.ts reflect --prompt [batch-id]  Output rendered prompt for Claude reflection
@@ -1161,6 +1185,40 @@ Cross-batch learning (#586):
       break;
     }
 
+    case 'dry-sweep': {
+      const repoIdx = args.indexOf('--repo');
+      const limitIdx = args.indexOf('--limit');
+      const postIdx = args.indexOf('--post');
+      const repo = resolveKaizenRepo(repoIdx >= 0 ? args[repoIdx + 1] : undefined, logsDir);
+      const limit = limitIdx >= 0 && args[limitIdx + 1] ? parseInt(args[limitIdx + 1], 10) : 20;
+      const report = buildDrySweepReport({
+        root: getRepoRoot(),
+        repo: repo || undefined,
+        recentPrLimit: Number.isFinite(limit) ? limit : 20,
+      });
+
+      if (args.includes('--json')) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        console.log(formatDrySweepReport(report));
+      }
+
+      if (postIdx >= 0) {
+        const issue = args[postIdx + 1];
+        if (!issue || !repo) {
+          console.error('Usage: auto-dent-ctl.ts dry-sweep --post ISSUE --repo owner/repo');
+          process.exit(1);
+        }
+        const url = writeAttachment(
+          { kind: 'issue', number: issue.replace(/^#/, ''), repo },
+          'auto-dent/dry-sweep',
+          formatDrySweepReport(report),
+        );
+        console.log(`Posted dry-sweep attachment: ${url}`);
+      }
+      break;
+    }
+
     case 'watchdog': {
       const thresholdIdx = args.indexOf('--threshold');
       const threshold = thresholdIdx >= 0 && args[thresholdIdx + 1]
@@ -1216,7 +1274,13 @@ Cross-batch learning (#586):
           continue;
         }
 
-        const reflection = buildBatchReflection(batch);
+        const repo = batch.state.kaizen_repo || batch.state.host_repo || resolveKaizenRepo(undefined, logsDir);
+        const drySweepReport = buildDrySweepReport({
+          root: getRepoRoot(),
+          repo: repo || undefined,
+          recentPrLimit: 20,
+        });
+        const reflection = buildBatchReflection(batch, { drySweepReport });
 
         if (showPrompt) {
           const vars = buildReflectionTemplateVars(reflection, batch.state);

--- a/scripts/auto-dent-dry-sweep.test.ts
+++ b/scripts/auto-dent-dry-sweep.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDrySweepReport,
+  collectMechanismDriftCandidates,
+  fetchRecentMergedPrs,
+  formatDrySweepReport,
+  type DrySweepFile,
+} from './auto-dent-dry-sweep.js';
+
+const files: DrySweepFile[] = [
+  {
+    path: 'scripts/auto-dent-run.ts',
+    content: `
+      import { writeAttachment } from '../src/section-editor.js';
+      import { ghExec } from './auto-dent-github.js';
+      function postProgress() {
+        ghExec(\`gh issue comment 1 --repo o/r --body "hi"\`);
+        writeAttachment({ kind: 'issue', number: '1', repo: 'o/r' }, 'review', 'body');
+      }
+    `,
+  },
+  {
+    path: 'scripts/auto-dent-ctl.ts',
+    content: `
+      import { execSync } from 'node:child_process';
+      function postReflection() {
+        execSync(\`gh issue comment 1 --repo o/r --body "reflection"\`);
+      }
+    `,
+  },
+  {
+    path: 'src/issue-backend.ts',
+    content: `
+      function shellExec(cmd: string) {
+        return cmd;
+      }
+    `,
+  },
+  {
+    path: 'scripts/auto-dent-events.ts',
+    content: 'export interface EventEnvelope { type: string }',
+  },
+  {
+    path: 'src/hooks/session-telemetry.ts',
+    content: 'export interface SessionEventEnvelope { type: string }',
+  },
+];
+
+describe('collectMechanismDriftCandidates', () => {
+  it('groups known duplicate mechanism families from current code evidence', () => {
+    const candidates = collectMechanismDriftCandidates(files);
+
+    expect(candidates.map(c => c.kind)).toEqual(expect.arrayContaining([
+      'github_execution',
+      'progress_comments',
+      'telemetry_events',
+    ]));
+    expect(candidates.find(c => c.kind === 'github_execution')?.evidence.map(e => e.path)).toEqual(
+      expect.arrayContaining(['scripts/auto-dent-run.ts', 'src/issue-backend.ts']),
+    );
+    expect(candidates.find(c => c.kind === 'progress_comments')?.suggestedUnificationTarget).toContain('writeAttachment');
+  });
+
+  it('orders competing evidence before shared targets so reports stay actionable', () => {
+    const progressComments = collectMechanismDriftCandidates(files).find(c => c.kind === 'progress_comments');
+
+    expect(progressComments?.evidence[0]).toMatchObject({
+      path: 'scripts/auto-dent-run.ts',
+      symbol: 'gh issue comment',
+    });
+    expect(progressComments?.evidence.at(-1)?.symbol).toBe('writeAttachment');
+  });
+
+  it('ignores weak one-off similarity', () => {
+    const candidates = collectMechanismDriftCandidates([
+      { path: 'scripts/one.ts', content: 'export function helper() { return 1; }' },
+      { path: 'scripts/unrelated.ts', content: 'export const value = 2;' },
+    ]);
+
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe('fetchRecentMergedPrs', () => {
+  it('uses argv-based gh collection with no shell command string', () => {
+    const calls: string[][] = [];
+    const prs = fetchRecentMergedPrs('Garsson-io/kaizen', 2, {
+      gh: (args) => {
+        calls.push(args);
+        return JSON.stringify([
+          {
+            number: 10,
+            title: 'refactor(auto-dent): share progress comments',
+            mergedAt: '2026-06-28T10:00:00Z',
+            files: [{ path: 'scripts/auto-dent-run.ts' }],
+            url: 'https://github.com/Garsson-io/kaizen/pull/10',
+          },
+        ]);
+      },
+    });
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0]).toMatchObject({ number: 10, changedFiles: ['scripts/auto-dent-run.ts'] });
+    expect(calls[0]).toEqual([
+      'pr',
+      'list',
+      '--repo',
+      'Garsson-io/kaizen',
+      '--state',
+      'merged',
+      '--limit',
+      '2',
+      '--json',
+      'number,title,mergedAt,files,url',
+    ]);
+  });
+});
+
+describe('buildDrySweepReport', () => {
+  it('adds recent PR evidence and renders an actionable report', () => {
+    const report = buildDrySweepReport({
+      files,
+      repo: 'Garsson-io/kaizen',
+      recentPrLimit: 5,
+      gh: () => JSON.stringify([
+        {
+          number: 1387,
+          title: 'refactor(hooks): ratchet bare truncate-helper drift',
+          mergedAt: '2026-06-28T09:00:00Z',
+          files: [{ path: 'scripts/auto-dent-run.ts' }, { path: 'src/hooks/session-telemetry.ts' }],
+          url: 'https://github.com/Garsson-io/kaizen/pull/1387',
+        },
+      ]),
+    });
+
+    expect(report.candidates.length).toBeGreaterThan(0);
+    expect(report.candidates.some(c => c.recentPrs.some(pr => pr.number === 1387))).toBe(true);
+
+    const text = formatDrySweepReport(report);
+    expect(text).toContain('DRY Sweep');
+    expect(text).toContain('github_execution');
+    expect(text).toContain('scripts/auto-dent-run.ts');
+    expect(text).toContain('#1387');
+  });
+});

--- a/scripts/auto-dent-dry-sweep.ts
+++ b/scripts/auto-dent-dry-sweep.ts
@@ -1,0 +1,437 @@
+#!/usr/bin/env npx tsx
+/**
+ * auto-dent-dry-sweep — deterministic cross-PR/codebase DRY drift context.
+ *
+ * This is the small, deterministic half of #1164. It does not refactor code
+ * itself; it produces concrete candidates that reflection/review can judge.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { gh as defaultGh } from '../src/lib/gh-exec.js';
+import { writeAttachment } from '../src/section-editor.js';
+import { escapeMarkdownTableCell } from './markdown-table.js';
+
+export type MechanismDriftKind =
+  | 'display_formatting'
+  | 'github_execution'
+  | 'progress_comments'
+  | 'telemetry_events'
+  | 'markdown_tables';
+
+export interface DrySweepFile {
+  path: string;
+  content: string;
+}
+
+export interface MechanismEvidence {
+  path: string;
+  line: number;
+  symbol: string;
+  detail: string;
+}
+
+export interface RecentMergedPr {
+  number: number;
+  title: string;
+  mergedAt: string;
+  changedFiles: string[];
+  url: string;
+}
+
+export interface MechanismDriftCandidate {
+  kind: MechanismDriftKind;
+  summary: string;
+  evidence: MechanismEvidence[];
+  files: string[];
+  recentPrs: RecentMergedPr[];
+  suggestedUnificationTarget: string;
+  confidence: number;
+}
+
+export interface DrySweepReport {
+  generatedAt: string;
+  repo?: string;
+  recentPrLimit: number;
+  candidates: MechanismDriftCandidate[];
+}
+
+interface EvidenceRule {
+  symbol: string;
+  detail: string;
+  re: RegExp;
+  sharedTarget?: boolean;
+}
+
+interface FamilyRule {
+  kind: MechanismDriftKind;
+  summary: string;
+  suggestedUnificationTarget: string;
+  confidence: number;
+  evidenceRules: EvidenceRule[];
+  requireSharedAndCompeting?: boolean;
+}
+
+const FAMILY_RULES: FamilyRule[] = [
+  {
+    kind: 'github_execution',
+    summary: 'GitHub CLI execution has multiple wrappers or shell-string paths',
+    suggestedUnificationTarget: 'src/lib/gh-exec.ts gh(args) / ghResult(args)',
+    confidence: 85,
+    requireSharedAndCompeting: true,
+    evidenceRules: [
+      { symbol: 'gh(args)', detail: 'argv-based shared GitHub CLI helper', re: /\bgh(?:Result)?\s*\(\s*\[/, sharedTarget: true },
+      { symbol: 'ghExec', detail: 'command-string GitHub CLI compatibility adapter', re: /\bghExec\s*\(/ },
+      { symbol: 'shellExec', detail: 'local shell-style command execution helper', re: /\bshellExec\s*\(/ },
+      { symbol: 'execSync(gh ...)', detail: 'direct gh command through execSync string', re: /\bexecSync\s*\(\s*`?gh\s+(?:issue|pr|api)\b/ },
+    ],
+  },
+  {
+    kind: 'progress_comments',
+    summary: 'Progress/comment persistence uses direct comments alongside marker attachments',
+    suggestedUnificationTarget: 'src/section-editor.ts writeAttachment marker-comment attachments',
+    confidence: 85,
+    requireSharedAndCompeting: true,
+    evidenceRules: [
+      { symbol: 'writeAttachment', detail: 'shared marker-comment attachment primitive', re: /\bwriteAttachment\s*\(/, sharedTarget: true },
+      { symbol: 'gh issue comment', detail: 'direct issue comment write', re: /gh\s+issue\s+comment\b/ },
+      { symbol: 'gh pr comment', detail: 'direct PR comment write', re: /gh\s+pr\s+comment\b/ },
+      { symbol: 'addSection', detail: 'body-section persistence path', re: /\baddSection\s*\(/ },
+    ],
+  },
+  {
+    kind: 'telemetry_events',
+    summary: 'Telemetry event envelopes have parallel schema definitions',
+    suggestedUnificationTarget: 'a shared event envelope contract for auto-dent and interactive telemetry',
+    confidence: 75,
+    evidenceRules: [
+      { symbol: 'EventEnvelope', detail: 'auto-dent event envelope shape', re: /\b(?:interface|type)\s+EventEnvelope\b/ },
+      { symbol: 'SessionEventEnvelope', detail: 'interactive session event envelope shape', re: /\b(?:interface|type)\s+SessionEventEnvelope\b/ },
+      { symbol: 'events.jsonl', detail: 'JSONL telemetry event stream', re: /\bevents\.jsonl\b/ },
+    ],
+  },
+  {
+    kind: 'display_formatting',
+    summary: 'Display/truncation helpers exist in several adjacent presentation paths',
+    suggestedUnificationTarget: 'scripts/auto-dent-display.ts and src/analysis/util.ts display helpers',
+    confidence: 70,
+    evidenceRules: [
+      { symbol: 'truncateDisplay', detail: 'shared auto-dent display truncation helper', re: /\bfunction\s+truncateDisplay\s*\(/, sharedTarget: true },
+      { symbol: 'truncateAfterPrefix', detail: 'prefix-preserving transcript truncation helper', re: /\bfunction\s+truncateAfterPrefix\s*\(/ },
+      { symbol: 'truncateMiddle', detail: 'middle truncation helper for large attachments', re: /\bfunction\s+truncateMiddle\s*\(/ },
+      { symbol: 'formatToolUse', detail: 'tool-use display formatter', re: /\bfunction\s+formatToolUse\s*\(/ },
+    ],
+  },
+  {
+    kind: 'markdown_tables',
+    summary: 'Markdown table escaping has adjacent local and shared implementations',
+    suggestedUnificationTarget: 'scripts/markdown-table.ts escapeMarkdownTableCell',
+    confidence: 70,
+    requireSharedAndCompeting: true,
+    evidenceRules: [
+      { symbol: 'escapeMarkdownTableCell', detail: 'shared markdown table escaping helper', re: /\bescapeMarkdownTableCell\s*\(/, sharedTarget: true },
+      { symbol: 'manual markdown table join', detail: 'manual table row escaping/joining path', re: /\.join\(' \| '\)|\.replace\(\/\^\// },
+    ],
+  },
+];
+
+const SKIP_DIRS = new Set([
+  '.git',
+  '.claude',
+  'node_modules',
+  'dist',
+  'coverage',
+  'logs',
+  '.vitest-results',
+]);
+
+const SCAN_ROOTS = ['scripts', 'src'];
+const SCAN_EXTENSIONS = new Set(['.ts', '.sh']);
+
+function lineFor(content: string, index: number): number {
+  return content.slice(0, index).split('\n').length;
+}
+
+function extension(path: string): string {
+  const i = path.lastIndexOf('.');
+  return i >= 0 ? path.slice(i) : '';
+}
+
+function isProductionScanFile(path: string): boolean {
+  return !(
+    path.endsWith('.test.ts') ||
+    path.endsWith('.e2e.test.ts') ||
+    path.includes('/test-utils') ||
+    path.includes('/e2e-test-utils')
+  );
+}
+
+function uniqueByLocation(evidence: MechanismEvidence[]): MechanismEvidence[] {
+  const seen = new Set<string>();
+  return evidence.filter((e) => {
+    const key = `${e.path}:${e.line}:${e.symbol}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function evidenceForRule(file: DrySweepFile, rule: EvidenceRule): MechanismEvidence[] {
+  const evidence: MechanismEvidence[] = [];
+  const re = new RegExp(rule.re.source, rule.re.flags.includes('g') ? rule.re.flags : `${rule.re.flags}g`);
+  for (const match of file.content.matchAll(re)) {
+    evidence.push({
+      path: file.path,
+      line: lineFor(file.content, match.index ?? 0),
+      symbol: rule.symbol,
+      detail: rule.detail,
+    });
+  }
+  return evidence;
+}
+
+function relatedRecentPrs(files: string[], prs: RecentMergedPr[]): RecentMergedPr[] {
+  const fileSet = new Set(files);
+  return prs.filter(pr => pr.changedFiles.some(f => fileSet.has(f)));
+}
+
+export function collectMechanismDriftCandidates(
+  files: DrySweepFile[],
+  recentPrs: RecentMergedPr[] = [],
+): MechanismDriftCandidate[] {
+  const candidates: MechanismDriftCandidate[] = [];
+
+  for (const family of FAMILY_RULES) {
+    const evidenceByRule = family.evidenceRules.map(rule => ({
+      rule,
+      evidence: uniqueByLocation(files.flatMap(file => evidenceForRule(file, rule))),
+    }));
+    const evidence = uniqueByLocation([
+      ...evidenceByRule.filter(r => !r.rule.sharedTarget).flatMap(r => r.evidence),
+      ...evidenceByRule.filter(r => r.rule.sharedTarget).flatMap(r => r.evidence),
+    ]);
+    const touchedFiles = [...new Set(evidence.map(e => e.path))].sort();
+    if (evidence.length < 2 || touchedFiles.length < 2) continue;
+
+    if (family.requireSharedAndCompeting) {
+      const hasSharedTarget = evidenceByRule.some(r => r.rule.sharedTarget && r.evidence.length > 0);
+      const competingRules = evidenceByRule.filter(r => !r.rule.sharedTarget && r.evidence.length > 0);
+      const hasCompetingPath = competingRules.length > 0;
+      const hasMultipleCompetingPaths = competingRules.length >= 2;
+      if ((!hasSharedTarget || !hasCompetingPath) && !hasMultipleCompetingPaths) continue;
+    }
+
+    candidates.push({
+      kind: family.kind,
+      summary: family.summary,
+      evidence,
+      files: touchedFiles,
+      recentPrs: relatedRecentPrs(touchedFiles, recentPrs),
+      suggestedUnificationTarget: family.suggestedUnificationTarget,
+      confidence: family.confidence,
+    });
+  }
+
+  return candidates.sort((a, b) => b.confidence - a.confidence || a.kind.localeCompare(b.kind));
+}
+
+export interface FetchRecentPrDeps {
+  gh?: (args: string[], timeoutMs?: number) => string;
+}
+
+interface GhPrPayload {
+  number?: number;
+  title?: string;
+  mergedAt?: string;
+  files?: Array<{ path?: string } | string>;
+  url?: string;
+}
+
+export function fetchRecentMergedPrs(
+  repo: string,
+  limit: number,
+  deps: FetchRecentPrDeps = {},
+): RecentMergedPr[] {
+  const runGh = deps.gh ?? defaultGh;
+  try {
+    const raw = runGh([
+      'pr',
+      'list',
+      '--repo',
+      repo,
+      '--state',
+      'merged',
+      '--limit',
+      String(limit),
+      '--json',
+      'number,title,mergedAt,files,url',
+    ]);
+    const parsed = JSON.parse(raw) as GhPrPayload[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((pr) => {
+      if (typeof pr.number !== 'number') return [];
+      const changedFiles = Array.isArray(pr.files)
+        ? pr.files.flatMap(f => typeof f === 'string' ? [f] : (f.path ? [f.path] : []))
+        : [];
+      return [{
+        number: pr.number,
+        title: pr.title ?? '',
+        mergedAt: pr.mergedAt ?? '',
+        changedFiles,
+        url: pr.url ?? '',
+      }];
+    });
+  } catch {
+    return [];
+  }
+}
+
+function readFilesFromDir(root: string, dir: string): DrySweepFile[] {
+  if (!existsSync(dir)) return [];
+  const files: DrySweepFile[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...readFilesFromDir(root, fullPath));
+    } else if (entry.isFile() && SCAN_EXTENSIONS.has(extension(entry.name))) {
+      const path = relative(root, fullPath).replace(/\\/g, '/');
+      if (isProductionScanFile(path)) {
+        files.push({
+          path,
+          content: readFileSync(fullPath, 'utf8'),
+        });
+      }
+    }
+  }
+  return files;
+}
+
+export function readDrySweepFiles(root: string): DrySweepFile[] {
+  return SCAN_ROOTS.flatMap(scanRoot => readFilesFromDir(root, join(root, scanRoot)));
+}
+
+export interface BuildDrySweepReportInput extends FetchRecentPrDeps {
+  files?: DrySweepFile[];
+  root?: string;
+  repo?: string;
+  recentPrLimit?: number;
+  now?: Date;
+}
+
+export function buildDrySweepReport(input: BuildDrySweepReportInput = {}): DrySweepReport {
+  const recentPrLimit = input.recentPrLimit ?? 20;
+  const files = input.files ?? readDrySweepFiles(input.root ?? process.cwd());
+  const recentPrs = input.repo ? fetchRecentMergedPrs(input.repo, recentPrLimit, { gh: input.gh }) : [];
+  return {
+    generatedAt: (input.now ?? new Date()).toISOString(),
+    repo: input.repo,
+    recentPrLimit,
+    candidates: collectMechanismDriftCandidates(files, recentPrs),
+  };
+}
+
+export function summarizeDrySweepReport(report: DrySweepReport, maxCandidates = 3): string {
+  if (report.candidates.length === 0) {
+    return 'DRY sweep found no current cross-PR mechanism drift candidates.';
+  }
+  const top = report.candidates.slice(0, maxCandidates).map((c) => {
+    const prs = c.recentPrs.length > 0
+      ? `; recent PRs ${c.recentPrs.slice(0, 3).map(pr => `#${pr.number}`).join(', ')}`
+      : '';
+    return `${c.kind}: ${c.summary} (${c.files.length} files, ${c.confidence}% confidence${prs})`;
+  });
+  return `DRY sweep found ${report.candidates.length} candidate(s): ${top.join(' | ')}`;
+}
+
+export function formatDrySweepReport(report: DrySweepReport): string {
+  const lines: string[] = [
+    '# DRY Sweep',
+    '',
+    `Generated: ${report.generatedAt}`,
+    report.repo ? `Repo: ${report.repo}` : 'Repo: local-only',
+    `Recent PR limit: ${report.recentPrLimit}`,
+    `Candidates: ${report.candidates.length}`,
+    '',
+  ];
+
+  if (report.candidates.length === 0) {
+    lines.push('No cross-PR mechanism drift candidates found.');
+    return lines.join('\n');
+  }
+
+  lines.push('| Kind | Confidence | Files | Recent PRs | Suggested target |');
+  lines.push('|------|------------|-------|------------|------------------|');
+  for (const candidate of report.candidates) {
+    lines.push([
+      candidate.kind,
+      `${candidate.confidence}%`,
+      candidate.files.join(', '),
+      candidate.recentPrs.map(pr => `#${pr.number}`).join(', ') || '-',
+      candidate.suggestedUnificationTarget,
+    ].map(value => escapeMarkdownTableCell(value)).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  for (const candidate of report.candidates) {
+    lines.push('', `## ${candidate.kind}`, '', candidate.summary, '', `Suggested target: ${candidate.suggestedUnificationTarget}`, '');
+    lines.push('Evidence:');
+    for (const evidence of candidate.evidence.slice(0, 12)) {
+      lines.push(`- ${evidence.path}:${evidence.line} ${evidence.symbol} — ${evidence.detail}`);
+    }
+    if (candidate.recentPrs.length > 0) {
+      lines.push('', 'Recent PR overlap:');
+      for (const pr of candidate.recentPrs.slice(0, 8)) {
+        lines.push(`- #${pr.number} ${pr.title} (${pr.mergedAt})`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function argValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function getRepoRoot(): string {
+  const result = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
+  return result.status === 0 ? result.stdout.trim() : process.cwd();
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const root = resolve(argValue(args, '--root') ?? getRepoRoot());
+  const repo = argValue(args, '--repo');
+  const limit = Number(argValue(args, '--limit') ?? '20');
+  const report = buildDrySweepReport({ root, repo, recentPrLimit: Number.isFinite(limit) ? limit : 20 });
+
+  if (args.includes('--json')) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatDrySweepReport(report));
+  }
+
+  const postIssue = argValue(args, '--post');
+  if (postIssue) {
+    if (!repo) {
+      console.error('Error: --post requires --repo');
+      process.exit(1);
+    }
+    const url = writeAttachment(
+      { kind: 'issue', number: postIssue.replace(/^#/, ''), repo },
+      'auto-dent/dry-sweep',
+      formatDrySweepReport(report),
+    );
+    console.error(`Posted dry-sweep attachment: ${url}`);
+  }
+}
+
+const isDirectRun =
+  process.argv[1]?.endsWith('auto-dent-dry-sweep.ts') ||
+  process.argv[1]?.endsWith('auto-dent-dry-sweep.js');
+
+if (isDirectRun) {
+  main();
+}

--- a/scripts/auto-dent-dry-sweep.ts
+++ b/scripts/auto-dent-dry-sweep.ts
@@ -8,8 +8,8 @@
 
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
-import { spawnSync } from 'node:child_process';
 import { gh as defaultGh } from '../src/lib/gh-exec.js';
+import { resolveProjectRoot } from '../src/lib/resolve-project-root.js';
 import { writeAttachment } from '../src/section-editor.js';
 import { escapeMarkdownTableCell } from './markdown-table.js';
 
@@ -395,14 +395,9 @@ function argValue(args: string[], flag: string): string | undefined {
   return idx >= 0 ? args[idx + 1] : undefined;
 }
 
-function getRepoRoot(): string {
-  const result = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
-  return result.status === 0 ? result.stdout.trim() : process.cwd();
-}
-
 function main(): void {
   const args = process.argv.slice(2);
-  const root = resolve(argValue(args, '--root') ?? getRepoRoot());
+  const root = resolve(argValue(args, '--root') ?? resolveProjectRoot(process.cwd()));
   const repo = argValue(args, '--repo');
   const limit = Number(argValue(args, '--limit') ?? '20');
   const report = buildDrySweepReport({ root, repo, recentPrLimit: Number.isFinite(limit) ? limit : 20 });

--- a/src/review-battery.test.ts
+++ b/src/review-battery.test.ts
@@ -405,6 +405,51 @@ describe('loadReviewPrompt', () => {
     expect(prompt).toContain('https://github.com/test/test/pull/1');
   });
 
+  it('discovers cross-pr-dry as a reflection dimension with history and codebase needs', () => {
+    const meta = loadDimensionMetas().find(m => m.name === 'cross-pr-dry');
+
+    expect(meta).toBeDefined();
+    expect(meta!.applies_to).toBe('reflection');
+    expect(meta!.needs).toEqual(expect.arrayContaining(['multiple_prs', 'git-history', 'codebase']));
+  });
+
+  it('renders extra review variables for reflection dimensions without breaking standard vars', async () => {
+    const text = JSON.stringify({
+      dimension: 'cross-pr-dry',
+      summary: 'context received',
+      findings: [{ requirement: 'dry sweep context', status: 'DONE', detail: 'ok' }],
+    });
+    let promptSent = '';
+    vi.mocked(spawnSync).mockImplementation((cmd: string) => {
+      if (cmd === 'git') return { status: 0, stdout: '', stderr: '', signal: null, pid: 0, output: [] } as any;
+      return { status: 0, stdout: '', stderr: '', signal: null, pid: 0, output: [] } as any;
+    });
+    vi.mocked(spawn).mockImplementation(() => {
+      const proc = new EventEmitter() as any;
+      proc.stdin = {
+        write: (chunk: string) => { promptSent += chunk; },
+        end: () => {},
+      };
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      setImmediate(() => {
+        proc.stdout.emit('data', Buffer.from(streamJsonPayload(text, 0.04)));
+        proc.emit('close', 0);
+      });
+      return proc;
+    });
+
+    const { review } = await spawnReview({
+      dimension: 'cross-pr-dry',
+      repo: 'Garsson-io/kaizen',
+      extraVars: { dry_sweep_context: 'Candidate: duplicate progress comments' },
+    });
+
+    expect(review?.dimension).toBe('cross-pr-dry');
+    expect(promptSent).toContain('Candidate: duplicate progress comments');
+    expect(promptSent).toContain('Garsson-io/kaizen');
+  });
+
   it('strips YAML frontmatter from rendered prompt', () => {
     // Invariant: the rendered prompt must NOT contain frontmatter fields.
     // If frontmatter is sent to the LLM, haiku treats the prompt as a document

--- a/src/review-battery.ts
+++ b/src/review-battery.ts
@@ -445,6 +445,8 @@ export interface SpawnReviewOptions {
   prBody?: string;
   /** PR diff stat (pre-fetched) */
   prDiffStat?: string;
+  /** Additional prompt variables for reflection or specialized dimensions. */
+  extraVars?: Record<string, string>;
   /** Working directory for the claude -p call */
   cwd?: string;
   /** Timeout in ms (default: 120000) */
@@ -485,6 +487,7 @@ export async function spawnReview(opts: SpawnReviewOptions): Promise<{
   }
 
   const vars: Record<string, string> = {
+    ...(opts.extraVars ?? {}),
     pr_url: opts.prUrl ?? '',
     issue_num: opts.issueNum ?? '',
     repo: opts.repo ?? '',
@@ -589,6 +592,7 @@ export async function spawnBatchReview(
   }
 
   const vars: Record<string, string> = {
+    ...(opts.extraVars ?? {}),
     pr_url: opts.prUrl ?? '',
     issue_num: opts.issueNum ?? '',
     repo: opts.repo ?? '',
@@ -663,6 +667,8 @@ export interface BatteryOptions {
   prDiffStat?: string;
   /** Plan text (for plan reviews) */
   planText?: string;
+  /** Additional prompt variables for reflection or specialized dimensions. */
+  extraVars?: Record<string, string>;
   /** Working directory */
   cwd?: string;
   /** Timeout per review in ms */
@@ -729,7 +735,7 @@ export async function reviewBattery(opts: BatteryOptions): Promise<BatteryResult
   const sharedOpts = {
     prUrl: opts.prUrl, issueNum: opts.issueNum, repo: opts.repo,
     issueBody: opts.issueBody, prBody: opts.prBody, prDiffStat: opts.prDiffStat,
-    planText, cwd: opts.cwd, timeoutMs: opts.timeoutMs, reviewProvider,
+    planText, extraVars: opts.extraVars, cwd: opts.cwd, timeoutMs: opts.timeoutMs, reviewProvider,
   };
 
   const batchResultGroups = await Promise.all(


### PR DESCRIPTION
## Story

Auto-dent already has strong single-PR DRY review, but #1164 describes the gap that shows up after several individually reasonable PRs merge: parallel GitHub wrappers, comment writers, telemetry shapes, display helpers, and table formatters can drift across PR boundaries.

This PR adds the first repeatable mechanism for that category. It keeps the scheduler unchanged and starts with a deterministic, reviewable dry-sweep report that reflection can surface as advisory steering.

## What Changed

- Added `scripts/auto-dent-dry-sweep.ts`, a deterministic collector for known mechanism-drift families:
  - GitHub execution wrappers
  - progress comments versus marker attachments
  - telemetry event envelopes
  - display/truncation helpers
  - markdown table helpers
- Added `prompts/review-cross-pr-dry.md` as a reflection-scoped review dimension using the existing `DimensionReview` JSON contract.
- Added `extraVars` plumbing to `spawnReview`, `spawnBatchReview`, and `reviewBattery` so reflection dimensions can receive collector context without hardcoding one dimension into the review battery.
- Added `auto-dent-ctl.ts dry-sweep [--repo R] [--limit N] [--json] [--post ISSUE]`.
- Wired `auto-dent-ctl.ts reflect` to run the same sweep and include a candidate-count summary in reflection insights.
- Documented the operator workflow and attachment path in `docs/auto-dent-operations.md`.

## Proof

- RED first: the initial focused run failed on the missing dry-sweep module, missing `cross-pr-dry` dimension, missing `extraVars`, and missing reflection insight.
- `npx vitest run scripts/auto-dent-dry-sweep.test.ts scripts/auto-dent-ctl.test.ts src/review-battery.test.ts` passed after implementation.
- `npm run typecheck` passed.
- `npm run test:fast` passed before rebase.
- `npm test` passed before rebase: 170 files, 4009 tests, 14 skipped.
- Post-rebase: `npm run typecheck` passed and the focused test suite passed: 293 tests.
- Manual smoke: `npx tsx scripts/auto-dent-ctl.ts dry-sweep --repo Garsson-io/kaizen --limit 2 --json` returned 5 candidate families with valid JSON.

## Related Issues

Fixes Garsson-io/kaizen#1164.
Related: Garsson-io/kaizen#1482, Garsson-io/kaizen#940, Garsson-io/kaizen#912.
