### PR TITLE
Derive auto-dent run closures from merged PR bodies

### DIFF
--- a/scripts/auto-dent-github.test.ts
+++ b/scripts/auto-dent-github.test.ts
@@ -18,6 +18,7 @@ import {
   syncEpicChecklists,
   verifyIssuesClosed,
   reconcileBatchClosedIssues,
+  closedIssueRefsFromVerifyCloseResults,
 } from './auto-dent-github.js';
 import { makeRunResult } from './auto-dent-test-helpers.js';
 
@@ -1094,5 +1095,24 @@ describe('reconcileBatchClosedIssues (#1173)', () => {
       'owner/repo',
     );
     expect(closed).toEqual(['#4', '#12', '#30']);
+  });
+});
+
+describe('closedIssueRefsFromVerifyCloseResults (#1210)', () => {
+  it('dedupes and sorts verified plus force-closed refs', () => {
+    const refs = closedIssueRefsFromVerifyCloseResults([
+      {
+        pr: 'https://github.com/owner/repo/pull/1',
+        verified: ['#20', '#5'],
+        forceClosed: ['#7'],
+      },
+      {
+        pr: 'https://github.com/owner/repo/pull/2',
+        verified: ['#5'],
+        forceClosed: ['#12'],
+      },
+    ]);
+
+    expect(refs).toEqual(['#5', '#7', '#12', '#20']);
   });
 });

--- a/scripts/auto-dent-github.ts
+++ b/scripts/auto-dent-github.ts
@@ -613,6 +613,17 @@ export function verifyIssuesClosed(
   return results;
 }
 
