### PR TITLE
feat(auto-dent): persist self-steering bandit decisions

### DIFF
--- a/prompts/plan-prepass.md
+++ b/prompts/plan-prepass.md
@@ -22,40 +22,49 @@ PRs already created (avoid overlapping work): {{prs}}
 
 ## Instructions
 
-1. List open issues matching the guidance:
+1. First inspect fresh scouted candidates from exploration runs:
+   ```
+   gh issue list --repo {{host_repo}} --state open --label source:auto-dent-explore --limit 50 --json number,title,labels
+   gh issue list --repo {{host_repo}} --state open --label source:ecosystem-research --limit 50 --json number,title,labels
+   find logs/auto-dent -name 'run-*-candidate-tasks-manifest.json' -mtime -14 -print
+   ```
+   Read any recent candidate task manifest that looks relevant to the guidance.
+   Treat manifest candidates as planning inputs, not as completed work.
+
+2. List open issues matching the guidance:
    ```
    gh issue list --repo {{host_repo}} --state open --limit 100 --json number,title,labels
    ```
 
-2. Check for in-progress work (open PRs, active worktrees):
+3. Check for in-progress work (open PRs, active worktrees):
    ```
    gh pr list --repo {{host_repo}} --state open --json number,title,headRefName
    ```
 
-3. Scan epics, PRDs, and horizons for decomposition opportunities:
+4. Scan epics, PRDs, and horizons for decomposition opportunities:
    ```
    gh issue list --repo {{host_repo}} --state open --label epic --json number,title,body
    gh issue list --repo {{host_repo}} --state open --label prd --json number,title,body
    ```
    Also check horizon docs in `docs/horizons/*.md` for maturity levels with concrete next steps.
 
-4. For each epic/PRD, check if it has concrete child issues already filed:
+5. For each epic/PRD, check if it has concrete child issues already filed:
    - If NO concrete child issues exist: this is a **decomposition opportunity**
    - Read the epic body or linked PRD doc to identify 1-3 concrete, PR-sized pieces
    - Add these as `item_type: "decompose"` items in the plan
 
-5. Score each candidate issue on:
+6. Score each candidate issue on:
    - **Relevance** to the guidance (0-10)
    - **Actionability** — is it concrete enough to implement in one PR? (0-10)
    - **Independence** — can it be done without blocking on other work? (0-10)
    - **Value** — how much does it improve the system? (0-10)
 
-6. Rank by composite score. Interleave regular leaf issues with decomposition items.
+7. Rank by composite score. Interleave regular leaf issues with decomposition items.
    Place at least one decomposition item in the top 5 if any exist.
 
-7. For each selected item, write a one-sentence approach.
+8. For each selected item, write a one-sentence approach.
 
-8. **Group related items into coordinated themes (aim for 3-5 items per theme).**
+9. **Group related items into coordinated themes (aim for 3-5 items per theme).**
    Issues that share a root cause, a file/subsystem, or a parent epic belong
    together so the batch drives a coherent body of work to completion instead
    of hopping across unrelated issues by score. Give each theme a kebab-case

--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -53,6 +53,25 @@ export interface RunPrCreatedEvent extends BaseEvent {
   pr_url: string;
 }
 
