### PR TITLE
feat(auto-dent): reward explore candidate manifests

### DIFF
--- a/prompts/explore-gaps.md
+++ b/prompts/explore-gaps.md
@@ -67,6 +67,27 @@ Pick the highest-value exploration from this list:
 
 ## Output
 
+### Required artifact
+
+Write a durable candidate-task manifest to:
+
+`{{candidate_manifest_path}}`
+
+This file is required even if you also file GitHub issues. It is the scouting
+artifact the next exploit/subtract run can consume. Use this JSON shape:
+
+```json
+{{candidate_manifest_schema}}
+```
+
+Rules:
+- Include every promising candidate you discovered, including candidates you did
+  not file as issues.
+- Use `suggested_mode` to describe how the next run should approach the candidate.
+- If no candidates exist, write `"candidates": []` and explain why in the run
+  summary.
+- A run that only files issues but writes no manifest is incomplete scouting.
+
 For each discovery:
 1. File a GitHub issue in {{kaizen_repo}} with clear title and context
 2. Label it `source:auto-dent-explore` and `kaizen`

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_BANDIT_C,
   banditExplorationC,
   modeSuccess,
+  parseCandidateTaskManifest,
   deriveRunOutcome,
   buildRunMetrics,
   buildRunCompleteEvent,
@@ -266,11 +267,84 @@ describe('buildTemplateVars', () => {
     expect(vars.claimed_plan_issue).toBe('');
   });
 
+  it('exposes a per-run candidate task manifest path under the log directory', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-vars-'));
+    const state = makeBatchState();
+
+    const vars = buildTemplateVars(state, 4, tmpDir);
+
+    expect(vars.candidate_manifest_path).toBe(join(tmpDir, 'run-4-candidate-tasks-manifest.json'));
+    expect(vars.candidate_manifest_schema).toContain('candidates');
+    expect(vars.candidate_manifest_schema).toContain('suggested_mode');
+  });
+
+  it('renders explore prompt with required candidate manifest artifact path', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-prompt-'));
+    const state = makeBatchState({ guidance: 'find gaps mode:explore' });
+
+    const meta = buildPromptWithMetadata(state, 2, tmpDir);
+
+    expect(meta.template).toBe('explore-gaps.md');
+    expect(meta.prompt).toContain('Required artifact');
+    expect(meta.prompt).toContain(join(tmpDir, 'run-2-candidate-tasks-manifest.json'));
+    expect(meta.prompt).toContain('candidate-task manifest');
+  });
+
   it('exposes the shared goal forcing contract as a template variable', () => {
     const vars = buildTemplateVars(makeBatchState(), 1);
     expect(vars.goal_forcing_contract).toContain('Headless /goal Equivalent');
     expect(vars.goal_forcing_contract).toContain('plan/test-plan gate');
     expect(vars.goal_forcing_contract).toContain('review/requirements/impact gates');
+  });
+});
+
+describe('parseCandidateTaskManifest', () => {
+  it('counts candidates from a valid manifest', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-valid-'));
+    const path = join(tmpDir, 'run-1-candidate-tasks-manifest.json');
+    writeFileSync(path, JSON.stringify({
+      version: 1,
+      runTag: 'batch/run-1',
+      generatedAt: '2026-06-29T00:00:00.000Z',
+      candidates: [
+        { id: 'a', title: 'First', rationale: 'why', refs: ['#1'], suggested_mode: 'exploit' },
+        { id: 'b', title: 'Second', rationale: 'why', refs: [], suggested_mode: 'subtract' },
+      ],
+    }));
+
+    const parsed = parseCandidateTaskManifest(path);
+
+    expect(parsed).toEqual({ path, count: 2, warnings: [] });
+  });
+
+  it('returns zero with warning for missing or malformed manifests', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-bad-'));
+    const missing = join(tmpDir, 'missing.json');
+    const malformed = join(tmpDir, 'bad.json');
+    writeFileSync(malformed, '{not-json');
+
+    expect(parseCandidateTaskManifest(missing)).toMatchObject({
+      path: missing,
+      count: 0,
+      warnings: [expect.stringContaining('missing')],
+    });
+    expect(parseCandidateTaskManifest(malformed)).toMatchObject({
+      path: malformed,
+      count: 0,
+      warnings: [expect.stringContaining('malformed')],
+    });
+  });
+
+  it('returns zero with warning when candidates is not an array', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-shape-'));
+    const path = join(tmpDir, 'shape.json');
+    writeFileSync(path, JSON.stringify({ version: 1, candidates: 'nope' }));
+
+    expect(parseCandidateTaskManifest(path)).toMatchObject({
+      path,
+      count: 0,
+      warnings: [expect.stringContaining('candidates')],
+    });
   });
 });
 
