### PR TITLE
feat(auto-dent): bind manifests to forced claims

### DIFF
--- a/scripts/auto-dent-plan.test.ts
+++ b/scripts/auto-dent-plan.test.ts
@@ -446,6 +446,42 @@ describe('plan file operations', () => {
     expect(item!.issue).toBe('#451');
   });
 
+  it('claimNextItem honors a forced target issue before normal ranking', () => {
+    const plan = makePlan({
+      items: [
+        { issue: '#302', title: 'High score unrelated', score: 10, approach: 'Do unrelated work', status: 'pending', item_type: 'leaf' },
+        { issue: '#451', title: 'Manifest target', score: 1, approach: 'Do forced work', status: 'pending', item_type: 'leaf' },
+      ],
+    });
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const item = claimNextItem(tmpDir, { targetIssue: '#451' });
+
+    expect(item).toMatchObject({
+      issue: '#451',
+      title: 'Manifest target',
+      status: 'assigned',
+    });
+    const updated = readPlan(tmpDir);
+    expect(updated!.items[0].status).toBe('pending');
+    expect(updated!.items[1].status).toBe('assigned');
+  });
+
+  it('claimNextItem creates a synthetic assignment when a forced target is missing from the plan', () => {
+    const plan = makePlan();
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify(plan));
+
+    const item = claimNextItem(tmpDir, { targetIssue: '#999' });
+
+    expect(item).toMatchObject({
+      issue: '#999',
+      status: 'assigned',
+      item_type: 'leaf',
+    });
+    const updated = readPlan(tmpDir);
+    expect(updated!.items[0]).toMatchObject({ issue: '#999', status: 'assigned' });
+  });
+
   it('claimNextItem returns null when all items are done', () => {
     const plan = makePlan();
     plan.items.forEach((i) => (i.status = 'done'));

--- a/scripts/auto-dent-plan.ts
+++ b/scripts/auto-dent-plan.ts
@@ -44,6 +44,10 @@ export interface PlanItem {
   theme?: string;
 }
 
+export interface ClaimNextItemOptions {
+  targetIssue?: string;
+}
+
 /**
  * A coordinated cluster of related work items — the unit of "bunching" that
  * lets a batch drive 3-5 related PRs to completion before switching topics,
@@ -626,16 +630,41 @@ export function selectNextItem(plan: BatchPlan): PlanItem | null {
   return pending[0];
 }
 
+function normalizeIssueRef(ref: string): string {
+  const match = ref.match(/(?:issues\/|#)?(\d+)\b/);
+  return match ? `#${match[1]}` : ref;
+}
+
+function syntheticForcedPlanItem(targetIssue: string): PlanItem {
+  return {
+    issue: targetIssue,
+    title: `manifest-forced target ${targetIssue}`,
+    score: 10,
+    approach: `Work the manifest-forced target ${targetIssue}; this assignment was inserted because a repeated explore candidate manifest selected it.`,
+    status: 'assigned',
+    item_type: 'leaf',
+  };
+}
+
 /**
  * Get the next item to work from a plan and mark it 'assigned' in the file.
  */
-export function claimNextItem(logDir: string): PlanItem | null {
+export function claimNextItem(logDir: string, options: ClaimNextItemOptions = {}): PlanItem | null {
   const plan = readPlan(logDir);
   if (!plan) return null;
 
-  const next = selectNextItem(plan);
+  const targetIssue = options.targetIssue ? normalizeIssueRef(options.targetIssue) : undefined;
+  const existingTarget = targetIssue
+    ? plan.items.find((i) => normalizeIssueRef(i.issue) === targetIssue)
+    : undefined;
+  const next = existingTarget
+    ? existingTarget.status === 'pending' ? existingTarget : null
+    : targetIssue ? syntheticForcedPlanItem(targetIssue) : selectNextItem(plan);
   if (!next) return null;
 
+  if (targetIssue && !existingTarget) {
+    plan.items.unshift(next);
+  }
   next.status = 'assigned';
   const planFile = resolve(logDir, 'plan.json');
   writeFileSync(planFile, JSON.stringify(plan, null, 2) + '\n');

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -2205,6 +2205,64 @@ describe('formatPlanAsMarkdown', () => {
 });
 
 describe('selectMode', () => {
+  const cleanupDirs: string[] = [];
+  afterEach(() => {
+    for (const dir of cleanupDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    cleanupDirs.length = 0;
+  });
+
+  it('forces exploit with a target issue when repeated candidate manifests name the same top candidate', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-mode-'));
+    cleanupDirs.push(tmpDir);
+    for (const run of [1, 2, 3]) {
+      writeFileSync(join(tmpDir, `run-${run}-candidate-tasks-manifest.json`), JSON.stringify({
+        version: 1,
+        runTag: `batch/run-${run}`,
+        candidates: [
+          {
+            id: 'self-steering',
+            title: 'Self-steering bundle',
+            rationale: 'Repeated top candidate',
+            refs: ['#1213', '#1189'],
+            suggested_mode: 'exploit',
+          },
+        ],
+      }));
+    }
+
+    const result = selectMode(makeBatchState(), 7, { logDir: tmpDir });
+
+    expect(result).toMatchObject({
+      mode: 'exploit',
+      template: 'deep-dive-default.md',
+      reason: 'manifest-forced',
+      target_issue: '#1213',
+    });
+  });
+
+  it('does not force a consumed manifest target again', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-consumed-'));
+    cleanupDirs.push(tmpDir);
+    for (const run of [1, 2, 3]) {
+      writeFileSync(join(tmpDir, `run-${run}-candidate-tasks-manifest.json`), JSON.stringify({
+        version: 1,
+        runTag: `batch/run-${run}`,
+        candidates: [{ id: 'self-steering', title: 'Self-steering bundle', refs: ['#1213'] }],
+      }));
+    }
+
+    const result = selectMode(
+      makeBatchState({ manifest_forced_targets_consumed: ['#1213'] }),
+      7,
+      { logDir: tmpDir },
+    );
+
+    expect(result.reason).not.toBe('manifest-forced');
+    expect(result.target_issue).toBeUndefined();
+  });
+
   it('selects exploit for runs 0-6 (mod 10)', () => {
     for (const run of [1, 2, 3, 4, 5, 6, 10, 11, 16]) {
       const { mode, template } = selectMode(makeBatchState(), run);
@@ -3373,8 +3431,9 @@ describe('buildPromptWithMetadata', () => {
     const end = AUTO_DENT_RUN_SOURCE.indexOf('function buildPromptInline');
     const source = AUTO_DENT_RUN_SOURCE.slice(start, end);
 
-    expect(source.match(/selectMode\(state, runNum\)/g)).toHaveLength(1);
-    expect(source).toContain('buildTemplateVars(state, runNum, logDir, { claimPlanItem: shouldClaimPlanItem })');
+    expect(source.match(/selectMode\(state, runNum, \{ logDir \}\)/g)).toHaveLength(1);
+    expect(source).toContain('buildTemplateVars(state, runNum, logDir, {');
+    expect(source).toContain('targetIssue: modeSelection.target_issue');
     expect(source).toContain("modeSelection.mode === 'exploit' && !state.test_task");
   });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -22,7 +22,7 @@
 
 import { spawn, execFileSync, execSync } from 'child_process';
 import { createHash } from 'crypto';
-import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { createInterface } from 'readline';
 import { dirname, join, resolve } from 'path';
 import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, formatIssuesClosedLine, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
@@ -258,6 +258,8 @@ export interface BatchState {
    * so observable cloud data biases this batch's choices.
    */
   cross_batch_steering?: string[];
+  /** Manifest-forced issue targets already consumed in this batch (#1213). */
+  manifest_forced_targets_consumed?: string[];
 }
 
 export interface RunMetrics {
@@ -507,6 +509,138 @@ function attachCandidateTaskManifest(result: RunResult, path: string): void {
   result.candidateManifestCount = parsed.count;
   result.candidateManifestWarnings = parsed.warnings;
 }
+
+export interface ManifestForcedTarget {
+  issue: string;
+  manifestPath: string;
+  observations: number;
+}
+
+export interface ManifestForcedTargetOptions {
+  repeatThreshold?: number;
+}
+
+function normalizeIssueRef(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return `#${value}`;
+  if (typeof value !== 'string') return null;
+  const match = value.match(/(?:issues\/|#)?(\d+)\b/);
+  return match ? `#${match[1]}` : null;
+}
+
+function firstIssueRef(values: unknown): string | null {
+  if (!Array.isArray(values)) return normalizeIssueRef(values);
+  for (const value of values) {
+    const ref = normalizeIssueRef(value);
+    if (ref) return ref;
+  }
+  return null;
+}
+
+function extractManifestTarget(parsed: Record<string, unknown>): string | null {
+  const topBundle = parsed.top_bundle;
+  if (topBundle && typeof topBundle === 'object' && !Array.isArray(topBundle)) {
+    const top = topBundle as Record<string, unknown>;
+    return normalizeIssueRef(top.umbrella) || firstIssueRef(top.issues);
+  }
+
+  const candidates = parsed.candidates;
+  if (Array.isArray(candidates) && candidates.length > 0) {
+    const first = candidates[0];
+    if (first && typeof first === 'object' && !Array.isArray(first)) {
+      const candidate = first as Record<string, unknown>;
+      return firstIssueRef(candidate.refs) || normalizeIssueRef(candidate.issue);
+    }
+  }
+
+  const bundles = parsed.bundles;
+  if (Array.isArray(bundles) && bundles.length > 0) {
+    const first = bundles[0];
+    if (first && typeof first === 'object' && !Array.isArray(first)) {
+      return firstIssueRef((first as Record<string, unknown>).issues);
+    }
+  }
+
+  return null;
+}
+
+function aggregateManifestObservationCount(parsed: Record<string, unknown>): number | null {
+  const topBundle = parsed.top_bundle;
+  if (!topBundle || typeof topBundle !== 'object' || Array.isArray(topBundle)) return null;
+  const evidence = (topBundle as Record<string, unknown>).evidence;
+  if (typeof evidence !== 'string') return 1;
+  const match = evidence.match(/(\d+)\s+explore runs?/i);
+  return match ? Number(match[1]) : 1;
+}
+
+function isCandidateManifestFile(name: string): boolean {
+  return name === 'candidate-tasks-manifest.json'
+    || /^run-\d+-(candidate-tasks-manifest|candidate-manifest)\.json$/.test(name);
+}
+
+function consumedManifestTarget(state: BatchState, issue: string): boolean {
+  const consumed = state.manifest_forced_targets_consumed || [];
+  return consumed.some((ref) => normalizeIssueRef(ref) === issue);
+}
+
+function closedInBatch(state: BatchState, issue: string): boolean {
+  return state.issues_closed.some((ref) => normalizeIssueRef(ref) === issue);
+}
+
+export function findManifestForcedTarget(
+  state: BatchState,
+  logDir?: string,
+  options: ManifestForcedTargetOptions = {},
+): ManifestForcedTarget | null {
+  if (!logDir || !existsSync(logDir)) return null;
+  const repeatThreshold = options.repeatThreshold ?? 3;
+
+  const observations: ManifestForcedTarget[] = [];
+  for (const name of readdirSync(logDir)) {
+    if (!isCandidateManifestFile(name)) continue;
+    const path = join(logDir, name);
+    const parsed = parseJsonObject(readFileSync(path, 'utf8'));
+    if (!parsed) continue;
+    const target = extractManifestTarget(parsed as Record<string, unknown>);
+    if (!target || consumedManifestTarget(state, target) || closedInBatch(state, target)) continue;
+
+    const aggregateCount = aggregateManifestObservationCount(parsed as Record<string, unknown>);
+    if (aggregateCount && aggregateCount >= repeatThreshold) {
+      return { issue: target, manifestPath: path, observations: aggregateCount };
+    }
+
+    observations.push({
+      issue: target,
+      manifestPath: path,
+      observations: 1,
+    });
+  }
+
+  observations.sort((a, b) =>
+    statSync(b.manifestPath).mtimeMs - statSync(a.manifestPath).mtimeMs
+    || b.manifestPath.localeCompare(a.manifestPath),
+  );
+  const latest = observations[0];
+  if (!latest) return null;
+
+  let consecutive = 0;
+  for (const observation of observations) {
+    if (observation.issue !== latest.issue) break;
+    consecutive += observation.observations;
+  }
+
+  return consecutive >= repeatThreshold
+    ? { ...latest, observations: consecutive }
+    : null;
+}
+
+export function recordManifestForcedTargetConsumed(state: BatchState, issue: string): void {
+  const normalized = normalizeIssueRef(issue);
+  if (!normalized) return;
+  const consumed = state.manifest_forced_targets_consumed || [];
+  if (!consumed.some((ref) => normalizeIssueRef(ref) === normalized)) {
+    state.manifest_forced_targets_consumed = [...consumed, normalized];
+  }
+}
 export { extractPlanText };
 
 // State I/O
@@ -606,7 +740,7 @@ export function buildTemplateVars(
   state: BatchState,
   runNum: number,
   logDir?: string,
-  options: { claimPlanItem?: boolean } = {},
+  options: { claimPlanItem?: boolean; targetIssue?: string } = {},
 ): Record<string, string> {
   const runTag = `${state.batch_id}/run-${runNum}`;
   const hostRepo = state.host_repo || state.kaizen_repo || 'unknown';
@@ -619,7 +753,7 @@ export function buildTemplateVars(
   let reflectionInsights = '';
   let priorReflections = '';
   if (logDir) {
-    const planItem = shouldClaimPlanItem ? claimNextItem(logDir) : null;
+    const planItem = shouldClaimPlanItem ? claimNextItem(logDir, { targetIssue: options.targetIssue }) : null;
     if (planItem) {
       claimedPlanIssue = planItem.issue;
       const lines = [
@@ -719,7 +853,7 @@ export function buildTemplateVars(
   const crossBatchSteeringText = crossBatchSteering.length > 0
     ? crossBatchSteering.map((r, i) => `${i + 1}. ${r}`).join('\n')
     : '';
-  const modeSelection = selectMode(state, runNum);
+  const modeSelection = selectMode(state, runNum, { logDir });
   const manifestPath = logDir
     ? candidateTaskManifestPath(logDir, runNum)
     : `run-${runNum}-candidate-tasks-manifest.json`;
@@ -786,6 +920,8 @@ export interface ModeSelection {
   reason: string;
   /** Full bandit breakdown when the selection came from the UCB1 policy (reason === 'bandit') */
   bandit?: BanditResult;
+  /** Concrete issue forced by a repeated candidate manifest (#1213). */
+  target_issue?: string;
 }
 
 const MODE_TEMPLATES: Record<string, string> = {
@@ -1302,7 +1438,12 @@ export function weightedModeSelect(
  *   5. Bandit selection: UCB1 explore/exploit weighting from run history
  *   6. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
  */
-export function selectMode(state: BatchState, runNum: number): ModeSelection {
+export interface SelectModeOptions {
+  logDir?: string;
+  manifestRepeatThreshold?: number;
+}
+
+export function selectMode(state: BatchState, runNum: number, options: SelectModeOptions = {}): ModeSelection {
   // Force mode from guidance (e.g., "mode:explore")
   const modeOverride = state.guidance.match(/\bmode:(\w+)/i);
   if (modeOverride) {
@@ -1317,6 +1458,18 @@ export function selectMode(state: BatchState, runNum: number): ModeSelection {
   // Test task always uses test template
   if (state.test_task) {
     return { mode: 'exploit', template: 'test-task.md', reason: 'test-task' };
+  }
+
+  const forcedTarget = findManifestForcedTarget(state, options.logDir, {
+    repeatThreshold: options.manifestRepeatThreshold,
+  });
+  if (forcedTarget) {
+    return {
+      mode: 'exploit',
+      template: MODE_TEMPLATES.exploit,
+      reason: 'manifest-forced',
+      target_issue: forcedTarget.issue,
+    };
   }
 
   // Signal-driven overrides (reactive to batch state)
@@ -1365,6 +1518,10 @@ export interface PromptMetadata {
   hash: string;
   /** Issue ref of the plan item claimed for this run (e.g., "#302"), if any */
   claimedPlanIssue?: string;
+}
+
+export interface BuildPromptWithMetadataOptions {
+  modeSelection?: ModeSelection;
 }
 
 export function buildPrompt(state: BatchState, runNum: number, logDir?: string): string {
@@ -1426,10 +1583,18 @@ export function populateCrossBatchSteering(
   return steering;
 }
 
-export function buildPromptWithMetadata(state: BatchState, runNum: number, logDir?: string): PromptMetadata {
-  const modeSelection = selectMode(state, runNum);
+export function buildPromptWithMetadata(
+  state: BatchState,
+  runNum: number,
+  logDir?: string,
+  options: BuildPromptWithMetadataOptions = {},
+): PromptMetadata {
+  const modeSelection = options.modeSelection ?? selectMode(state, runNum, { logDir });
   const shouldClaimPlanItem = modeSelection.mode === 'exploit' && !state.test_task;
-  const vars = buildTemplateVars(state, runNum, logDir, { claimPlanItem: shouldClaimPlanItem });
+  const vars = buildTemplateVars(state, runNum, logDir, {
+    claimPlanItem: shouldClaimPlanItem,
+    targetIssue: modeSelection.target_issue,
+  });
   const claimedPlanIssue = vars.claimed_plan_issue || undefined;
 
   const templateFile = modeSelection.template;
@@ -1985,7 +2150,14 @@ async function runClaude(
       .join('  ');
     console.log(`  [bandit] N=${b.totalPlays} c=${b.explorationC.toFixed(2)}  ${breakdown}`);
   }
-  const promptMeta = buildPromptWithMetadata(state, runNum, logDir);
+  const promptMeta = buildPromptWithMetadata(state, runNum, logDir, { modeSelection });
+  if (
+    modeSelection.target_issue
+    && normalizeIssueRef(promptMeta.claimedPlanIssue) === normalizeIssueRef(modeSelection.target_issue)
+  ) {
+    recordManifestForcedTargetConsumed(state, modeSelection.target_issue);
+    writeState(stateFile, state);
+  }
   const prompt = promptMeta.prompt;
   if (state.test_task && !result.pickedIssue) {
     result.pickedIssue = 'not applicable';


### PR DESCRIPTION
## Problem

Explore runs could keep producing the same high-value candidate manifest, but exploit runs still claimed generic `plan.json` work. #1597 made the loop visible; #1213 needs the deterministic binding that lets a repeated manifest actually steer a downstream exploit claim.

Fixes #1213.
Related: #1176, #1189, #1196, #940.

## Discovery

The current harness had two disconnected seams:

- `selectMode()` chose a mode only; there was no target issue field.
- `claimNextItem(logDir)` always selected from `plan.json` by theme/rank and had no way to honor a manifest-selected target.

The repo also has more than one manifest shape in the wild: new per-run `run-<N>-candidate-tasks-manifest.json`, older `run-<N>-candidate-manifest.json`, and aggregate `candidate-tasks-manifest.json` with `top_bundle.umbrella`.

## Solution

- Add a tolerant manifest target reader that extracts top issue targets from the current and legacy manifest shapes.
- Extend `selectMode(state, runNum, { logDir })` so a repeated unconsumed manifest target returns `mode: "exploit"`, `reason: "manifest-forced"`, and `target_issue`.
- Extend `claimNextItem(logDir, { targetIssue })` to assign the matching pending plan item, or insert a minimal synthetic assigned item when the plan omitted the forced target.
- Thread `target_issue` through prompt construction and record consumed manifest-forced targets in `state.json` once the prompt claims that issue, preventing exploit lock-in.

## Evidence

- RED: `npx vitest run scripts/auto-dent-run.test.ts -t "manifest-forced|selectMode"` failed because repeated manifests were ignored.
- RED: `npx vitest run scripts/auto-dent-plan.test.ts -t "claimNextItem"` failed because forced targets were ignored by plan claiming.
- GREEN: `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts` passed, 430 tests.
- GREEN: `npm run check:fast` passed, typecheck plus 652 tests / 2 skipped.
- GREEN: `git diff --check`.

## Scope Notes

This does not change UCB1 reward math and does not perform live GitHub API validation inside mode selection. It is the claim-time binding seam: repeated manifest evidence can now force one exploit assignment, and then the target is consumed for the batch.
