### PR TITLE
feat(setup): install lefthook hooks by remote ref

### DIFF
--- a/.agents/skills/kaizen-setup/SKILL.md
+++ b/.agents/skills/kaizen-setup/SKILL.md
@@ -85,7 +85,7 @@ Result reports the detected framework, modified files, and any post-install comm
 - Framework-specific injection (one of):
   - pre-commit: adds a remote `https://github.com/Garsson-io/kaizen` repo hook `kaizen-pre-push` with a pinned `rev`; no `.kaizen-hooks/` host wrapper is written
   - husky: writes `.kaizen-hooks/pre-push` and appends a chain block to `.husky/pre-push`
-  - lefthook: writes `.kaizen-hooks/pre-push` and adds `pre-push.commands.kaizen-pre-push` to `lefthook.yml`
+  - lefthook: adds a remote `https://github.com/Garsson-io/kaizen` config `lefthook-kaizen.yml` with a branch/tag `ref`; no `.kaizen-hooks/` host wrapper is written
   - raw `.git/hooks/pre-push`: writes `.kaizen-hooks/pre-push` and appends a chain block
   - none: writes `.kaizen-hooks/pre-push`, creates `.githooks/pre-push`, and sets `git config core.hooksPath .githooks`
 

--- a/docs/git-hooks-design.md
+++ b/docs/git-hooks-design.md
@@ -106,7 +106,7 @@ The detection order in `src/setup-git-hooks.ts`:
 
 ### Framework-specific injection
 
-For pre-commit hosts, kaizen registers a remote repo hook and writes no host-side kaizen wrapper. For husky, lefthook, raw, and standalone installs, kaizen writes `.kaizen-hooks/pre-push` (a **thin wrapper** that execs the plugin-resident entry — see below) to the host project root, then registers that wrapper with the host framework.
+For pre-commit and lefthook hosts, kaizen registers a remote repo/provider config and writes no host-side kaizen wrapper. For husky, raw, and standalone installs, kaizen writes `.kaizen-hooks/pre-push` (a **thin wrapper** that execs the plugin-resident entry — see below) to the host project root, then registers that wrapper with the host framework.
 
 **pre-commit** (PRIMARY):
 
@@ -139,11 +139,14 @@ fi
 **lefthook**:
 
 ```yaml
-pre-push:
-  commands:
-    kaizen-pre-push:
-      run: ./.kaizen-hooks/pre-push
+remotes:
+  - git_url: https://github.com/Garsson-io/kaizen
+    ref: main
+    configs:
+      - lefthook-kaizen.yml
 ```
+
+The hook provider contract lives in kaizen's root `lefthook-kaizen.yml`. Lefthook merges that remote config into the host config, syncs the remote checkout under `.git/info/lefthook-remotes`, and runs the provider command from the host root. Because Lefthook's `ref` is a branch or tag name, kaizen uses the matching plugin version tag when present and otherwise falls back to the current branch (usually `main` after release), not a commit SHA.
 
 **raw** `.git/hooks/pre-push` — appends a `KAIZEN_CHAIN_START`-marked block that execs `.kaizen-hooks/pre-push`.
 
@@ -153,7 +156,7 @@ All injection is **idempotent**: running `/kaizen-setup install-git-hooks` twice
 
 ### The `.kaizen-hooks/pre-push` thin wrapper (#1086)
 
-For husky, lefthook, raw, and standalone installs, `/kaizen-setup install-git-hooks` writes a **thin wrapper** (~25–35 lines) into the host repo at `.kaizen-hooks/pre-push`. It is NOT a copy of the gate logic — it only:
+For husky, raw, and standalone installs, `/kaizen-setup install-git-hooks` writes a **thin wrapper** (~25–35 lines) into the host repo at `.kaizen-hooks/pre-push`. It is NOT a copy of the gate logic — it only:
 
 1. Resolves the kaizen plugin root: `$CLAUDE_PLUGIN_ROOT` → baked-in install path → `$HOME/.claude/plugins/cache` search → fail-open.
 2. Exports the resolved root as `$CLAUDE_PLUGIN_ROOT`.