@@ -2557,8 +2631,10 @@ describe('modeSuccess', () => {
     expect(modeSuccess('exploit', makeRunMetrics({ prs: [] }))).toBe(0);
   });
 
-  it('explore uses issues_filed', () => {
+  it('explore uses candidate manifest count plus issues_filed', () => {
     expect(modeSuccess('explore', makeRunMetrics({ issues_filed: ['#1', '#2', '#3'] }))).toBe(3);
+    expect(modeSuccess('explore', makeRunMetrics({ issues_filed: [], candidate_manifest_count: 4 }))).toBe(4);
+    expect(modeSuccess('explore', makeRunMetrics({ issues_filed: ['#1'], candidate_manifest_count: 2 }))).toBe(3);
     expect(modeSuccess('explore', makeRunMetrics({ prs: ['pr1'], issues_filed: [] }))).toBe(0);
   });
 
@@ -2748,6 +2824,27 @@ describe('buildRunMetrics', () => {
       final_claim_status: 'valid',
       final_claim_path: '/tmp/final-claim.json',
       final_claim_warnings: ['warning'],
+    });
+  });
+
+  it('maps candidate task manifest metadata from RunResult', () => {
+    const metrics = buildRunMetrics({
+      runNum: 5,
+      runStartEpoch: 1742680900,
+      duration: 30,
+      exitCode: 0,
+      runMode: 'explore',
+      result: makeRunResult({
+        candidateManifestPath: '/tmp/run-5-candidate-tasks-manifest.json',
+        candidateManifestCount: 3,
+        candidateManifestWarnings: ['warning'],
+      }),
+    });
+
+    expect(metrics).toMatchObject({
+      candidate_manifest_path: '/tmp/run-5-candidate-tasks-manifest.json',
+      candidate_manifest_count: 3,
+      candidate_manifest_warnings: ['warning'],
     });
   });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -24,7 +24,7 @@ import { spawn, execFileSync, execSync } from 'child_process';
 import { createHash } from 'crypto';
 import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
 import { createInterface } from 'readline';
-import { dirname, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, formatIssuesClosedLine, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
 import { firstHookReason } from './hook-signals.js';
 import { claimNextItem, markItem, resetAssignedItems, readPlan, themeProgress } from './auto-dent-plan.js';
@@ -61,6 +61,7 @@ import { truncateAtWordBoundary } from './auto-dent-display.js';
 import { parseJsonObject } from '../src/lib/json-value.js';
 import { readDurableJsonValueFile, readJsonValueFile, writeDurableJsonValueFile } from '../src/lib/json-file.js';
 import { hasHardQualityFailure } from '../src/verdict-binding-policy.js';
+import { extractPlanText } from '../src/structured-data.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -275,6 +276,12 @@ export interface RunMetrics {
   lines_deleted?: number;
   /** Issues closed as obsolete/duplicate (not-planned), not fixed */
   issues_pruned?: number;
+  /** Per-run explore-mode candidate-task manifest path, when available (#1196). */
+  candidate_manifest_path?: string;
+  /** Number of candidates parsed from the explore-mode candidate-task manifest (#1196). */
+  candidate_manifest_count?: number;
+  /** Non-fatal candidate manifest parse/read warnings (#1196). */
+  candidate_manifest_warnings?: string[];
   /** Prompt template file name used for this run */
   prompt_template?: string;
   /** SHA-256 hash of the prompt template content (first 12 chars) */
@@ -341,6 +348,12 @@ export interface RunResult {
   linesDeleted: number;
   /** Issues closed as not-planned (pruned, not fixed) */
   issuesPruned: number;
+  /** Per-run explore-mode candidate-task manifest path, when available (#1196). */
+  candidateManifestPath?: string;
+  /** Number of candidates parsed from the explore-mode candidate-task manifest (#1196). */
+  candidateManifestCount?: number;
+  /** Non-fatal candidate manifest parse/read warnings (#1196). */
+  candidateManifestWarnings?: string[];
   /** Structured failure classification */
   failureClass?: string;
   /** Whether the run was killed by the wall-clock timeout watchdog (#686) */
@@ -382,6 +395,9 @@ type RunMetricsBaseField =
   | 'mode'
   | 'lines_deleted'
   | 'issues_pruned'
+  | 'candidate_manifest_path'
+  | 'candidate_manifest_count'
+  | 'candidate_manifest_warnings'
   | 'final_claim_status'
   | 'final_claim'
   | 'final_claim_path'
@@ -419,6 +435,9 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     mode: runMode,
     lines_deleted: result.linesDeleted,
     issues_pruned: result.issuesPruned,
+    candidate_manifest_path: result.candidateManifestPath,
+    candidate_manifest_count: result.candidateManifestCount,
+    candidate_manifest_warnings: result.candidateManifestWarnings,
     final_claim_status: result.finalClaimStatus,
     final_claim: result.finalClaim,
     final_claim_path: result.finalClaimPath,
@@ -427,7 +446,59 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     ...metadata,
   };
 }
