### PR TITLE
test: remove external work from pr-kaizen-clear seams

### DIFF
--- a/src/hooks/pr-kaizen-clear-seams.test.ts
+++ b/src/hooks/pr-kaizen-clear-seams.test.ts
@@ -20,6 +20,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { processHookInput } from './pr-kaizen-clear.js';
 import { listStateFilesAnyBranch } from './state-utils.js';
 
+type HookOptions = NonNullable<Parameters<typeof processHookInput>[1]>;
+
 let testStateDir: string;
 let testAuditDir: string;
 
@@ -59,7 +61,26 @@ function gateStatus(): string | null {
   return m ? m[1] : null;
 }
 
+function seamHookOptions(overrides: HookOptions = {}): HookOptions {
+  return {
+    stateDir: testStateDir,
+    postComment: () => {},
+    getPrFiles: () => [],
+    gh: () => '',
+    verifyRef: () => 'exists',
+    ...overrides,
+  };
+}
+
 // ── KAIZEN_UNFINISHED seam ────────────────────────────────────────────
+
+describe('test runtime invariant', () => {
+  it('injects local hook boundaries for in-process seam tests', () => {
+    expect(seamHookOptions.toString()).toContain('postComment');
+    expect(seamHookOptions.toString()).toContain('getPrFiles');
+    expect(seamHookOptions.toString()).toContain('verifyRef');
+  });
+});
 
 describe('KAIZEN_UNFINISHED seam: grep pattern false-positive prevention', () => {
   it('INVARIANT: grep command containing KAIZEN_UNFINISHED: as search term does NOT trigger gate clearing', () => {
@@ -71,7 +92,7 @@ describe('KAIZEN_UNFINISHED seam: grep pattern false-positive prevention', () =>
         tool_input: { command: 'grep "KAIZEN_UNFINISHED:" logs.txt' },
         tool_response: { stdout: '', stderr: '', exit_code: '0' },
       },
-      { stateDir: testStateDir },
+      seamHookOptions(),
     );
     // Must NOT clear the gate — it's just a grep search, not a declaration
     expect(result).toBeNull();
@@ -87,7 +108,7 @@ describe('KAIZEN_UNFINISHED seam: grep pattern false-positive prevention', () =>
         tool_input: { command: 'git log --oneline | grep KAIZEN_UNFINISHED:' },
         tool_response: { stdout: '', stderr: '', exit_code: '0' },
       },
-      { stateDir: testStateDir },
+      seamHookOptions(),
     );
     expect(result).toBeNull();
     expect(gateStatus()).toBe('needs_pr_kaizen');
@@ -105,7 +126,7 @@ describe('KAIZEN_UNFINISHED seam: grep pattern false-positive prevention', () =>
           exit_code: '0',
         },
       },
-      { stateDir: testStateDir },
+      seamHookOptions(),
     );
     // Must clear the gate and return a message
     expect(result).not.toBeNull();
@@ -146,7 +167,7 @@ describe('KAIZEN_IMPEDIMENTS seam: piped command extraction', () => {
           exit_code: '0',
         },
       },
-      { stateDir: testStateDir },
+      seamHookOptions(),
     );
     // Declaration in stdout must succeed regardless of how the command was structured
     expect(result).not.toBeNull();
@@ -174,7 +195,7 @@ describe('KAIZEN_IMPEDIMENTS seam: non-array JSON', () => {
           exit_code: '0',
         },
       },
-      { stateDir: testStateDir },
+      seamHookOptions(),
     );
     // Must return an explicit error, not null (silent failure)
     expect(result).not.toBeNull();
@@ -197,7 +218,7 @@ describe('KAIZEN_IMPEDIMENTS seam: non-array JSON', () => {
           exit_code: '0',
         },
       },
-      { stateDir: testStateDir },
+      seamHookOptions(),
     );
     expect(result).not.toBeNull();
     expect(result).toContain('Invalid JSON');