+export interface AutoDentBanditDecisionDetail {
+  mode: string;
+  plays: number;
+  mean_reward: number;
+  exploit_term: number;
+  explore_bonus: number;
+  ucb: number;
+  weight: number;
+}
+
+export interface AutoDentBanditDecision {
+  selected_mode: string;
+  reason: string;
+  total_plays: number;
+  exploration_c: number;
+  weights: Record<string, number>;
+  details: AutoDentBanditDecisionDetail[];
+}
+
 export interface RunCompleteEvent extends BaseEvent {
   type: 'run.complete';
   duration_ms: number;
@@ -92,6 +111,8 @@ export interface RunCompleteEvent extends BaseEvent {
   review_cost_usd?: number;
   /** Hook-activation verdict from the session init event or explicit unknown fallback (#1501). */
   hook_activation?: HookActivationVerdict;
+  /** Durable UCB1 decision payload for the selected cognitive mode (#1189). */
+  bandit_decision?: AutoDentBanditDecision;
   /**
    * Provider + billing mode per lifecycle phase (#1143, epic #1134).
    * Absent on older events. Keyed by phase → { provider, billing }.

--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -759,6 +759,68 @@ describe('buildPlanPrompt', () => {
     expect(prompt).toContain('decomposition');
     expect(prompt).toContain('item_type');
   });
+
+  it('surfaces recent auto-dent exploration issue sources in plan prompt', () => {
+    const state = {
+      batch_id: 'batch-test',
+      batch_start: 0,
+      guidance: 'close the explore to exploit loop',
+      max_runs: 10,
+      cooldown: 30,
+      budget: '3.00',
+      max_failures: 3,
+      kaizen_repo: 'Garsson-io/kaizen',
+      host_repo: 'Garsson-io/kaizen',
+      run: 0,
+      prs: [],
+      issues_filed: [],
+      issues_closed: [],
+      cases: [],
+      consecutive_failures: 0,
+      current_cooldown: 30,
+      stop_reason: '',
+      last_issue: '',
+      last_pr: '',
+      last_case: '',
+      last_branch: '',
+      last_worktree: '',
+    };
+    const prompt = buildPlanPrompt(state);
+
+    expect(prompt).toContain('source:auto-dent-explore');
+    expect(prompt).toContain('source:ecosystem-research');
+  });
+
+  it('instructs planning to inspect recent candidate task manifests', () => {
+    const state = {
+      batch_id: 'batch-test',
+      batch_start: 0,
+      guidance: 'use explored candidates',
+      max_runs: 10,
+      cooldown: 30,
+      budget: '3.00',
+      max_failures: 3,
+      kaizen_repo: 'Garsson-io/kaizen',
+      host_repo: 'Garsson-io/kaizen',
+      run: 0,
+      prs: [],
+      issues_filed: [],
+      issues_closed: [],
+      cases: [],
+      consecutive_failures: 0,
+      current_cooldown: 30,
+      stop_reason: '',
+      last_issue: '',
+      last_pr: '',
+      last_case: '',
+      last_branch: '',
+      last_worktree: '',
+    };
+    const prompt = buildPlanPrompt(state);
+
+    expect(prompt).toContain('run-*-candidate-tasks-manifest.json');
+    expect(prompt).toContain('candidate task manifest');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -2363,6 +2363,34 @@ describe('checkSignalOverrides', () => {
     expect(result!.reason).toBe('signal:no-recent-prs');
   });
 
+  it('uses learned non-exploit bandit choice for no-recent-prs when history is sufficient', () => {
+    const state = makeBatchState({
+      consecutive_failures: 0,
+      run_history: [
+        makeRunMetrics({ mode: 'exploit', prs: ['pr'] }),
+        makeRunMetrics({ mode: 'explore', issues_filed: ['#1'] }),
+        makeRunMetrics({ mode: 'reflect', issues_filed: ['#2'] }),
+        makeRunMetrics({ mode: 'subtract', lines_deleted: 500 }),
+        makeRunMetrics({ mode: 'subtract', lines_deleted: 500 }),
+        makeRunMetrics({ mode: 'subtract', lines_deleted: 500 }),
+        makeRunMetrics({ mode: 'exploit', prs: [] }),
+        makeRunMetrics({ mode: 'explore', prs: [] }),
+        makeRunMetrics({ mode: 'reflect', prs: [] }),
+        makeRunMetrics({ mode: 'subtract', prs: [], lines_deleted: 500 }),
+        makeRunMetrics({ mode: 'exploit', prs: [] }),
+      ],
+    });
+
+    const result = checkSignalOverrides(state);
+
+    expect(result).toMatchObject({
+      mode: 'subtract',
+      template: 'subtract-prune.md',
+      reason: 'signal:no-recent-prs:bandit',
+    });
+    expect(result!.bandit).toBeDefined();
+  });
+
   it('does not force explore when PRs exist in last 5 runs', () => {
     const state = makeBatchState({
       consecutive_failures: 0,
@@ -2407,6 +2435,34 @@ describe('checkSignalOverrides', () => {
     expect(result).not.toBeNull();
     expect(result!.mode).toBe('contemplate');
     expect(result!.reason).toBe('signal:mode-streak-explore');
+  });
+
+  it('breaks mode streak with learned non-stale schedulable mode instead of contemplate', () => {
+    const state = makeBatchState({
+      consecutive_failures: 0,
+      run_history: [
+        makeRunMetrics({ mode: 'exploit', prs: ['pr'] }),
+        makeRunMetrics({ mode: 'exploit', prs: ['pr'] }),
+        makeRunMetrics({ mode: 'reflect', issues_filed: ['#1', '#2', '#3'] }),
+        makeRunMetrics({ mode: 'reflect', issues_filed: ['#4', '#5', '#6'] }),
+        makeRunMetrics({ mode: 'subtract', lines_deleted: 100 }),
+        makeRunMetrics({ mode: 'exploit', prs: ['pr'] }),
+        makeRunMetrics({ mode: 'explore', prs: ['pr'] }),
+        makeRunMetrics({ mode: 'explore', prs: ['pr'] }),
+        makeRunMetrics({ mode: 'explore', prs: ['pr'] }),
+        makeRunMetrics({ mode: 'explore', prs: ['pr'] }),
+      ],
+    });
+
+    const result = checkSignalOverrides(state);
+
+    expect(result).toMatchObject({
+      mode: 'reflect',
+      template: 'reflect-batch.md',
+      reason: 'signal:mode-streak-explore:bandit',
+    });
+    expect(result!.mode).not.toBe('contemplate');
+    expect(result!.bandit).toBeDefined();
   });
 
   it('consecutive failures takes priority over no-prs signal', () => {
@@ -2848,6 +2904,46 @@ describe('buildRunMetrics', () => {
     });
   });
 
+  it('persists selected bandit decision metadata', () => {
+    const bandit = computeBanditWeights([
+      makeRunMetrics({ mode: 'exploit', prs: ['pr'] }),
+      makeRunMetrics({ mode: 'exploit', prs: ['pr'] }),
+      makeRunMetrics({ mode: 'exploit', prs: ['pr'] }),
+      makeRunMetrics({ mode: 'explore', issues_filed: ['#1'], candidate_manifest_count: 2 }),
+      makeRunMetrics({ mode: 'explore', issues_filed: ['#2'], candidate_manifest_count: 2 }),
+      makeRunMetrics({ mode: 'reflect', issues_filed: ['#3'] }),
+      makeRunMetrics({ mode: 'reflect', issues_filed: ['#4'] }),
+      makeRunMetrics({ mode: 'subtract', lines_deleted: 300 }),
+      makeRunMetrics({ mode: 'subtract', lines_deleted: 300 }),
+      makeRunMetrics({ mode: 'subtract', lines_deleted: 300 }),
+    ], { explorationC: 1.25 })!;
+
+    const metrics = buildRunMetrics({
+      runNum: 5,
+      runStartEpoch: 1742680900,
+      duration: 30,
+      exitCode: 0,
+      runMode: 'subtract',
+      result: makeRunResult(),
+      modeSelection: {
+        mode: 'subtract',
+        template: 'subtract-prune.md',
+        reason: 'bandit',
+        bandit,
+      },
+    });
+
+    expect(metrics.bandit_decision).toMatchObject({
+      selected_mode: 'subtract',
+      reason: 'bandit',
+      total_plays: bandit.totalPlays,
+      exploration_c: 1.25,
+      weights: bandit.weights,
+    });
+    expect(metrics.bandit_decision!.details).toHaveLength(4);
+    expect(metrics.bandit_decision!.details[0]).toHaveProperty('mean_reward');
+  });
+
   it('persists the hook-activation verdict to state.json metrics (#843)', () => {
     const metrics = buildRunMetrics({
       runNum: 5,
@@ -2948,6 +3044,43 @@ describe('buildRunMetrics', () => {
       status: 'unknown',
       degraded: true,
     });
+  });
+
+  it('emits bandit decision metadata on run.complete telemetry', () => {
+    const result = makeRunResult();
+    const metrics = buildRunMetrics({
+      runNum: 8,
+      runStartEpoch: 1742681300,
+      duration: 8,
+      exitCode: 0,
+      runMode: 'explore',
+      result,
+      metadata: {
+        bandit_decision: {
+          selected_mode: 'explore',
+          reason: 'bandit',
+          total_plays: 12,
+          exploration_c: 1.41,
+          weights: { exploit: 0.1, explore: 0.7, reflect: 0.1, subtract: 0.1 },
+          details: [],
+        },
+      },
+    });
+
+    const event = buildRunCompleteEvent({
+      runId: 'batch/run-8',
+      batchId: 'batch',
+      runNum: 8,
+      duration: 8,
+      exitCode: 0,
+      result,
+      runMode: 'explore',
+      outcome: 'success',
+      runMetricsForOutcome: metrics,
+      lifecycleViolationCount: 0,
+    });
+
+    expect(event.bandit_decision).toEqual(metrics.bandit_decision);
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -36,7 +36,13 @@ import {
   resolvePromptsDir,
   renderTemplate,
 } from '../src/review-battery.js';
-import { EventEmitter, makeRunId, type AutoDentEvent, type RunCompleteEvent } from './auto-dent-events.js';
+import {
+  EventEmitter,
+  makeRunId,
+  type AutoDentBanditDecision,
+  type AutoDentEvent,
+  type RunCompleteEvent,
+} from './auto-dent-events.js';
 import { defaultReviewFixProviders, runFixLoop } from './review-fix.js';
 import { buildRunManifest, writeRunManifest, bundleArtifacts, formatManifestSummary } from './auto-dent-artifacts.js';
 import { uploadBatchArtifacts } from './batch-artifacts-upload.js';
@@ -327,6 +333,8 @@ export interface RunMetrics {
    * kaizen plugin absent — the run was NOT gated by kaizen enforcement.
    */
   hook_activation?: HookActivationVerdict;
+  /** Durable UCB1 decision payload for the selected cognitive mode (#1189). */
+  bandit_decision?: AutoDentBanditDecision;
 }
 
 export interface RunResult {
@@ -413,13 +421,15 @@ export interface BuildRunMetricsInput {
   runMode: string;
   result: RunResult;
   provider?: Provider;
+  modeSelection?: ModeSelection;
   metadata?: RunMetricsMetadata;
 }
 
 export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
-  const { runNum, runStartEpoch, duration, exitCode, runMode, result, provider, metadata = {} } = input;
+  const { runNum, runStartEpoch, duration, exitCode, runMode, result, provider, modeSelection, metadata = {} } = input;
   const hookActivation = result.hookActivation
     ?? (provider ? unknownHookActivationVerdict(provider, 'no system.init observed') : undefined);
+  const banditDecision = buildBanditDecision(modeSelection);
   return {
     run: runNum,
     start_epoch: runStartEpoch,
@@ -444,6 +454,7 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     final_claim_warnings: result.finalClaimWarnings,
     hook_activation: hookActivation,
     ...metadata,
+    bandit_decision: banditDecision ?? metadata.bandit_decision,
   };
 }
 
@@ -788,6 +799,48 @@ const MODE_TEMPLATES: Record<string, string> = {
   contemplate: 'contemplate-strategy.md',
 };
 
+export function buildBanditDecision(selection?: ModeSelection): AutoDentBanditDecision | undefined {
+  if (!selection?.bandit) return undefined;
+  return {
+    selected_mode: selection.mode,
+    reason: selection.reason,
+    total_plays: selection.bandit.totalPlays,
+    exploration_c: selection.bandit.explorationC,
+    weights: selection.bandit.weights,
+    details: selection.bandit.details.map((detail) => ({
+      mode: detail.mode,
+      plays: detail.plays,
+      mean_reward: detail.meanReward,
+      exploit_term: detail.exploitTerm,
+      explore_bonus: detail.exploreBonus,
+      ucb: detail.ucb,
+      weight: detail.weight,
+    })),
+  };
+}
+
+function selectBanditSignalOverride(
+  history: RunMetrics[],
+  excludedModes: Set<string>,
+  reason: string,
+): ModeSelection | null {
+  const bandit = computeBanditWeights(history, { explorationC: banditExplorationC() });
+  if (!bandit) return null;
+
+  const best = [...bandit.details]
+    .filter((detail) => SCHEDULABLE_MODES.includes(detail.mode as (typeof SCHEDULABLE_MODES)[number]))
+    .filter((detail) => !excludedModes.has(detail.mode))
+    .sort((a, b) => b.ucb - a.ucb || b.weight - a.weight || a.mode.localeCompare(b.mode))[0];
+  if (!best) return null;
+
+  return {
+    mode: best.mode,
+    template: MODE_TEMPLATES[best.mode] || MODE_TEMPLATES.exploit,
+    reason,
+    bandit,
+  };
+}
+
 /**
  * Check signal-driven overrides based on batch state.
  * Returns a ModeSelection if a signal fires, or null to fall through to the schedule.
@@ -815,6 +868,8 @@ export function checkSignalOverrides(state: BatchState): ModeSelection | null {
     const recent5 = history.slice(-5);
     const recentPRs = recent5.reduce((sum, r) => sum + r.prs.length, 0);
     if (recentPRs === 0) {
+      const learned = selectBanditSignalOverride(history, new Set(['exploit']), 'signal:no-recent-prs:bandit');
+      if (learned) return learned;
       return {
         mode: 'explore',
         template: MODE_TEMPLATES.explore,
@@ -829,6 +884,8 @@ export function checkSignalOverrides(state: BatchState): ModeSelection | null {
     const modes = recent4.map(r => r.mode || 'exploit');
     if (modes.every(m => m === modes[0])) {
       const staleMode = modes[0];
+      const learned = selectBanditSignalOverride(history, new Set([staleMode]), `signal:mode-streak-${staleMode}:bandit`);
+      if (learned) return learned;
       // Pick a different mode: if stuck on exploit, explore; otherwise contemplate
       const breakMode = staleMode === 'exploit' ? 'explore' : 'contemplate';
       return {
@@ -994,6 +1051,7 @@ export function buildRunCompleteEvent(input: BuildRunCompleteEventInput): RunCom
     review_cost_usd: reviewCostUsd,
     phase_providers: phaseProviders,
     hook_activation: runMetricsForOutcome.hook_activation,
+    bandit_decision: runMetricsForOutcome.bandit_decision,
     outcome,
     mode: runMode,
   };
@@ -1768,6 +1826,7 @@ interface ProviderRunResult {
   result: RunResult;
   mode: string;
   modeReason: string;
+  modeSelection: ModeSelection;
   promptMeta: PromptMetadata;
 }
 
@@ -1780,8 +1839,7 @@ async function runCodex(
     stateFile: string;
     prompt: string;
     promptMeta: PromptMetadata;
-    mode: string;
-    modeReason: string;
+    modeSelection: ModeSelection;
     result: RunResult;
   },
 ): Promise<ProviderRunResult> {
@@ -1870,8 +1928,9 @@ async function runCodex(
         exitCode,
         duration,
         result: input.result,
-        mode: input.mode,
-        modeReason: input.modeReason,
+        mode: input.modeSelection.mode,
+        modeReason: input.modeSelection.reason,
+        modeSelection: input.modeSelection,
         promptMeta: input.promptMeta,
       });
     };
@@ -1890,7 +1949,7 @@ async function runClaude(
   logFile: string,
   repoRoot: string,
   stateFile: string,
-): Promise<{ exitCode: number; duration: number; result: RunResult; mode: string; modeReason: string; promptMeta: PromptMetadata }> {
+): Promise<ProviderRunResult> {
   const result: RunResult = {
     prs: [],
     issuesFiled: [],
@@ -1960,8 +2019,7 @@ async function runClaude(
       stateFile,
       prompt,
       promptMeta,
-      mode: modeSelection.mode,
-      modeReason: modeSelection.reason,
+      modeSelection,
       result,
     });
     if (candidateManifestPath) {
@@ -2126,7 +2184,15 @@ async function runClaude(
       if (candidateManifestPath) {
         attachCandidateTaskManifest(result, candidateManifestPath);
       }
-      resolvePromise({ exitCode: code ?? 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, promptMeta });
+      resolvePromise({
+        exitCode: code ?? 1,
+        duration,
+        result,
+        mode: modeSelection.mode,
+        modeReason: modeSelection.reason,
+        modeSelection,
+        promptMeta,
+      });
     });
 
     child.on('error', (err) => {
@@ -2137,7 +2203,15 @@ async function runClaude(
       if (candidateManifestPath) {
         attachCandidateTaskManifest(result, candidateManifestPath);
       }
-      resolvePromise({ exitCode: 1, duration, result, mode: modeSelection.mode, modeReason: modeSelection.reason, promptMeta });
+      resolvePromise({
+        exitCode: 1,
+        duration,
+        result,
+        mode: modeSelection.mode,
+        modeReason: modeSelection.reason,
+        modeSelection,
+        promptMeta,
+      });
     });
   });
 }
@@ -2513,7 +2587,7 @@ async function main(): Promise<void> {
 
   const runStartEpoch = Math.floor(Date.now() / 1000);
   const runStartDate = new Date();
-  const { exitCode, duration, result, mode: runMode, modeReason: runModeReason, promptMeta } = await runClaude(
+  const { exitCode, duration, result, mode: runMode, modeReason: runModeReason, modeSelection, promptMeta } = await runClaude(
     state,
     runNum,
     logFile,
@@ -2884,6 +2958,7 @@ async function main(): Promise<void> {
       runMode,
       result,
       provider: state.provider ?? 'claude',
+      modeSelection,
     });
     // Bind the run-success stamp to the verdicts this run already recorded
     // (#1224, meta #1227): a review FAIL / process-incomplete / critical
@@ -3117,6 +3192,7 @@ async function main(): Promise<void> {
     runMode,
     result,
     provider: state.provider ?? 'claude',
+    modeSelection,
     metadata: {
       prompt_template: promptMeta.template,
       prompt_hash: promptMeta.hash,


### PR DESCRIPTION
## Problem

Auto-dent had a self-steering loop, but the selected UCB1 decision was not durable and signal overrides could still hijack learned choices with fixed modes. Planning also did not surface fresh explore outputs or candidate manifests, leaving the explore to exploit loop easy to miss.

Fixes #1189.
Related: #1176, #1178, #1182, #1213.

## Discovery

The normal bandit path already computed a rich per-mode breakdown, but `runClaude` dropped the `ModeSelection` before metrics and `run.complete` telemetry were built. Separately, `checkSignalOverrides` returned hard-coded `explore` or `contemplate` decisions before the bandit path could run.

## Solution

- Persist a snake_case `bandit_decision` payload in run metrics and `run.complete` telemetry, including selected mode, reason, total plays, exploration constant, weights, and per-mode UCB details.
- Carry the actual `ModeSelection` through provider execution into both run metric construction paths.
- Let no-recent-PR and mode-streak signal overrides choose the highest-UCB eligible schedulable mode when bandit data exists, while preserving the old cold-start fallback behavior.
- Teach the plan prepass prompt to inspect `source:auto-dent-explore`, `source:ecosystem-research`, and recent `run-*-candidate-tasks-manifest.json` artifacts before broad backlog scoring.

## Evidence

- RED: `npx vitest run scripts/auto-dent-run.test.ts -t "buildRunMetrics|checkSignalOverrides"` failed on the missing telemetry and hard-coded override choices.
- RED: `npx vitest run scripts/auto-dent-plan.test.ts -t "buildPlanPrompt"` failed on missing exploration-source and manifest instructions.
- GREEN: `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts` passed, 425 tests.
- GREEN: `npm run check:fast` passed, typecheck plus 665 tests / 2 skipped.
- GREEN: `git diff --check`.

## Scope Note

This closes the #1189 observability and steering bundle as planned. It does not implement the full automatic candidate-manifest-to-claim consumer tracked under the broader #1213 work.