### PR TITLE
fix(hooks): surface corrupt hook syntax in doctor

### DIFF
--- a/.claude/hooks/kaizen-session-snapshot.sh
+++ b/.claude/hooks/kaizen-session-snapshot.sh
@@ -9,7 +9,7 @@
 # interpolated the project path raw into a heredoc, producing invalid
 # JSON on paths with quotes or newlines.
 #
-# Non-blocking. Silent on success. Exits 0 even on write failure.
+# Non-blocking. Silent on success. Exits 0 even on write/check failure.
 
 set -u
 source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || exit 0
@@ -20,7 +20,9 @@ TS="${KAIZEN_DIR}/scripts/kaizen-doctor.ts"
 LOCAL_TSX="${KAIZEN_DIR}/node_modules/.bin/tsx"
 if [ -x "${LOCAL_TSX}" ]; then
   "${LOCAL_TSX}" "${TS}" snapshot >/dev/null 2>&1 || true
+  "${LOCAL_TSX}" "${TS}" hook-syntax --quiet || true
 elif command -v npx >/dev/null 2>&1; then
   npx --prefix "${KAIZEN_DIR}" tsx "${TS}" snapshot >/dev/null 2>&1 || true
+  npx --prefix "${KAIZEN_DIR}" tsx "${TS}" hook-syntax --quiet || true
 fi
 exit 0