-import { extractPlanText } from '../src/structured-data.js';
+
+export interface CandidateTaskManifestParseResult {
+  path: string;
+  count: number;
+  warnings: string[];
+}
+
+export function candidateTaskManifestPath(logDir: string, runNum: number): string {
+  return join(logDir, `run-${runNum}-candidate-tasks-manifest.json`);
+}
+
+export const CANDIDATE_TASK_MANIFEST_SCHEMA = [
+  '{',
+  '  "version": 1,',
+  '  "runTag": "<batch-id>/run-<N>",',
+  '  "generatedAt": "<ISO timestamp>",',
+  '  "candidates": [',
+  '    {',
+  '      "id": "<stable short id>",',
+  '      "title": "<candidate task title>",',
+  '      "rationale": "<why this should be worked>",',
+  '      "refs": ["#123", "path/to/file.ts"],',
+  '      "suggested_mode": "exploit|subtract|reflect|contemplate"',
+  '    }',
+  '  ]',
+  '}',
+].join('\n');
+
+export function parseCandidateTaskManifest(path: string): CandidateTaskManifestParseResult {
+  if (!existsSync(path)) {
+    return { path, count: 0, warnings: [`candidate task manifest missing: ${path}`] };
+  }
+
+  const raw = readFileSync(path, 'utf8');
+  const parsed = parseJsonObject(raw);
+  if (!parsed) {
+    return { path, count: 0, warnings: [`candidate task manifest malformed JSON: ${path}`] };
+  }
+
+  const candidates = (parsed as { candidates?: unknown }).candidates;
+  if (!Array.isArray(candidates)) {
+    return { path, count: 0, warnings: [`candidate task manifest candidates must be an array: ${path}`] };
+  }
+
+  return { path, count: candidates.length, warnings: [] };
+}
+
+function attachCandidateTaskManifest(result: RunResult, path: string): void {
+  const parsed = parseCandidateTaskManifest(path);
+  result.candidateManifestPath = parsed.path;
+  result.candidateManifestCount = parsed.count;
+  result.candidateManifestWarnings = parsed.warnings;
+}
 export { extractPlanText };
 
 // State I/O