@@ -165,11 +168,11 @@ For husky, lefthook, raw, and standalone installs, `/kaizen-setup install-git-ho
 
 **No agent-env gate in the wrapper — deliberate.** `kaizen-host-entry.sh` already gates on the agent-env vars as its first action, and `src/hooks/agent-env-agreement.test.ts` pins that var list against `pre-push.ts` so it can't drift. Adding the gate to the wrapper would create a *third* copy of that list to keep in sync — the exact drift hazard the agreement test exists to prevent. In the common case the baked-in path resolves without a cache scan, so a human push still exits fast once it reaches the entry's gate.
 
-**Migration is automatic.** For pre-commit hosts, the next `/kaizen-setup` removes the legacy local `kaizen-pre-push` hook, removes kaizen-owned `.kaizen-hooks/` when safe, and injects the remote repo block. For other frameworks, `writeEntryScript` overwrites `.kaizen-hooks/pre-push` on every setup run, so an existing host swaps the stale copy for the wrapper.
+**Migration is automatic.** For pre-commit hosts, the next `/kaizen-setup` removes the legacy local `kaizen-pre-push` hook, removes kaizen-owned `.kaizen-hooks/` when safe, and injects the remote repo block. Lefthook follows the same model: the legacy local `pre-push.commands.kaizen-pre-push` command is removed, kaizen-owned `.kaizen-hooks/` is cleaned when safe, and the `remotes:` block is injected. For husky/raw/standalone, `writeEntryScript` overwrites `.kaizen-hooks/pre-push` on every setup run, so an existing host swaps the stale copy for the wrapper.
 
 Builder: `buildThinWrapper(pluginRoot)` in `src/setup-git-hooks.ts`. The dispatch target template lives at `src/hooks/kaizen-host-entry.sh` in the kaizen plugin.
 
-Remote-repo hook references for lefthook remain tracked in #1089. Husky has no equivalent remote-repo provider model, so it continues to use the thin wrapper path.
+Husky has no equivalent remote-repo provider model, so it continues to use the thin wrapper path.
 
 ## Worktree semantics
 

--- a/lefthook-kaizen.yml
+++ b/lefthook-kaizen.yml
@@ -1,0 +1,7 @@
+pre-push:
+  commands:
+    kaizen-pre-push:
+      run: |
+        KAIZEN_ENTRY=$(find "$(git rev-parse --path-format=absolute --git-path info)/lefthook-remotes" -maxdepth 5 -path "*/src/hooks/kaizen-host-entry.sh" -print -quit 2>/dev/null || true)
+        [ -n "$KAIZEN_ENTRY" ] || exit 0
+        exec bash "$KAIZEN_ENTRY"

--- a/src/setup-git-hooks.test.ts
+++ b/src/setup-git-hooks.test.ts
@@ -25,7 +25,9 @@ import {
   KAIZEN_ENTRY_PATH,
   writeEntryScript,
   KAIZEN_PRE_COMMIT_REPO,
+  KAIZEN_LEFTHOOK_CONFIG,
   resolveKaizenPreCommitRev,
+  resolveKaizenLefthookRef,
 } from './setup-git-hooks.js';
 import { AGENT_ENV_VARS } from './hooks/pre-push.js';
 
@@ -308,6 +310,37 @@ describe('resolveKaizenPreCommitRev', () => {
   });
 });
 
+describe('resolveKaizenLefthookRef', () => {
+  it('uses plugin version only when the matching local git tag exists', () => {
+    write('.claude-plugin/plugin.json', JSON.stringify({ version: '1.2.3' }));
+    write('marker.txt', 'tagged\n');
+    commitFixtureRepo();
+    execSync('git tag v1.2.3', { cwd: tmpDir });
+
+    expect(resolveKaizenLefthookRef(tmpDir)).toBe('v1.2.3');
+  });
+
+  it('falls back to the current branch, not a commit SHA, when the version tag is absent', () => {
+    write('.claude-plugin/plugin.json', JSON.stringify({ version: '1.2.3' }));
+    write('marker.txt', 'untagged\n');
+    commitFixtureRepo();
+
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: tmpDir, encoding: 'utf-8' }).trim();
+    expect(resolveKaizenLefthookRef(tmpDir)).toBe(branch);
+    expect(resolveKaizenLefthookRef(tmpDir)).not.toBe('v1.2.3');
+    expect(resolveKaizenLefthookRef(tmpDir)).not.toMatch(/^[0-9a-f]{7,40}$/);
+  });
+
+  it('falls back to main for slash-containing case branches', () => {
+    write('.claude-plugin/plugin.json', JSON.stringify({ version: '1.2.3' }));
+    write('marker.txt', 'case branch\n');
+    commitFixtureRepo();
+    execSync('git checkout -b case/test-lefthook-ref --quiet', { cwd: tmpDir });
+
+    expect(resolveKaizenLefthookRef(tmpDir)).toBe('main');
+  });
+});
+
 // ── injectIntoHusky ───────────────────────────────────────────────────
 
 describe('injectIntoHusky', () => {
@@ -352,11 +385,16 @@ describe('injectIntoLefthook', () => {
     write('lefthook.yml', 'pre-push:\n  commands:\n    existing:\n      run: echo hi\n');
   });
 
-  it('adds pre-push.commands.kaizen-pre-push entry', () => {
+  it('adds remotes entry for the kaizen provider config', () => {
     const result = injectIntoLefthook(tmpDir);
     expect(result.action).toBe('installed');
     const parsed = YAML.parse(read('lefthook.yml'));
-    expect(parsed['pre-push'].commands[KAIZEN_HOOK_ID].run).toBe(`./${KAIZEN_ENTRY_PATH}`);
+    const remote = parsed.remotes.find((r: { git_url: string }) => r.git_url === KAIZEN_PRE_COMMIT_REPO);
+    expect(remote).toBeDefined();
+    expect(remote.ref).toMatch(/^[^\s]+$/);
+    expect(remote.ref).not.toMatch(/^[0-9a-f]{7,40}$/);
+    expect(remote.configs).toContain(KAIZEN_LEFTHOOK_CONFIG);
+    expect(parsed['pre-push'].commands[KAIZEN_HOOK_ID]).toBeUndefined();
   });
 
   it('preserves existing commands', () => {
@@ -369,13 +407,71 @@ describe('injectIntoLefthook', () => {
     injectIntoLefthook(tmpDir);
     const result2 = injectIntoLefthook(tmpDir);
     expect(result2.action).toBe('already_installed');
+    const parsed = YAML.parse(read('lefthook.yml'));
+    expect(parsed.remotes.filter((r: { git_url: string }) => r.git_url === KAIZEN_PRE_COMMIT_REPO)).toHaveLength(1);
   });
 
-  it('creates pre-push section when absent', () => {
+  it('creates remotes section when absent', () => {
     write('lefthook.yml', '# empty\n');
     injectIntoLefthook(tmpDir);
     const parsed = YAML.parse(read('lefthook.yml'));
-    expect(parsed['pre-push'].commands[KAIZEN_HOOK_ID]).toBeDefined();
+    expect(parsed.remotes[0]).toMatchObject({
+      git_url: KAIZEN_PRE_COMMIT_REPO,
+      configs: [KAIZEN_LEFTHOOK_CONFIG],
+    });
+  });
+
+  it('preserves existing remotes and adds missing kaizen config to an existing kaizen remote', () => {
+    write('lefthook.yml', `remotes:
+  - git_url: https://github.com/example/hooks
+    ref: main
+    configs:
+      - lefthook.yml
+  - git_url: ${KAIZEN_PRE_COMMIT_REPO}
+    ref: main
+    configs:
+      - other.yml
+`);
+    injectIntoLefthook(tmpDir);
+    const parsed = YAML.parse(read('lefthook.yml'));
+    expect(parsed.remotes.find((r: { git_url: string }) => r.git_url === 'https://github.com/example/hooks')).toBeDefined();
+    const remote = parsed.remotes.find((r: { git_url: string }) => r.git_url === KAIZEN_PRE_COMMIT_REPO);
+    expect(remote.configs).toEqual(['other.yml', KAIZEN_LEFTHOOK_CONFIG]);
+  });
+
+  it('migrates legacy local command and removes kaizen-owned hook directory', () => {
+    write('lefthook.yml', `pre-push:
+  commands:
+    existing:
+      run: echo hi
+    ${KAIZEN_HOOK_ID}:
+      run: ./${KAIZEN_ENTRY_PATH}
+`);
+    writeEntryScript(tmpDir, stubEntryContent);
+
+    const result = injectIntoLefthook(tmpDir);
+    expect(result.action).toBe('updated');
+    expect(exists('.kaizen-hooks')).toBe(false);
+
+    const parsed = YAML.parse(read('lefthook.yml'));
+    expect(parsed['pre-push'].commands.existing).toBeDefined();
+    expect(parsed['pre-push'].commands[KAIZEN_HOOK_ID]).toBeUndefined();
+    expect(parsed.remotes.find((r: { git_url: string }) => r.git_url === KAIZEN_PRE_COMMIT_REPO)).toBeDefined();
+  });
+
+  it('migration preserves non-kaizen files in .kaizen-hooks', () => {
+    write('lefthook.yml', `pre-push:
+  commands:
+    ${KAIZEN_HOOK_ID}:
+      run: ./${KAIZEN_ENTRY_PATH}
+`);
+    writeEntryScript(tmpDir, stubEntryContent);
+    write('.kaizen-hooks/custom', 'keep\n');
+
+    injectIntoLefthook(tmpDir);
+    expect(exists('.kaizen-hooks')).toBe(true);
+    expect(exists('.kaizen-hooks/pre-push')).toBe(false);
+    expect(read('.kaizen-hooks/custom')).toBe('keep\n');
   });
 });
 
@@ -452,6 +548,16 @@ describe('installGitHooks — end-to-end', () => {
     expect(exists('.husky/pre-push')).toBe(true);
   });
 
+  it('lefthook path: injects remote config without writing host entry script', () => {
+    write('lefthook.yml', 'pre-push:\n  commands: {}\n');
+    const result = installGitHooks({ cwd: tmpDir, entryScriptContent: stubEntryContent });
+    expect(result.framework).toBe('lefthook');
+    expect(exists('.kaizen-hooks/pre-push')).toBe(false);
+    expect(result.postInstallCommands).toContain('lefthook install');
+    const parsed = YAML.parse(read('lefthook.yml'));
+    expect(parsed.remotes.find((r: { git_url: string }) => r.git_url === KAIZEN_PRE_COMMIT_REPO)).toBeDefined();
+  });
+
   it('none path → standalone', () => {
     const result = installGitHooks({ cwd: tmpDir, entryScriptContent: stubEntryContent });
     expect(result.framework).toBe('none');
@@ -519,5 +625,17 @@ describe('pre-commit provider manifest', () => {
     expect(entry).toContain('while [ -L "$SOURCE" ]; do');
     expect(entry).toContain('SELF_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)');
     expect(entry.indexOf('SELF_ROOT=')).toBeLessThan(entry.indexOf('__KAIZEN_PLUGIN_ROOT__'));
+  });
+});
+
+describe('lefthook provider config', () => {
+  it('declares kaizen-pre-push and resolves the synced remote checkout at runtime', () => {
+    const configPath = path.resolve(__dirname, '..', KAIZEN_LEFTHOOK_CONFIG);
+    const config = YAML.parse(fs.readFileSync(configPath, 'utf-8'));
+    const command = config['pre-push'].commands[KAIZEN_HOOK_ID];
+    expect(command.run).toContain('lefthook-remotes');
+    expect(command.run).toContain('src/hooks/kaizen-host-entry.sh');
+    expect(command.run).toContain('exec bash "$KAIZEN_ENTRY"');
+    expect(command.run).not.toContain(KAIZEN_ENTRY_PATH);
   });
 });

--- a/src/setup-git-hooks.ts
+++ b/src/setup-git-hooks.ts
@@ -86,13 +86,22 @@ export interface InstallOptions {
 
 export const KAIZEN_ENTRY_PATH = '.kaizen-hooks/pre-push';
 export const KAIZEN_HOOK_ID = 'kaizen-pre-push';
-export const KAIZEN_PRE_COMMIT_REPO = 'https://github.com/Garsson-io/kaizen';
+export const KAIZEN_REMOTE_REPO = 'https://github.com/Garsson-io/kaizen';
+export const KAIZEN_PRE_COMMIT_REPO = KAIZEN_REMOTE_REPO;
+export const KAIZEN_LEFTHOOK_CONFIG = 'lefthook-kaizen.yml';
 export const KAIZEN_CHAIN_MARKER = '# KAIZEN_CHAIN_START';
 export const KAIZEN_CHAIN_END_MARKER = '# KAIZEN_CHAIN_END';
 
 type PreCommitHook = { id: string; [k: string]: unknown };
 type PreCommitRepo = { repo: string; rev?: string; hooks?: PreCommitHook[]; [k: string]: unknown };
 type PreCommitConfig = { repos?: PreCommitRepo[]; [k: string]: unknown };
+type LefthookRemote = { git_url: string; ref?: string; configs?: string[]; [k: string]: unknown };
+type LefthookCommand = { run?: string; [k: string]: unknown };
+type LefthookConfig = {
+  remotes?: LefthookRemote[];
+  'pre-push'?: { commands?: Record<string, LefthookCommand>; [k: string]: unknown };
+  [k: string]: unknown;
+};
 
 function moduleRepoRoot(): string {
   return dirname(dirname(fileURLToPath(import.meta.url)));
@@ -113,6 +122,32 @@ function resolveKaizenRoot(pluginRoot?: string): string {
 
 export function resolveKaizenPreCommitRev(pluginRoot?: string): string {
   const root = resolveKaizenRoot(pluginRoot);
+  const tag = resolveKaizenVersionTag(root);
+  if (tag) return tag;
+
+  try {
+    return execFileSync('git', ['rev-parse', '--short=12', 'HEAD'], { cwd: root, encoding: 'utf-8', stdio: 'pipe' }).trim();
+  } catch {
+    return 'main';
+  }
+}
+
+export function resolveKaizenLefthookRef(pluginRoot?: string): string {
+  const root = resolveKaizenRoot(pluginRoot);
+  const tag = resolveKaizenVersionTag(root);
+  if (tag) return tag;
+
+  try {
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: root, encoding: 'utf-8', stdio: 'pipe' }).trim();
+    if (branch && branch !== 'HEAD' && !branch.includes('/')) return branch;
+  } catch {
+    // Fall through to stable default.
+  }
+
+  return 'main';
+}
+
+function resolveKaizenVersionTag(root: string): string | null {
   const pluginJson = tryReadFileSync(join(root, '.claude-plugin', 'plugin.json'));
   if (pluginJson) {
     const parsed = JSON.parse(pluginJson) as { version?: unknown };
@@ -127,17 +162,12 @@ export function resolveKaizenPreCommitRev(pluginRoot?: string): string {
         });
         return tag;
       } catch {
-        // Do not emit an unfetchable provider rev. The plugin version is only
-        // a valid pre-commit rev once the corresponding git tag exists.
+        // Do not emit an unfetchable provider ref. The plugin version is only
+        // a valid remote-provider ref once the corresponding git tag exists.
       }
     }
   }
-
-  try {
-    return execFileSync('git', ['rev-parse', '--short=12', 'HEAD'], { cwd: root, encoding: 'utf-8', stdio: 'pipe' }).trim();
-  } catch {
-    return 'main';
-  }
+  return null;
 }
 
 function kaizenPreCommitRepo(pluginRoot?: string): PreCommitRepo {
@@ -150,6 +180,14 @@ function kaizenPreCommitRepo(pluginRoot?: string): PreCommitRepo {
         stages: ['pre-push'],
       },
     ],
+  };
+}
+
+function kaizenLefthookRemote(pluginRoot?: string): LefthookRemote {
+  return {
+    git_url: KAIZEN_PRE_COMMIT_REPO,
+    ref: resolveKaizenLefthookRef(pluginRoot),
+    configs: [KAIZEN_LEFTHOOK_CONFIG],
   };
 }
 
@@ -445,38 +483,66 @@ export function injectIntoHusky(cwd: string): InstallResult {
 /**
  * Inject into lefthook.yml.
  */
-export function injectIntoLefthook(cwd: string): InstallResult {
+export function injectIntoLefthook(cwd: string, opts: { pluginRoot?: string } = {}): InstallResult {
   const configPath = join(cwd, 'lefthook.yml');
   const raw = readFileSync(configPath, 'utf-8');
-  const parsed = (YAML.parse(raw) ?? {}) as {
-    'pre-push'?: { commands?: Record<string, { run: string; [k: string]: unknown }> };
-  };
+  const parsed = (YAML.parse(raw) ?? {}) as LefthookConfig;
 
-  if (!parsed['pre-push']) parsed['pre-push'] = {};
-  if (!parsed['pre-push'].commands) parsed['pre-push'].commands = {};
+  let changed = false;
+  let removedLegacyCommand = false;
 
-  if (parsed['pre-push'].commands[KAIZEN_HOOK_ID]) {
+  const commands = parsed['pre-push']?.commands;
+  if (commands?.[KAIZEN_HOOK_ID]) {
+    delete commands[KAIZEN_HOOK_ID];
+    removedLegacyCommand = true;
+    changed = true;
+    if (Object.keys(commands).length === 0 && parsed['pre-push']) {
+      delete parsed['pre-push'].commands;
+    }
+  }
+
+  const cleanedHookDir = removedLegacyCommand ? cleanupLegacyKaizenHookDir(cwd) : false;
+  changed = changed || cleanedHookDir;
+
+  if (!Array.isArray(parsed.remotes)) parsed.remotes = [];
+  let remote = parsed.remotes.find((r) => r.git_url === KAIZEN_PRE_COMMIT_REPO);
+  if (!remote) {
+    remote = kaizenLefthookRemote(opts.pluginRoot);
+    parsed.remotes.push(remote);
+    changed = true;
+  } else {
+    if (!remote.ref) {
+      remote.ref = resolveKaizenLefthookRef(opts.pluginRoot);
+      changed = true;
+    }
+    if (!Array.isArray(remote.configs)) {
+      remote.configs = [];
+      changed = true;
+    }
+    if (!remote.configs.includes(KAIZEN_LEFTHOOK_CONFIG)) {
+      remote.configs.push(KAIZEN_LEFTHOOK_CONFIG);
+      changed = true;
+    }
+  }
+
+  if (!changed) {
     return {
       framework: 'lefthook',
       action: 'already_installed',
       filesModified: [],
       postInstallCommands: [],
-      logMessage: `lefthook: command '${KAIZEN_HOOK_ID}' already present — no change`,
+      logMessage: `lefthook: remote config '${KAIZEN_LEFTHOOK_CONFIG}' already present in ${configPath} — no change`,
     };
   }
-
-  parsed['pre-push'].commands[KAIZEN_HOOK_ID] = {
-    run: `./${KAIZEN_ENTRY_PATH}`,
-  };
 
   writeFileSync(configPath, YAML.stringify(parsed));
 
   return {
     framework: 'lefthook',
-    action: 'installed',
-    filesModified: [configPath],
+    action: removedLegacyCommand || cleanedHookDir ? 'updated' : 'installed',
+    filesModified: cleanedHookDir ? [configPath, join(cwd, '.kaizen-hooks')] : [configPath],
     postInstallCommands: ['lefthook install'],
-    logMessage: `lefthook: added command '${KAIZEN_HOOK_ID}' to ${configPath}`,
+    logMessage: `lefthook: added remote config '${KAIZEN_LEFTHOOK_CONFIG}' to ${configPath}. Run 'lefthook install' to activate.`,
   };
 }
 
@@ -585,11 +651,11 @@ export function installStandalone(cwd: string): InstallResult {
 export function installGitHooks(options: InstallOptions): InstallResult {
   const { cwd, entryScriptContent } = options;
 
-  // 1. Detect framework before writing host files. The pre-commit remote-repo
-  // path intentionally writes no host-side kaizen wrapper.
+  // 1. Detect framework before writing host files. Framework-native remote
+  // paths intentionally write no host-side kaizen wrapper.
   const detection = detectHostFramework(cwd);
 
-  if (detection.framework !== 'pre-commit') {
+  if (detection.framework !== 'pre-commit' && detection.framework !== 'lefthook') {
     writeEntryScript(cwd, entryScriptContent);
   }
 
@@ -603,7 +669,7 @@ export function installGitHooks(options: InstallOptions): InstallResult {
       result = injectIntoHusky(cwd);
       break;
     case 'lefthook':
-      result = injectIntoLefthook(cwd);
+      result = injectIntoLefthook(cwd, { pluginRoot: options.pluginRoot });
       break;
     case 'raw':
       result = injectIntoRaw(cwd);


### PR DESCRIPTION
Fixes #1089

Parent: #1087
Refs: #1086, #1088, #1090

## Story

Once upon a time, Lefthook hosts used the same local-wrapper path as husky/raw installs: `/kaizen-setup --step install-git-hooks` wrote `.kaizen-hooks/pre-push` into the host repo and added `pre-push.commands.kaizen-pre-push` to `lefthook.yml`.

Every day, that kept kaizen-owned code in the host repo and required setup reruns for host-wrapper changes.

One day, #1089 made the framework-specific path clear: Lefthook supports remote configs through `remotes:`, so the host can reference kaizen by repo/ref/config instead of owning a kaizen script.

Because of that, this PR adds kaizen's root `lefthook-kaizen.yml`, switches the Lefthook installer branch to `remotes: [{ git_url, ref, configs: [lefthook-kaizen.yml] }]`, and skips `.kaizen-hooks/` writes for Lefthook hosts. Husky, raw, and standalone still use the wrapper path.

Because of that, legacy Lefthook hosts migrate in place: the old local `kaizen-pre-push` command is removed, unrelated commands survive, and kaizen-owned `.kaizen-hooks/` is removed when safe.

Until finally, meet-reality showed a Lefthook-specific constraint: `ref` is branch-or-tag, not commit SHA. The resolver now uses a matching plugin version tag when it exists, otherwise a slash-free branch ref, otherwise `main`.

## Architecture

```text
lefthook host
  lefthook.yml
    remotes:
      - git_url: https://github.com/Garsson-io/kaizen
        ref: <version tag | branch | main>
        configs: [lefthook-kaizen.yml]
          |
          v
