### PR TITLE
feat(hooks): prompt periodic issue audits after merges

### DIFF
--- a/src/hooks/kaizen-reflect.test.ts
+++ b/src/hooks/kaizen-reflect.test.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HookInput } from './hook-io.js';
 import {
+  AUDIT_ISSUES_MERGE_INTERVAL,
+  formatAuditIssuesAdvisory,
   generateCreateReflection,
   generateMergeReflection,
   processHookInput,
@@ -232,6 +234,40 @@ describe('processHookInput', () => {
         expect.stringContaining('Use shared gh helper'),
       );
     });
+
+    it('adds the audit-issues advisory at the periodic merge interval', () => {
+      const input = makeInput({
+        command:
+          'gh pr merge https://github.com/Garsson-io/kaizen/pull/42 --squash',
+        stdout: '✓ Pull request merged',
+      });
+
+      const output = processHookInput(input, {
+        ...defaultOpts,
+        sendNotification: vi.fn(),
+        mergedPrCount: AUDIT_ISSUES_MERGE_INTERVAL,
+      });
+
+      expect(output).toContain('/kaizen-audit-issues');
+      expect(output).toContain(`${AUDIT_ISSUES_MERGE_INTERVAL} merged PRs`);
+      expect(output).toContain('non-blocking');
+    });
+
+    it('omits the audit-issues advisory outside the periodic merge interval', () => {
+      const input = makeInput({
+        command:
+          'gh pr merge https://github.com/Garsson-io/kaizen/pull/42 --squash',
+        stdout: '✓ Pull request merged',
+      });
+
+      const output = processHookInput(input, {
+        ...defaultOpts,
+        sendNotification: vi.fn(),
+        mergedPrCount: AUDIT_ISSUES_MERGE_INTERVAL - 1,
+      });
+
+      expect(output).not.toContain('/kaizen-audit-issues');
+    });
   });
 
   describe('non-PR commands', () => {
@@ -412,6 +448,23 @@ describe('generateMergeReflection', () => {
   it('shows fallback message when no transcript_path', () => {
     const output = generateMergeReflection('url', 'branch', 'files', '/main');
     expect(output).toContain('no transcript path available');
+  });
+});
+
+describe('formatAuditIssuesAdvisory', () => {
+  it('renders a non-blocking audit advisory on the merge interval', () => {
+    const output = formatAuditIssuesAdvisory(AUDIT_ISSUES_MERGE_INTERVAL);
+
+    expect(output).toContain('/kaizen-audit-issues');
+    expect(output).toContain(`${AUDIT_ISSUES_MERGE_INTERVAL} merged PRs`);
+    expect(output).toContain('non-blocking');
+    expect(output).toContain('#237');
+  });
+
+  it('returns empty text below and between intervals', () => {
+    expect(formatAuditIssuesAdvisory(0)).toBe('');
+    expect(formatAuditIssuesAdvisory(AUDIT_ISSUES_MERGE_INTERVAL - 1)).toBe('');
+    expect(formatAuditIssuesAdvisory(AUDIT_ISSUES_MERGE_INTERVAL + 1)).toBe('');
   });
 });
 

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -34,6 +34,7 @@ import {
   writeStateFile,
 } from './state-utils.js';
 import {
+  countSessionEvents,
   countChangedFiles,
   emitSessionEvent,
 } from './session-telemetry.js';
@@ -162,6 +163,8 @@ function runHookTimingSentinel(changedFiles: string): string {
 
 type HookTimingRunner = (changedFiles: string) => string;
 
+export const AUDIT_ISSUES_MERGE_INTERVAL = 10;
+
 /** Build the transcript instruction line for subagent prompts. */
 function transcriptInstruction(transcriptPath?: string): string {
   if (transcriptPath) {
@@ -234,6 +237,7 @@ export function generateMergeReflection(
   changed: string,
   mainCheckout: string,
   transcriptPath?: string,
+  auditIssuesAdvisory = '',
 ): string {
   return `
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -284,8 +288,18 @@ Valid categories: docs-only, formatting, typo, config-only, test-only, trivial-r
 - Sync main: \`git -C ${mainCheckout} fetch origin main && git -C ${mainCheckout} merge --ff-only origin/main\`
 - Close resolved kaizen issues
 - Delete merged branch and worktree
+${auditIssuesAdvisory}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 `;
+}
+
+export function formatAuditIssuesAdvisory(mergedPrCount: number): string {
+  if (mergedPrCount <= 0 || mergedPrCount % AUDIT_ISSUES_MERGE_INTERVAL !== 0) return '';
+  return `
+
+**Periodic aggregate-health advisory (#237):** ${mergedPrCount} merged PRs have been recorded locally.
+Run \`/kaizen-audit-issues\` when post-merge cleanup is done. This is non-blocking;
+the reflection gate above still clears through KAIZEN_IMPEDIMENTS or KAIZEN_NO_ACTION.`;
 }
 
 /**
@@ -304,6 +318,7 @@ export function processHookInput(
     sendNotification?: (text: string) => void;
     telemetryDir?: string;
     runHookTimingSentinel?: HookTimingRunner;
+    mergedPrCount?: number;
   } = {},
 ): string | null {
   const command = input.tool_input?.command ?? '';
@@ -385,6 +400,10 @@ export function processHookInput(
     changed,
     mainCheckout,
     transcriptPath,
+    formatAuditIssuesAdvisory(
+      options.mergedPrCount ??
+        countSessionEvents('session.pr_merged', { telemetryDir: options.telemetryDir }),
+    ),
   );
 
   // Send Telegram notification for merges

--- a/src/hooks/session-telemetry.test.ts
+++ b/src/hooks/session-telemetry.test.ts
@@ -1,8 +1,10 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   countChangedFiles,
+  countSessionEvents,
   emitSessionEvent,
   type SessionEventEnvelope,
   type SessionPrCreatedEvent,
@@ -11,6 +13,10 @@ import {
 } from './session-telemetry.js';
 
 const SESSION_TELEMETRY_SOURCE = readFileSync(new URL('./session-telemetry.ts', import.meta.url), 'utf-8');
+
+function makeTelemetryTestDir(suffix: string): string {
+  return mkdtempSync(join(tmpdir(), `.test-st-${suffix}-`));
+}
 
 describe('json-lines helper source invariant', () => {
   it('routes telemetry JSONL appends through appendJsonLine', () => {
@@ -22,7 +28,7 @@ describe('json-lines helper source invariant', () => {
 
 describe('emitSessionEvent', () => {
   it('writes a pr_created event with correct envelope', () => {
-    const dir = `/tmp/.test-st-${Date.now()}-a`;
+    const dir = makeTelemetryTestDir('a');
     emitSessionEvent(
       {
         type: 'session.pr_created',
@@ -45,7 +51,7 @@ describe('emitSessionEvent', () => {
   });
 
   it('appends multiple event types', () => {
-    const dir = `/tmp/.test-st-${Date.now()}-b`;
+    const dir = makeTelemetryTestDir('b');
     emitSessionEvent(
       { type: 'session.pr_merged', session_id: 's2', pr_url: 'url', branch: 'b', changed_files_count: 5 },
       { telemetryDir: dir },
@@ -63,7 +69,7 @@ describe('emitSessionEvent', () => {
   });
 
   it('creates nested directories', () => {
-    const dir = `/tmp/.test-st-${Date.now()}-c`;
+    const dir = makeTelemetryTestDir('c');
     const nested = join(dir, 'nested', 'deep');
     emitSessionEvent(
       { type: 'session.pr_created', session_id: 's1', pr_url: 'u', branch: 'b', changed_files_count: 0 },
@@ -74,7 +80,7 @@ describe('emitSessionEvent', () => {
   });
 
   it('writes a stop_gate event with diagnostics', () => {
-    const dir = `/tmp/.test-st-${Date.now()}-sg`;
+    const dir = makeTelemetryTestDir('sg');
     emitSessionEvent(
       {
         type: 'session.stop_gate',
@@ -110,6 +116,31 @@ describe('emitSessionEvent', () => {
         { telemetryDir: '/dev/null/impossible' },
       );
     }).not.toThrow();
+  });
+});
+
+describe('countSessionEvents', () => {
+  it('counts matching telemetry events and ignores malformed or unrelated rows', () => {
+    const dir = makeTelemetryTestDir('count');
+    writeFileSync(
+      join(dir, 'events.jsonl'),
+      [
+        JSON.stringify({ timestamp: 't1', source: 'interactive', event: { type: 'session.pr_merged' } }),
+        'not json',
+        JSON.stringify({ timestamp: 't2', source: 'interactive', event: { type: 'session.pr_created' } }),
+        JSON.stringify({ timestamp: 't3', source: 'interactive', event: { type: 'session.pr_merged' } }),
+        JSON.stringify({ timestamp: 't4', source: 'interactive' }),
+      ].join('\n'),
+    );
+
+    expect(countSessionEvents('session.pr_merged', { telemetryDir: dir })).toBe(2);
+    expect(countSessionEvents('session.pr_created', { telemetryDir: dir })).toBe(1);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns zero when the telemetry file is missing or unreadable', () => {
+    expect(countSessionEvents('session.pr_merged', { telemetryDir: '/tmp/does-not-exist-kaizen-st' })).toBe(0);
+    expect(countSessionEvents('session.pr_merged', { telemetryDir: '/dev/null/impossible' })).toBe(0);
   });
 });
 

--- a/src/hooks/session-telemetry.ts
+++ b/src/hooks/session-telemetry.ts
@@ -14,6 +14,7 @@
  * Part of horizon #249 (Observability), issue #671.
  */
 
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { appendJsonLine } from '../lib/json-lines.js';
 
@@ -98,6 +99,35 @@ export function emitSessionEvent(
     appendJsonLine(filePath, envelope);
   } catch {
     // Telemetry is best-effort — never break the hook
+  }
+}
+
+/**
+ * Count events already persisted in events.jsonl.
+ * Best-effort: malformed rows and missing files count as zero, because hook
+ * telemetry must never make advisory prompts brittle.
+ */
+export function countSessionEvents(
+  type: SessionEvent['type'],
+  options?: { telemetryDir?: string },
+): number {
+  try {
+    const dir = options?.telemetryDir ?? resolveTelemetryDir();
+    const filePath = resolve(dir, 'events.jsonl');
+    const content = readFileSync(filePath, 'utf-8');
+    let count = 0;
+    for (const line of content.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const envelope = JSON.parse(line) as Partial<SessionEventEnvelope>;
+        if (envelope.event?.type === type) count += 1;
+      } catch {
+        // Ignore partial/corrupt rows; telemetry is advisory.
+      }
+    }
+    return count;
+  } catch {
+    return 0;
   }
 }
 


### PR DESCRIPTION
## Once upon a time...

#237 created `/kaizen-audit-issues` so issue hygiene, label coverage, incident density, horizon coverage, and epic health could be audited deliberately. But Phase 2 stayed open: the audit was still something an agent or human had to remember to run.

## Every day...

The post-merge reflection hook already appeared after `gh pr merge`, and session telemetry already recorded `session.pr_merged` events. Yet the post-merge prompt only asked for PR reflection and cleanup; it never surfaced aggregate issue health at the exact point where repeated merge activity should trigger periodic maintenance.

## One day...

#1586 split the Phase 2 hook-trigger slice out of #237. I reused the local telemetry file rather than adding a GitHub scan or a blocking gate.

## Because of that...

- `src/hooks/session-telemetry.ts` now has `countSessionEvents()`, a best-effort JSONL reader that tolerates missing files and malformed rows.
- `src/hooks/kaizen-reflect.ts` now counts local `session.pr_merged` events after emitting the current merge event.
- Every 10 recorded merges, the post-merge reflection prompt appends a non-blocking `/kaizen-audit-issues` advisory.
- Existing reflection gate semantics stay unchanged: the agent still clears via `KAIZEN_IMPEDIMENTS` or `KAIZEN_NO_ACTION`.

## Until finally...

The issue-audit skill has a concrete post-merge trigger path, moving #237 Phase 2 from documentation to an observable hook advisory without slowing every merge on network/API work.

Fixes #1586
Refs #237
Refs #244
Refs #953

## Plan / Test Plan

- Plan and test plan: https://github.com/Garsson-io/kaizen/issues/1586#issuecomment-4827591766

## Verification

- RED: `npx vitest run src/hooks/session-telemetry.test.ts src/hooks/kaizen-reflect.test.ts --reporter=verbose` failed on missing `countSessionEvents`, missing `formatAuditIssuesAdvisory`, and absent merge advisory.
- GREEN: `npx vitest run src/hooks/session-telemetry.test.ts src/hooks/kaizen-reflect.test.ts --reporter=verbose` passed: 41 tests.
- `npm run check:fast` passed: typecheck plus 182 changed tests.
- `npm run test:hooks` passed: 435 shell hook tests.
- `npm run test:ci:shard -- --shard=1/2` passed and wrote blob report.
- `npm run test:ci:shard -- --shard=2/2` passed and wrote blob report; stderr included the existing parser-test `Unknown option: --bogus` line.
- `git diff --check` passed.
