### PR TITLE
feat(auto-dent): persist self-steering decisions

### DIFF
--- a/prompts/plan-prepass.md
+++ b/prompts/plan-prepass.md
@@ -22,40 +22,53 @@ PRs already created (avoid overlapping work): {{prs}}
 
 ## Instructions
 
-1. List open issues matching the guidance:
+1. First, surface fresh scouting output as a distinct candidate pool:
+   ```
+   gh issue list --repo {{host_repo}} --state open --label source:auto-dent-explore --limit 50 --json number,title,labels,updatedAt
+   gh issue list --repo {{host_repo}} --state open --label source:ecosystem-research --limit 50 --json number,title,labels,updatedAt
+   find logs/auto-dent -name 'run-*-candidate-tasks-manifest.json' -mtime -14 -print 2>/dev/null || true
+   ```
+   Read any recent candidate-task manifest files you find. Treat high-value
+   manifest candidates and fresh explore-sourced issues as first-class planning
+   inputs, not as ordinary stale backlog items.
+
+2. List open issues matching the guidance:
    ```
    gh issue list --repo {{host_repo}} --state open --limit 100 --json number,title,labels
    ```
 
-2. Check for in-progress work (open PRs, active worktrees):
+3. Check for in-progress work (open PRs, active worktrees):
    ```
    gh pr list --repo {{host_repo}} --state open --json number,title,headRefName
    ```
 
-3. Scan epics, PRDs, and horizons for decomposition opportunities:
+4. Scan epics, PRDs, and horizons for decomposition opportunities:
    ```
    gh issue list --repo {{host_repo}} --state open --label epic --json number,title,body
    gh issue list --repo {{host_repo}} --state open --label prd --json number,title,body
    ```
    Also check horizon docs in `docs/horizons/*.md` for maturity levels with concrete next steps.
 
-4. For each epic/PRD, check if it has concrete child issues already filed:
+5. For each epic/PRD, check if it has concrete child issues already filed:
    - If NO concrete child issues exist: this is a **decomposition opportunity**
    - Read the epic body or linked PRD doc to identify 1-3 concrete, PR-sized pieces
    - Add these as `item_type: "decompose"` items in the plan
 
-5. Score each candidate issue on:
+6. Score each candidate issue on:
    - **Relevance** to the guidance (0-10)
    - **Actionability** — is it concrete enough to implement in one PR? (0-10)
    - **Independence** — can it be done without blocking on other work? (0-10)
    - **Value** — how much does it improve the system? (0-10)
+   - **Fresh scouting signal** — recent `source:auto-dent-explore`,
+     `source:ecosystem-research`, or candidate-task manifest evidence should
+     increase priority when the candidate is otherwise actionable.
 
-6. Rank by composite score. Interleave regular leaf issues with decomposition items.
+7. Rank by composite score. Interleave regular leaf issues with decomposition items.
    Place at least one decomposition item in the top 5 if any exist.
 
-7. For each selected item, write a one-sentence approach.
+8. For each selected item, write a one-sentence approach.
 
-8. **Group related items into coordinated themes (aim for 3-5 items per theme).**
+9. **Group related items into coordinated themes (aim for 3-5 items per theme).**
    Issues that share a root cause, a file/subsystem, or a parent epic belong
    together so the batch drives a coherent body of work to completion instead
    of hopping across unrelated issues by score. Give each theme a kebab-case

--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -555,6 +555,30 @@ describe('buildBatchReflection', () => {
     expect(reflection.avgCostPerPr).toBeCloseTo(3.25);
   });
 
