### PR TITLE
feat(setup): smooth first-install kaizen UX

### DIFF
--- a/.agents/kaizen/instructions-fragment.md
+++ b/.agents/kaizen/instructions-fragment.md
@@ -2,7 +2,7 @@
 
 ## Kaizen — Continuous Improvement
 
-Kaizen is installed at `{{KAIZEN_ROOT}}`. It provides enforcement hooks, reflection workflows, and dev workflow skills. Configuration in `kaizen.config.json`.
+Kaizen is installed as an active Claude Code plugin. It provides enforcement hooks, reflection workflows, and dev workflow skills. Configuration lives in `kaizen.config.json`.
 
 ### Kaizen Skills
 
@@ -18,7 +18,7 @@ Kaizen is installed at `{{KAIZEN_ROOT}}`. It provides enforcement hooks, reflect
 
 ### Dev work skill chain — MUST follow this workflow
 
-**Full workflow docs:** [`{{KAIZEN_ROOT}}/.agents/kaizen/workflow.md`]({{KAIZEN_ROOT}}/.agents/kaizen/workflow.md)
+**Full workflow docs:** use `/kaizen-do` for the goal-driven workflow and `/kaizen-zen` for the operating philosophy. The plugin source of truth is the `Garsson-io/kaizen` repository.
 
 Key triggers — activate the right skill for the user's intent:
 
@@ -32,20 +32,20 @@ Key triggers — activate the right skill for the user's intent:
 
 ### The Zen of Kaizen
 
-Run `/kaizen-zen` to see the full commentary ([`{{KAIZEN_ROOT}}/.agents/kaizen/zen.md`]({{KAIZEN_ROOT}}/.agents/kaizen/zen.md)).
+Run `/kaizen-zen` to see the full commentary.
 
 ### Kaizen Policies
 
-**Generic policies:** [`{{KAIZEN_ROOT}}/.agents/kaizen/policies.md`]({{KAIZEN_ROOT}}/.agents/kaizen/policies.md) — recursive kaizen, hooks infrastructure, worktree isolation, co-commit tests, smoke tests ship with feature.
+**Generic policies:** provided by the kaizen plugin — recursive kaizen, hooks infrastructure, worktree isolation, co-commit tests, smoke tests ship with feature.
 
 **Host-specific policies:** [`.agents/kaizen/local/policies-local.md`](.agents/kaizen/local/policies-local.md) — project-specific enforcement rules.
 
 ### Verification Discipline
 
-**Read [`{{KAIZEN_ROOT}}/.agents/kaizen/verification.md`]({{KAIZEN_ROOT}}/.agents/kaizen/verification.md)** before writing fixes or tests. Covers: path tracing, invariant statements, runtime artifact verification, smoke tests.
+**Read the plugin's verification guidance** before writing fixes or tests. Covers: path tracing, invariant statements, runtime artifact verification, smoke tests.
 
 ### Kaizen Backlog
 
-Future work tracked as GitHub Issues. Issue taxonomy in [`{{KAIZEN_ROOT}}/docs/issue-taxonomy.md`]({{KAIZEN_ROOT}}/docs/issue-taxonomy.md). Every issue MUST have: `kaizen` + level (`level-1`/`level-2`/`level-3`) + area label.
+Future work is tracked as GitHub Issues. Every issue MUST have: `kaizen` + level (`level-1`/`level-2`/`level-3`) + area label.
 
 <!-- END KAIZEN PLUGIN -->

--- a/.agents/skills/kaizen-setup/SKILL.md
+++ b/.agents/skills/kaizen-setup/SKILL.md
@@ -8,19 +8,39 @@ user_invocable: true
 
 Configure kaizen for the current project. Plugin hooks, skills, and agents are registered automatically via `plugin.json`. This setup creates host-project config files.
 
-## Step 0: Check installation
+## Step 0: Resolve plugin root
 
-Verify kaizen is installed:
+`CLAUDE_PLUGIN_ROOT` is reliable inside hook invocations, but it may be empty in
+ad-hoc Bash calls made while this skill runs. Prefer it when present; otherwise
+derive the root from Claude Code's plugin registry.
+
 ```bash
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  CLAUDE_PLUGIN_ROOT="$(claude plugin list --json 2>/dev/null \
+    | jq -r '.[]? | select((.id // .name // .plugin) == "kaizen@kaizen" or (.id // .name // .plugin) == "kaizen") | (.installPath // .path // .root // .cachePath)')"
+  export CLAUDE_PLUGIN_ROOT
+fi
 echo "CLAUDE_PLUGIN_ROOT=$CLAUDE_PLUGIN_ROOT"
 ```
 
-If `CLAUDE_PLUGIN_ROOT` is empty, the plugin isn't installed. Tell the user:
+If it is still empty, the plugin isn't installed for this project. Tell the user:
 ```
-/plugin marketplace add Garsson-io/kaizen
-/plugin install kaizen@kaizen
+/plugin marketplace add Garsson-io/kaizen --scope project
+/plugin install kaizen@kaizen --scope project
 ```
