### PR TITLE
fix(auto-dent): wire manifest-forced targets into live runs

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -3225,6 +3225,93 @@ describe('selectMode bandit integration', () => {
   });
 });
 
+describe('selectMode manifest-forced target binding', () => {
+  function writePlanAndManifestTarget(tmpDir: string, issue = '#1213', status = 'pending') {
+    writeFileSync(join(tmpDir, 'plan.json'), JSON.stringify({
+      created_at: '2026-06-29T00:00:00.000Z',
+      guidance: 'bind manifests',
+      items: [
+        { issue: '#999', title: 'Other', score: 9, approach: 'normal pick', status: 'pending', item_type: 'leaf' },
+        { issue, title: 'Manifest target', score: 1, approach: 'forced pick', status, item_type: 'leaf' },
+      ],
+      wip_excluded: [],
+      epics_scanned: [],
+    }));
+    for (const run of [4, 5, 6]) {
+      writeFileSync(join(tmpDir, `run-${run}-candidate-tasks-manifest.json`), JSON.stringify({
+        version: 1,
+        runTag: `batch/run-${run}`,
+        generatedAt: '2026-06-29T00:00:00.000Z',
+        candidates: [
+          { id: 'top', title: 'Top bundle', rationale: 'repeated', refs: [issue], suggested_mode: 'exploit' },
+        ],
+      }));
+    }
+  }
+
+  it('forces exploit when repeated latest manifests name a pending plan issue', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-mode-'));
+    writePlanAndManifestTarget(tmpDir);
+    const state = makeBatchState({
+      run_history: Array.from({ length: 12 }, (_, i) => makeRunMetrics({ run: i, mode: 'exploit', prs: ['pr'] })),
+    });
+
+    const result = selectMode(state, 12, { logDir: tmpDir, manifestRepeatThreshold: 2 });
+
+    expect(result).toMatchObject({
+      mode: 'exploit',
+      reason: 'manifest-forced',
+      target_issue: '#1213',
+    });
+  });
+
+  it('does not force when the repeated target is no longer pending', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-assigned-'));
+    writePlanAndManifestTarget(tmpDir, '#1213', 'assigned');
+    const state = makeBatchState({ run_history: [] });
+
+    const result = selectMode(state, 1, { logDir: tmpDir, manifestRepeatThreshold: 2 });
+
+    expect(result.reason).not.toBe('manifest-forced');
+  });
+
+  it('does not force exploit for repeated non-exploit manifest candidates', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-non-exploit-'));
+    writePlanAndManifestTarget(tmpDir);
+    for (const run of [4, 5, 6]) {
+      writeFileSync(join(tmpDir, `run-${run}-candidate-tasks-manifest.json`), JSON.stringify({
+        version: 1,
+        runTag: `batch/run-${run}`,
+        generatedAt: '2026-06-29T00:00:00.000Z',
+        candidates: [
+          { id: 'top', title: 'Top bundle', rationale: 'repeated', refs: ['#1213'], suggested_mode: 'reflect' },
+        ],
+      }));
+    }
+    const state = makeBatchState({ run_history: [] });
+
+    const result = selectMode(state, 1, { logDir: tmpDir, manifestRepeatThreshold: 2 });
+
+    expect(result.reason).not.toBe('manifest-forced');
+  });
+
+  it('renders the forced manifest target as the claimed plan issue', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-prompt-'));
+    writePlanAndManifestTarget(tmpDir);
+    const state = makeBatchState({ guidance: 'work from manifest' });
+
+    const meta = buildPromptWithMetadata(state, 6, tmpDir);
+
+    expect(meta.template).toBe('deep-dive-default.md');
+    expect(meta.claimedPlanIssue).toBe('#1213');
+    expect(meta.prompt).toContain('Manifest target');
+    expect(meta.prompt).toContain('#1213');
+    const plan = JSON.parse(readFileSync(join(tmpDir, 'plan.json'), 'utf8'));
+    expect(plan.items.find((i: any) => i.issue === '#1213').status).toBe('assigned');
+    expect(plan.items.find((i: any) => i.issue === '#999').status).toBe('pending');
+  });
+});
+
 describe('computeModeDistribution', () => {
   it('counts modes from run history', () => {
     const history = [
@@ -3434,6 +3521,8 @@ describe('buildPromptWithMetadata', () => {
     expect(source.match(/selectMode\(state, runNum, \{ logDir \}\)/g)).toHaveLength(1);
     expect(source).toContain('buildTemplateVars(state, runNum, logDir, {');
     expect(source).toContain('targetIssue: modeSelection.target_issue');
+    expect(source).toContain('claimPlanItem: shouldClaimPlanItem');
+    expect(source).toContain('modeSelection');
     expect(source).toContain("modeSelection.mode === 'exploit' && !state.test_task");
   });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -548,6 +548,9 @@ function extractManifestTarget(parsed: Record<string, unknown>): string | null {
     const first = candidates[0];
     if (first && typeof first === 'object' && !Array.isArray(first)) {
       const candidate = first as Record<string, unknown>;
+      if (typeof candidate.suggested_mode === 'string' && candidate.suggested_mode !== 'exploit') {
+        return null;
+      }
       return firstIssueRef(candidate.refs) || normalizeIssueRef(candidate.issue);
     }
   }
@@ -586,6 +589,13 @@ function closedInBatch(state: BatchState, issue: string): boolean {
   return state.issues_closed.some((ref) => normalizeIssueRef(ref) === issue);
 }
 
+function manifestTargetClaimable(logDir: string, issue: string): boolean {
+  const plan = readPlan(logDir);
+  if (!plan) return true;
+  const item = plan.items.find((candidate) => normalizeIssueRef(candidate.issue) === issue);
+  return !item || item.status === 'pending';
+}
+
 export function findManifestForcedTarget(
   state: BatchState,
   logDir?: string,
@@ -601,7 +611,12 @@ export function findManifestForcedTarget(
     const parsed = parseJsonObject(readFileSync(path, 'utf8'));
     if (!parsed) continue;
     const target = extractManifestTarget(parsed as Record<string, unknown>);
-    if (!target || consumedManifestTarget(state, target) || closedInBatch(state, target)) continue;
+    if (
+      !target
+      || consumedManifestTarget(state, target)
+      || closedInBatch(state, target)
+      || !manifestTargetClaimable(logDir, target)
+    ) continue;
 
     const aggregateCount = aggregateManifestObservationCount(parsed as Record<string, unknown>);
     if (aggregateCount && aggregateCount >= repeatThreshold) {
@@ -740,7 +755,7 @@ export function buildTemplateVars(
   state: BatchState,
   runNum: number,
   logDir?: string,
-  options: { claimPlanItem?: boolean; targetIssue?: string } = {},
+  options: { claimPlanItem?: boolean; targetIssue?: string; modeSelection?: ModeSelection } = {},
 ): Record<string, string> {
   const runTag = `${state.batch_id}/run-${runNum}`;
   const hostRepo = state.host_repo || state.kaizen_repo || 'unknown';
@@ -853,7 +868,7 @@ export function buildTemplateVars(
   const crossBatchSteeringText = crossBatchSteering.length > 0
     ? crossBatchSteering.map((r, i) => `${i + 1}. ${r}`).join('\n')
     : '';
-  const modeSelection = selectMode(state, runNum, { logDir });
+  const modeSelection = options.modeSelection ?? selectMode(state, runNum, { logDir });
   const manifestPath = logDir
     ? candidateTaskManifestPath(logDir, runNum)
     : `run-${runNum}-candidate-tasks-manifest.json`;
@@ -1433,10 +1448,11 @@ export function weightedModeSelect(
  * Priority (highest first):
  *   1. Guidance override: "mode:<name>" in guidance forces that mode
  *   2. Test task: always exploit with test template
- *   3. Signal-driven: reactive to batch state (failures, stalls, streaks)
- *   4. Contemplate overlay: every 15th run for strategic assessment
- *   5. Bandit selection: UCB1 explore/exploit weighting from run history
- *   6. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
+ *   3. Manifest-forced: repeated explore manifests bind a pending plan target
+ *   4. Signal-driven: reactive to batch state (failures, stalls, streaks)
+ *   5. Contemplate overlay: every 15th run for strategic assessment
+ *   6. Bandit selection: UCB1 explore/exploit weighting from run history
+ *   7. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
  */
 export interface SelectModeOptions {
   logDir?: string;
@@ -1594,6 +1610,7 @@ export function buildPromptWithMetadata(
   const vars = buildTemplateVars(state, runNum, logDir, {
     claimPlanItem: shouldClaimPlanItem,
     targetIssue: modeSelection.target_issue,
+    modeSelection,
   });
   const claimedPlanIssue = vars.claimed_plan_issue || undefined;
 
@@ -2138,7 +2155,7 @@ async function runClaude(
   const ctx: StreamContext = { provider: 'claude' };
 
   const logDir = dirname(stateFile);
-  const modeSelection = selectMode(state, runNum);
+  const modeSelection = selectMode(state, runNum, { logDir });
   if (modeSelection.mode !== 'exploit' || modeSelection.reason !== 'schedule') {
     console.log(`  [mode] run #${runNum}: ${modeSelection.mode} (${modeSelection.reason}, template: ${modeSelection.template})`);
   }


### PR DESCRIPTION
## Problem

PR #1607 added manifest-forced target selection and target-aware plan claiming, but the live Claude run path could still choose a mode without `logDir`. That means direct helper/prompt tests could see manifest-forced targets while the real run path missed them.

Fixes #1608.
Related: #1607, #1213.

## Solution

- Pass the batch `logDir` into `selectMode()` from `runClaude()`.
- Thread the selected `ModeSelection` into `buildTemplateVars()` so template choice and plan claim policy share one decision.
- Ignore manifest candidates whose `suggested_mode` is explicitly non-exploit.
- Treat an existing non-pending plan target as not claimable, while preserving #1607 synthetic assignment behavior for absent targets.

## Evidence

- GREEN: `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-plan.test.ts` passed, 434 tests.
- GREEN: `npm run typecheck`.
- GREEN: `npm run test:fast` passed, 656 tests / 2 skipped.
- GREEN: `npm test` passed, 4060 tests / 14 skipped.

## Scope Notes

This does not change UCB1 reward math, manifest schemas, or add live GitHub validation inside mode selection. It only wires the manifest-forced decision into the live run and guards stale/non-exploit targets.