### PR TITLE
feat(auto-dent): bind repeated manifests to run targets

### DIFF
--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -446,6 +446,30 @@ describe('plan file operations', () => {
     expect(item!.issue).toBe('#451');
   });
 
+  it('claimNextItem claims a preferred pending issue before normal order', () => {
+    const plan = makePlan();
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const item = claimNextItem(tmpDir, { preferredIssue: '#451' });
+
+    expect(item).not.toBeNull();
+    expect(item!.issue).toBe('#451');
+    const updated = readPlan(tmpDir)!;
+    expect(updated.items.find((i) => i.issue === '#451')!.status).toBe('assigned');
+    expect(updated.items.find((i) => i.issue === '#302')!.status).toBe('pending');
+  });
+
+  it('claimNextItem falls back when preferred issue is not pending', () => {
+    const plan = makePlan();
+    plan.items.find((i) => i.issue === '#451')!.status = 'done';
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const item = claimNextItem(tmpDir, { preferredIssue: '#451' });
+
+    expect(item).not.toBeNull();
+    expect(item!.issue).toBe('#302');
+  });
+
   it('claimNextItem returns null when all items are done', () => {
     const plan = makePlan();
     plan.items.forEach((i) => (i.status = 'done'));

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -601,9 +601,13 @@ export function readPlan(logDir: string): BatchPlan | null {
  * When the plan carries no themes, this reduces to the legacy behavior
  * (first pending item in plan/array order) — a strict no-op for theme-less plans.
  */
-export function selectNextItem(plan: BatchPlan): PlanItem | null {
+export function selectNextItem(plan: BatchPlan, preferredIssue?: string): PlanItem | null {
   const pending = plan.items.filter((i) => i.status === 'pending');
   if (pending.length === 0) return null;
+  if (preferredIssue) {
+    const preferred = pending.find((i) => i.issue === preferredIssue);
+    if (preferred) return preferred;
+  }
 
   const themes = plan.themes || [];
   if (themes.length > 0) {
@@ -629,11 +633,11 @@ export function selectNextItem(plan: BatchPlan): PlanItem | null {
 /**
  * Get the next item to work from a plan and mark it 'assigned' in the file.
  */
-export function claimNextItem(logDir: string): PlanItem | null {
+export function claimNextItem(logDir: string, options: { preferredIssue?: string } = {}): PlanItem | null {
   const plan = readPlan(logDir);
   if (!plan) return null;
 
-  const next = selectNextItem(plan);
+  const next = selectNextItem(plan, options.preferredIssue);
   if (!next) return null;
 
   next.status = 'assigned';

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -3167,6 +3167,93 @@ describe('selectMode bandit integration', () => {
   });
 });
 
+describe('selectMode manifest-forced target binding', () => {
+  function writePlanAndManifestTarget(tmpDir: string, issue = '#1213', status = 'pending') {
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify({
+      created_at: '2026-06-29T00:00:00.000Z',
+      guidance: 'bind manifests',
+      items: [
+        { issue: '#999', title: 'Other', score: 9, approach: 'normal pick', status: 'pending', item_type: 'leaf' },
+        { issue, title: 'Manifest target', score: 1, approach: 'forced pick', status, item_type: 'leaf' },
+      ],
+      wip_excluded: [],
+      epics_scanned: [],
+    }));
+    for (const run of [4, 5]) {
+      writeFileSync(join(tmpDir, `run-${run}-candidate-tasks-manifest.json`), JSON.stringify({
+        version: 1,
+        runTag: `batch/run-${run}`,
+        generatedAt: '2026-06-29T00:00:00.000Z',
+        candidates: [
+          { id: 'top', title: 'Top bundle', rationale: 'repeated', refs: [issue], suggested_mode: 'exploit' },
+        ],
+      }));
+    }
+  }
+
+  it('forces exploit when repeated latest manifests name a pending plan issue', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-mode-'));
+    writePlanAndManifestTarget(tmpDir);
+    const state = makeBatchState({
+      run_history: Array.from({ length: 12 }, (_, i) => makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr'] })),
+    });
+
+    const result = selectMode(state, 12, { logDir: tmpDir, manifestForceThreshold: 2 });
+
+    expect(result).toMatchObject({
+      mode: 'exploit',
+      reason: 'manifest-forced',
+      targetIssue: '#1213',
+    });
+  });
+
+  it('does not force when the repeated target is no longer pending', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-assigned-'));
+    writePlanAndManifestTarget(tmpDir, '#1213', 'assigned');
+    const state = makeBatchState({ run_history: [] });
+
+    const result = selectMode(state, 1, { logDir: tmpDir, manifestForceThreshold: 2 });
+
+    expect(result.reason).not.toBe('manifest-forced');
+  });
+
+  it('does not force exploit for repeated non-exploit manifest candidates', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-non-exploit-'));
+    writePlanAndManifestTarget(tmpDir);
+    for (const run of [4, 5]) {
+      writeFileSync(join(tmpDir, `run-${run}-candidate-tasks-manifest.json`), JSON.stringify({
+        version: 1,
+        runTag: `batch/run-${run}`,
+        generatedAt: '2026-06-29T00:00:00.000Z',
+        candidates: [
+          { id: 'top', title: 'Top bundle', rationale: 'repeated', refs: ['#1213'], suggested_mode: 'reflect' },
+        ],
+      }));
+    }
+    const state = makeBatchState({ run_history: [] });
+
+    const result = selectMode(state, 1, { logDir: tmpDir, manifestForceThreshold: 2 });
+
+    expect(result.reason).not.toBe('manifest-forced');
+  });
+
+  it('renders the forced manifest target as the claimed plan issue', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-prompt-'));
+    writePlanAndManifestTarget(tmpDir);
+    const state = makeBatchState({ guidance: 'work from manifest' });
+
+    const meta = buildPromptWithMetadata(state, 6, tmpDir);
+
+    expect(meta.template).toBe('deep-dive-default.md');
+    expect(meta.claimedPlanIssue).toBe('#1213');
+    expect(meta.prompt).toContain('Manifest target');
+    expect(meta.prompt).toContain('#1213');
+    const plan = JSON.parse(readFileSync(join(tmpDir, 'plan.json'), 'utf8'));
+    expect(plan.items.find((i: any) => i.issue === '#1213').status).toBe('assigned');
+    expect(plan.items.find((i: any) => i.issue === '#999').status).toBe('pending');
+  });
+});
+
 describe('computeModeDistribution', () => {
   it('counts modes from run history', () => {
     const history = [
@@ -3373,8 +3460,10 @@ describe('buildPromptWithMetadata', () => {
     const end = AUTO_DENT_RUN_SOURCE.indexOf('function buildPromptInline');
     const source = AUTO_DENT_RUN_SOURCE.slice(start, end);
 
-    expect(source.match(/selectMode\(state, runNum\)/g)).toHaveLength(1);
-    expect(source).toContain('buildTemplateVars(state, runNum, logDir, { claimPlanItem: shouldClaimPlanItem })');
+    expect(source.match(/selectMode\(state, runNum, \{ logDir \}\)/g)).toHaveLength(1);
+    expect(source).toContain('buildTemplateVars(state, runNum, logDir, {');
+    expect(source).toContain('claimPlanItem: shouldClaimPlanItem');
+    expect(source).toContain('modeSelection');
     expect(source).toContain("modeSelection.mode === 'exploit' && !state.test_task");
   });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -22,7 +22,7 @@
 
 import { spawn, execFileSync, execSync } from 'child_process';
 import { createHash } from 'crypto';
-import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, readdirSync } from 'fs';
 import { createInterface } from 'readline';
 import { dirname, join, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, formatIssuesClosedLine, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
@@ -606,7 +606,7 @@ export function buildTemplateVars(
   state: BatchState,
   runNum: number,
   logDir?: string,
-  options: { claimPlanItem?: boolean } = {},
+  options: { claimPlanItem?: boolean; preferredPlanIssue?: string; modeSelection?: ModeSelection } = {},
 ): Record<string, string> {
   const runTag = `${state.batch_id}/run-${runNum}`;
   const hostRepo = state.host_repo || state.kaizen_repo || 'unknown';
@@ -619,7 +619,7 @@ export function buildTemplateVars(
   let reflectionInsights = '';
   let priorReflections = '';
   if (logDir) {
-    const planItem = shouldClaimPlanItem ? claimNextItem(logDir) : null;
+    const planItem = shouldClaimPlanItem ? claimNextItem(logDir, { preferredIssue: options.preferredPlanIssue }) : null;
     if (planItem) {
       claimedPlanIssue = planItem.issue;
       const lines = [
@@ -719,7 +719,7 @@ export function buildTemplateVars(
   const crossBatchSteeringText = crossBatchSteering.length > 0
     ? crossBatchSteering.map((r, i) => `${i + 1}. ${r}`).join('\n')
     : '';
-  const modeSelection = selectMode(state, runNum);
+  const modeSelection = options.modeSelection ?? selectMode(state, runNum, { logDir });
   const manifestPath = logDir
     ? candidateTaskManifestPath(logDir, runNum)
     : `run-${runNum}-candidate-tasks-manifest.json`;
@@ -784,6 +784,8 @@ export interface ModeSelection {
   template: string;
   /** Why this mode was selected (signal name, 'schedule', 'guidance', or 'bandit') */
   reason: string;
+  /** Preferred plan issue to claim when this selection is manifest-forced (#1213). */
+  targetIssue?: string;
   /** Full bandit breakdown when the selection came from the UCB1 policy (reason === 'bandit') */
   bandit?: BanditResult;
 }
@@ -1291,18 +1293,86 @@ export function weightedModeSelect(
   return entries[entries.length - 1][0];
 }
 
+function normalizeIssueRef(ref: string): string | null {
+  const match = ref.match(/(?:issues\/|#)?(\d+)\b/);
+  return match ? `#${match[1]}` : null;
+}
+
+function firstCandidateIssueRef(raw: unknown): string | null {
+  const parsed = typeof raw === 'string' ? parseJsonObject(raw) : raw;
+  if (!parsed || typeof parsed !== 'object') return null;
+  const candidates = (parsed as { candidates?: unknown }).candidates;
+  if (!Array.isArray(candidates) || candidates.length === 0) return null;
+  const first = candidates[0];
+  if (!first || typeof first !== 'object') return null;
+  const suggestedMode = (first as { suggested_mode?: unknown }).suggested_mode;
+  if (typeof suggestedMode === 'string' && suggestedMode !== 'exploit') return null;
+  const refs = (first as { refs?: unknown }).refs;
+  if (!Array.isArray(refs)) return null;
+  for (const ref of refs) {
+    if (typeof ref !== 'string') continue;
+    const issue = normalizeIssueRef(ref);
+    if (issue) return issue;
+  }
+  return null;
+}
+
+function recentCandidateManifestPaths(logDir: string): string[] {
+  try {
+    return readdirSync(logDir)
+      .map((name) => {
+        const match = name.match(/^run-(\d+)-candidate-tasks-manifest\.json$/);
+        return match ? { name, run: Number(match[1]) } : null;
+      })
+      .filter((entry): entry is { name: string; run: number } => Boolean(entry))
+      .sort((a, b) => b.run - a.run)
+      .map((entry) => join(logDir, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+function selectManifestForcedTarget(logDir: string | undefined, threshold = 2): string | null {
+  if (!logDir || threshold <= 0) return null;
+  const plan = readPlan(logDir);
+  if (!plan) return null;
+  const pending = new Set(plan.items.filter((item) => item.status === 'pending').map((item) => item.issue));
+  if (pending.size === 0) return null;
+
+  const issues = recentCandidateManifestPaths(logDir)
+    .map((path) => {
+      try {
+        return firstCandidateIssueRef(readFileSync(path, 'utf8'));
+      } catch {
+        return null;
+      }
+    })
+    .filter((issue): issue is string => Boolean(issue));
+  if (issues.length < threshold) return null;
+
+  const target = issues[0];
+  const repeated = issues.slice(0, threshold).every((issue) => issue === target);
+  return repeated && pending.has(target) ? target : null;
+}
+
 /**
  * Select the cognitive mode for a given run.
  *
  * Priority (highest first):
  *   1. Guidance override: "mode:<name>" in guidance forces that mode
  *   2. Test task: always exploit with test template
- *   3. Signal-driven: reactive to batch state (failures, stalls, streaks)
- *   4. Contemplate overlay: every 15th run for strategic assessment
- *   5. Bandit selection: UCB1 explore/exploit weighting from run history
- *   6. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
+ *   3. Manifest-forced: repeated explore manifests bind a pending plan target
+ *   4. Signal-driven: reactive to batch state (failures, stalls, streaks)
+ *   5. Contemplate overlay: every 15th run for strategic assessment
+ *   6. Bandit selection: UCB1 explore/exploit weighting from run history
+ *   7. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
  */
-export function selectMode(state: BatchState, runNum: number): ModeSelection {
+export interface SelectModeOptions {
+  logDir?: string;
+  manifestForceThreshold?: number;
+}
+
+export function selectMode(state: BatchState, runNum: number, options: SelectModeOptions = {}): ModeSelection {
   // Force mode from guidance (e.g., "mode:explore")
   const modeOverride = state.guidance.match(/\bmode:(\w+)/i);
   if (modeOverride) {
@@ -1317,6 +1387,16 @@ export function selectMode(state: BatchState, runNum: number): ModeSelection {
   // Test task always uses test template
   if (state.test_task) {
     return { mode: 'exploit', template: 'test-task.md', reason: 'test-task' };
+  }
+
+  const manifestTarget = selectManifestForcedTarget(options.logDir, options.manifestForceThreshold);
+  if (manifestTarget) {
+    return {
+      mode: 'exploit',
+      template: MODE_TEMPLATES.exploit,
+      reason: 'manifest-forced',
+      targetIssue: manifestTarget,
+    };
   }
 
   // Signal-driven overrides (reactive to batch state)
@@ -1427,9 +1507,13 @@ export function populateCrossBatchSteering(
 }
 
 export function buildPromptWithMetadata(state: BatchState, runNum: number, logDir?: string): PromptMetadata {
-  const modeSelection = selectMode(state, runNum);
+  const modeSelection = selectMode(state, runNum, { logDir });
   const shouldClaimPlanItem = modeSelection.mode === 'exploit' && !state.test_task;
-  const vars = buildTemplateVars(state, runNum, logDir, { claimPlanItem: shouldClaimPlanItem });
+  const vars = buildTemplateVars(state, runNum, logDir, {
+    claimPlanItem: shouldClaimPlanItem,
+    preferredPlanIssue: modeSelection.targetIssue,
+    modeSelection,
+  });
   const claimedPlanIssue = vars.claimed_plan_issue || undefined;
 
   const templateFile = modeSelection.template;
@@ -1973,7 +2057,7 @@ async function runClaude(
   const ctx: StreamContext = { provider: 'claude' };
 
   const logDir = dirname(stateFile);
-  const modeSelection = selectMode(state, runNum);
+  const modeSelection = selectMode(state, runNum, { logDir });
   if (modeSelection.mode !== 'exploit' || modeSelection.reason !== 'schedule') {
     console.log(`  [mode] run #${runNum}: ${modeSelection.mode} (${modeSelection.reason}, template: ${modeSelection.template})`);
   }


### PR DESCRIPTION
## Summary

Fixes Garsson-io/kaizen#1213.

Explore candidate manifests can now bind an actual downstream exploit target when the latest manifests repeatedly agree on a pending plan issue. This closes the last local gap after #1196 made manifests durable and #1597 made planning/metrics aware of them.

## Changes

- Add preferred-issue support to `selectNextItem()` / `claimNextItem()`.
- Let `selectMode(state, runNum, { logDir })` scan recent `run-*-candidate-tasks-manifest.json` files.
- Force `exploit` with `reason: "manifest-forced"` when the latest repeated manifests name the same pending plan issue.
- Thread the forced target through `buildPromptWithMetadata()` so the rendered prompt claims that exact plan item.
- Preserve fallback behavior when the target is absent, assigned, done, or manifests do not repeat.

## Evidence

- RED: focused tests failed before implementation for preferred plan claims and manifest-forced mode selection.
- `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts`
- `npm run typecheck`
- `npm run test:fast`
- `npm test`

## Scope Notes

This uses pending `plan.json` items as the local open-work proxy. It does not add live GitHub all-open/0-PR checks, synthesize new plan items from manifests, or add cross-batch manifest memory.

Plan: https://github.com/Garsson-io/kaizen/issues/1213#issuecomment-4827692546

Test plan: https://github.com/Garsson-io/kaizen/issues/1213#issuecomment-4827692639

Related: #1196 #1597 #1176 #1189 #940 #698