--- a/scripts/kaizen-doctor.test.ts
+++ b/scripts/kaizen-doctor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -8,6 +9,7 @@ import {
   checkStalePluginCache,
   checkRestartNeeded,
   checkHookExecSmoke,
+  checkHookSyntaxSmoke,
   checkSingleRegistrationPath,
   checkCodexReadiness,
   runAllChecks,
@@ -39,10 +41,10 @@ function writePluginJson(projectRoot: string, content: unknown): void {
   writeFileSync(join(projectRoot, '.claude-plugin/plugin.json'), JSON.stringify(content, null, 2));
 }
 
-function writeHook(projectRoot: string, rel: string, executable = true): string {
+function writeHook(projectRoot: string, rel: string, executable = true, content = '#!/bin/bash\nexit 0\n'): string {
   const p = join(projectRoot, rel);
   mkdirSync(join(p, '..'), { recursive: true });
-  writeFileSync(p, '#!/bin/bash\nexit 0\n');
+  writeFileSync(p, content);
   if (executable) chmodSync(p, 0o755);
   else chmodSync(p, 0o644);
   return p;
@@ -316,6 +318,110 @@ describe('checkHookExecSmoke', () => {
   });
 });
 
+describe('checkHookSyntaxSmoke', () => {
+  let proj: string, home: string;
+  beforeEach(() => { proj = makeProject(); home = makeHome(); });
+  afterEach(() => { rmSync(proj, { recursive: true, force: true }); rmSync(home, { recursive: true, force: true }); });
+
+  it('PASS when referenced hooks have valid bash syntax', () => {
+    writeHook(proj, '.claude/hooks/foo.sh', true);
+    writePluginJson(proj, { hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/.claude/hooks/foo.sh' }] }] } });
+
+    const r = checkHookSyntaxSmoke({ projectRoot: proj, homeDir: home });
+
+    expect(r.status).toBe('PASS');
+    expect(r.detail).toContain('all 1 hook files pass syntax checks');
+  });
+
+  it('FAILs on conflict markers even when the hook is present and executable', () => {
+    writeHook(proj, '.claude/hooks/conflicted.sh', true, [
+      '#!/bin/bash',
+      '<<<<<<< HEAD',
+      'echo ours',
+      '=======',
+      'echo theirs',
+      '>>>>>>> branch',
+      '',
+    ].join('\n'));
+    writePluginJson(proj, { hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/.claude/hooks/conflicted.sh' }] }] } });
+
+    const r = checkHookSyntaxSmoke({ projectRoot: proj, homeDir: home });
+
+    expect(r.status).toBe('FAIL');
+    expect(r.detail).toContain('conflicted.sh');
+    expect(r.detail).toContain('conflict markers');
+  });
+
+  it('FAILs on shell syntax errors with bounded diagnostic detail', () => {
+    writeHook(proj, '.claude/hooks/bad.sh', true, '#!/bin/bash\necho "unterminated\n');
+    writeSettings(proj, { hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: './.claude/hooks/bad.sh' }] }] } });
+
+    const r = checkHookSyntaxSmoke({ projectRoot: proj, homeDir: home });
+
+    expect(r.status).toBe('FAIL');
+    expect(r.detail).toContain('bad.sh');
+    expect(r.detail).toContain('syntax error');
+    expect(r.detail.length).toBeLessThan(700);
+  });
+});
+
+describe('hook-syntax CLI and SessionStart wrapper', () => {
+  let proj: string, home: string;
+  beforeEach(() => { proj = makeProject(); home = makeHome(); });
+  afterEach(() => { rmSync(proj, { recursive: true, force: true }); rmSync(home, { recursive: true, force: true }); });
+
+  function writeConflictedPluginHook(): void {
+    writeHook(proj, '.claude/hooks/conflicted.sh', true, [
+      '#!/bin/bash',
+      '<<<<<<< HEAD',
+      'echo ours',
+      '=======',
+      'echo theirs',
+      '>>>>>>> branch',
+      '',
+    ].join('\n'));
+    writePluginJson(proj, { hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/.claude/hooks/conflicted.sh' }] }] } });
+  }
+
+  it('hook-syntax --quiet is silent on pass and exits non-zero on corrupt hooks', () => {
+    writeHook(proj, '.claude/hooks/foo.sh', true);
+    writePluginJson(proj, { hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/.claude/hooks/foo.sh' }] }] } });
+
+    const ok = spawnSync('npx', ['--prefix', process.cwd(), 'tsx', join(process.cwd(), 'scripts/kaizen-doctor.ts'), 'hook-syntax', '--quiet'], {
+      cwd: proj,
+      env: { ...process.env, HOME: home },
+      encoding: 'utf8',
+    });
+    expect(ok.status).toBe(0);
+    expect(ok.stdout).toBe('');
+
+    rmSync(join(proj, '.claude/hooks/foo.sh'));
+    writeConflictedPluginHook();
+    const bad = spawnSync('npx', ['--prefix', process.cwd(), 'tsx', join(process.cwd(), 'scripts/kaizen-doctor.ts'), 'hook-syntax', '--quiet'], {
+      cwd: proj,
+      env: { ...process.env, HOME: home },
+      encoding: 'utf8',
+    });
+    expect(bad.status).toBe(1);
+    expect(bad.stdout).toContain('[FAIL] hook-syntax-smoke');
+    expect(bad.stdout).toContain('conflict markers');
+  });
+
+  it('SessionStart snapshot hook surfaces corrupt hooks but exits 0', () => {
+    writeConflictedPluginHook();
+
+    const result = spawnSync('bash', [join(process.cwd(), '.claude/hooks/kaizen-session-snapshot.sh')], {
+      cwd: proj,
+      env: { ...process.env, HOME: home },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('[FAIL] hook-syntax-smoke');
+    expect(result.stdout).toContain('conflict markers');
+  });
+});
+
 describe('checkSingleRegistrationPath (#1063)', () => {
   let proj: string, home: string;
   beforeEach(() => { proj = makeProject(); home = makeHome(); });
@@ -569,6 +675,7 @@ describe('runAllChecks + exitCodeFor', () => {
       'stale-plugin-cache',
       'restart-needed',
       'hook-exec-smoke',
+      'hook-syntax-smoke',
       'codex-readiness',
     ]);
     expect(codexRun).toHaveBeenCalledWith('codex', ['--version']);

--- a/scripts/kaizen-doctor.ts
+++ b/scripts/kaizen-doctor.ts
@@ -103,6 +103,32 @@ function collectHookCommands(cfg: unknown): string[] {
   return out;
 }
 
+interface ReferencedHook {
+  label: string;
+  command: string;
+  path: string;
+}
+
+function collectReferencedHooks(opts: DoctorOpts): ReferencedHook[] {
+  const cfgs: Array<{ path: string; label: string }> = [
+    { path: join(opts.projectRoot, '.claude/settings.json'), label: 'settings.json' },
+    { path: join(opts.projectRoot, '.claude-plugin/plugin.json'), label: 'plugin.json' },
+  ];
+  const hooks: ReferencedHook[] = [];
+  for (const cfg of cfgs) {
+    const data = readJsonValueFile(cfg.path);
+    if (!data) continue;
+    for (const command of collectHookCommands(data)) {
+      hooks.push({
+        label: cfg.label,
+        command,
+        path: resolveHookPath(command, opts.projectRoot),
+      });
+    }
+  }
+  return hooks;
+}
+
 /** Extract the executable path from a hook `command` string.
  *  Handles:
  *    - shell-style quotes: `"path with spaces/foo.sh" arg`  → `path with spaces/foo.sh`
@@ -182,24 +208,14 @@ export function checkPluginDoubleInstall(opts: DoctorOpts): CheckResult {
 
 /** Check 2: every referenced hook command resolves to an existing file. */
 export function checkDanglingHookPaths(opts: DoctorOpts): CheckResult {
-  const cfgs: Array<{ path: string; label: string }> = [
-    { path: join(opts.projectRoot, '.claude/settings.json'), label: 'settings.json' },
-    { path: join(opts.projectRoot, '.claude-plugin/plugin.json'), label: 'plugin.json' },
-  ];
   const missing: string[] = [];
-  let total = 0;
-  for (const cfg of cfgs) {
-    const data = readJsonValueFile(cfg.path);
-    if (!data) continue;
-    for (const c of collectHookCommands(data)) {
-      total++;
-      const hookPath = resolveHookPath(c, opts.projectRoot);
-      if (!existsSync(hookPath)) {
-        missing.push(`${cfg.label}: ${hookPath}`);
-      }
+  const hooks = collectReferencedHooks(opts);
+  for (const hook of hooks) {
+    if (!existsSync(hook.path)) {
+      missing.push(`${hook.label}: ${hook.path}`);
     }
   }
-  if (total === 0) {
+  if (hooks.length === 0) {
     return {
       name: 'dangling-hook-paths',
       status: 'WARN',
@@ -210,13 +226,13 @@ export function checkDanglingHookPaths(opts: DoctorOpts): CheckResult {
     return {
       name: 'dangling-hook-paths',
       status: 'FAIL',
-      detail: `${missing.length}/${total} hook paths missing: ${missing.slice(0, 3).join('; ')}${missing.length > 3 ? ` (+${missing.length - 3} more)` : ''}`,
+      detail: `${missing.length}/${hooks.length} hook paths missing: ${missing.slice(0, 3).join('; ')}${missing.length > 3 ? ` (+${missing.length - 3} more)` : ''}`,
     };
   }
   return {
     name: 'dangling-hook-paths',
     status: 'PASS',
-    detail: `all ${total} hook paths resolve.`,
+    detail: `all ${hooks.length} hook paths resolve.`,
   };
 }
 
@@ -402,24 +418,15 @@ export function checkSingleRegistrationPath(opts: DoctorOpts): CheckResult {
 
 /** Check 5: every referenced hook file is executable. */
 export function checkHookExecSmoke(opts: DoctorOpts): CheckResult {
-  const cfgs = [
-    join(opts.projectRoot, '.claude/settings.json'),
-    join(opts.projectRoot, '.claude-plugin/plugin.json'),
-  ];
   const nonExec: string[] = [];
   let total = 0;
-  for (const cfgPath of cfgs) {
-    const data = readJsonValueFile(cfgPath);
-    if (!data) continue;
-    for (const c of collectHookCommands(data)) {
-      const hookPath = resolveHookPath(c, opts.projectRoot);
-      if (!existsSync(hookPath)) continue;
-      total++;
-      try {
-        accessSync(hookPath, fsConstants.X_OK);
-      } catch {
-        nonExec.push(hookPath);
-      }
+  for (const hook of collectReferencedHooks(opts)) {
+    if (!existsSync(hook.path)) continue;
+    total++;
+    try {
+      accessSync(hook.path, fsConstants.X_OK);
+    } catch {
+      nonExec.push(hook.path);
     }
   }
   if (total === 0) {
@@ -440,6 +447,75 @@ export function checkHookExecSmoke(opts: DoctorOpts): CheckResult {
     name: 'hook-exec-smoke',
     status: 'PASS',
     detail: `all ${total} hook files executable.`,
+  };
+}
+
+function bounded(text: string, max = 240): string {
+  const compact = text.replace(/\s+/g, ' ').trim();
+  if (compact.length <= max) return compact;
+  return compact.slice(0, max - 12) + '...<truncated>';
+}
+
+function hasConflictMarkers(body: string): boolean {
+  return /^(<<<<<<<|=======|>>>>>>>)(?:\s|$)/m.test(body);
+}
+
+/** Check 6: referenced hook files must be parseable shell scripts.
+ *
+ * CI already runs validate-hook-integrity.sh before merge. This doctor check
+ * covers the runtime/install-state version of #371: a local or cached hook can
+ * be present and executable while containing merge markers or broken syntax.
+ */
+export function checkHookSyntaxSmoke(opts: DoctorOpts): CheckResult {
+  const bad: string[] = [];
+  let total = 0;
+  for (const hook of collectReferencedHooks(opts)) {
+    if (!existsSync(hook.path)) continue;
+    total++;
+
+    let body = '';
+    try {
+      body = readFileSync(hook.path, 'utf8');
+    } catch (err) {
+      bad.push(`${hook.path}: unreadable (${bounded(String(err))})`);
+      continue;
+    }
+
+    if (hasConflictMarkers(body)) {
+      bad.push(`${hook.path}: conflict markers present`);
+      continue;
+    }
+
+    try {
+      execFileSync('bash', ['-n', hook.path], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 5_000,
+      });
+    } catch (err) {
+      const e = err as { stderr?: string; message?: string };
+      bad.push(`${hook.path}: syntax error${e.stderr ? ` (${bounded(e.stderr)})` : e.message ? ` (${bounded(e.message)})` : ''}`);
+    }
+  }
+
+  if (total === 0) {
+    return {
+      name: 'hook-syntax-smoke',
+      status: 'PASS',
+      detail: 'no resolvable hook paths to check.',
+    };
+  }
+  if (bad.length > 0) {
+    return {
+      name: 'hook-syntax-smoke',
+      status: 'FAIL',
+      detail: `${bad.length}/${total} hook files failed syntax checks: ${bad.slice(0, 3).join('; ')}${bad.length > 3 ? ` (+${bad.length - 3} more)` : ''}`,
+    };
+  }
+  return {
+    name: 'hook-syntax-smoke',
+    status: 'PASS',
+    detail: `all ${total} hook files pass syntax checks.`,
   };
 }
 
@@ -611,6 +687,7 @@ export function runAllChecks(opts: DoctorOpts): CheckResult[] {
     checkStalePluginCache(opts),
     checkRestartNeeded(opts),
     checkHookExecSmoke(opts),
+    checkHookSyntaxSmoke(opts),
     checkCodexReadiness(opts.codexReadiness),
   ];
 }
@@ -648,6 +725,16 @@ if (isMain) {
   if (argv[0] === 'snapshot') {
     try { writeSessionSnapshot(opts); } catch {}
     process.exit(0);
+  }
+
+  // Narrow SessionStart/doctor path for #371. Avoids noisy unrelated WARNs
+  // (for example Codex readiness) while still surfacing corrupt hook files.
+  if (argv[0] === 'hook-syntax') {
+    const result = checkHookSyntaxSmoke(opts);
+    if (!(argv.includes('--quiet') && result.status === 'PASS')) {
+      process.stdout.write(formatResult(result) + '\n');
+    }
+    process.exit(result.status === 'FAIL' ? 1 : 0);
   }
 
   const json = argv.includes('--json');


### PR DESCRIPTION
## Story

Once upon a time, kaizen already had CI protection for hook syntax through `validate-hook-integrity.sh`. Every day, that kept bad hook files from merging when CI ran normally.

One day, #371 described the runtime version of the same failure: an active hook file gained merge conflict markers, Bash/PostToolUse hooks started failing, and the session had no in-band way to diagnose the corrupt hook before the gate flow deadlocked.

Because of that, this PR moves the #371 condition into `kaizen-doctor` itself. The doctor now reuses the existing hook command resolver, scans referenced hook files for explicit conflict markers, runs `bash -n`, and reports a bounded `hook-syntax-smoke` diagnostic.

Because of that, the SessionStart snapshot hook now runs `kaizen-doctor hook-syntax --quiet` after writing its snapshot. Normal startup stays silent, but a corrupt hook file is visible before the next normal workflow depends on it, and the wrapper still exits 0.

Until finally, the original synthetic repro changed from “hook path resolves and executable bit passes” to `[FAIL] hook-syntax-smoke ... conflict markers present`, while focused doctor tests, the fast check, full Vitest, and the hook suite all pass.

Fixes #371

## Architecture

```text
.claude-plugin/plugin.json / .claude/settings.json
  -> collect referenced command hooks
  -> resolveHookPath(command, projectRoot)
  -> checkHookSyntaxSmoke
       -> conflict marker scan
       -> bash -n syntax check
  -> kaizen-doctor --json / --quiet / hook-syntax --quiet
  -> SessionStart kaizen-session-snapshot.sh (fail-open)
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add the check to `kaizen-doctor` | Runtime/install-state diagnostics belong next to existing hook setup checks | Doctor has one more check, but it reuses existing path resolution |
| Add `hook-syntax --quiet` | SessionStart needs the #371 check without noisy unrelated doctor WARNs | New narrow CLI subcommand |
| Detect markers before `bash -n` | Produces an actionable “conflict markers present” reason | Slightly more logic than relying on Bash stderr |
| Do not quarantine in this PR | Loaded hook registries may still point at renamed files; repair needs a broader rollback contract | This PR detects and notifies, not full self-healing |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/kaizen-doctor.ts` | Adds shared referenced-hook collection, `hook-syntax-smoke`, and `hook-syntax` CLI mode |
| `scripts/kaizen-doctor.test.ts` | Adds valid/conflicted/syntax-error tests plus CLI and SessionStart smoke coverage |
| `.claude/hooks/kaizen-session-snapshot.sh` | Runs the quiet hook-syntax check at SessionStart and remains fail-open |

## Impact (goal -> before/after -> match)

- Goal (#371): corrupted active hook files should not stay invisible until they deadlock a session.
- Acceptance signal: an executable referenced hook containing conflict markers is reported by runtime doctor/startup diagnostics.
- BEFORE: temp-project `kaizen-doctor --json` saw the conflicted hook as present and executable; no syntax result existed.
- AFTER: the same temp-project probe returns `[FAIL] hook-syntax-smoke — 1/1 hook files failed syntax checks: ... conflict markers present`.
- Delta: #371 moved from CI-only prevention to runtime doctor/SessionStart detection, with bounded diagnostic detail and fail-open startup behavior.
- Goal met?: yes for detect/notify; auto-quarantine remains broader self-healing scope.
- Residual scan: existing CI `validate-hook-integrity.sh` remains the pre-merge guard; no second hook command parser was added.

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status | Evidence |
|---|---|---|---|---|
| 1 | Valid referenced hook remains PASS | Unit | Tested | `scripts/kaizen-doctor.test.ts` |
| 2 | Conflict-marker hook is detected even when executable | Unit | Tested | `scripts/kaizen-doctor.test.ts` |
| 3 | Plain shell syntax error is detected via `bash -n` | Unit | Tested | `scripts/kaizen-doctor.test.ts` |
| 4 | `kaizen-doctor hook-syntax --quiet` exposes the diagnostic | Integration | Tested | CLI smoke in `scripts/kaizen-doctor.test.ts` + manual temp-project probe |
| 5 | SessionStart-visible integrity path exits 0 while surfacing diagnostics | System | Tested | wrapper smoke in `scripts/kaizen-doctor.test.ts` |
| 6 | Real repo hook integrity and hook suite remain green | System | Tested | `npm run test:hooks` |

## Validation

- [x] RED first: focused doctor tests failed because `checkHookSyntaxSmoke` did not exist and `runAllChecks` had no syntax check.
- [x] `npx vitest run scripts/kaizen-doctor.test.ts --reporter=verbose` — 50 passed.
- [x] `npm run check:fast` — typecheck + changed tests passed.
- [x] `npm test` — 170 files passed, 2 skipped; 4088 tests passed, 14 skipped.
- [x] `npm run test:hooks` — 435/435 passed.
- [x] Manual temp-project after-proof: conflicted executable hook now returns `[FAIL] hook-syntax-smoke ... conflict markers present`.

## Known Limitations

This does not auto-quarantine or rewrite corrupted hook files. The safer scoped fix is runtime detection and clear notification; automated repair belongs with the broader self-healing infrastructure work.