### PR TITLE
Short-circuit stale explore manifests

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -2241,9 +2241,7 @@ describe('selectMode', () => {
     cleanupDirs.length = 0;
   });
 
-  it('forces exploit with a target issue when repeated candidate manifests name the same top candidate', () => {
-    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-mode-'));
-    cleanupDirs.push(tmpDir);
+  function writeRepeatedCandidateManifests(tmpDir: string, issue = '#1213', suggestedMode = 'exploit') {
     for (const run of [1, 2, 3]) {
       writeFileSync(join(tmpDir, `run-${run}-candidate-tasks-manifest.json`), JSON.stringify({
         version: 1,
@@ -2253,12 +2251,18 @@ describe('selectMode', () => {
             id: 'self-steering',
             title: 'Self-steering bundle',
             rationale: 'Repeated top candidate',
-            refs: ['#1213', '#1189'],
-            suggested_mode: 'exploit',
+            refs: [issue, '#1189'],
+            suggested_mode: suggestedMode,
           },
         ],
       }));
     }
+  }
+
+  it('forces exploit with a target issue when repeated candidate manifests name the same top candidate', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-mode-'));
+    cleanupDirs.push(tmpDir);
+    writeRepeatedCandidateManifests(tmpDir);
 
     const result = selectMode(makeBatchState(), 7, { logDir: tmpDir });
 
@@ -2273,13 +2277,7 @@ describe('selectMode', () => {
   it('does not force a consumed manifest target again', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-forced-consumed-'));
     cleanupDirs.push(tmpDir);
-    for (const run of [1, 2, 3]) {
-      writeFileSync(join(tmpDir, `run-${run}-candidate-tasks-manifest.json`), JSON.stringify({
-        version: 1,
-        runTag: `batch/run-${run}`,
-        candidates: [{ id: 'self-steering', title: 'Self-steering bundle', refs: ['#1213'] }],
-      }));
-    }
+    writeRepeatedCandidateManifests(tmpDir);
 
     const result = selectMode(
       makeBatchState({ manifest_forced_targets_consumed: ['#1213'] }),
@@ -2288,6 +2286,36 @@ describe('selectMode', () => {
     );
 
     expect(result.reason).not.toBe('manifest-forced');
+    expect(result.target_issue).toBeUndefined();
+  });
+
+  it('short-circuits forced explore when a fresh repeated manifest target exists', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-fresh-explore-'));
+    cleanupDirs.push(tmpDir);
+    writeRepeatedCandidateManifests(tmpDir, '#1191');
+
+    const result = selectMode(makeBatchState({ guidance: 're-scout gaps mode:explore' }), 7, { logDir: tmpDir });
+
+    expect(result).toMatchObject({
+      mode: 'exploit',
+      template: 'deep-dive-default.md',
+      reason: 'manifest-fresh-short-circuit',
+      target_issue: '#1191',
+    });
+  });
+
+  it('does not short-circuit non-explore guidance', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'manifest-fresh-reflect-'));
+    cleanupDirs.push(tmpDir);
+    writeRepeatedCandidateManifests(tmpDir, '#1191');
+
+    const result = selectMode(makeBatchState({ guidance: 'think about the batch mode:reflect' }), 7, { logDir: tmpDir });
+
+    expect(result).toMatchObject({
+      mode: 'reflect',
+      template: 'reflect-batch.md',
+      reason: 'guidance',
+    });
     expect(result.target_issue).toBeUndefined();
   });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -1483,13 +1483,14 @@ export function weightedModeSelect(
  * Select the cognitive mode for a given run.
  *
  * Priority (highest first):
- *   1. Guidance override: "mode:<name>" in guidance forces that mode
- *   2. Test task: always exploit with test template
- *   3. Manifest-forced: repeated explore manifests bind a pending plan target
- *   4. Signal-driven: reactive to batch state (failures, stalls, streaks)
- *   5. Contemplate overlay: every 15th run for strategic assessment
- *   6. Bandit selection: UCB1 explore/exploit weighting from run history
- *   7. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
+ *   1. Explore freshness: repeated manifests can short-circuit mode:explore
+ *   2. Guidance override: "mode:<name>" in guidance forces that mode
+ *   3. Test task: always exploit with test template
+ *   4. Manifest-forced: repeated explore manifests bind a pending plan target
+ *   5. Signal-driven: reactive to batch state (failures, stalls, streaks)
+ *   6. Contemplate overlay: every 15th run for strategic assessment
+ *   7. Bandit selection: UCB1 explore/exploit weighting from run history
+ *   8. Base cycle (mod 10): 0-6 exploit, 7 explore, 8 reflect, 9 subtract
  */
 export interface SelectModeOptions {
   logDir?: string;
@@ -1497,10 +1498,22 @@ export interface SelectModeOptions {
 }
 
 export function selectMode(state: BatchState, runNum: number, options: SelectModeOptions = {}): ModeSelection {
+  const forcedTarget = findManifestForcedTarget(state, options.logDir, {
+    repeatThreshold: options.manifestRepeatThreshold,
+  });
+
   // Force mode from guidance (e.g., "mode:explore")
   const modeOverride = state.guidance.match(/\bmode:(\w+)/i);
   if (modeOverride) {
     const forced = modeOverride[1].toLowerCase();
+    if (forced === 'explore' && forcedTarget) {
+      return {
+        mode: 'exploit',
+        template: MODE_TEMPLATES.exploit,
+        reason: 'manifest-fresh-short-circuit',
+        target_issue: forcedTarget.issue,
+      };
+    }
     return {
       mode: forced,
       template: MODE_TEMPLATES[forced] || MODE_TEMPLATES.exploit,
@@ -1513,9 +1526,6 @@ export function selectMode(state: BatchState, runNum: number, options: SelectMod
     return { mode: 'exploit', template: 'test-task.md', reason: 'test-task' };
   }
 
-  const forcedTarget = findManifestForcedTarget(state, options.logDir, {
-    repeatThreshold: options.manifestRepeatThreshold,
-  });
   if (forcedTarget) {
     return {
       mode: 'exploit',


### PR DESCRIPTION
## Summary
Fixes #1191.

A forced `mode:explore` run no longer re-scouts from scratch when the batch already has a fresh repeated candidate manifest with a claimable target. `selectMode()` now runs the existing repeated-manifest detector before guidance handling and converts only `mode:explore` guidance into an exploit of the manifest target with reason `manifest-fresh-short-circuit`.

## Contract
- Reuses `findManifestForcedTarget()` as the freshness signal; no second manifest parser.
- Non-explore guidance remains authoritative.
- Existing scheduled/bandit/signal manifest binding still returns `reason: manifest-forced`.
- The short-circuit is observable through `mode_reason` / mode-selection telemetry and carries `target_issue` through the normal exploit claim path.

## Proof
- RED: forced explore with repeated fresh manifests initially returned `mode: explore`, `reason: guidance`.
- GREEN: forced explore now returns `mode: exploit`, `reason: manifest-fresh-short-circuit`, and the manifest target.
- Regression: forced reflect with the same repeated manifests still returns guidance reflect.

## Verification
- `npx vitest run scripts/auto-dent-run.test.ts -t "short-circuits forced explore|does not short-circuit non-explore|forces exploit with a target issue|does not force a consumed"`
- `npx vitest run scripts/auto-dent-run.test.ts`
- `npm run check:fast`
- `git diff --check`