-Then restart Claude Code and re-run `/kaizen-setup`.
+Then run `/reload-plugins` or restart Claude Code and re-run `/kaizen-setup`.
+
+## Step 0.25: Check project-scope preconditions
+
+Project-scope install writes activation to `.claude/settings.json`. If the host
+repo gitignores the whole `.claude/` directory, activation silently stays local.
+
+```bash
+npx --prefix "$CLAUDE_PLUGIN_ROOT" tsx "$CLAUDE_PLUGIN_ROOT/src/kaizen-setup.ts" --step precondition
+```
+
+If this reports `status:"warn"`, replace broad `.claude/` ignores with the
+narrow session-local entries shown in the warning.
 
 ## Step 0.5: Enable at project scope (#1063)
 
@@ -60,7 +80,15 @@ Creates `.agents/kaizen/local/policies-local.md` if it doesn't exist.
 
 ## Step 3: Inject CLAUDE.md section
 
-Read the fragment at `${CLAUDE_PLUGIN_ROOT}/.agents/kaizen/instructions-fragment.md` and append it to the host agent-instructions file (typically `CLAUDE.md`; if your host workflow uses `AGENTS.md` as the primary instructions file, append there instead). If the target file doesn't exist, create it. If it already has a kaizen section, skip.
+Append the kaizen section to the host agent-instructions file mechanically:
+
+```bash
+npx --prefix "$CLAUDE_PLUGIN_ROOT" tsx "$CLAUDE_PLUGIN_ROOT/src/kaizen-setup.ts" --step inject-instructions
+```
+
+The step picks `CLAUDE.md` when present, falls back to `AGENTS.md`, creates
+`CLAUDE.md` when neither exists, replaces the legacy root placeholder, and
+skips when the kaizen section is already present.
 
 ## Step 4: Verify
 
@@ -95,9 +123,9 @@ See `docs/git-hooks-design.md` for architecture and decision rationale.
 
 | # | Task | Description |
 |---|------|-------------|
-| 1 | Check installation | Verify CLAUDE_PLUGIN_ROOT is set |
+| 1 | Resolve root and preconditions | Resolve `CLAUDE_PLUGIN_ROOT`, run `precondition` |
 | 2 | Create config and policies | Run CLI for config + scaffold steps |
