### PR TITLE
fix(auto-dent): avoid plan claims in non-exploit prompts

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
-import { writeFileSync, unlinkSync, mkdtempSync, existsSync, readFileSync } from 'fs';
+import { writeFileSync, unlinkSync, mkdtempSync, existsSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -3189,7 +3189,7 @@ describe('buildPromptWithMetadata', () => {
     expect(meta.prompt).toBe(prompt);
   });
 
-  it('propagates claimedPlanIssue from plan', () => {
+  it('propagates claimedPlanIssue from plan for exploit prompts', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'meta-plan-'));
     const plan = {
       created_at: '2026-03-23T00:00:00Z',
@@ -3205,6 +3205,47 @@ describe('buildPromptWithMetadata', () => {
     const state = makeBatchState();
     const meta = buildPromptWithMetadata(state, 1, tmpDir);
     expect(meta.claimedPlanIssue).toBe('#451');
+    expect(meta.prompt).toContain('## Assigned Work');
+    expect(meta.prompt).toContain('#451');
+
+    const updated = JSON.parse(readFileSync(join(tmpDir, 'plan.json'), 'utf8'));
+    expect(updated.items[0].status).toBe('assigned');
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not consume plan items for explore prompts', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'meta-plan-explore-'));
+    const plan = {
+      created_at: '2026-03-23T00:00:00Z',
+      guidance: 'test',
+      items: [
+        { issue: '#1213', title: 'Manifest binding', score: 9, approach: 'bind it', status: 'pending' },
+      ],
+      wip_excluded: [],
+      epics_scanned: [],
+    };
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const state = makeBatchState({ guidance: 'mode:explore' });
+    const meta = buildPromptWithMetadata(state, 1, tmpDir);
+
+    expect(meta.template).toBe('explore-gaps.md');
+    expect(meta.claimedPlanIssue).toBeUndefined();
+    expect(meta.prompt).not.toContain('## Assigned Work');
+
+    const updated = JSON.parse(readFileSync(join(tmpDir, 'plan.json'), 'utf8'));
+    expect(updated.items[0].status).toBe('pending');
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('uses one selected mode for template choice and plan claim policy', () => {
+    const start = AUTO_DENT_RUN_SOURCE.indexOf('export function buildPromptWithMetadata');
+    const end = AUTO_DENT_RUN_SOURCE.indexOf('function buildPromptInline');
+    const source = AUTO_DENT_RUN_SOURCE.slice(start, end);
+
+    expect(source.match(/selectMode\(state, runNum\)/g)).toHaveLength(1);
+    expect(source).toContain('buildTemplateVars(state, runNum, logDir, { claimPlanItem: shouldClaimPlanItem })');
+    expect(source).toContain("modeSelection.mode === 'exploit' && !state.test_task");
   });
 
   it('claimedPlanIssue is undefined when no plan exists', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -598,10 +598,12 @@ export function buildTemplateVars(
   state: BatchState,
   runNum: number,
   logDir?: string,
+  options: { claimPlanItem?: boolean } = {},
 ): Record<string, string> {
   const runTag = `${state.batch_id}/run-${runNum}`;
   const hostRepo = state.host_repo || state.kaizen_repo || 'unknown';
   const now = new Date();
+  const shouldClaimPlanItem = options.claimPlanItem ?? true;
 
   // Try to claim next item from plan (if a plan exists)
   let planAssignment = '';
@@ -609,7 +611,7 @@ export function buildTemplateVars(
   let reflectionInsights = '';
   let priorReflections = '';
   if (logDir) {
-    const planItem = claimNextItem(logDir);
+    const planItem = shouldClaimPlanItem ? claimNextItem(logDir) : null;
     if (planItem) {
       claimedPlanIssue = planItem.issue;
       const lines = [
@@ -1359,10 +1361,12 @@ export function populateCrossBatchSteering(
 }
 
 export function buildPromptWithMetadata(state: BatchState, runNum: number, logDir?: string): PromptMetadata {
-  const vars = buildTemplateVars(state, runNum, logDir);
+  const modeSelection = selectMode(state, runNum);
+  const shouldClaimPlanItem = modeSelection.mode === 'exploit' && !state.test_task;
+  const vars = buildTemplateVars(state, runNum, logDir, { claimPlanItem: shouldClaimPlanItem });
   const claimedPlanIssue = vars.claimed_plan_issue || undefined;
 
-  const { template: templateFile } = selectMode(state, runNum);
+  const templateFile = modeSelection.template;
   const templateContent = loadPromptTemplate(templateFile);
 
   if (templateContent) {
@@ -1377,14 +1381,14 @@ export function buildPromptWithMetadata(state: BatchState, runNum: number, logDi
 
   // Inline fallback (kept for backward compatibility)
   return {
-    prompt: buildPromptInline(state, runNum),
+    prompt: buildPromptInline(state, runNum, modeSelection),
     template: 'inline',
     hash: 'none',
     claimedPlanIssue,
   };
 }
 
-function buildPromptInline(state: BatchState, runNum: number): string {
+function buildPromptInline(state: BatchState, runNum: number, modeSelection: ModeSelection): string {
   const runTag = `${state.batch_id}/run-${runNum}`;
   const kaizenRepo = state.kaizen_repo || 'unknown';
   const hostRepo = state.host_repo || kaizenRepo;
@@ -1429,7 +1433,7 @@ You are running inside an auto-dent batch loop (run ${runNum}${state.max_runs > 
 After this run completes, the loop will start another run with fresh context.
 Run to completion. Do not ask for confirmation — make autonomous decisions.`;
 
-  prompt += `\n\n${renderAutoDentGoalContract(selectMode(state, runNum).mode)}`;
+  prompt += `\n\n${renderAutoDentGoalContract(modeSelection.mode)}`;
 
   if (state.issues_closed.length > 0) {
     prompt += `\n\nIssues already addressed in previous runs (do not rework): ${state.issues_closed.join(' ')}`;


### PR DESCRIPTION
Once upon a time, auto-dent had a batch planning pre-pass that wrote `plan.json`, and implementation prompts could claim the next planned issue through `claimNextItem()`. Every day, that made exploit runs more directed: the prompt rendered `## Assigned Work`, the run recorded `claimedPlanIssue`, and the plan item moved to `assigned`.

One day, while following the #1213/#940 steering thread, we found the claim happened earlier than the selected prompt mode. `buildTemplateVars()` consumed the plan item before `buildPromptWithMetadata()` chose `explore`, `reflect`, `subtract`, or `contemplate`, so a non-exploit prompt could mark a target assigned without ever showing it to the agent.

Because of that, this PR makes prompt construction compute `selectMode()` once and pass an explicit claim policy into template-variable construction. Only implementation-producing exploit prompts claim plan items; non-exploit prompts can still render their normal context without mutating `plan.json`.

Until finally, the focused RED case reproduced the bug: an explore prompt assigned `#1213`. The GREEN path leaves that item pending for explore while preserving exploit assignment behavior.

Fixes #1594
Parent context: #1213, #1201, #940, #842

## Architecture

```text
buildPromptWithMetadata()
  -> selectMode(state, runNum)              # one decision
  -> shouldClaimPlanItem = mode === exploit && !test_task
  -> buildTemplateVars(..., { claimPlanItem })
       -> claimNextItem(logDir) only when allowed
  -> render selected template
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Gate plan mutation at `buildTemplateVars()` with an explicit option | This is the existing mutation seam, so plan/theme selection stays centralized in `auto-dent-plan.ts`. | Direct callers keep the default claim behavior for compatibility; prompt construction now passes the safer policy explicitly. |
| Claim only for `mode === "exploit"` and non-test tasks | Exploit is the mode whose prompt renders `## Assigned Work` and can execute the planned item. | Future modes that deliberately execute assigned work must opt into the policy rather than inheriting mutation silently. |
| Compute mode once per prompt metadata build | Template selection, goal contract, and plan mutation now share the same decision. | Small signature change for inline fallback. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-run.ts` | Adds explicit plan-claim policy and threads the selected mode through prompt construction. |
| `scripts/auto-dent-run.test.ts` | Adds regression coverage for explore vs exploit prompt plan consumption and a source invariant for one mode decision. |

## Impact (goal -> before/after -> match)

- Goal (#1594): auto-dent plan assignments are consumed only by runs that can act on assigned implementation work.
- Acceptance signal: focused tests show explore prompt builds leave `plan.json` pending and exploit prompt builds assign exactly one item.
- BEFORE: `buildTemplateVars(state, runNum, logDir)` always called `claimNextItem(logDir)` when a plan existed. RED output showed `does not consume plan items for explore prompts` failed because `meta.claimedPlanIssue` was `"#1213"` and stdout printed `[plan] assigned #1213: Manifest binding`.
- AFTER: `buildPromptWithMetadata()` computes mode once, passes `{ claimPlanItem: false }` for explore, and the same focused test passes with the item still `pending`.
- Delta: non-exploit prompt builds no longer mutate the plan queue; exploit prompt builds still render `## Assigned Work` and persist `assigned`.
- Goal met?: yes for #1594. Broader manifest-forced override and cross-batch prior work remain tracked by #1213/#1201/#940.
- Residual scan: `rg -n "claimNextItem\(|selectMode\(state, runNum\)|buildTemplateVars\(" scripts/auto-dent-run.ts scripts/auto-dent-plan.ts scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts` found plan mutation still centralized through `claimNextItem()` and no duplicate scheduler path.

## Test Plan (Behaviors × Levels)

| # | Behavior | Level | Coverage Status | Evidence |
|---|---|---|---|---|
| 1 | Non-exploit prompt builds do not mutate `plan.json` or consume `claimedPlanIssue`. | Integration | tested | `scripts/auto-dent-run.test.ts` explore prompt regression. |
| 2 | Exploit prompt builds still claim one pending plan item, render `## Assigned Work`, and persist `assigned`. | Integration | tested | `scripts/auto-dent-run.test.ts` exploit prompt positive coverage. |
| 3 | Prompt construction uses one selected mode for template choice, plan-claim policy, and goal-contract rendering. | Unit/source assertion | tested | Source invariant around `buildPromptWithMetadata()`. |
| 4 | Plan/theme selection remains centralized in `scripts/auto-dent-plan.ts`; no duplicate plan scheduler appears in the run loop. | Unit/source assertion | tested | Residual `rg` scan plus affected tests. |

No Agentic or Workflow behaviors are deferred for this slice; the failure is deterministic local state mutation during prompt construction.

## Validation

- RED: `npx vitest run scripts/auto-dent-run.test.ts -t "buildPromptWithMetadata"` failed before implementation on `expected '#1213' to be undefined`.
- GREEN focused: `npx vitest run scripts/auto-dent-run.test.ts -t "buildPromptWithMetadata"` → 9 passed.
- Affected files: `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts` → 413 passed.
- Fast check: `npm run check:fast` → typecheck passed; changed fast tests 634 passed, 2 skipped.
- Whitespace: `git diff --check` → clean.

## Known Limitations

This does not implement the broader #1213 manifest-forced override, nor the #1201 cross-batch reward prior. It closes the deterministic plan-consumption bug that could make those steering mechanisms lose targets before an exploit run sees them.
