### PR TITLE
test(setup): prove husky wrapper follows plugin entry

### DIFF
--- a/src/setup-git-hooks.test.ts
+++ b/src/setup-git-hooks.test.ts
@@ -584,6 +584,29 @@ describe('installGitHooks — end-to-end', () => {
     expect(installed).not.toContain('pre-push.ts');
   });
 
+  it('husky wrapper picks up plugin entry changes without rerunning setup (#1090)', () => {
+    fs.mkdirSync(path.join(tmpDir, '.husky'));
+    const pluginRoot = path.join(tmpDir, 'plugin-root');
+    fs.mkdirSync(path.join(pluginRoot, 'src/hooks'), { recursive: true });
+    fs.writeFileSync(path.join(pluginRoot, '.claude-plugin-placeholder'), '');
+    fs.writeFileSync(
+      path.join(pluginRoot, 'src/hooks/kaizen-host-entry.sh'),
+      '#!/usr/bin/env bash\necho initial > propagation.txt\n',
+      { mode: 0o755 },
+    );
+
+    installGitHooks({ cwd: tmpDir, entryScriptContent: buildThinWrapper(pluginRoot) });
+
+    fs.writeFileSync(
+      path.join(pluginRoot, 'src/hooks/kaizen-host-entry.sh'),
+      '#!/usr/bin/env bash\necho propagated > propagation.txt\n',
+      { mode: 0o755 },
+    );
+
+    execSync('bash .husky/pre-push', { cwd: tmpDir });
+    expect(read('propagation.txt')).toBe('propagated\n');
+  });
+
   it('migration: re-install overwrites a stale 66-line copy with the thin wrapper (#1086)', () => {
     fs.mkdirSync(path.join(tmpDir, '.husky'));
     // Simulate a host that previously installed the old full COPY of the entry.


### PR DESCRIPTION
Fixes #1090

Parent: #1087
Refs: #1086, #1088, #1089

## Story

The husky wrapper implementation already landed while closing the broader host-code-duplication work: husky installs now write a thin `.kaizen-hooks/pre-push` wrapper that execs the plugin-resident `src/hooks/kaizen-host-entry.sh`, and existing tests prove it is not a snapshot copy of `pre-push.ts`.

This PR closes the remaining proof gap from #1090: after setup installs the wrapper once, changing only the plugin-resident entry must change what the host hook does, without rerunning `/kaizen-setup`.

## Change

Adds a focused propagation test in `src/setup-git-hooks.test.ts`:

1. Create a temp husky host.
2. Create a temp plugin root with `src/hooks/kaizen-host-entry.sh`.
3. Install the husky wrapper once with `installGitHooks()`.
4. Rewrite only the plugin-resident entry to emit a different marker.
5. Run the already-installed `.husky/pre-push`.
6. Assert the new marker is observed.

That proves the host wrapper delegates to plugin-owned code at execution time, not to a stale host snapshot.

## Validation

- [x] `npx vitest run src/setup-git-hooks.test.ts --reporter=verbose` -> 54 passed.
- [x] `npx tsc --noEmit` passed.
- [x] `npm run check:fast` -> 1 file / 54 tests passed.
- [x] `git diff --check` passed.

## Scope

This is intentionally a proof/test PR. The implementation and docs for the wrapper path already exist on `main` from #1088/#1089.
