### PR TITLE
Warm-start auto-dent bandit from prior batch outcomes

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -496,6 +496,33 @@ describe('populateCrossBatchSteering — close the loop (#940 Phase 2)', () => {
     expect(readState(f).cross_batch_steering).toEqual(result);
   });
 
+  it('persists a cross-batch bandit prior from the same outcome read', () => {
+    const state = makeBatchState({ batch_id: 'self' });
+    const f = tmpState(state);
+    populateCrossBatchSteering(state, f, {
+      read: () => [
+        {
+          schema_version: 1, batch_id: 'p1', guidance: 'g', batch_start: 1, batch_end: 2,
+          wall_seconds: 1, stop_reason: 'completed',
+          totals: { runs: 6, successful_runs: 3, prs: 3, issues_closed: 3, issues_filed: 0, cost_usd: 6, duration_seconds: 100, lines_deleted: 0, issues_pruned: 0 },
+          success_rate: 0.5, avg_cost_per_success: 2, overall_efficiency: 0.5, review_fail_rate: 0,
+          cost_anomaly_count: 0, mode_diversity: 2, trend: null,
+          mode_breakdown: [
+            { mode: 'exploit', runs: 3, successes: 3, success_rate: 1, cost_usd: 3, prs: 3, avg_cost: 1, efficiency: 1, lines_deleted: 0, issues_pruned: 0 },
+            { mode: 'explore', runs: 3, successes: 0, success_rate: 0, cost_usd: 3, prs: 0, avg_cost: 1, efficiency: 0, lines_deleted: 0, issues_pruned: 0 },
+          ],
+          prs: [], issues_closed: [], issues_filed: [],
+        },
+      ],
+    });
+
+    expect(state.cross_batch_bandit_prior).toMatchObject({
+      source: 'batch-outcome',
+      source_batches: 1,
+    });
+    expect(readState(f).cross_batch_bandit_prior).toEqual(state.cross_batch_bandit_prior);
+  });
+
   it('is idempotent — does not refetch when already populated', () => {
     const state = makeBatchState({ cross_batch_steering: ['already here'] });
     const f = tmpState(state);
@@ -2607,6 +2634,30 @@ describe('computeBanditWeights', () => {
     expect(computeBanditWeights(history)).toBeNull();
   });
 
+  it('uses prior plays and rewards to warm-start a fresh batch below minRuns', () => {
+    const result = computeBanditWeights([], {
+      minRuns: 10,
+      explorationC: 0,
+      prior: {
+        source: 'batch-outcome',
+        source_batches: 2,
+        decay: 1,
+        modes: {
+          exploit: { plays: 10, total_reward: 10 },
+          explore: { plays: 10, total_reward: 0 },
+          reflect: { plays: 10, total_reward: 0 },
+          subtract: { plays: 10, total_reward: 0 },
+        },
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.totalPlays).toBe(40);
+    expect(result!.weights.exploit).toBeCloseTo(1, 5);
+    expect(result!.weights.explore).toBeCloseTo(0, 5);
+    expect(result!.details.find((d) => d.mode === 'exploit')!.plays).toBe(10);
+  });
+
   it('returns weights that sum to 1.0 with sufficient data', () => {
     const history = makeHistory(
       { exploit: 9, explore: 1, reflect: 1, subtract: 1 },
@@ -3205,6 +3256,31 @@ describe('selectMode bandit integration', () => {
     const result = selectMode(state, 7);
     expect(result.reason).toBe('schedule');
     expect(result.mode).toBe('explore');
+  });
+
+  it('uses cross-batch bandit prior instead of scheduled explore in a fresh batch', () => {
+    const state = makeBatchState({
+      run_history: [makeRunMetrics({ run: 0, mode: 'exploit', prs: ['pr'] })],
+      cross_batch_bandit_prior: {
+        source: 'batch-outcome',
+        source_batches: 2,
+        decay: 1,
+        modes: {
+          exploit: { plays: 12, total_reward: 12 },
+          explore: { plays: 12, total_reward: 0 },
+          reflect: { plays: 12, total_reward: 0 },
+          subtract: { plays: 12, total_reward: 0 },
+        },
+      },
+    });
+
+    const result = selectMode(state, 7);
+
+    expect(result.reason).toBe('bandit');
+    expect(result.bandit).toBeDefined();
+    expect(result.bandit!.details.find((d) => d.mode === 'exploit')!.meanReward).toBeGreaterThan(
+      result.bandit!.details.find((d) => d.mode === 'explore')!.meanReward,
+    );
   });
 
   it('signal overrides take priority over adaptive selection', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -46,6 +46,8 @@ import {
   writeBatchOutcomeAttachment,
   readBatchOutcomesFromGithub,
   computeSteeringRecommendations,
+  deriveBanditPriorFromOutcomes,
+  type BanditPrior,
 } from './batch-outcome.js';
 import { phaseProvidersForAgentProvider, type PhaseProviderRecord, type Provider } from './auto-dent-provider.js';
 import { computeExploreExploitConversion, formatExploreExploitConversion } from './auto-dent-explore-conversion.js';
@@ -258,6 +260,8 @@ export interface BatchState {
    * so observable cloud data biases this batch's choices.
    */
   cross_batch_steering?: string[];
+  /** UCB1 warm-start prior derived from PRIOR batches' batch-outcome attachments (#1201). */
+  cross_batch_bandit_prior?: BanditPrior;
   /** Manifest-forced issue targets already consumed in this batch (#1213). */
   manifest_forced_targets_consumed?: string[];
 }
@@ -996,7 +1000,10 @@ function learnedSignalMode(
   excludedModes: Set<string>,
   reason: string,
 ): ModeSelection | null {
-  const bandit = computeBanditWeights(state.run_history || [], { explorationC: banditExplorationC() });
+  const bandit = computeBanditWeights(state.run_history || [], {
+    explorationC: banditExplorationC(),
+    prior: state.cross_batch_bandit_prior,
+  });
   if (!bandit) return null;
 
   const best = bandit.details
@@ -1316,14 +1323,18 @@ export function buildBanditDecisionTelemetry(
  */
 export function computeBanditWeights(
   history: RunMetrics[],
-  opts: { minRuns?: number; explorationC?: number } = {},
+  opts: { minRuns?: number; explorationC?: number; prior?: BanditPrior } = {},
 ): BanditResult | null {
   const minRuns = opts.minRuns ?? 10;
   const explorationC = opts.explorationC ?? DEFAULT_BANDIT_C;
+  const prior = opts.prior;
 
   // Only runs with mode data count toward bandit statistics.
   const withMode = history.filter(r => r.mode);
-  if (withMode.length < minRuns) return null;
+  const priorPlaysTotal = prior
+    ? SCHEDULABLE_MODES.reduce((sum, mode) => sum + (prior.modes[mode]?.plays ?? 0), 0)
+    : 0;
+  if (withMode.length + priorPlaysTotal < minRuns) return null;
 
   // Group runs by mode.
   const byMode = new Map<string, RunMetrics[]>();
@@ -1338,9 +1349,13 @@ export function computeBanditWeights(
   const meanReward: Record<string, number> = {};
   for (const mode of SCHEDULABLE_MODES) {
     const runs = byMode.get(mode) || [];
-    plays[mode] = runs.length;
-    meanReward[mode] = runs.length
-      ? runs.reduce((s, r) => s + modeSuccess(mode, r), 0) / runs.length
+    const priorMode = prior?.modes[mode];
+    const priorPlays = priorMode?.plays ?? 0;
+    const priorReward = priorMode?.total_reward ?? 0;
+    const currentReward = runs.reduce((s, r) => s + modeSuccess(mode, r), 0);
+    plays[mode] = priorPlays + runs.length;
+    meanReward[mode] = plays[mode] > 0
+      ? (priorReward + currentReward) / plays[mode]
       : 0;
   }
 
@@ -1482,7 +1497,10 @@ export function selectMode(state: BatchState, runNum: number, options: SelectMod
   }
 
   // Bandit selection: principled UCB1 explore/exploit weighting when data allows.
-  const bandit = computeBanditWeights(state.run_history || [], { explorationC: banditExplorationC() });
+  const bandit = computeBanditWeights(state.run_history || [], {
+    explorationC: banditExplorationC(),
+    prior: state.cross_batch_bandit_prior,
+  });
   if (bandit) {
     const mode = weightedModeSelect(bandit.weights, runNum, state.batch_id);
     return { mode, template: MODE_TEMPLATES[mode] || MODE_TEMPLATES.exploit, reason: 'bandit', bandit };
@@ -1550,11 +1568,13 @@ export function populateCrossBatchSteering(
 
   const repo = state.kaizen_repo;
   let steering: string[] = [];
+  let banditPrior: BanditPrior | undefined;
   if (repo && repo !== 'unknown') {
     try {
       const read = deps.read ?? readBatchOutcomesFromGithub;
       const outcomes = read(repo, { excludeBatchId: state.batch_id });
       const report = computeSteeringRecommendations(outcomes);
+      banditPrior = deriveBanditPriorFromOutcomes(outcomes) ?? undefined;
       steering = report.recommendations.map((r) => r.text);
       if (steering.length > 0) {
         console.log(
@@ -1575,6 +1595,7 @@ export function populateCrossBatchSteering(
   }
 
   state.cross_batch_steering = steering;
+  state.cross_batch_bandit_prior = banditPrior;
   try {
     writeState(stateFile, state);
   } catch {

--- a/scripts/batch-outcome.test.ts
+++ b/scripts/batch-outcome.test.ts
@@ -6,6 +6,7 @@ import {
   readBatchOutcome,
   readBatchOutcomesFromGithub,
   computeSteeringRecommendations,
+  deriveBanditPriorFromOutcomes,
   formatSteeringReport,
   steeringPromptText,
   BatchOutcomeSchema,
@@ -233,6 +234,37 @@ const mode = (mode: string, runs: number, successes: number, prs: number, cost: 
   mode, runs, successes, success_rate: runs ? successes / runs : 0,
   cost_usd: cost, prs, avg_cost: runs ? cost / runs : 0,
   efficiency: cost ? prs / cost : 0, lines_deleted: 0, issues_pruned: 0,
+});
+
+describe('deriveBanditPriorFromOutcomes — pure mode prior adapter', () => {
+  it('converts recent batch outcomes into decayed prior plays and rewards', () => {
+    const older = makeOutcome({
+      batch_id: 'older',
+      batch_start: 1,
+      mode_breakdown: [mode('exploit', 4, 4, 4, 8), mode('explore', 4, 0, 0, 8)],
+    });
+    const newer = makeOutcome({
+      batch_id: 'newer',
+      batch_start: 2,
+      mode_breakdown: [mode('exploit', 2, 2, 2, 4), mode('explore', 2, 0, 0, 4)],
+    });
+
+    const prior = deriveBanditPriorFromOutcomes([older, newer], { decay: 0.5 });
+
+    expect(prior).toMatchObject({
+      source: 'batch-outcome',
+      source_batches: 2,
+      decay: 0.5,
+    });
+    expect(prior!.modes.exploit.plays).toBeCloseTo(4);
+    expect(prior!.modes.exploit.total_reward).toBeCloseTo(4);
+    expect(prior!.modes.explore.plays).toBeCloseTo(4);
+    expect(prior!.modes.explore.total_reward).toBe(0);
+  });
+
+  it('returns null when no outcome has mode evidence', () => {
+    expect(deriveBanditPriorFromOutcomes([makeOutcome({ mode_breakdown: [] })])).toBeNull();
+  });
 });
 
 describe('computeSteeringRecommendations — pure analysis', () => {

--- a/scripts/batch-outcome.ts
+++ b/scripts/batch-outcome.ts
@@ -300,9 +300,37 @@ interface ModeRollup {
   efficiency: number; // PRs per $ — higher is better
 }
 
+export interface BanditPriorMode {
+  /** Decayed cross-batch plays for this mode. */
+  plays: number;
+  /** Decayed cross-batch reward total for this mode. */
+  total_reward: number;
+}
+
+export interface BanditPrior {
+  source: 'batch-outcome';
+  /** Number of batch outcomes that contributed at least one mode row. */
+  source_batches: number;
+  /** Recency decay applied per batch, newest outcome weight = 1. */
+  decay: number;
+  /** Per-mode prior evidence keyed by mode name. */
+  modes: Record<string, BanditPriorMode>;
+}
+
+function outcomesWithModeEvidence(
+  outcomes: BatchOutcome[],
+  opts: { newestFirst?: boolean; limit?: number } = {},
+): BatchOutcome[] {
+  const filtered = outcomes.filter((outcome) => outcome.mode_breakdown.length > 0);
+  const ordered = opts.newestFirst
+    ? [...filtered].sort((a, b) => b.batch_start - a.batch_start)
+    : filtered;
+  return ordered.slice(0, opts.limit ?? ordered.length);
+}
+
 function rollupModes(outcomes: BatchOutcome[]): ModeRollup[] {
   const acc = new Map<string, { runs: number; successes: number; prs: number; cost: number }>();
-  for (const o of outcomes) {
+  for (const o of outcomesWithModeEvidence(outcomes)) {
     for (const m of o.mode_breakdown) {
       const cur = acc.get(m.mode) ?? { runs: 0, successes: 0, prs: 0, cost: 0 };
       cur.runs += m.runs;
@@ -321,6 +349,36 @@ function rollupModes(outcomes: BatchOutcome[]): ModeRollup[] {
     success_rate: v.runs > 0 ? v.successes / v.runs : 0,
     efficiency: v.cost > 0 ? v.prs / v.cost : 0,
   }));
+}
+
+export function deriveBanditPriorFromOutcomes(
+  outcomes: BatchOutcome[],
+  opts: { decay?: number; limit?: number } = {},
+): BanditPrior | null {
+  const decay = opts.decay ?? 0.8;
+  const limit = opts.limit ?? outcomes.length;
+  const sorted = outcomesWithModeEvidence(outcomes, { newestFirst: true, limit });
+  if (sorted.length === 0) return null;
+
+  const modes: Record<string, BanditPriorMode> = {};
+  for (let i = 0; i < sorted.length; i++) {
+    const weight = Math.pow(decay, i);
+    for (const mode of sorted[i].mode_breakdown) {
+      const cur = modes[mode.mode] ?? { plays: 0, total_reward: 0 };
+      cur.plays += mode.runs * weight;
+      // Consume the durable BatchOutcome success proxy so every cross-batch
+      // reader learns from the same structured observation contract.
+      cur.total_reward += mode.successes * weight;
+      modes[mode.mode] = cur;
+    }
+  }
+
+  return {
+    source: 'batch-outcome',
+    source_batches: sorted.length,
+    decay,
+    modes,
+  };
 }
 
 const pct = (x: number): string => `${Math.round(x * 100)}%`;


### PR DESCRIPTION
## Summary
Fixes #1201.

Auto-dent's UCB1 bandit no longer cold-starts every batch from only the current batch's `run_history`. Prior batches now produce a structured `BanditPrior` from durable `batch-outcome` `mode_breakdown` rows, and a new batch persists that prior alongside existing cross-batch steering during the same once-per-batch GitHub outcome read.

## Contract
- `batch-outcome.ts` owns the producer contract with `deriveBanditPriorFromOutcomes` and shared `outcomesWithModeEvidence` filtering for mode evidence.
- `populateCrossBatchSteering` reads prior outcomes once, derives prose steering and `cross_batch_bandit_prior`, and writes both into state.
- `computeBanditWeights` accepts the prior as plays/reward evidence, so it can activate below the old in-batch `minRuns` threshold without mutating `state.run_history`.
- `selectMode` and signal-driven learned-mode selection both consume the same persisted prior.

## Proof
- RED: `deriveBanditPriorFromOutcomes` initially failed because no adapter existed.
- RED: cross-batch prior persistence initially failed because `populateCrossBatchSteering` only stored prose steering.
- RED: `computeBanditWeights([], { minRuns: 10, prior })` initially returned `null`.
- RED: `selectMode(state, 7)` with strong prior initially fell back to the scheduled explore slot.
- GREEN: all of the above are now covered by focused tests.

## DRY / Refactor Sweep
- Reused the existing `batch-outcome` structured observation path instead of parsing steering prose.
- Added a shared mode-evidence helper used by both steering rollup and bandit prior derivation.
- Kept prior data out of synthetic `run_history` rows; the bandit math combines prior and current evidence at the consumer boundary.

## Verification
- `npx vitest run scripts/batch-outcome.test.ts -t "deriveBanditPriorFromOutcomes"`
- `npx vitest run scripts/auto-dent-run.test.ts -t "cross-batch bandit prior|warm-start|selectMode bandit integration"`
- `npx vitest run scripts/batch-outcome.test.ts scripts/auto-dent-run.test.ts`
- `npm run check:fast`
- `git diff --check`