@@ -639,6 +710,9 @@ export function buildTemplateVars(
     ? crossBatchSteering.map((r, i) => `${i + 1}. ${r}`).join('\n')
     : '';
   const modeSelection = selectMode(state, runNum);
+  const manifestPath = logDir
+    ? candidateTaskManifestPath(logDir, runNum)
+    : `run-${runNum}-candidate-tasks-manifest.json`;
 
   return {
     guidance: state.guidance,
@@ -666,6 +740,8 @@ export function buildTemplateVars(
     prior_reflections: priorReflections,
     failure_class_summary: failureClassSummary,
     contemplation_recommendations: contemplationRecsText,
+    candidate_manifest_path: manifestPath,
+    candidate_manifest_schema: CANDIDATE_TASK_MANIFEST_SCHEMA,
     goal_forcing_contract: renderAutoDentGoalContract(modeSelection.mode),
   };
 }
@@ -768,7 +844,7 @@ export function checkSignalOverrides(state: BatchState): ModeSelection | null {
  * Compute mode-appropriate success metric for a run.
  * Each mode has its own definition of "success":
  *   - exploit: PRs produced
- *   - explore: issues filed (its purpose is discovery, not PRs)
+ *   - explore: candidate-task manifest entries + issues filed (durable scouting)
  *   - reflect: issues filed (insights that become actionable issues)
  *   - subtract: lines deleted + issues pruned (reduction, not addition)
  *   - contemplate: fixed baseline (strategic value not measurable per-run)
@@ -778,7 +854,7 @@ export function modeSuccess(mode: string, metrics: RunMetrics): number {
     case 'exploit':
       return metrics.prs.length;
     case 'explore':
-      return metrics.issues_filed.length;
+      return metrics.issues_filed.length + (metrics.candidate_manifest_count ?? 0);
     case 'reflect':
       return metrics.issues_filed.length;
     case 'subtract':
@@ -1867,9 +1943,12 @@ async function runClaude(
   // Save rendered prompt for observability (#602)
   const promptFile = `${logDir}/run-${runNum}-prompt.md`;
   writeFileSync(promptFile, prompt + '\n');
+  const candidateManifestPath = modeSelection.mode === 'explore'
+    ? candidateTaskManifestPath(logDir, runNum)
+    : undefined;
 
   if (shouldRunCodexProvider(state)) {
-    return runCodex({
+    const codexResult = await runCodex({
       state,
       runNum,
       logFile,
@@ -1881,6 +1960,10 @@ async function runClaude(
       modeReason: modeSelection.reason,
       result,
     });
+    if (candidateManifestPath) {
+      attachCandidateTaskManifest(codexResult.result, candidateManifestPath);
+    }
+    return codexResult;
   }
 
   const nonce = `${new Date()
@@ -2036,6 +2119,9 @@ async function runClaude(
       processExited = true;
       cleanup(heartbeatInterval, livenessInterval, inFlightInterval, wallTimer, postResultTimer);
       const duration = Math.floor((Date.now() - runStart) / 1000);
+      if (candidateManifestPath) {
+        attachCandidateTaskManifest(result, candidateManifestPath);
+      }
       resolvePromise({ exitCode: code ?? 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, promptMeta });
     });
 
@@ -2044,6 +2130,9 @@ async function runClaude(
       cleanup(heartbeatInterval, livenessInterval, inFlightInterval, wallTimer, postResultTimer);
       appendFileSync(logFile, `\nProcess error: ${err.message}\n`);
       const duration = Math.floor((Date.now() - runStart) / 1000);
+      if (candidateManifestPath) {
+        attachCandidateTaskManifest(result, candidateManifestPath);
+      }
       resolvePromise({ exitCode: 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, promptMeta });
     });
   });


### PR DESCRIPTION
## Summary

Fixes Garsson-io/kaizen#1196.

Explore mode previously claimed a candidate-task manifest mandate, but the producer prompt did not require one and `modeSuccess('explore')` only rewarded filed issues. This PR makes scouting durable by requiring each explore run to write a per-run candidate manifest, parsing that artifact after provider completion, and feeding the parsed count into run metrics and explore success scoring.

## Changes

- Add a required candidate-task manifest artifact to `prompts/explore-gaps.md`, including the concrete per-run output path and JSON schema.
- Add candidate manifest path/schema template vars, parser helpers, and explore-only run-result attachment.
- Persist `candidate_manifest_path`, `candidate_manifest_count`, and parse warnings into run metrics.
- Change explore mode success from `issues_filed.length` to `issues_filed.length + candidate_manifest_count`.
- Cover prompt rendering, manifest parsing warnings, metric propagation, and explore scoring in tests.

## Evidence

- RED: focused tests failed before implementation for missing manifest template vars/scoring behavior.
- `npx vitest run scripts/auto-dent-run.test.ts`
- `npm run typecheck`
- `npm run test:fast`
- `npm test`

## Notes

Plan: https://github.com/Garsson-io/kaizen/issues/1196#issuecomment-4827617722

Test plan: https://github.com/Garsson-io/kaizen/issues/1196#issuecomment-4827617808

Out of scope: manifest consumers/prepass (#1176), steering bundle integration (#1189), and hard lifecycle failure for missing or malformed manifests.