+  it('surfaces explore to exploit conversion in reflection comments', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        run: 3,
+        run_history: [
+          makeRunMetrics({ run: 1, mode: 'explore', issues_filed: ['#10', '#11'] }),
+          makeRunMetrics({ run: 2, mode: 'exploit', prs: ['pr1'], issues_closed: ['https://github.com/Garsson-io/kaizen/issues/10'] }),
+          makeRunMetrics({ run: 3, mode: 'reflect', issues_closed: ['#11'] }),
+        ],
+      }),
+    });
+
+    const reflection = buildBatchReflection(batch);
+    const comment = formatBatchReflectionComment(reflection);
+
+    expect(reflection.exploreExploitConversion).toMatchObject({
+      exploreIssuesFiled: 2,
+      exploreIssuesClosedByExploit: 1,
+      conversionRate: 0.5,
+    });
+    expect(comment).toContain('Explore->exploit conversion');
+    expect(comment).toContain('1/2 (50%)');
+  });
+
   it('detects high success rate pattern', () => {
     const runs = Array.from({ length: 5 }, (_, i) =>
       makeRunMetrics({ run: i + 1, cost_usd: 2.0, prs: ['https://github.com/Garsson-io/kaizen/pull/' + (100 + i)] }),

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -52,6 +52,11 @@ import {
   summarizeDrySweepReport,
   type DrySweepReport,
 } from './auto-dent-dry-sweep.js';
+import {
+  computeExploreExploitConversion,
+  formatExploreExploitConversion,
+  type ExploreExploitConversion,
+} from './auto-dent-explore-conversion.js';
 
 function getRepoRoot(): string {
   try {
@@ -393,6 +398,7 @@ export interface BatchReflection {
   issuesClosedCount: number;
   successRate: number;
   avgCostPerPr: number;
+  exploreExploitConversion: ExploreExploitConversion;
   insights: ReflectionInsight[];
   runHistoryTable: string;
 }
@@ -421,6 +427,7 @@ export function buildBatchReflection(
   const failedRuns = scores.filter((r) => !r.success);
   const successRate = scores.length > 0 ? successfulRuns.length / scores.length : 0;
   const avgCostPerPr = totalPrs > 0 ? totalCost / totalPrs : 0;
+  const exploreExploitConversion = computeExploreExploitConversion(history);
 
   // Insight: overall success rate
   if (scores.length >= 3) {
@@ -532,6 +539,13 @@ export function buildBatchReflection(
     });
   }
 
+  if (exploreExploitConversion.exploreIssuesFiled > 0) {
+    insights.push({
+      type: exploreExploitConversion.exploreIssuesClosedByExploit > 0 ? 'success_pattern' : 'recommendation',
+      message: `Explore->exploit conversion: ${formatExploreExploitConversion(exploreExploitConversion)} explore-filed issue(s) closed by exploit runs`,
+    });
+  }
+
   // Build run history table
   const tableLines: string[] = [
     '| Run | Duration | Cost | PRs | Issues | Status |',
@@ -554,6 +568,7 @@ export function buildBatchReflection(
     issuesClosedCount: totalIssuesClosed,
     successRate,
     avgCostPerPr,
+    exploreExploitConversion,
     insights,
     runHistoryTable: tableLines.join('\n'),
   };
@@ -575,6 +590,7 @@ export function formatBatchReflectionComment(reflection: BatchReflection): strin
     `| **PRs created** | ${reflection.totalPrs} |`,
     `| **Issues closed** | ${reflection.issuesClosedCount} |`,
     `| **Avg cost/PR** | ${reflection.avgCostPerPr > 0 ? '$' + reflection.avgCostPerPr.toFixed(2) : 'N/A'} |`,
+    `| **Explore->exploit conversion** | ${reflection.exploreExploitConversion.exploreIssuesFiled > 0 ? formatExploreExploitConversion(reflection.exploreExploitConversion) : 'N/A'} |`,
     '',
   ];
 

--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -24,6 +24,25 @@ import type { WorkflowGateId, WorkflowGateState } from './workflow-gate-ledger.j
 
 // Event type definitions
 
+export interface BanditDecisionDetailTelemetry {
+  mode: string;
+  plays: number;
+  mean_reward: number;
+  exploit_term: number;
+  explore_bonus: number;
+  ucb: number;
+  weight: number;
+}
+
+export interface BanditDecisionTelemetry {
+  selected_mode: string;
+  reason: string;
+  weights: Record<string, number>;
+  details: BanditDecisionDetailTelemetry[];
+  total_plays: number;
+  exploration_c: number;
+}
+
 /** #899: Base fields shared by all auto-dent events */
 export interface BaseEvent {
   run_id: string;
@@ -86,6 +105,8 @@ export interface RunCompleteEvent extends BaseEvent {
   outcome: 'success' | 'empty_success' | 'failure' | 'stop';
   /** Cognitive mode used, for context in analysis */
   mode?: string;
+  /** Durable UCB1 decision breakdown used for this run's mode selection (#1178). */
+  bandit_decision?: BanditDecisionTelemetry;
   /** Review battery verdict for PRs created in this run */
   review_verdict?: 'pass' | 'fail' | 'skipped';
   /** Review battery cost (USD) */

--- a/scripts/auto-dent-explore-conversion.ts
+++ b/scripts/auto-dent-explore-conversion.ts
@@ -1,0 +1,49 @@
+export interface ExploreConversionRun {
+  mode?: string;
+  issues_filed: string[];
+  issues_closed: string[];
+}
+
+export interface ExploreExploitConversion {
+  exploreIssuesFiled: number;
+  exploreIssuesClosedByExploit: number;
+  conversionRate: number;
+}
+
+function issueKey(ref: string): string | null {
+  const match = ref.match(/(?:issues\/|#)?(\d+)\b/);
+  return match ? match[1] : null;
+}
+
+export function computeExploreExploitConversion(history: ExploreConversionRun[]): ExploreExploitConversion {
+  const exploreFiled = new Set<string>();
+  const exploitClosed = new Set<string>();
+
+  for (const run of history) {
+    const mode = run.mode || 'exploit';
+    if (mode === 'exploit') {
+      for (const ref of run.issues_closed) {
+        const key = issueKey(ref);
+        if (key && exploreFiled.has(key)) exploitClosed.add(key);
+      }
+    }
+
+    if (mode === 'explore') {
+      for (const ref of run.issues_filed) {
+        const key = issueKey(ref);
+        if (key) exploreFiled.add(key);
+      }
+    }
+  }
+
+  return {
+    exploreIssuesFiled: exploreFiled.size,
+    exploreIssuesClosedByExploit: exploitClosed.size,
+    conversionRate: exploreFiled.size > 0 ? exploitClosed.size / exploreFiled.size : 0,
+  };
+}
+
+export function formatExploreExploitConversion(conversion: ExploreExploitConversion): string {
+  const pct = Math.round(conversion.conversionRate * 100);
+  return `${conversion.exploreIssuesClosedByExploit}/${conversion.exploreIssuesFiled} (${pct}%)`;
+}

--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -1141,4 +1141,22 @@ describe('plan-prepass template includes theme instructions', () => {
     const prompt = buildPlanPrompt(state);
     expect(prompt.toLowerCase()).toContain('theme');
   });
+
+  it('buildPlanPrompt surfaces explore-sourced issues and candidate manifests', () => {
+    const state = {
+      batch_id: 'b', batch_start: 0, guidance: 'g', max_runs: 10, cooldown: 30,
+      budget: '3.00', max_failures: 3, kaizen_repo: 'Garsson-io/kaizen',
+      host_repo: 'Garsson-io/kaizen', run: 0, prs: [], issues_filed: [],
+      issues_closed: [], cases: [], consecutive_failures: 0, current_cooldown: 30,
+      stop_reason: '', last_issue: '', last_pr: '', last_case: '', last_branch: '',
+      last_worktree: '',
+    };
+
+    const prompt = buildPlanPrompt(state);
+
+    expect(prompt).toContain('source:auto-dent-explore');
+    expect(prompt).toContain('source:ecosystem-research');
+    expect(prompt).toContain('run-*-candidate-tasks-manifest.json');
+    expect(prompt).toContain('candidate-task manifest');
+  });
 });

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -2363,6 +2363,24 @@ describe('checkSignalOverrides', () => {
     expect(result!.reason).toBe('signal:no-recent-prs');
   });
 
+  it('uses the highest learned non-exploit schedulable mode for no-recent-prs when bandit history exists', () => {
+    const history = [
+      ...Array.from({ length: 5 }, (_, i) => makeRunMetrics({ run: i, mode: 'exploit', prs: [] })),
+      ...Array.from({ length: 5 }, (_, i) => makeRunMetrics({ run: i + 5, mode: 'reflect', issues_filed: [`#${i}`], prs: [] })),
+      ...Array.from({ length: 3 }, (_, i) => makeRunMetrics({ run: i + 10, mode: 'explore', issues_filed: [], prs: [] })),
+      ...Array.from({ length: 2 }, (_, i) => makeRunMetrics({ run: i + 13, mode: 'subtract', lines_deleted: 0, prs: [] })),
+    ];
+    const state = makeBatchState({ consecutive_failures: 0, run_history: history });
+
+    const result = checkSignalOverrides(state);
+
+    expect(result).toMatchObject({
+      mode: 'reflect',
+      reason: 'signal:no-recent-prs:bandit-non-exploit',
+    });
+    expect(result!.bandit).toBeDefined();
+  });
+
   it('does not force explore when PRs exist in last 5 runs', () => {
     const state = makeBatchState({
       consecutive_failures: 0,
@@ -2393,6 +2411,25 @@ describe('checkSignalOverrides', () => {
     expect(result!.reason).toBe('signal:mode-streak-exploit');
   });
 
+  it('breaks an exploit streak with the highest learned non-stale schedulable mode', () => {
+    const history = [
+      ...Array.from({ length: 6 }, (_, i) => makeRunMetrics({ run: i, mode: 'reflect', issues_filed: [`#${i}`] })),
+      ...Array.from({ length: 6 }, (_, i) => makeRunMetrics({ run: i + 6, mode: 'subtract', lines_deleted: 0 })),
+      ...Array.from({ length: 5 }, (_, i) => makeRunMetrics({ run: i + 12, mode: 'explore', issues_filed: [] })),
+      ...Array.from({ length: 4 }, (_, i) => makeRunMetrics({ run: i + 17, mode: 'exploit', prs: [`pr-${i}`] })),
+    ];
+    const state = makeBatchState({ consecutive_failures: 0, run_history: history });
+
+    const result = checkSignalOverrides(state);
+
+    expect(result).toMatchObject({
+      mode: 'reflect',
+      reason: 'signal:mode-streak-exploit:bandit-non-stale',
+    });
+    expect(result!.bandit).toBeDefined();
+    expect(result!.mode).not.toBe('explore');
+  });
+
   it('breaks non-exploit mode streak with contemplate', () => {
     const state = makeBatchState({
       consecutive_failures: 0,
@@ -2407,6 +2444,23 @@ describe('checkSignalOverrides', () => {
     expect(result).not.toBeNull();
     expect(result!.mode).toBe('contemplate');
     expect(result!.reason).toBe('signal:mode-streak-explore');
+  });
+
+  it('does not use contemplate as a learned streak-breaker replacement', () => {
+    const history = [
+      ...Array.from({ length: 6 }, (_, i) => makeRunMetrics({ run: i, mode: 'exploit', prs: [`pr-${i}`] })),
+      ...Array.from({ length: 5 }, (_, i) => makeRunMetrics({ run: i + 6, mode: 'reflect', issues_filed: [] })),
+      ...Array.from({ length: 4 }, (_, i) => makeRunMetrics({ run: i + 11, mode: 'explore', issues_filed: [] })),
+    ];
+    history[history.length - 1] = makeRunMetrics({ run: 14, mode: 'explore', issues_filed: [], prs: ['diagnostic-pr'] });
+    const state = makeBatchState({ consecutive_failures: 0, run_history: history });
+
+    const result = checkSignalOverrides(state);
+
+    expect(result!.reason).toBe('signal:mode-streak-explore:bandit-non-stale');
+    expect(SCHEDULABLE_MODES).toContain(result!.mode as any);
+    expect(result!.mode).not.toBe('contemplate');
+    expect(result!.mode).not.toBe('explore');
   });
 
   it('consecutive failures takes priority over no-prs signal', () => {
@@ -2848,6 +2902,33 @@ describe('buildRunMetrics', () => {
     });
   });
 
+  it('persists bandit decision metadata to run metrics', () => {
+    const bandit = computeBanditWeights([
+      ...Array.from({ length: 5 }, (_, i) => makeRunMetrics({ run: i, mode: 'exploit', prs: [`pr-${i}`] })),
+      ...Array.from({ length: 5 }, (_, i) => makeRunMetrics({ run: i + 5, mode: 'explore', issues_filed: [] })),
+    ], { minRuns: 10 })!;
+
+    const metrics = buildRunMetrics({
+      runNum: 5,
+      runStartEpoch: 1742680900,
+      duration: 30,
+      exitCode: 0,
+      runMode: 'exploit',
+      result: makeRunResult(),
+      modeReason: 'bandit',
+      bandit,
+    });
+
+    expect(metrics.bandit_decision).toMatchObject({
+      selected_mode: 'exploit',
+      reason: 'bandit',
+      total_plays: bandit.totalPlays,
+      exploration_c: bandit.explorationC,
+    });
+    expect(metrics.bandit_decision?.weights).toEqual(bandit.weights);
+    expect(metrics.bandit_decision?.details).toHaveLength(SCHEDULABLE_MODES.length);
+  });
+
   it('persists the hook-activation verdict to state.json metrics (#843)', () => {
     const metrics = buildRunMetrics({
       runNum: 5,
@@ -2948,6 +3029,39 @@ describe('buildRunMetrics', () => {
       status: 'unknown',
       degraded: true,
     });
+  });
+
+  it('emits bandit decision metadata on run.complete telemetry', () => {
+    const bandit = computeBanditWeights([
+      ...Array.from({ length: 5 }, (_, i) => makeRunMetrics({ run: i, mode: 'exploit', prs: [`pr-${i}`] })),
+      ...Array.from({ length: 5 }, (_, i) => makeRunMetrics({ run: i + 5, mode: 'explore', issues_filed: [] })),
+    ], { minRuns: 10 })!;
+    const result = makeRunResult();
+    const metrics = buildRunMetrics({
+      runNum: 9,
+      runStartEpoch: 1742681400,
+      duration: 8,
+      exitCode: 0,
+      runMode: 'exploit',
+      result,
+      modeReason: 'bandit',
+      bandit,
+    });
+
+    const event = buildRunCompleteEvent({
+      runId: 'batch/run-9',
+      batchId: 'batch',
+      runNum: 9,
+      duration: 8,
+      exitCode: 0,
+      result,
+      runMode: 'exploit',
+      outcome: 'success',
+      runMetricsForOutcome: metrics,
+      lifecycleViolationCount: 0,
+    });
+
+    expect(event.bandit_decision).toEqual(metrics.bandit_decision);
   });
 });
 
@@ -3128,6 +3242,22 @@ describe('formatBatchFooter', () => {
     expect(output).toContain('Modes:');
     expect(output).toContain('exploit:2');
     expect(output).toContain('explore:1');
+  });
+
+  it('shows explore to exploit conversion when explore-filed issues close in exploit runs', () => {
+    const state = makeBatchState({
+      run: 3,
+      prs: ['pr1'],
+      run_history: [
+        makeRunMetrics({ run: 1, mode: 'explore', issues_filed: ['#10', '#11'] }),
+        makeRunMetrics({ run: 2, mode: 'exploit', prs: ['pr1'], issues_closed: ['https://github.com/org/repo/issues/10'] }),
+        makeRunMetrics({ run: 3, mode: 'reflect', issues_closed: ['#11'] }),
+      ],
+    });
+
+    const output = formatBatchFooter(state);
+
+    expect(output).toContain('Explore->exploit: 1/2 (50%)');
   });
 
   it('omits mode line when no history', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -36,7 +36,7 @@ import {
   resolvePromptsDir,
   renderTemplate,
 } from '../src/review-battery.js';
-import { EventEmitter, makeRunId, type AutoDentEvent, type RunCompleteEvent } from './auto-dent-events.js';
+import { EventEmitter, makeRunId, type AutoDentEvent, type BanditDecisionTelemetry, type RunCompleteEvent } from './auto-dent-events.js';
 import { defaultReviewFixProviders, runFixLoop } from './review-fix.js';
 import { buildRunManifest, writeRunManifest, bundleArtifacts, formatManifestSummary } from './auto-dent-artifacts.js';
 import { uploadBatchArtifacts } from './batch-artifacts-upload.js';
@@ -48,6 +48,7 @@ import {
   computeSteeringRecommendations,
 } from './batch-outcome.js';
 import { phaseProvidersForAgentProvider, type PhaseProviderRecord, type Provider } from './auto-dent-provider.js';
+import { computeExploreExploitConversion, formatExploreExploitConversion } from './auto-dent-explore-conversion.js';
 import {
   buildKaizenCycleSteps,
   formatIssueForDisplay,
@@ -97,6 +98,7 @@ export {
   type RunPrCreatedEvent,
   type RunCompleteEvent,
   type BatchReflectEvent,
+  type BanditDecisionTelemetry,
   type EventEnvelope,
 } from './auto-dent-events.js';
 
@@ -282,6 +284,8 @@ export interface RunMetrics {
   candidate_manifest_count?: number;
   /** Non-fatal candidate manifest parse/read warnings (#1196). */
   candidate_manifest_warnings?: string[];
+  /** Durable UCB1 decision breakdown used for mode selection (#1178). */
+  bandit_decision?: BanditDecisionTelemetry;
   /** Prompt template file name used for this run */
   prompt_template?: string;
   /** SHA-256 hash of the prompt template content (first 12 chars) */
@@ -398,6 +402,7 @@ type RunMetricsBaseField =
   | 'candidate_manifest_path'
   | 'candidate_manifest_count'
   | 'candidate_manifest_warnings'
+  | 'bandit_decision'
   | 'final_claim_status'
   | 'final_claim'
   | 'final_claim_path'
@@ -412,12 +417,14 @@ export interface BuildRunMetricsInput {
   exitCode: number;
   runMode: string;
   result: RunResult;
+  modeReason?: string;
+  bandit?: BanditResult;
   provider?: Provider;
   metadata?: RunMetricsMetadata;
 }
 
 export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
-  const { runNum, runStartEpoch, duration, exitCode, runMode, result, provider, metadata = {} } = input;
+  const { runNum, runStartEpoch, duration, exitCode, runMode, result, modeReason, bandit, provider, metadata = {} } = input;
   const hookActivation = result.hookActivation
     ?? (provider ? unknownHookActivationVerdict(provider, 'no system.init observed') : undefined);
   return {
@@ -438,6 +445,7 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     candidate_manifest_path: result.candidateManifestPath,
     candidate_manifest_count: result.candidateManifestCount,
     candidate_manifest_warnings: result.candidateManifestWarnings,
+    bandit_decision: buildBanditDecisionTelemetry(runMode, modeReason, bandit),
     final_claim_status: result.finalClaimStatus,
     final_claim: result.finalClaim,
     final_claim_path: result.finalClaimPath,
@@ -794,8 +802,8 @@ const MODE_TEMPLATES: Record<string, string> = {
  *
  * Signals (checked in priority order):
  *   1. 3+ consecutive failures -> reflect (diagnose what's going wrong)
- *   2. No PRs in last 5 runs with history -> explore (backlog may be exhausted)
- *   3. Same mode 4+ times consecutively -> force a different mode
+ *   2. No PRs in last 5 runs with history -> learned non-exploit mode, or explore during cold start
+ *   3. Same mode 4+ times consecutively -> learned non-stale schedulable mode, or legacy cold-start fallback
  */
 export function checkSignalOverrides(state: BatchState): ModeSelection | null {
   const history = state.run_history || [];
@@ -810,11 +818,14 @@ export function checkSignalOverrides(state: BatchState): ModeSelection | null {
     };
   }
 
-  // Signal 2: no PRs in last 5 runs -> explore (backlog may be exhausted)
+  // Signal 2: no PRs in last 5 runs -> avoid exploit; let the learned policy
+  // choose among schedulable alternatives once enough history exists.
   if (history.length >= 5) {
     const recent5 = history.slice(-5);
     const recentPRs = recent5.reduce((sum, r) => sum + r.prs.length, 0);
     if (recentPRs === 0) {
+      const learned = learnedSignalMode(state, new Set(['exploit']), 'signal:no-recent-prs:bandit-non-exploit');
+      if (learned) return learned;
       return {
         mode: 'explore',
         template: MODE_TEMPLATES.explore,
@@ -829,6 +840,8 @@ export function checkSignalOverrides(state: BatchState): ModeSelection | null {
     const modes = recent4.map(r => r.mode || 'exploit');
     if (modes.every(m => m === modes[0])) {
       const staleMode = modes[0];
+      const learned = learnedSignalMode(state, new Set([staleMode]), `signal:mode-streak-${staleMode}:bandit-non-stale`);
+      if (learned) return learned;
       // Pick a different mode: if stuck on exploit, explore; otherwise contemplate
       const breakMode = staleMode === 'exploit' ? 'explore' : 'contemplate';
       return {
@@ -840,6 +853,34 @@ export function checkSignalOverrides(state: BatchState): ModeSelection | null {
   }
 
   return null;
+}
+
+function learnedSignalMode(
+  state: BatchState,
+  excludedModes: Set<string>,
+  reason: string,
+): ModeSelection | null {
+  const bandit = computeBanditWeights(state.run_history || [], { explorationC: banditExplorationC() });
+  if (!bandit) return null;
+
+  const best = bandit.details
+    .filter((detail) =>
+      (SCHEDULABLE_MODES as readonly string[]).includes(detail.mode)
+      && !excludedModes.has(detail.mode),
+    )
+    .sort((a, b) =>
+      b.ucb - a.ucb
+      || b.weight - a.weight
+      || a.mode.localeCompare(b.mode),
+    )[0];
+  if (!best) return null;
+
+  return {
+    mode: best.mode,
+    template: MODE_TEMPLATES[best.mode] || MODE_TEMPLATES.exploit,
+    reason,
+    bandit,
+  };
 }
 
 /**
@@ -994,6 +1035,7 @@ export function buildRunCompleteEvent(input: BuildRunCompleteEventInput): RunCom
     review_cost_usd: reviewCostUsd,
     phase_providers: phaseProviders,
     hook_activation: runMetricsForOutcome.hook_activation,
+    bandit_decision: runMetricsForOutcome.bandit_decision,
     outcome,
     mode: runMode,
   };
@@ -1087,6 +1129,30 @@ export interface BanditResult {
   totalPlays: number;
   /** Exploration constant actually used. */
   explorationC: number;
+}
+
+export function buildBanditDecisionTelemetry(
+  selectedMode: string,
+  reason: string | undefined,
+  bandit: BanditResult | undefined,
+): BanditDecisionTelemetry | undefined {
+  if (!bandit) return undefined;
+  return {
+    selected_mode: selectedMode,
+    reason: reason ?? 'bandit',
+    weights: bandit.weights,
+    details: bandit.details.map((detail) => ({
+      mode: detail.mode,
+      plays: detail.plays,
+      mean_reward: detail.meanReward,
+      exploit_term: detail.exploitTerm,
+      explore_bonus: detail.exploreBonus,
+      ucb: detail.ucb,
+      weight: detail.weight,
+    })),
+    total_plays: bandit.totalPlays,
+    exploration_c: bandit.explorationC,
+  };
 }
 
 /**
@@ -1890,7 +1956,7 @@ async function runClaude(
   logFile: string,
   repoRoot: string,
   stateFile: string,
-): Promise<{ exitCode: number; duration: number; result: RunResult; mode: string; modeReason: string; promptMeta: PromptMetadata }> {
+): Promise<{ exitCode: number; duration: number; result: RunResult; mode: string; modeReason: string; bandit?: BanditResult; promptMeta: PromptMetadata }> {
   const result: RunResult = {
     prs: [],
     issuesFiled: [],
@@ -1967,7 +2033,7 @@ async function runClaude(
     if (candidateManifestPath) {
       attachCandidateTaskManifest(codexResult.result, candidateManifestPath);
     }
-    return codexResult;
+    return { ...codexResult, bandit: modeSelection.bandit };
   }
 
   const nonce = `${new Date()
@@ -2126,7 +2192,7 @@ async function runClaude(
       if (candidateManifestPath) {
         attachCandidateTaskManifest(result, candidateManifestPath);
       }
-      resolvePromise({ exitCode: code ?? 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, promptMeta });
+      resolvePromise({ exitCode: code ?? 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, bandit: modeSelection.bandit, promptMeta });
     });
 
     child.on('error', (err) => {
@@ -2137,7 +2203,7 @@ async function runClaude(
       if (candidateManifestPath) {
         attachCandidateTaskManifest(result, candidateManifestPath);
       }
-      resolvePromise({ exitCode: 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, promptMeta });
+      resolvePromise({ exitCode: 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, bandit: modeSelection.bandit, promptMeta });
     });
   });
 }
@@ -2180,6 +2246,11 @@ export function formatBatchFooter(state: BatchState): string {
 
   if (modeStr) {
     lines.push(`  ${color.dim(`  Modes: ${modeStr}`)}`);
+  }
+
+  const conversion = computeExploreExploitConversion(history);
+  if (conversion.exploreIssuesFiled > 0) {
+    lines.push(`  ${color.dim(`  Explore->exploit: ${formatExploreExploitConversion(conversion)}`)}`);
   }
 
   lines.push(`  ${color.dim(bar)}`);
@@ -2513,7 +2584,7 @@ async function main(): Promise<void> {
 
   const runStartEpoch = Math.floor(Date.now() / 1000);
   const runStartDate = new Date();
-  const { exitCode, duration, result, mode: runMode, modeReason: runModeReason, promptMeta } = await runClaude(
+  const { exitCode, duration, result, mode: runMode, modeReason: runModeReason, bandit: runBandit, promptMeta } = await runClaude(
     state,
     runNum,
     logFile,
@@ -2883,6 +2954,8 @@ async function main(): Promise<void> {
       exitCode,
       runMode,
       result,
+      modeReason: runModeReason,
+      bandit: runBandit,
       provider: state.provider ?? 'claude',
     });
     // Bind the run-success stamp to the verdicts this run already recorded
@@ -3116,6 +3189,8 @@ async function main(): Promise<void> {
     exitCode,
     runMode,
     result,
+    modeReason: runModeReason,
+    bandit: runBandit,
     provider: state.provider ?? 'claude',
     metadata: {
       prompt_template: promptMeta.template,


### PR DESCRIPTION
## Summary

Fixes Garsson-io/kaizen#1189.

This bundles the coupled auto-dent self-steering fixes from #1178, #1182, and the concrete #1176 loop closure work after #1196 made explore manifests real.

## Changes

- Persist the selected UCB1 bandit decision into `RunMetrics` as `bandit_decision`.
- Emit the same bandit decision payload on `run.complete` telemetry.
- Make advisory signal overrides use the highest learned schedulable non-stale/non-exploit mode when bandit history exists, instead of hardcoding `explore` or unscheduled `contemplate`.
- Feed planning with fresh `source:auto-dent-explore`, `source:ecosystem-research`, and recent `run-*-candidate-tasks-manifest.json` candidates.
- Add a computed explore->exploit conversion metric and surface it in the operator footer and mid-batch reflection/progress comment.

## Evidence

- RED: focused tests failed before implementation for prompt scouting input, learned signal override behavior, and durable bandit metadata.
- `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts scripts/auto-dent-ctl.test.ts`
- `npm run typecheck`
- `npm run test:fast`
- `npm test`

## Scope Notes

This does not implement a full automatic manifest-to-claim consumer or change UCB1 math. It makes the steering decision auditable, stops the override layer from contradicting learned policy when bandit data exists, gives the planner first-class scouting inputs, and exposes a conversion metric for reflection.

Plan: https://github.com/Garsson-io/kaizen/issues/1189#issuecomment-4827650539

Test plan: https://github.com/Garsson-io/kaizen/issues/1189#issuecomment-4827650631

Related: #1176 #1178 #1182 #1196 #1137 #940
