### PR TITLE
fix(auto-dent): checkpoint live run state

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -30,6 +30,7 @@ import {
 import type { DrySweepReport } from './auto-dent-dry-sweep.js';
 import type { RunMetrics } from './auto-dent-run.js';
 import { makeBatchState } from './auto-dent-test-utils.js';
+import { checkpointRunState, writeState } from './auto-dent-run.js';
 
 const AUTO_DENT_CTL_SOURCE = readFileSync(new URL('./auto-dent-ctl.ts', import.meta.url), 'utf8');
 
@@ -71,6 +72,41 @@ describe('discoverBatches', () => {
       expect(source).not.toContain("JSON.parse(readFileSync(stateFile, 'utf8'))");
       expect(source).toMatch(/readState,/);
       expect(source).toContain("from './auto-dent-run.js'");
+    } finally {
+      rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('watchdog live-run checkpoint reality proof', () => {
+  it('classifies checkpointed active runs by heartbeat age instead of no_heartbeat', () => {
+    const logsDir = mkdtempSync(join(tmpdir(), 'watchdog-checkpoint-'));
+    try {
+      const batchDir = join(logsDir, 'batch-live');
+      mkdirSync(batchDir, { recursive: true });
+      const stateFile = join(batchDir, 'state.json');
+      writeState(stateFile, makeBatchState({
+        batch_id: 'batch-live',
+        run: 0,
+        last_heartbeat: 0,
+      }));
+
+      checkpointRunState(stateFile, { runNum: 1, heartbeatEpoch: 1_742_680_900 });
+      const [fresh] = runWatchdog(logsDir, 60, 1_742_680_930);
+      const [stale] = runWatchdog(logsDir, 60, 1_742_681_100);
+
+      expect(fresh).toMatchObject({
+        batchId: 'batch-live',
+        action: 'healthy',
+        heartbeatAge: 30,
+      });
+      expect(stale).toMatchObject({
+        batchId: 'batch-live',
+        action: 'halt_created',
+        heartbeatAge: 200,
+      });
+      expect(formatWatchdogResult(fresh)).not.toContain('no heartbeat recorded');
+      expect(existsSync(join(batchDir, 'HALT'))).toBe(true);
     } finally {
       rmSync(logsDir, { recursive: true, force: true });
     }

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -38,6 +38,7 @@ import {
   weightedModeSelect,
   computeModeDistribution,
   formatBatchFooter,
+  checkpointRunState,
   readState,
   writeState,
   color,
@@ -3525,6 +3526,81 @@ describe('formatBatchFooter', () => {
     const state = makeBatchState({ run: 0, prs: [], run_history: [] });
     const output = formatBatchFooter(state);
     expect(output).not.toContain('Modes:');
+  });
+});
+
+describe('run state checkpointing', () => {
+  it('checkpoints run identity and heartbeat before provider work finishes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'run-checkpoint-start-'));
+    const stateFile = join(dir, 'state.json');
+    writeState(stateFile, makeBatchState({ run: 0, last_heartbeat: 0 }));
+
+    checkpointRunState(stateFile, { runNum: 1, heartbeatEpoch: 1742680900 });
+
+    const updated = readState(stateFile);
+    expect(updated.run).toBe(1);
+    expect(updated.last_heartbeat).toBe(1742680900);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('checkpoints assigned issue and observed artifacts idempotently for recovery', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'run-checkpoint-artifacts-'));
+    const stateFile = join(dir, 'state.json');
+    writeState(stateFile, makeBatchState({
+      run: 0,
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1'],
+      issues_filed: ['#10'],
+      issues_closed: [],
+      cases: [],
+    }));
+    const result = makeRunResult({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1', 'https://github.com/Garsson-io/kaizen/pull/2'],
+      issuesFiled: ['#10', '#11'],
+      issuesClosed: ['https://github.com/Garsson-io/kaizen/issues/12'],
+      cases: ['260629-k1591-run-state-heartbeat'],
+    });
+
+    checkpointRunState(stateFile, {
+      runNum: 1,
+      heartbeatEpoch: 1742680910,
+      pickedIssue: '#1591',
+      result,
+    });
+    checkpointRunState(stateFile, {
+      runNum: 1,
+      heartbeatEpoch: 1742680920,
+      pickedIssue: '#1591',
+      result,
+    });
+
+    const updated = readState(stateFile);
+    expect(updated.run).toBe(1);
+    expect(updated.last_heartbeat).toBe(1742680920);
+    expect(updated.prs).toEqual([
+      'https://github.com/Garsson-io/kaizen/pull/1',
+      'https://github.com/Garsson-io/kaizen/pull/2',
+    ]);
+    expect(updated.issues_filed).toEqual(['#10', '#11']);
+    expect(updated.issues_closed).toEqual(['https://github.com/Garsson-io/kaizen/issues/12']);
+    expect(updated.cases).toEqual(['260629-k1591-run-state-heartbeat']);
+    expect(updated.last_issue).toBe('https://github.com/Garsson-io/kaizen/issues/12');
+    expect(updated.last_pr).toBe('https://github.com/Garsson-io/kaizen/pull/2');
+    expect(updated.last_case).toBe('260629-k1591-run-state-heartbeat');
+    expect(updated.last_branch).toBe('case/260629-k1591-run-state-heartbeat');
+    expect(updated.last_worktree).toBe('.claude/worktrees/260629-k1591-run-state-heartbeat');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('starts live state heartbeat around runClaude instead of inside a provider-only branch', () => {
+    const mainStart = AUTO_DENT_RUN_SOURCE.indexOf('async function main()');
+    const runClaudeStart = AUTO_DENT_RUN_SOURCE.indexOf('async function runClaude(');
+    const runClaudeEnd = AUTO_DENT_RUN_SOURCE.indexOf('// Main', runClaudeStart);
+    const mainSection = AUTO_DENT_RUN_SOURCE.slice(mainStart);
+    const runClaudeSection = AUTO_DENT_RUN_SOURCE.slice(runClaudeStart, runClaudeEnd);
+
+    expect(mainSection).toContain('startRunStateHeartbeat(stateFile, runNum');
+    expect(mainSection).toContain('runHeartbeat.stop()');
+    expect(runClaudeSection).not.toContain('s.last_heartbeat = Math.floor(Date.now() / 1000)');
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -699,6 +699,106 @@ export function writeState(stateFile: string, state: BatchState): void {
   writeDurableJsonValueFile(stateFile, state, { backup: true });
 }
 
+export interface RunStateCheckpointInput {
+  runNum: number;
+  heartbeatEpoch?: number;
+  pickedIssue?: string;
+  result?: Pick<RunResult, 'prs' | 'issuesFiled' | 'issuesClosed' | 'cases'>;
+}
+
+function appendUnique(items: string[], additions: string[]): void {
+  for (const item of additions) {
+    if (!items.includes(item)) items.push(item);
+  }
+}
+
+function mergeRunArtifactsIntoState(
+  state: BatchState,
+  result?: Pick<RunResult, 'prs' | 'issuesFiled' | 'issuesClosed' | 'cases'>,
+): void {
+  if (!result) return;
+
+  appendUnique(state.prs, result.prs);
+  appendUnique(state.issues_filed, result.issuesFiled);
+  appendUnique(state.issues_closed, result.issuesClosed);
+  appendUnique(state.cases, result.cases);
+
+  if (result.prs.length > 0) {
+    state.last_pr = result.prs[result.prs.length - 1];
+  }
+  if (result.issuesFiled.length > 0) {
+    state.last_issue = result.issuesFiled[result.issuesFiled.length - 1];
+  }
+  if (result.issuesClosed.length > 0) {
+    state.last_issue = result.issuesClosed[result.issuesClosed.length - 1];
+  }
+  if (result.cases.length > 0) {
+    const lastCase = result.cases[result.cases.length - 1];
+    state.last_case = lastCase;
+    state.last_branch = `case/${lastCase}`;
+    state.last_worktree = `.claude/worktrees/${lastCase}`;
+  }
+}
+
+function runProgressCheckpointSignature(result: RunResult): string {
+  return JSON.stringify([
+    result.pickedIssue || '',
+    result.prs,
+    result.issuesFiled,
+    result.issuesClosed,
+    result.cases,
+  ]);
+}
+
+function checkpointRunProgressIfChanged(
+  stateFile: string,
+  runNum: number,
+  result: RunResult,
+  checkpoint: { signature: string },
+): void {
+  const signature = runProgressCheckpointSignature(result);
+  if (signature === checkpoint.signature) return;
+  checkpoint.signature = signature;
+  checkpointRunState(stateFile, {
+    runNum,
+    pickedIssue: result.pickedIssue,
+    result,
+  });
+}
+
+export function checkpointRunState(
+  stateFile: string,
+  input: RunStateCheckpointInput,
+): BatchState {
+  const state = readState(stateFile);
+  state.run = Math.max(state.run || 0, input.runNum);
+  state.last_heartbeat = input.heartbeatEpoch ?? Math.floor(Date.now() / 1000);
+  if (input.pickedIssue) {
+    state.last_issue = input.pickedIssue;
+  }
+  mergeRunArtifactsIntoState(state, input.result);
+  writeState(stateFile, state);
+  return state;
+}
+
+export function startRunStateHeartbeat(
+  stateFile: string,
+  runNum: number,
+  intervalMs = 30_000,
+): { stop(): void } {
+  checkpointRunState(stateFile, { runNum });
+  const interval = setInterval(() => {
+    try {
+      checkpointRunState(stateFile, { runNum });
+    } catch {
+      // A transient state write failure must not kill provider work.
+    }
+  }, intervalMs);
+  return {
+    stop: () => clearInterval(interval),
+  };
+}
+
 // Resolve repo root
 
 function getRepoRoot(): string {
@@ -2096,6 +2196,7 @@ async function runCodex(
   return new Promise((resolvePromise) => {
     let processExited = false;
     let raw = '';
+    const progressCheckpoint = { signature: runProgressCheckpointSignature(input.result) };
     const ctx: StreamContext = { provider: 'codex' };
     const child = spawn('codex', buildCodexExecArgs(input.repoRoot), {
       cwd: input.repoRoot,
@@ -2127,6 +2228,7 @@ async function runCodex(
         for (const streamMessage of normalizeCodexEventToStreamMessages(event)) {
           processStreamMessage(streamMessage, input.result, runStart, ctx);
         }
+        checkpointRunProgressIfChanged(input.stateFile, input.runNum, input.result, progressCheckpoint);
       } catch {
         // Raw JSONL remains durable; a malformed display row should not hide run completion.
       }
@@ -2145,6 +2247,7 @@ async function runCodex(
         for (const streamMessage of normalizeCodexFinalTextToStreamMessages(parsed.finalText)) {
           processStreamMessage(streamMessage, input.result, runStart, ctx);
         }
+        checkpointRunProgressIfChanged(input.stateFile, input.runNum, input.result, progressCheckpoint);
       }
 
       appendFileSync(input.logFile, `\n--- codex final text ---\n${parsed.finalText || parsed.text}\n`);
@@ -2222,6 +2325,7 @@ async function runClaude(
   if (state.test_task && !result.pickedIssue) {
     result.pickedIssue = 'not applicable';
     result.pickedIssueTitle = 'synthetic test task';
+    checkpointRunState(stateFile, { runNum, pickedIssue: result.pickedIssue });
   }
   if (promptMeta.claimedPlanIssue && !result.pickedIssue) {
     result.pickedIssue = promptMeta.claimedPlanIssue;
@@ -2240,6 +2344,7 @@ async function runClaude(
       detail: `batch plan item ${promptMeta.claimedPlanIssue}`,
       url: formatIssueUrl(promptMeta.claimedPlanIssue, state.kaizen_repo || state.host_repo || ''),
     });
+    checkpointRunState(stateFile, { runNum, pickedIssue: promptMeta.claimedPlanIssue });
   }
 
   // Save rendered prompt for observability (#602)
@@ -2302,6 +2407,7 @@ async function runClaude(
 
   return new Promise((resolvePromise) => {
     let processExited = false;
+    const progressCheckpoint = { signature: runProgressCheckpointSignature(result) };
 
     const child = spawn('claude', args, {
       cwd: repoRoot,
@@ -2321,17 +2427,6 @@ async function runClaude(
       const silence = Math.floor((Date.now() - lastOutputTime) / 1000);
       if (silence >= 55) {
         console.log(formatHeartbeat(runStart, result.toolCalls, ctx));
-      }
-    }, 60_000);
-
-    // Liveness marker: update state.json periodically (#357)
-    const livenessInterval = setInterval(() => {
-      try {
-        const s = readState(stateFile);
-        s.last_heartbeat = Math.floor(Date.now() / 1000);
-        writeState(stateFile, s);
-      } catch {
-        // State file write failure is non-fatal
       }
     }, 60_000);
 
@@ -2386,6 +2481,7 @@ async function runClaude(
 
       try {
         processStreamMessage(msg, result, runStart, ctx);
+        checkpointRunProgressIfChanged(stateFile, runNum, result, progressCheckpoint);
 
         // Start post-result kill timer when result is received
         if (msg.type === 'result' && !postResultTimer) {
@@ -2419,7 +2515,7 @@ async function runClaude(
 
     child.on('close', (code) => {
       processExited = true;
-      cleanup(heartbeatInterval, livenessInterval, inFlightInterval, wallTimer, postResultTimer);
+      cleanup(heartbeatInterval, inFlightInterval, wallTimer, postResultTimer);
       const duration = Math.floor((Date.now() - runStart) / 1000);
       if (candidateManifestPath) {
         attachCandidateTaskManifest(result, candidateManifestPath);
@@ -2429,7 +2525,7 @@ async function runClaude(
 
     child.on('error', (err) => {
       processExited = true;
-      cleanup(heartbeatInterval, livenessInterval, inFlightInterval, wallTimer, postResultTimer);
+      cleanup(heartbeatInterval, inFlightInterval, wallTimer, postResultTimer);
       appendFileSync(logFile, `\nProcess error: ${err.message}\n`);
       const duration = Math.floor((Date.now() - runStart) / 1000);
       if (candidateManifestPath) {
@@ -2816,13 +2912,20 @@ async function main(): Promise<void> {
 
   const runStartEpoch = Math.floor(Date.now() / 1000);
   const runStartDate = new Date();
-  const { exitCode, duration, result, mode: runMode, modeReason: runModeReason, bandit: runBandit, promptMeta } = await runClaude(
-    state,
-    runNum,
-    logFile,
-    repoRoot,
-    stateFile,
-  );
+  const runHeartbeat = startRunStateHeartbeat(stateFile, runNum);
+  let runOutput: Awaited<ReturnType<typeof runClaude>>;
+  try {
+    runOutput = await runClaude(
+      state,
+      runNum,
+      logFile,
+      repoRoot,
+      stateFile,
+    );
+  } finally {
+    runHeartbeat.stop();
+  }
+  const { exitCode, duration, result, mode: runMode, modeReason: runModeReason, bandit: runBandit, promptMeta } = runOutput;
   const runId = makeRunId(state.batch_id, runNum);
   if (!result.hookActivation) {
     result.hookActivation = unknownHookActivationVerdict(
@@ -3452,24 +3555,10 @@ async function main(): Promise<void> {
   }
   if (!freshState.run_history) freshState.run_history = [];
   freshState.run_history.push(runMetrics);
-
-  for (const pr of result.prs) {
-    if (!freshState.prs.includes(pr)) freshState.prs.push(pr);
-  }
-  for (const issue of result.issuesFiled) {
-    if (!freshState.issues_filed.includes(issue))
-      freshState.issues_filed.push(issue);
-  }
-  for (const closed of result.issuesClosed) {
-    if (!freshState.issues_closed.includes(closed))
-      freshState.issues_closed.push(closed);
-  }
-  for (const closed of verifiedClosedThisBatch) {
-    if (!freshState.issues_closed.includes(closed))
-      freshState.issues_closed.push(closed);
-  }
-  for (const caseName of result.cases) {
-    if (!freshState.cases.includes(caseName)) freshState.cases.push(caseName);
+  mergeRunArtifactsIntoState(freshState, result);
+  appendUnique(freshState.issues_closed, verifiedClosedThisBatch);
+  if (verifiedClosedThisBatch.length > 0 && result.issuesClosed.length === 0) {
+    freshState.last_issue = verifiedClosedThisBatch[verifiedClosedThisBatch.length - 1];
   }
 
   // Store contemplation recommendations in batch state (#631)
@@ -3513,21 +3602,6 @@ async function main(): Promise<void> {
       freshState.reflection_insights.push(workflowRepairPrompt);
       console.log(`  ${color.yellow('[workflow-repair]')} targeted evidence repair queued for next run`);
     }
-  }
-
-  if (result.prs.length > 0) {
-    freshState.last_pr = result.prs[result.prs.length - 1];
-  }
-  if (result.issuesFiled.length > 0) {
-    freshState.last_issue = result.issuesFiled[result.issuesFiled.length - 1];
-  } else if (result.issuesClosed.length > 0) {
-    freshState.last_issue = result.issuesClosed[result.issuesClosed.length - 1];
-  }
-  if (result.cases.length > 0) {
-    const lastCase = result.cases[result.cases.length - 1];
-    freshState.last_case = lastCase;
-    freshState.last_branch = `case/${lastCase}`;
-    freshState.last_worktree = `.claude/worktrees/${lastCase}`;
   }
 
   const hasPrs = result.prs.length > 0;


### PR DESCRIPTION
## Problem
#1591 captured a live auto-dent failure where a productive Codex run still looked like `run: 0`, `last_heartbeat: 0`, and no artifacts in durable state. Watchdog skipped it as `no heartbeat recorded`, and halted recovery lost visibility into the produced PR/case evidence.

## Discovery
`runClaude()` owns both Claude and Codex provider dispatch, but the old liveness interval lived below the Codex early return in the Claude-only branch. `main()` also wrote `freshState.run = runNum` only after provider execution, review, merge tracking, and final summary work finished. That left active or interrupted provider work invisible to `auto-dent-ctl`.

## Solution
- add a provider-neutral run-state checkpoint helper that persists the live run number, heartbeat, picked issue, and observed PR/issue/case artifacts idempotently
- start a live heartbeat in `main()` before awaiting provider work and stop it in `finally`, so Claude and Codex share the same liveness contract
- checkpoint assigned issues and stream-observed artifacts as soon as they are known
- reuse the shared artifact merge in the final state update, including the latest merged-PR closure data from #1612

Closes #1591

## Impact (goal -> before/after -> match)
| Goal | Before | After | Goal met? |
|---|---|---|---|
| In-flight provider work appears as a real run | Incident state from `logs/auto-dent/immense-cow/state.json`: `run: 0`, `last_heartbeat: 0`, empty artifact fields after productive provider work | `checkpointRunState()` immediately writes `run: 1` and non-zero `last_heartbeat`; `startRunStateHeartbeat()` refreshes it around provider execution | yes |
| Watchdog classifies active runs by heartbeat age, not `no_heartbeat` | `auto-dent-ctl watchdog --threshold 60` skipped the active batch as `no heartbeat recorded` | Direct proof reports `OK batch-live — heartbeat 0m30s ago` and `STALE batch-live — heartbeat 3m20s ago — HALT file created` | yes |
| Interrupted finalization keeps recovery artifacts visible | Artifact arrays and `last_*` fields were only updated at the terminal state write | Stream checkpoints merge PRs, filed/closed issues, cases, and last-worked-on fields idempotently before terminal post-run work | yes |

Residual scan: provider cwd isolation (#1592), Codex terminal rendering (#1208), and provider runtime matrix work (#1580) are adjacent but out of scope for this state/watchdog fix.

## Verification
- `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-ctl.test.ts`
- `npm run check:fast`
- `npm test`
- direct watchdog proof against a temporary active batch state: checkpointed run reports `OK` at 30s and `STALE` at 3m20s with HALT creation

## Risk
`state.run` now advances at run start instead of only after the provider exits, so crashed live runs remain visible to watchdog/status instead of looking like run 0/no heartbeat. Completed-run metrics still append only at the existing final update.