lefthook synced remote checkout
  lefthook-kaizen.yml
    pre-push.commands.kaizen-pre-push
      find .git/info/lefthook-remotes/.../src/hooks/kaizen-host-entry.sh
          |
          v
kaizen-host-entry.sh -> src/hooks/pre-push.ts
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Use native Lefthook `remotes:` | Removes host-side kaizen wrapper for frameworks that support remote configs | Lefthook command runs from host root, so provider config must locate the synced remote checkout |
| Use branch/tag `ref`, not SHA | Lefthook schema and CLI use `git clone --branch <ref>` | Untagged releases fall back to `main` or a simple branch instead of exact commit pinning |
| Keep wrapper path for husky/raw/standalone | Those paths do not have a native remote-provider contract in scope | Husky remains #1090 |

## Impact

- BEFORE: Lefthook install wrote `.kaizen-hooks/pre-push` and local `pre-push.commands.kaizen-pre-push.run: ./.kaizen-hooks/pre-push`.
- AFTER: `kaizen-setup --step install-git-hooks --plugin-root <worktree>` in a temp Lefthook host wrote `remotes:` with `git_url: https://github.com/Garsson-io/kaizen`, `ref: main`, `configs: [lefthook-kaizen.yml]`, and `KAIZEN_HOOKS_EXISTS=no`.
- Reality proof: `npx lefthook@2.1.9 run pre-push --force --command kaizen-pre-push --verbose` against a local remote provider synced the config and executed the provider entry (`remote-entry-ran`).
- Goal met?: yes for the Lefthook sub-issue.

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Coverage |
|---|---|---|---|---|
| 1 | Fresh Lefthook config receives kaizen `remotes:` block with non-empty branch/tag `ref` and `lefthook-kaizen.yml`. | code | Unit | `src/setup-git-hooks.test.ts` |
| 2 | Lefthook `installGitHooks()` does not write `.kaizen-hooks/pre-push`; wrapper-backed frameworks still do. | code | Unit | `src/setup-git-hooks.test.ts` |
| 3 | Legacy local Lefthook command migrates to remote config and cleans kaizen-owned `.kaizen-hooks/` safely. | user/operator | Integration | `src/setup-git-hooks.test.ts` |
| 4 | Root `lefthook-kaizen.yml` parses and exposes `kaizen-pre-push`. | code | Unit/System | `src/setup-git-hooks.test.ts`; `LEFTHOOK_CONFIG=lefthook-kaizen.yml npx lefthook@2.1.9 validate` |
| 5 | Real setup CLI leaves host-visible remote shape. | user/operator | System | Manual temp-host `kaizen-setup` smoke |
| 6 | Real Lefthook CLI syncs remote config and runs the provider command. | user/operator | System | Manual local-provider Lefthook smoke |

## Validation

- [x] `npx vitest run src/setup-git-hooks.test.ts scripts/hook-gym-scenarios.test.ts scripts/hook-gym-seed-files.test.ts --reporter=verbose` -> 73 passed.
- [x] `npx vitest run src/setup-git-hooks.test.ts --reporter=verbose` -> 53 passed after slash-ref guard.
- [x] `LEFTHOOK_CONFIG=lefthook-kaizen.yml npx lefthook@2.1.9 validate` -> All good.
- [x] Generated Lefthook host smoke: real setup CLI produced `framework: "lefthook"`, `remotes:` block, `ref: main`, and no `.kaizen-hooks/`.
- [x] Lefthook remote execution smoke: local provider with `ref: main` synced through Lefthook and executed `kaizen-pre-push` provider entry.
- [x] `npm run check:fast` -> 2 files / 96 tests passed.
- [x] `git diff --check` passed.

## Known Limitations

This PR intentionally closes only the Lefthook sub-issue. Husky has no native remote-provider model and remains #1090.