--- a/src/hooks/pr-kaizen-clear.test.ts
+++ b/src/hooks/pr-kaizen-clear.test.ts
@@ -33,10 +33,11 @@
  * [x] Gate cleared with specific PR URL targeting (kaizen #309)
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { buildTypeScriptSubprocess } from '../../scripts/test-typescript-runner.js';
 import {
   classifyReflectionQuality,
   detectFixableFiledImpediments,
@@ -51,6 +52,9 @@ import {
 let testStateDir: string;
 let testAuditDir: string;
 const HOOK_PATH = path.resolve(__dirname, 'pr-kaizen-clear.ts');
+const HOOK_RUNNER = buildTypeScriptSubprocess(HOOK_PATH, {
+  startDir: __dirname,
+});
 const HOOK_SOURCE = fs.readFileSync(HOOK_PATH, 'utf-8');
 
 beforeEach(() => {
@@ -97,18 +101,21 @@ describe('test runtime invariant', () => {
   it('keeps repeated hook behavior cases on the in-process seam', () => {
     expect(runHook.toString()).toContain('processHookInput');
     expect(runHook.toString()).not.toContain('execSync');
-    expect(runHookSubprocess.toString()).toContain('execSync');
+    expect(runHookSubprocess.toString()).toContain('HOOK_RUNNER');
+    expect(runHookSubprocess.toString()).toContain('execFileSync');
+    expect(runHookSubprocess.toString()).not.toContain('npx tsx');
   });
 });
 
 function runHookSubprocess(input: object): string {
-  const json = JSON.stringify(input);
   try {
-    return execSync(
-      `echo '${json.replace(/'/g, "'\\''")}' | npx tsx "${HOOK_PATH}"`,
+    return execFileSync(
+      HOOK_RUNNER.command,
+      HOOK_RUNNER.args,
       {
         encoding: 'utf-8',
         env: { ...process.env, STATE_DIR: testStateDir, AUDIT_DIR: testAuditDir },
+        input: JSON.stringify(input),
         stdio: ['pipe', 'pipe', 'pipe'],
         timeout: 15000,
       },


### PR DESCRIPTION
## Summary

Closes #1616. Part of #1532.

This removes the remaining accidental external work from `pr-kaizen-clear` seam tests while preserving one real subprocess smoke boundary:

- `src/hooks/pr-kaizen-clear-seams.test.ts` now uses `seamHookOptions()` for in-process `processHookInput()` coverage, injecting no-op/local `postComment`, `getPrFiles`, `gh`, and `verifyRef` boundaries.
- `src/hooks/pr-kaizen-clear.test.ts` keeps the subprocess smoke, but routes it through the shared `buildTypeScriptSubprocess()` Bun-first runner instead of shelling through `echo ... | npx tsx`.
- Added regression invariants so repeated hook behavior stays in-process and seam tests keep explicit local boundaries.

## Proof

Baseline on `main`:

```text
/usr/bin/time -p npx vitest run src/hooks/pr-kaizen-clear.test.ts src/hooks/pr-kaizen-clear-seams.test.ts --reporter=verbose --coverage.enabled=false
Test Files 2 passed
Tests 109 passed
Duration 3.90s
real 4.63

slow cases:
- pr-kaizen-clear-seams piped KAIZEN_IMPEDIMENTS seam: 2177ms
- pr-kaizen-clear subprocess smoke: 2260ms
```

After this PR:

```text
/usr/bin/time -p npx vitest run src/hooks/pr-kaizen-clear.test.ts src/hooks/pr-kaizen-clear-seams.test.ts --reporter=verbose --coverage.enabled=false
Test Files 2 passed
Tests 110 passed
Duration 3.66s
real 4.34

slow cases:
- pr-kaizen-clear-seams piped KAIZEN_IMPEDIMENTS seam: 21ms
- pr-kaizen-clear subprocess smoke: 1790ms
```

The key categorical fix is the seam case: it no longer calls production external defaults after clearing a gate.

## Verification

```text
npm run typecheck
npm run check:fast
/usr/bin/time -p npx vitest run src/hooks/pr-kaizen-clear.test.ts src/hooks/pr-kaizen-clear-seams.test.ts --reporter=verbose --coverage.enabled=false
git diff --check
```