-| 3 | Inject CLAUDE.md and verify | Append kaizen section, run verify |
+| 3 | Inject instructions and verify | Run `inject-instructions`, then `verify` |
 | 4 | Install git hooks | Run `install-git-hooks` step (epic #1059) |
 
 ## Idempotency

--- a/README.md
+++ b/README.md
@@ -28,11 +28,16 @@ Claude will install the plugin and tell you to restart. After restarting, run `/
 
 ### Manual installation
 
-**Step 1:** Install the plugin (in Claude Code):
+**Step 1:** Install the plugin for this project (in Claude Code):
 ```
-/plugin marketplace add Garsson-io/kaizen
-/plugin install kaizen@kaizen
+/plugin marketplace add Garsson-io/kaizen --scope project
+/plugin install kaizen@kaizen --scope project
 ```
+
+Project scope is the recommended default for repo/team enforcement: it records
+the plugin activation in the project so collaborators get the same hooks and
+skills after pulling. Use the default user scope only when you want kaizen for
+your own sessions without changing the repo.
 
 **Step 2:** Exit and restart Claude Code. Skills only load on startup.
 
@@ -40,6 +45,7 @@ Claude will install the plugin and tell you to restart. After restarting, run `/
 - `kaizen.config.json` — project configuration
 - `.agents/kaizen/local/policies-local.md` — project-specific policies
 - Kaizen section in `CLAUDE.md`
+- Kaizen `pre-push` git hook integration for your hook framework
 
 **No Node.js required in your host project.** Kaizen runs from its own plugin directory.
 

--- a/src/hooks/enforce-plan-stored.test.ts
+++ b/src/hooks/enforce-plan-stored.test.ts
@@ -535,6 +535,15 @@ describe('checkPlanBeforePr', () => {
     expect(result.allowed).toBe(false);
   });
 
+  it('DENIES with direct store-plan remediation when a plan is missing (#1085)', () => {
+    const result = checkPlanBeforePr(ghPrCreate('Closes #1055'), makeDeps({ retrievePlan: () => null }));
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('/kaizen-write-plan');
+    expect(result.reason).toContain('store-plan');
+    expect(result.reason).toContain('--issue 1055 --repo Garsson-io/kaizen');
+    expect(result.reason).toContain('retrieve-testplan');
+  });
+
   it('DENIES when no testplan', () => {
     const result = checkPlanBeforePr(ghPrCreate('Closes #1055'), makeDeps({ retrieveTestPlan: () => null }));
     expect(result.allowed).toBe(false);

--- a/src/hooks/enforce-plan-stored.ts
+++ b/src/hooks/enforce-plan-stored.ts
@@ -600,7 +600,12 @@ This hook enforces I3 (stored test plan) and I8 (plan before implementation).`,
 ${gate.reason}
 
 Run /kaizen-write-plan — the skill knows how to create and store the plan correctly.
-  Skill({ skill: "kaizen-write-plan", args: "#${issueNum}" })`,
+  Skill({ skill: "kaizen-write-plan", args: "#${issueNum}" })
+
+If you already have a substantive plan file, store it directly and verify that
+the embedded test plan is retrievable before creating the PR:
+  npx tsx src/cli-structured-data.ts store-plan --issue ${issueNum} --repo ${repo} --file plan.md
+  npx tsx src/cli-structured-data.ts retrieve-testplan --issue ${issueNum} --repo ${repo}`,
     };
   }
 

--- a/src/hooks/enforce-pr-review.test.ts
+++ b/src/hooks/enforce-pr-review.test.ts
@@ -85,6 +85,16 @@ describe('enforce-pr-review PreToolUse — Bash commands', () => {
     expect(result.reason).toContain('round 3');
   });
 
+  it('gives the concrete store-review-summary + second diff sequence (#1085)', () => {
+    createReviewGate('https://github.com/org/repo/pull/42', '3');
+    const result = processPreToolUse('git push origin feature', TEST_BRANCH, TEST_STATE_DIR);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('store-review-summary');
+    expect(result.reason).toContain('--pr 42 --repo org/repo --round 3');
+    expect(result.reason).toContain('gh pr diff https://github.com/org/repo/pull/42');
+    expect(result.reason).toContain('/kaizen-review-pr 42');
+  });
+
   it('INVARIANT: Bash deny message identifies the blocked tool as "Bash" (kaizen #971)', () => {
     // The gate message must identify WHICH matcher fired (Bash/Edit|Write/Agent).
     // PR #964 debugging wasted significant time because the message said

--- a/src/hooks/enforce-pr-review.ts
+++ b/src/hooks/enforce-pr-review.ts
@@ -26,13 +26,25 @@ import { findStateWithStatus } from './state-utils.js';
 const BLOCKED_TOOLS = new Set(['Edit', 'Write']);
 
 function buildDenyMessage(toolLabel: string, prUrl: string, round: string): string {
+  const prNum = prUrl.match(/\/pull\/(\d+)/)?.[1] ?? '<N>';
+  const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)/)?.[1] ?? '<owner/repo>';
+
   return `BLOCKED: ${toolLabel} is not allowed during PR review.
 
 You have an active PR review that must be completed first:
   PR: ${prUrl} (round ${round})
 
-Run \`gh pr diff ${prUrl}\` to review the diff, then work through the
-self-review checklist. Only after reviewing can you proceed with other work.
+Use the review skill for the normal path:
+  /kaizen-review-pr ${prNum}
+
+If you already performed the review manually, clearing this gate is a two-step
+mechanism:
+  1. Store a real review summary:
+     npx tsx src/cli-structured-data.ts store-review-summary --pr ${prNum} --repo ${repo} --round ${round} --text "REVIEW: <summary>"
+  2. Re-run the diff command so the PostToolUse hook observes the stored summary:
+     gh pr diff ${prUrl}
+
+The summary must describe what was reviewed. A placeholder defeats the gate.
 
 Allowed commands during review:
   gh pr diff, gh pr view, gh pr comment, gh pr edit

--- a/src/kaizen-setup.test.ts
+++ b/src/kaizen-setup.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "path";
 import { tmpdir } from "os";
 import { rmSync } from "fs";
 import { fileURLToPath } from "url";
+import { execFileSync } from "child_process";
 import {
   detectInstall,
   generateConfig,
@@ -12,6 +13,8 @@ import {
   verifyPluginContract,
   postUpdateValidate,
   enablePlugin,
+  checkPreconditions,
+  injectInstructions,
 } from "./kaizen-setup.js";
 
 let tempDir: string;
@@ -123,6 +126,18 @@ describe("scaffoldPolicies", () => {
     expect(existsSync(join(tempDir, ".agents", "kaizen", "local", "policies-local.md"))).toBe(true);
   });
 
+  it("adds every kaizen session-local directory to .gitignore, including telemetry", () => {
+    const result = scaffoldPolicies(tempDir);
+    expect(result.status).toBe("ok");
+
+    const gitignore = readFileSync(join(tempDir, ".gitignore"), "utf-8");
+    expect(gitignore).toContain(".claude/review-fix/");
+    expect(gitignore).toContain(".claude/audit/");
+    expect(gitignore).toContain(".agents/kaizen/local/audit/");
+    expect(gitignore).toContain(".claude/worktrees/");
+    expect(gitignore).toContain("data/telemetry/");
+  });
+
   it("skips if already exists", () => {
     mkdirSync(join(tempDir, ".agents", "kaizen", "local"), { recursive: true });
     writeFileSync(join(tempDir, ".agents", "kaizen", "local", "policies-local.md"), "existing content");
@@ -132,6 +147,126 @@ describe("scaffoldPolicies", () => {
 
     const content = readFileSync(join(tempDir, ".agents", "kaizen", "local", "policies-local.md"), "utf-8");
     expect(content).toBe("existing content");
+  });
+});
+
+describe("checkPreconditions (#1085 — project-scope install can be silently hidden)", () => {
+  it("returns ok when no .gitignore exists", () => {
+    expect(checkPreconditions(tempDir)).toEqual({ step: "precondition", status: "ok", warnings: [] });
+  });
+
+  it("warns when .gitignore broadly ignores .claude/", () => {
+    writeFileSync(join(tempDir, ".gitignore"), ".claude/\n");
+    const result = checkPreconditions(tempDir);
+    expect(result.status).toBe("warn");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain(".claude/settings.json");
+    expect(result.warnings[0]).toContain(".claude/review-fix/");
+  });
+
+  it("warns for leading-slash and no-slash variants", () => {
+    writeFileSync(join(tempDir, ".gitignore"), "/.claude\n");
+    expect(checkPreconditions(tempDir).status).toBe("warn");
+  });
+
+  it("does not warn for narrow session-local ignores", () => {
+    writeFileSync(
+      join(tempDir, ".gitignore"),
+      ".claude/review-fix/\n.claude/audit/\n.claude/worktrees/\n.claude/settings.local.json\n",
+    );
+    expect(checkPreconditions(tempDir).status).toBe("ok");
+  });
+});
+
+describe("injectInstructions (#1085 — no manual {{KAIZEN_ROOT}} substitution)", () => {
+  function makePluginRoot(fragment: string): string {
+    const pluginRoot = join(tempDir, "plugin");
+    mkdirSync(join(pluginRoot, ".agents", "kaizen"), { recursive: true });
+    writeFileSync(join(pluginRoot, ".agents", "kaizen", "instructions-fragment.md"), fragment);
+    return pluginRoot;
+  }
+
+  it("creates CLAUDE.md from the fragment and replaces the root placeholder", () => {
+    const pluginRoot = makePluginRoot("Kaizen root: {{KAIZEN_ROOT}}\n");
+    const result = injectInstructions({ cwd: tempDir, pluginRoot });
+    expect(result).toMatchObject({ step: "inject-instructions", status: "ok", path: join(tempDir, "CLAUDE.md") });
+
+    const content = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    expect(content).toContain(`Kaizen root: ${pluginRoot}`);
+    expect(content).not.toContain("{{KAIZEN_ROOT}}");
+  });
+
+  it("appends idempotently with a blank-line separator", () => {
+    const pluginRoot = makePluginRoot("<!-- BEGIN KAIZEN PLUGIN -->\n## Kaizen\n<!-- END KAIZEN PLUGIN -->\n");
+    writeFileSync(join(tempDir, "CLAUDE.md"), "# Existing");
+
+    const first = injectInstructions({ cwd: tempDir, pluginRoot });
+    const afterFirst = readFileSync(first.path!, "utf-8");
+    const second = injectInstructions({ cwd: tempDir, pluginRoot });
+
+    expect(afterFirst).toBe("# Existing\n\n<!-- BEGIN KAIZEN PLUGIN -->\n## Kaizen\n<!-- END KAIZEN PLUGIN -->\n");
+    expect(second.status).toBe("skipped");
+    expect(readFileSync(second.path!, "utf-8")).toBe(afterFirst);
+  });
+
+  it("falls back to AGENTS.md when CLAUDE.md is absent", () => {
+    const pluginRoot = makePluginRoot("## Kaizen\n");
+    writeFileSync(join(tempDir, "AGENTS.md"), "# Agents\n");
+    const result = injectInstructions({ cwd: tempDir, pluginRoot });
+    expect(result.path).toBe(join(tempDir, "AGENTS.md"));
+    expect(readFileSync(join(tempDir, "AGENTS.md"), "utf-8")).toContain("## Kaizen");
+  });
+
+  it("honors an explicit target", () => {
+    const pluginRoot = makePluginRoot("## Kaizen\n");
+    const target = join(tempDir, "CUSTOM.md");
+    const result = injectInstructions({ cwd: tempDir, pluginRoot, target });
+    expect(result.path).toBe(target);
+    expect(readFileSync(target, "utf-8")).toContain("## Kaizen");
+  });
+
+  it("CLI smoke exposes precondition and inject-instructions as JSON steps", () => {
+    const pluginRoot = makePluginRoot("<!-- BEGIN KAIZEN PLUGIN -->\nKaizen {{KAIZEN_ROOT}}\n<!-- END KAIZEN PLUGIN -->\n");
+    writeFileSync(join(tempDir, ".gitignore"), ".claude/\n");
+    const setupScript = fileURLToPath(new URL("./kaizen-setup.ts", import.meta.url));
+
+    const precondition = JSON.parse(execFileSync(
+      "npx",
+      ["tsx", setupScript, "--step", "precondition", "--cwd", tempDir],
+      { encoding: "utf-8" },
+    ));
+    expect(precondition).toMatchObject({ step: "precondition", status: "warn" });
+
+    const injected = JSON.parse(execFileSync(
+      "npx",
+      ["tsx", setupScript, "--step", "inject-instructions", "--cwd", tempDir, "--plugin-root", pluginRoot],
+      { encoding: "utf-8" },
+    ));
+    expect(injected).toMatchObject({ step: "inject-instructions", status: "ok" });
+    const content = readFileSync(join(tempDir, "CLAUDE.md"), "utf-8");
+    expect(content).toContain(pluginRoot);
+    expect(content).not.toContain("{{KAIZEN_ROOT}}");
+  });
+});
+
+describe("setup docs contracts (#1085/#1080)", () => {
+  it("README recommends project-scoped install for team enforcement", () => {
+    const readme = readFileSync(new URL("../README.md", import.meta.url), "utf-8");
+    expect(readme).toContain("/plugin marketplace add Garsson-io/kaizen --scope project");
+    expect(readme).toContain("/plugin install kaizen@kaizen --scope project");
+    expect(readme).toContain("Use the default user scope only");
+  });
+
+  it("setup skill uses mechanistic precondition and injection steps", () => {
+    const skill = readFileSync(new URL("../.agents/skills/kaizen-setup/SKILL.md", import.meta.url), "utf-8");
+    expect(skill).toContain("--step precondition");
+    expect(skill).toContain("--step inject-instructions");
+    expect(skill).not.toContain("If `CLAUDE_PLUGIN_ROOT` is empty, the plugin isn't installed");
+  });
+
+  it("instruction fragment has no raw root placeholder", () => {
+    const fragment = readFileSync(new URL("../.agents/kaizen/instructions-fragment.md", import.meta.url), "utf-8");
+    expect(fragment).not.toContain("{{KAIZEN_ROOT}}");
   });
 });
 

--- a/src/kaizen-setup.ts
+++ b/src/kaizen-setup.ts
@@ -65,6 +65,20 @@ export interface ScaffoldResult {
   reason?: string;
 }
 
+export interface PreconditionResult {
+  step: "precondition";
+  status: "ok" | "warn";
+  warnings: string[];
+}
+
+export interface InjectInstructionsResult {
+  step: "inject-instructions";
+  status: "ok" | "skipped" | "error";
+  path?: string;
+  reason?: string;
+  error?: string;
+}
+
 interface VerifyCheck {
   name: string;
   ok: boolean;
@@ -187,11 +201,58 @@ export function enablePlugin(cwd: string, pluginName = KAIZEN_PLUGIN_SOURCE): En
   return { step: "enable", status: "ok", path, changed: true };
 }
 
+const KAIZEN_GITIGNORE_ENTRIES = [
+  ".claude/review-fix/",
+  ".claude/audit/",
+  ".agents/kaizen/local/audit/",
+  ".claude/worktrees/",
+  "data/telemetry/",
+];
+
+function ensureGitignoreEntries(cwd: string): void {
+  const gitignorePath = join(cwd, ".gitignore");
+  const existing = existsSync(gitignorePath)
+    ? readFileSync(gitignorePath, "utf-8")
+    : "";
+  const missing = KAIZEN_GITIGNORE_ENTRIES.filter(e => !existing.includes(e));
+  if (missing.length === 0) return;
+
+  const addition = (existing.endsWith("\n") || existing === "" ? "" : "\n")
+    + "# kaizen session-local state (not committed)\n"
+    + missing.join("\n") + "\n";
+  writeFileSync(gitignorePath, existing + addition);
+}
+
+export function checkPreconditions(cwd: string): PreconditionResult {
+  const warnings: string[] = [];
+  const gitignorePath = join(cwd, ".gitignore");
+  if (existsSync(gitignorePath)) {
+    const body = readFileSync(gitignorePath, "utf-8");
+    const broadClaudeIgnore = body.split(/\r?\n/).some(raw => {
+      const line = raw.trim();
+      if (!line || line.startsWith("#")) return false;
+      return /^\/?\.claude\/?$/.test(line);
+    });
+
+    if (broadClaudeIgnore) {
+      warnings.push(
+        "This repo gitignores .claude/ broadly, so project-scope plugin activation in " +
+        ".claude/settings.json will not propagate to collaborators. Replace the broad " +
+        "entry with narrower session-local entries such as .claude/review-fix/, " +
+        ".claude/audit/, .claude/worktrees/, and .claude/settings.local.json.",
+      );
+    }
+  }
+
+  return { step: "precondition", status: warnings.length > 0 ? "warn" : "ok", warnings };
+}
+
 export function scaffoldPolicies(cwd: string): ScaffoldResult {
   const dir = join(cwd, ".agents", "kaizen", "local");
   const path = join(dir, "policies-local.md");
 
   if (existsSync(path)) {
+    ensureGitignoreEntries(cwd);
     return { step: "scaffold", status: "skipped", path, reason: "already exists" };
   }
 
@@ -210,26 +271,42 @@ Add project-specific enforcement rules here.
 `
   );
 
-  // Ensure kaizen session-local directories are gitignored in the host project
-  const gitignorePath = join(cwd, ".gitignore");
-  const gitignoreEntries = [
-    ".claude/review-fix/",
-    ".claude/audit/",
-    ".agents/kaizen/local/audit/",
-    ".claude/worktrees/",
-  ];
-  const existing = existsSync(gitignorePath)
-    ? readFileSync(gitignorePath, "utf-8")
-    : "";
-  const missing = gitignoreEntries.filter(e => !existing.includes(e));
-  if (missing.length > 0) {
-    const addition = (existing.endsWith("\n") || existing === "" ? "" : "\n")
-      + "# kaizen session-local state (not committed)\n"
-      + missing.join("\n") + "\n";
-    writeFileSync(gitignorePath, existing + addition);
-  }
+  ensureGitignoreEntries(cwd);
 
   return { step: "scaffold", status: "ok", path };
+}
+
+function chooseInstructionsTarget(cwd: string, target?: string): string {
+  if (target) return target;
+  const claudeMd = join(cwd, "CLAUDE.md");
+  if (existsSync(claudeMd)) return claudeMd;
+  const agentsMd = join(cwd, "AGENTS.md");
+  if (existsSync(agentsMd)) return agentsMd;
+  return claudeMd;
+}
+
+function appendWithBlankLine(existing: string, fragment: string): string {
+  if (!existing) return fragment;
+  if (existing.endsWith("\n\n")) return existing + fragment;
+  if (existing.endsWith("\n")) return existing + "\n" + fragment;
+  return existing + "\n\n" + fragment;
+}
+
+export function injectInstructions(opts: { cwd: string; pluginRoot: string; target?: string }): InjectInstructionsResult {
+  const fragmentPath = join(opts.pluginRoot, ".agents", "kaizen", "instructions-fragment.md");
+  if (!existsSync(fragmentPath)) {
+    return { step: "inject-instructions", status: "error", error: `fragment not found: ${fragmentPath}` };
+  }
+
+  const path = chooseInstructionsTarget(opts.cwd, opts.target);
+  const fragment = readFileSync(fragmentPath, "utf-8").replace(/\{\{KAIZEN_ROOT\}\}/g, opts.pluginRoot);
+  const existing = existsSync(path) ? readFileSync(path, "utf-8") : "";
+  if (existing.includes("<!-- BEGIN KAIZEN PLUGIN")) {
+    return { step: "inject-instructions", status: "skipped", path, reason: "kaizen section already present" };
+  }
+
+  writeFileSync(path, appendWithBlankLine(existing, fragment));
+  return { step: "inject-instructions", status: "ok", path };
 }
 
 interface PluginContractCheck {
@@ -465,6 +542,7 @@ if (process.argv[1]?.endsWith("kaizen-setup.ts") || process.argv[1]?.endsWith("k
       "plugin-root": { type: "string" },
       "run-post-install": { type: "string" },
       "plugin": { type: "string" },
+      target: { type: "string" },
     },
     strict: false,
   }) as { values: Record<string, string | undefined> };
@@ -491,9 +569,19 @@ if (process.argv[1]?.endsWith("kaizen-setup.ts") || process.argv[1]?.endsWith("k
       console.log(JSON.stringify(scaffoldPolicies(cwd)));
       break;
 
+    case "precondition":
+      console.log(JSON.stringify(checkPreconditions(cwd)));
+      break;
+
     case "enable":
       console.log(JSON.stringify(enablePlugin(cwd, values["plugin"] ?? KAIZEN_PLUGIN_SOURCE)));
       break;
+
+    case "inject-instructions": {
+      const pluginRoot = values["plugin-root"] ?? process.env.CLAUDE_PLUGIN_ROOT ?? process.cwd();
+      console.log(JSON.stringify(injectInstructions({ cwd, pluginRoot, target: values.target })));
+      break;
+    }
 
     case "verify": {
       const pluginRoot = values["plugin-root"] ?? process.env.CLAUDE_PLUGIN_ROOT;
@@ -542,7 +630,7 @@ if (process.argv[1]?.endsWith("kaizen-setup.ts") || process.argv[1]?.endsWith("k
 
     default:
       console.error(`Unknown step: ${values.step}`);
-      console.error("Steps: detect, config, scaffold, enable, verify, post-update-validate, install-git-hooks");
+      console.error("Steps: detect, precondition, config, scaffold, enable, inject-instructions, verify, post-update-validate, install-git-hooks");
       process.exit(1);
   }
 }

--- a/src/kaizen-setup.ts
+++ b/src/kaizen-setup.ts
@@ -14,7 +14,7 @@
  *   2. .agents/kaizen/local/policies-local.md — host-specific policies
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { execSync } from "child_process";
 import { join } from "path";
 import { parseArgs } from "util";
@@ -209,25 +209,32 @@ const KAIZEN_GITIGNORE_ENTRIES = [
   "data/telemetry/",
 ];
 
+function readTextFileIfExists(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
 function ensureGitignoreEntries(cwd: string): void {
   const gitignorePath = join(cwd, ".gitignore");
-  const existing = existsSync(gitignorePath)
-    ? readFileSync(gitignorePath, "utf-8")
-    : "";
+  const existing = readTextFileIfExists(gitignorePath) ?? "";
   const missing = KAIZEN_GITIGNORE_ENTRIES.filter(e => !existing.includes(e));
   if (missing.length === 0) return;
 
   const addition = (existing.endsWith("\n") || existing === "" ? "" : "\n")
     + "# kaizen session-local state (not committed)\n"
     + missing.join("\n") + "\n";
-  writeFileSync(gitignorePath, existing + addition);
+  appendFileSync(gitignorePath, addition);
 }
 
 export function checkPreconditions(cwd: string): PreconditionResult {
   const warnings: string[] = [];
   const gitignorePath = join(cwd, ".gitignore");
-  if (existsSync(gitignorePath)) {
-    const body = readFileSync(gitignorePath, "utf-8");
+  const body = readTextFileIfExists(gitignorePath);
+  if (body !== null) {
     const broadClaudeIgnore = body.split(/\r?\n/).some(raw => {
       const line = raw.trim();
       if (!line || line.startsWith("#")) return false;
@@ -294,18 +301,19 @@ function appendWithBlankLine(existing: string, fragment: string): string {
 
 export function injectInstructions(opts: { cwd: string; pluginRoot: string; target?: string }): InjectInstructionsResult {
   const fragmentPath = join(opts.pluginRoot, ".agents", "kaizen", "instructions-fragment.md");
-  if (!existsSync(fragmentPath)) {
+  const fragmentTemplate = readTextFileIfExists(fragmentPath);
+  if (fragmentTemplate === null) {
     return { step: "inject-instructions", status: "error", error: `fragment not found: ${fragmentPath}` };
   }
 
   const path = chooseInstructionsTarget(opts.cwd, opts.target);
-  const fragment = readFileSync(fragmentPath, "utf-8").replace(/\{\{KAIZEN_ROOT\}\}/g, opts.pluginRoot);
-  const existing = existsSync(path) ? readFileSync(path, "utf-8") : "";
+  const fragment = fragmentTemplate.replace(/\{\{KAIZEN_ROOT\}\}/g, opts.pluginRoot);
+  const existing = readTextFileIfExists(path) ?? "";
   if (existing.includes("<!-- BEGIN KAIZEN PLUGIN")) {
     return { step: "inject-instructions", status: "skipped", path, reason: "kaizen section already present" };
   }
 
-  writeFileSync(path, appendWithBlankLine(existing, fragment));
+  appendFileSync(path, appendWithBlankLine(existing, fragment).slice(existing.length));
   return { step: "inject-instructions", status: "ok", path };
 }
 


### PR DESCRIPTION
## Story

Once upon a time, `/kaizen-setup` was already strong at writing config, scaffolding policies, verifying state, and installing git hooks. Every day, new host repos could adopt kaizen, but the path still assumed the agent knew the plugin cache path and could manually append the right instruction fragment.

One day, #1085 captured a first-install session where the install worked, but the ceremony cliff was sharp: README commands defaulted to user scope, `.claude/` could be gitignored and silently hide project activation, `CLAUDE_PLUGIN_ROOT` was treated as definitive even outside hook contexts, `{{KAIZEN_ROOT}}` was left for agents to guess, `data/telemetry/` appeared unignored, and review/plan gates required source spelunking to clear.

Because of that, this PR turns the remaining setup UX into testable mechanisms: setup now has a `precondition` step, an `inject-instructions` step, shared gitignore hygiene including telemetry, and gate messages with exact structured-data commands. Because of that, the setup skill and README now steer project-scope installs and call the mechanistic steps instead of asking agents to hand-roll them.

Until finally, the temp-host smoke shows the flow as a user would see it: broad `.claude/` ignore warns, config/scaffold/inject run as JSON CLI steps, verify returns `ok`, the generated `CLAUDE.md` has no root placeholder, and `.gitignore` contains `data/telemetry/`.

Fixes #1085
Fixes #1080

## Architecture

```text
/kaizen-setup skill
  -> resolve plugin root
  -> kaizen-setup.ts --step precondition
  -> kaizen-setup.ts --step scaffold
       -> shared KAIZEN_GITIGNORE_ENTRIES
  -> kaizen-setup.ts --step inject-instructions
       -> instructions-fragment.md -> CLAUDE.md/AGENTS.md
  -> kaizen-setup.ts --step verify

gate deny messages
  -> preferred skill path
  -> exact structured-data fallback command
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add setup CLI steps instead of prose-only docs | Agents can run and test concrete setup operations | Slightly larger `kaizen-setup.ts` surface |
| Keep instruction injection in `kaizen-setup.ts` | Reuses existing setup command pattern and test file | Does not add a separate standalone CLI |
| Preserve placeholder replacement support while removing placeholders from the shipped fragment | Backward-compatible with custom fragments and proves clean current output | The replacement is now mostly defensive |
| Put direct structured-data commands in gate denials | Agents blocked at gates get the real clearing mechanism immediately | Messages are longer, but materially more actionable |

## What's In This PR

| File | Purpose |
|---|---|
| `src/kaizen-setup.ts` | Adds `precondition`, shared gitignore hygiene, and `inject-instructions` |
| `src/kaizen-setup.test.ts` | Covers setup preconditions, instruction injection, docs contracts, and subprocess CLI smoke |
| `src/hooks/enforce-pr-review.ts` | Adds exact review-summary + second-diff clearing sequence |
| `src/hooks/enforce-plan-stored.ts` | Adds exact `store-plan` + `retrieve-testplan` remediation path |
| `.agents/skills/kaizen-setup/SKILL.md` | Updates setup workflow to project-scope and mechanistic steps |
| `.agents/kaizen/instructions-fragment.md` | Removes raw local root placeholder links from installed host instructions |
| `README.md` | Makes project-scope install the default team/repo path |

## Impact (goal -> before/after -> match)

- Goal (#1085): First-time setup should not force agents to guess plugin paths, manually substitute placeholders, miss hidden project-scope failures, or reverse-engineer gate-clearing commands.
- Acceptance signal: Setup CLI + docs + hook denials expose mechanistic paths, and a fresh temp host shows generated state with no `{{KAIZEN_ROOT}}` and telemetry ignored.
- BEFORE: Stored plan baseline found `{{KAIZEN_ROOT}}` in the fragment, README install without `--scope project`, no `precondition`/`inject-instructions` steps, no `data/telemetry/` gitignore entry, and no `store-review-summary` in the review-gate denial.
- AFTER: Temp-host smoke returned `precondition` warn, `config/scaffold/inject` ok, `verify` ok, `PLACEHOLDER_COUNT=` empty, `GITIGNORE_TELEMETRY=7:data/telemetry/`, and `CLAUDE.md` marker present. Residual `rg` over install-facing docs/source found no raw placeholder or stale false-negative wording.
- Delta: Setup friction moved from manual guessing/source reading to explicit CLI steps and exact remediation commands, with 155 focused tests, full Vitest, and shell hook tests passing.
- Goal met?: yes.
- Residual scan: #1082 was already closed; pre-commit remote/wrapper friction was already resolved by #1593/#1599/#1606; no additional first-install issue matched this PR scope beyond #1080.

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status | Evidence |
|---|---|---|---|---|
| 1 | Broad `.claude/` gitignore warns; narrow session-local ignores do not | Unit | Tested | `src/kaizen-setup.test.ts` |
| 2 | Setup appends session-local gitignore entries including `data/telemetry/` | Unit | Tested | `src/kaizen-setup.test.ts` |
| 3 | Instruction injection creates/updates host instructions with no raw placeholder and skips on rerun | Integration | Tested | `src/kaizen-setup.test.ts` |
| 4 | CLI exposes `precondition` and `inject-instructions` as JSON steps | System | Tested | subprocess smoke in `src/kaizen-setup.test.ts` + manual temp-host smoke |
| 5 | README/setup skill steer project-scope install and avoid stale env-var false negative | Unit/static | Tested | docs contract tests + residual `rg` |
| 6 | Review gate denial names `store-review-summary` and second `gh pr diff` | Unit | Tested | `src/hooks/enforce-pr-review.test.ts` |
| 7 | Plan gate denial names `store-plan` and `retrieve-testplan` fallback | Unit | Tested | `src/hooks/enforce-plan-stored.test.ts` |
| 8 | End-to-end setup smoke proves host observable state changed | System | Tested | temp-host smoke output in validation below |

## Validation

- [x] RED first: focused tests failed on current behavior for telemetry ignore, missing setup functions, and missing gate commands.
- [x] `npx vitest run src/kaizen-setup.test.ts src/hooks/enforce-pr-review.test.ts src/hooks/enforce-plan-stored.test.ts --reporter=verbose` — 155 passed.
- [x] `npm run check:fast` — typecheck + changed tests passed.
- [x] `npm test` — 170 files passed, 2 skipped; 4071 tests passed, 14 skipped.
- [x] `npm run test:hooks` — 435/435 passed.
- [x] Temp-host setup smoke: `precondition` warned on broad `.claude/`; `config`, `scaffold`, `inject-instructions` succeeded; `verify` returned `ok`; placeholder count empty; `data/telemetry/` present in `.gitignore`.
- [x] Residual scan: no raw `{{KAIZEN_ROOT}}`, stale install false-negative wording, or manual fragment-append prose in install-facing docs/source.

## Known Limitations

This PR does not build the larger ceremony issue/plan auto-filer from the old unmerged branch. The scoped #1085 fix here removes the remaining first-install dead ends directly; future automation can still build on these CLI steps.