+export function closedIssueRefsFromVerifyCloseResults(results: VerifyCloseResult[]): string[] {
+  const closed = new Set<string>();
+  for (const r of results) {
+    for (const ref of r.verified) closed.add(ref);
+    for (const ref of r.forceClosed) closed.add(ref);
+  }
+  return [...closed].sort(
+    (a, b) => Number(a.replace('#', '')) - Number(b.replace('#', '')),
+  );
+}
+
 /**
  * Authoritative batch-level set of issues actually closed by a batch's merged PRs.
  *
@@ -633,12 +644,5 @@ export function reconcileBatchClosedIssues(
   repo: string,
 ): string[] {
   const results = verifyIssuesClosed(prUrls, repo);
-  const closed = new Set<string>();
-  for (const r of results) {
-    for (const ref of r.verified) closed.add(ref);
-    for (const ref of r.forceClosed) closed.add(ref);
-  }
-  return [...closed].sort(
-    (a, b) => Number(a.replace('#', '')) - Number(b.replace('#', '')),
-  );
+  return closedIssueRefsFromVerifyCloseResults(results);
 }

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -34,6 +34,7 @@ import {
   deriveRunOutcome,
   buildRunMetrics,
   buildRunCompleteEvent,
+  mergeVerifiedClosedIssuesIntoRunResult,
   weightedModeSelect,
   computeModeDistribution,
   formatBatchFooter,
@@ -3171,6 +3172,45 @@ describe('buildRunMetrics', () => {
     });
 
     expect(event.bandit_decision).toEqual(metrics.bandit_decision);
+  });
+});
+
+describe('mergeVerifiedClosedIssuesIntoRunResult (#1210)', () => {
+  it('adds merged-PR closing refs for this run without importing older batch PRs', () => {
+    const result = makeRunResult({
+      prs: ['https://github.com/owner/repo/pull/2'],
+      issuesClosed: ['#99'],
+    });
+
+    const added = mergeVerifiedClosedIssuesIntoRunResult(result, [
+      {
+        pr: 'https://github.com/owner/repo/pull/1',
+        verified: ['#1'],
+        forceClosed: [],
+      },
+      {
+        pr: 'https://github.com/owner/repo/pull/2',
+        verified: ['#20'],
+        forceClosed: ['#10'],
+      },
+      {
+        pr: 'https://github.com/owner/repo/pull/3',
+        verified: ['#30'],
+        forceClosed: [],
+      },
+    ]);
+
+    expect(added).toEqual(['#10', '#20']);
+    expect(result.issuesClosed).toEqual(['#99', '#10', '#20']);
+  });
+
+  it('runs before persisted run metrics are built', () => {
+    const mergeIndex = AUTO_DENT_RUN_SOURCE.indexOf('mergeVerifiedClosedIssuesIntoRunResult(result, verifyResults)');
+    const metricsIndex = AUTO_DENT_RUN_SOURCE.indexOf('const runMetrics = buildRunMetrics({');
+
+    expect(mergeIndex).toBeGreaterThan(-1);
+    expect(metricsIndex).toBeGreaterThan(-1);
+    expect(mergeIndex).toBeLessThan(metricsIndex);
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -80,6 +80,7 @@ export {
   syncEpicChecklists,
   verifyIssuesClosed,
   reconcileBatchClosedIssues,
+  closedIssueRefsFromVerifyCloseResults,
   type MergeStatus,
   type DriveStatus,
   type DriveReason,
@@ -155,7 +156,9 @@ import {
   fetchIssueLabels,
   verifyIssuesClosed,
   reconcileBatchClosedIssues,
+  closedIssueRefsFromVerifyCloseResults,
   syncEpicChecklists,
+  type VerifyCloseResult,
 } from './auto-dent-github.js';
 import {
   color,
@@ -538,6 +541,25 @@ function firstIssueRef(values: unknown): string | null {
     if (ref) return ref;
   }
   return null;
+}
+
+export function mergeVerifiedClosedIssuesIntoRunResult(
+  result: RunResult,
+  verifyResults: VerifyCloseResult[],
+): string[] {
+  const currentRunPrs = new Set(result.prs);
+  const currentRunResults = verifyResults.filter((entry) => currentRunPrs.has(entry.pr));
+  const closedRefs = closedIssueRefsFromVerifyCloseResults(currentRunResults);
+  const existing = new Set(result.issuesClosed.map((ref) => normalizeIssueRef(ref)).filter(Boolean));
+  const added: string[] = [];
+  for (const ref of closedRefs) {
+    const normalized = normalizeIssueRef(ref);
+    if (!normalized || existing.has(normalized)) continue;
+    result.issuesClosed.push(normalized);
+    existing.add(normalized);
+    added.push(normalized);
+  }
+  return added;
 }
 
 function extractManifestTarget(parsed: Record<string, unknown>): string | null {
@@ -3347,19 +3369,19 @@ async function main(): Promise<void> {
   // Verify issues claimed by merged PRs are actually closed (#730, Gap 2)
   // Must run before epic sync so force-closed issues are included
   const allBatchPRsForVerify = [...new Set([...state.prs, ...result.prs])];
+  let verifiedClosedThisBatch: string[] = [];
   if (allBatchPRsForVerify.length > 0) {
     const verifyResults = verifyIssuesClosed(allBatchPRsForVerify, state.kaizen_repo);
+    verifiedClosedThisBatch = closedIssueRefsFromVerifyCloseResults(verifyResults);
+    const currentRunClosed = mergeVerifiedClosedIssuesIntoRunResult(result, verifyResults);
+    if (currentRunClosed.length > 0) {
+      console.log(
+        `  [verify-close] current run closed ${currentRunClosed.length} issue(s) via merged PR body: ${currentRunClosed.join(', ')}`,
+      );
+    }
     const forceClosed = verifyResults.flatMap((r) => r.forceClosed);
     if (forceClosed.length > 0) {
       console.log(`  [verify-close] force-closed ${forceClosed.length} issue(s): ${forceClosed.join(', ')}`);
-      // Add force-closed issues to the result so they're tracked in state
-      for (const issue of forceClosed) {
-        const num = issue.replace('#', '');
-        const url = `https://github.com/${state.kaizen_repo}/issues/${num}`;
-        if (!result.issuesClosed.includes(url) && !result.issuesClosed.includes(issue)) {
-          result.issuesClosed.push(url);
-        }
-      }
     }
   }
 
@@ -3367,6 +3389,7 @@ async function main(): Promise<void> {
   const allClosedNums = [...new Set([
     ...state.issues_closed,
     ...result.issuesClosed,
+    ...verifiedClosedThisBatch,
   ])].map((ref) => {
     const m = ref.match(/(\d+)/);
     return m ? m[1] : '';
@@ -3438,6 +3461,10 @@ async function main(): Promise<void> {
       freshState.issues_filed.push(issue);
   }
   for (const closed of result.issuesClosed) {
+    if (!freshState.issues_closed.includes(closed))
+      freshState.issues_closed.push(closed);
+  }
+  for (const closed of verifiedClosedThisBatch) {
     if (!freshState.issues_closed.includes(closed))
       freshState.issues_closed.push(closed);
   }


### PR DESCRIPTION
## Summary
Fixes #1210.

Auto-dent run-level `issues_closed` no longer depends only on live stream narration. During finalize, the existing verify-close pass reads merged PR bodies through `verifyIssuesClosed()`, then the current run merges the verified/force-closed refs for its own PRs into `result.issuesClosed` before `buildRunMetrics()` persists the run.

## Contract
- `verifyIssuesClosed()` remains the single source for PR-body close keyword parsing and GitHub close verification.
- New `closedIssueRefsFromVerifyCloseResults()` dedupes/sorts `verified ∪ forceClosed`, and `reconcileBatchClosedIssues()` reuses it.
- New `mergeVerifiedClosedIssuesIntoRunResult()` filters verify results to the current run's PRs, preserves stream-scraped fallback hints, and normalizes issue refs to avoid `#N`/URL duplicates.
- The full all-batch verified set still feeds epic sync and batch state, but only current-run PR closures feed current-run metrics.

## Proof
- RED: helper test initially failed because there was no reusable verified/force-closed ref adapter.
- RED: run merge test initially failed because there was no per-run merge from verified PR-body refs.
- GREEN: focused tests now prove dedupe/sort, current-run filtering, fallback preservation, and merge-before-metrics ordering.

## Verification
- `npx vitest run scripts/auto-dent-github.test.ts -t "closedIssueRefsFromVerifyCloseResults|reconcileBatchClosedIssues"`
- `npx vitest run scripts/auto-dent-run.test.ts -t "mergeVerifiedClosedIssuesIntoRunResult"`
- `npx vitest run scripts/auto-dent-github.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent-score.test.ts scripts/batch-outcome.test.ts`
- `npm run check:fast`
- `git diff --check`
