### PR TITLE
fix(auto-dent): anchor providers to assigned worktree

### DIFF
--- a/scripts/auto-dent-provider-workspace.ts
+++ b/scripts/auto-dent-provider-workspace.ts
@@ -1,0 +1,176 @@
+import { execFileSync } from 'child_process';
+import { isAbsolute, join, relative, resolve } from 'path';
+
+import { parseWorktreePorcelain, type WorktreeEntry } from '../src/hooks/worktree-integrity.js';
+import { makeGitRun, readBoundIssue } from '../src/issue-binding.js';
+
+export interface ProviderWorkspaceInput {
+  repoRoot: string;
+  invocationRoot: string;
+  assignedIssue?: unknown;
+  knownCases?: string[];
+}
+
+export type ProviderWorkspaceResolution =
+  | {
+      ok: true;
+      providerRoot: string;
+      issue: number | null;
+      source: 'unassigned' | 'invocation-root' | 'known-case' | 'worktree-list';
+    }
+  | {
+      ok: false;
+      reason: 'binding-mismatch' | 'missing-binding' | 'missing-worktree';
+      issue: number;
+      providerRoot?: string;
+      actualIssue?: number | null;
+      detail: string;
+    };
+
+export interface ProviderWorkspaceDeps {
+  listWorktrees?: (repoRoot: string) => WorktreeEntry[];
+  readBoundIssue?: (root: string) => number | null;
+}
+
+export function issueNumberFromRef(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+  if (typeof value !== 'string') return null;
+  const match = value.match(/(?:issues\/|#)?(\d+)\b/);
+  return match ? Number(match[1]) : null;
+}
+
+function sameRoot(a: string, b: string): boolean {
+  return resolve(a) === resolve(b);
+}
+
+function defaultListWorktrees(repoRoot: string): WorktreeEntry[] {
+  const output = execFileSync(
+    'git',
+    ['-C', repoRoot, 'worktree', 'list', '--porcelain'],
+    { encoding: 'utf8' },
+  );
+  return parseWorktreePorcelain(output);
+}
+
+function defaultReadBoundIssue(root: string): number | null {
+  return readBoundIssue(makeGitRun(root));
+}
+
+function isWithin(parent: string, child: string): boolean {
+  const rel = relative(resolve(parent), resolve(child));
+  return rel === '' || (rel.length > 0 && !rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function caseRoot(repoRoot: string, nameOrPath: string): string | null {
+  const worktreesDir = join(repoRoot, '.claude', 'worktrees');
+  const root = nameOrPath.startsWith('/')
+    ? nameOrPath
+    : nameOrPath.startsWith('.claude/worktrees/')
+      ? join(repoRoot, nameOrPath)
+      : join(worktreesDir, nameOrPath);
+  return isWithin(worktreesDir, root) ? root : null;
+}
+
+function worktreeLooksAssigned(entry: WorktreeEntry, issue: number): boolean {
+  const issueToken = new RegExp(`(^|[-/])k${issue}($|[-/])`);
+  return Boolean(issueToken.test(entry.branch ?? '') || issueToken.test(entry.path));
+}
+
+function validateAssignedRoot(
+  root: string,
+  issue: number,
+  source: 'invocation-root' | 'known-case' | 'worktree-list',
+  readIssue: (root: string) => number | null,
+): ProviderWorkspaceResolution {
+  const actualIssue = readIssue(root);
+  if (actualIssue == null) {
+    return {
+      ok: false,
+      reason: 'missing-binding',
+      issue,
+      providerRoot: root,
+      actualIssue,
+      detail: `provider workspace ${root} has no kaizen.issue binding for assigned issue #${issue}`,
+    };
+  }
+  if (actualIssue !== issue) {
+    return {
+      ok: false,
+      reason: 'binding-mismatch',
+      issue,
+      providerRoot: root,
+      actualIssue,
+      detail: `provider workspace ${root} is bound to #${actualIssue}, not assigned issue #${issue}`,
+    };
+  }
+  return { ok: true, providerRoot: root, issue, source };
+}
+
+export function resolveProviderWorkspaceRoot(
+  input: ProviderWorkspaceInput,
+  deps: ProviderWorkspaceDeps = {},
+): ProviderWorkspaceResolution {
+  const issue = issueNumberFromRef(input.assignedIssue);
+  const repoRoot = resolve(input.repoRoot);
+  const invocationRoot = resolve(input.invocationRoot || input.repoRoot);
+  const readIssue = deps.readBoundIssue ?? defaultReadBoundIssue;
+  const listWorktrees = deps.listWorktrees ?? defaultListWorktrees;
+
+  if (issue == null) {
+    return {
+      ok: true,
+      providerRoot: repoRoot,
+      issue: null,
+      source: 'unassigned',
+    };
+  }
+
+  if (!sameRoot(invocationRoot, repoRoot)) {
+    return validateAssignedRoot(invocationRoot, issue, 'invocation-root', readIssue);
+  }
+
+  for (const knownCase of input.knownCases ?? []) {
+    if (!knownCase) continue;
+    const knownRoot = caseRoot(repoRoot, knownCase);
+    if (!knownRoot) continue;
+    const root = resolve(knownRoot);
+    if (sameRoot(root, repoRoot)) continue;
+    const resolved = validateAssignedRoot(root, issue, 'known-case', readIssue);
+    if (resolved.ok || resolved.reason !== 'missing-binding') return resolved;
+  }
+
+  let sawAssignedWorktree = false;
+  let firstAssignedFailure: ProviderWorkspaceResolution | undefined;
+  for (const entry of listWorktrees(repoRoot)) {
+    const root = resolve(entry.path);
+    if (sameRoot(root, repoRoot)) continue;
+    if (!worktreeLooksAssigned(entry, issue)) continue;
+
+    sawAssignedWorktree = true;
+    const resolved = validateAssignedRoot(root, issue, 'worktree-list', readIssue);
+    if (resolved.ok) return resolved;
+    firstAssignedFailure = firstAssignedFailure ?? resolved;
+  }
+
+  if (sawAssignedWorktree && firstAssignedFailure) return firstAssignedFailure;
+
+  return {
+    ok: false,
+    reason: 'missing-worktree',
+    issue,
+    detail: `no non-main case worktree found for assigned issue #${issue}`,
+  };
+}
+
+export function formatProviderWorkspaceResolution(resolution: ProviderWorkspaceResolution): string {
+  if (resolution.ok) {
+    return `provider_workspace=${resolution.providerRoot} issue=${resolution.issue ?? 'unassigned'} source=${resolution.source}`;
+  }
+  return [
+    `provider_workspace_error=${resolution.reason}`,
+    `issue=#${resolution.issue}`,
+    resolution.providerRoot ? `provider_workspace=${resolution.providerRoot}` : '',
+    resolution.actualIssue != null ? `actual_issue=#${resolution.actualIssue}` : '',
+    resolution.detail,
+  ].filter(Boolean).join(' ');
+}

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -59,6 +59,9 @@ import {
   shouldRunCodexProvider,
   attachRunTranscripts,
 } from './auto-dent-run.js';
+import {
+  resolveProviderWorkspaceRoot,
+} from './auto-dent-provider-workspace.js';
 import { deriveRunTestHealth } from './auto-dent-test-health.js';
 import * as github from './auto-dent-github.js';
 import { makeBatchState, makeRunResult } from './auto-dent-test-utils.js';
@@ -4015,6 +4018,172 @@ describe('runOnce stream-json line parsing', () => {
     expect(runCodexSection).toContain('normalizeCodexEventToStreamMessages');
     expect(runCodexSection).toContain('processStreamMessage(streamMessage');
     expect(runCodexSection).not.toContain('extractArtifacts([parsed.text, parsed.finalText]');
+  });
+});
+
+describe('provider workspace contract', () => {
+  const repoRoot = '/repo/main';
+  const caseRoot = '/repo/.claude/worktrees/260629-0120-k1164-cross-pr-dry-sweep';
+
+  it('uses the invocation case worktree when its binding matches the assigned issue', () => {
+    const resolved = resolveProviderWorkspaceRoot({
+      repoRoot,
+      invocationRoot: caseRoot,
+      assignedIssue: '#1164',
+    }, {
+      listWorktrees: () => [],
+      readBoundIssue: (root) => root === caseRoot ? 1164 : 1586,
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      providerRoot: caseRoot,
+      issue: 1164,
+      source: 'invocation-root',
+    });
+  });
+
+  it('fails closed when the invocation worktree binding mismatches the assigned issue', () => {
+    const resolved = resolveProviderWorkspaceRoot({
+      repoRoot,
+      invocationRoot: caseRoot,
+      assignedIssue: '#1164',
+    }, {
+      listWorktrees: () => [{ path: caseRoot, branch: 'case/260629-0120-k1164-cross-pr-dry-sweep' }],
+      readBoundIssue: () => 1586,
+    });
+
+    expect(resolved).toMatchObject({
+      ok: false,
+      issue: 1164,
+      reason: 'binding-mismatch',
+      providerRoot: caseRoot,
+      actualIssue: 1586,
+    });
+  });
+
+  it('selects an existing matching case worktree instead of the main checkout', () => {
+    const resolved = resolveProviderWorkspaceRoot({
+      repoRoot,
+      invocationRoot: repoRoot,
+      assignedIssue: 'https://github.com/Garsson-io/kaizen/issues/1164',
+    }, {
+      listWorktrees: () => [
+        { path: repoRoot, branch: 'main' },
+        { path: caseRoot, branch: 'case/260629-0120-k1164-cross-pr-dry-sweep' },
+      ],
+      readBoundIssue: (root) => root === caseRoot ? 1164 : 1586,
+    });
+
+    expect(resolved).toMatchObject({
+      ok: true,
+      providerRoot: caseRoot,
+      source: 'worktree-list',
+      issue: 1164,
+    });
+  });
+
+  it('does not trust known case paths outside the managed worktree directory', () => {
+    const externalRoot = '/tmp/not-a-kaizen-case';
+    const resolved = resolveProviderWorkspaceRoot({
+      repoRoot,
+      invocationRoot: repoRoot,
+      assignedIssue: '#1164',
+      knownCases: [externalRoot],
+    }, {
+      listWorktrees: () => [{ path: repoRoot, branch: 'main' }],
+      readBoundIssue: (root) => root === externalRoot ? 1164 : 1586,
+    });
+
+    expect(resolved).toMatchObject({
+      ok: false,
+      reason: 'missing-worktree',
+      issue: 1164,
+    });
+  });
+
+  it('fails closed when an assigned issue has no matching case worktree', () => {
+    const resolved = resolveProviderWorkspaceRoot({
+      repoRoot,
+      invocationRoot: repoRoot,
+      assignedIssue: '#1164',
+    }, {
+      listWorktrees: () => [{ path: repoRoot, branch: 'main' }],
+      readBoundIssue: () => 1586,
+    });
+
+    expect(resolved).toMatchObject({
+      ok: false,
+      reason: 'missing-worktree',
+      issue: 1164,
+    });
+  });
+
+  it('does not select another worktree whose issue token only shares a prefix', () => {
+    const resolved = resolveProviderWorkspaceRoot({
+      repoRoot,
+      invocationRoot: repoRoot,
+      assignedIssue: '#1164',
+    }, {
+      listWorktrees: () => [
+        { path: repoRoot, branch: 'main' },
+        { path: '/repo/.claude/worktrees/260629-k11640-prefix-collision', branch: 'case/260629-k11640-prefix-collision' },
+      ],
+      readBoundIssue: () => 11640,
+    });
+
+    expect(resolved).toMatchObject({
+      ok: false,
+      reason: 'missing-worktree',
+      issue: 1164,
+    });
+  });
+
+  it('leaves unassigned synthetic runs on the harness root', () => {
+    const resolved = resolveProviderWorkspaceRoot({
+      repoRoot,
+      invocationRoot: repoRoot,
+      assignedIssue: undefined,
+    }, {
+      listWorktrees: () => [],
+      readBoundIssue: () => null,
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      providerRoot: repoRoot,
+      issue: null,
+      source: 'unassigned',
+    });
+  });
+
+  it('threads the resolved provider root through Codex argv and cwd', () => {
+    const source = AUTO_DENT_RUN_SOURCE;
+    const runCodexStart = source.indexOf('async function runCodex');
+    const runCodexEnd = source.indexOf('async function runClaude', runCodexStart);
+    const runCodexSection = source.slice(runCodexStart, runCodexEnd);
+
+    expect(runCodexSection).toContain('providerRoot: string');
+    expect(runCodexSection).toContain('buildCodexExecArgs(input.providerRoot)');
+    expect(runCodexSection).toContain('cwd: input.providerRoot');
+    expect(runCodexSection).not.toContain('buildCodexExecArgs(input.repoRoot)');
+  });
+
+  it('resolves and validates the provider root before either provider can spawn', () => {
+    const source = AUTO_DENT_RUN_SOURCE;
+    const runClaudeStart = source.indexOf('async function runClaude');
+    const runClaudeEnd = source.indexOf('// Execute one run', runClaudeStart);
+    const runClaudeSection = source.slice(runClaudeStart, runClaudeEnd);
+    const resolverIndex = runClaudeSection.indexOf('resolveProviderWorkspaceRoot');
+    const codexIndex = runClaudeSection.indexOf('runCodex({');
+    const claudeSpawnIndex = runClaudeSection.indexOf("spawn('claude'");
+
+    expect(resolverIndex).toBeGreaterThanOrEqual(0);
+    expect(runClaudeSection).toContain('providerWorkspaceFailureResult');
+    expect(resolverIndex).toBeLessThan(codexIndex);
+    expect(resolverIndex).toBeLessThan(claudeSpawnIndex);
+    expect(runClaudeSection).toContain('providerRoot: providerWorkspace.providerRoot');
+    expect(runClaudeSection).toContain('cwd: providerWorkspace.providerRoot');
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -211,6 +211,11 @@ import { createDefaultGitExec } from '../src/hooks/lib/git-state.js';
 import { runStalePrTriageMaintenance } from './stale-pr-triage.js';
 import { runBacklogHealthMaintenance } from './backlog-health.js';
 import { gh as ghArgs } from '../src/lib/gh-exec.js';
+import {
+  formatProviderWorkspaceResolution,
+  resolveProviderWorkspaceRoot,
+  type ProviderWorkspaceResolution,
+} from './auto-dent-provider-workspace.js';
 
 // Types
 
@@ -810,6 +815,17 @@ function getRepoRoot(): string {
     return gitCommonDir.replace(/\/\.git$/, '');
   } catch {
     return resolve(dirname(new URL(import.meta.url).pathname), '..');
+  }
+}
+
+function getInvocationWorktreeRoot(): string {
+  try {
+    return execSync(
+      'git rev-parse --path-format=absolute --show-toplevel',
+      { encoding: 'utf8' },
+    ).trim();
+  } catch {
+    return getRepoRoot();
   }
 }
 
@@ -2172,12 +2188,37 @@ interface ProviderRunResult {
   promptMeta: PromptMetadata;
 }
 
+function providerWorkspaceFailureResult(
+  input: {
+    logFile: string;
+    result: RunResult;
+    mode: string;
+    modeReason: string;
+    promptMeta: PromptMetadata;
+    workspace: Exclude<ProviderWorkspaceResolution, { ok: true }>;
+  },
+): ProviderRunResult {
+  input.result.stopRequested = true;
+  appendFileSync(
+    input.logFile,
+    `\n[provider-workspace] ${formatProviderWorkspaceResolution(input.workspace)}\n`,
+  );
+  return {
+    exitCode: 1,
+    duration: 0,
+    result: input.result,
+    mode: input.mode,
+    modeReason: input.modeReason,
+    promptMeta: input.promptMeta,
+  };
+}
+
 async function runCodex(
   input: {
     state: BatchState;
     runNum: number;
     logFile: string;
-    repoRoot: string;
+    providerRoot: string;
     stateFile: string;
     prompt: string;
     promptMeta: PromptMetadata;
@@ -2200,6 +2241,7 @@ async function runCodex(
 
   appendFileSync(input.logFile, `[provider] codex subscription-cli\n`);
   appendFileSync(input.logFile, `[provider] version=${version}\n`);
+  appendFileSync(input.logFile, `[provider] workspace=${input.providerRoot}\n`);
   appendFileSync(input.logFile, `[provider] raw_jsonl=${rawFile}\n`);
   writeFileSync(rawFile, '');
 
@@ -2208,8 +2250,8 @@ async function runCodex(
     let raw = '';
     const progressCheckpoint = { signature: runProgressCheckpointSignature(input.result) };
     const ctx: StreamContext = { provider: 'codex' };
-    const child = spawn('codex', buildCodexExecArgs(input.repoRoot), {
-      cwd: input.repoRoot,
+    const child = spawn('codex', buildCodexExecArgs(input.providerRoot), {
+      cwd: input.providerRoot,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
@@ -2293,6 +2335,7 @@ async function runClaude(
   runNum: number,
   logFile: string,
   repoRoot: string,
+  invocationRoot: string,
   stateFile: string,
 ): Promise<{ exitCode: number; duration: number; result: RunResult; mode: string; modeReason: string; bandit?: BanditResult; promptMeta: PromptMetadata }> {
   const result: RunResult = {
@@ -2363,13 +2406,35 @@ async function runClaude(
   const candidateManifestPath = modeSelection.mode === 'explore'
     ? candidateTaskManifestPath(logDir, runNum)
     : undefined;
+  const providerWorkspace = resolveProviderWorkspaceRoot({
+    repoRoot,
+    invocationRoot,
+    assignedIssue: promptMeta.claimedPlanIssue,
+    knownCases: [
+      ...state.cases,
+      state.last_case,
+      state.last_worktree,
+      ...result.cases,
+    ].filter(Boolean),
+  });
+  appendFileSync(logFile, `[provider-workspace] ${formatProviderWorkspaceResolution(providerWorkspace)}\n`);
+  if (!providerWorkspace.ok) {
+    return providerWorkspaceFailureResult({
+      logFile,
+      result,
+      mode: modeSelection.mode,
+      modeReason: modeSelection.reason,
+      promptMeta,
+      workspace: providerWorkspace,
+    });
+  }
 
   if (shouldRunCodexProvider(state)) {
     const codexResult = await runCodex({
       state,
       runNum,
       logFile,
-      repoRoot,
+      providerRoot: providerWorkspace.providerRoot,
       stateFile,
       prompt,
       promptMeta,
@@ -2420,9 +2485,15 @@ async function runClaude(
     const progressCheckpoint = { signature: runProgressCheckpointSignature(result) };
 
     const child = spawn('claude', args, {
-      cwd: repoRoot,
+      cwd: providerWorkspace.providerRoot,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, KAIZEN_RUN_TAG: agentRunTag, KAIZEN_RUN_ID: agentRunId },
+      env: {
+        ...process.env,
+        KAIZEN_RUN_TAG: agentRunTag,
+        KAIZEN_RUN_ID: agentRunId,
+        KAIZEN_PROVIDER_WORKSPACE: providerWorkspace.providerRoot,
+        KAIZEN_PROVIDER_ISSUE: providerWorkspace.issue != null ? String(providerWorkspace.issue) : '',
+      },
     });
 
     const cleanup = (...timers: (ReturnType<typeof setInterval> | ReturnType<typeof setTimeout> | undefined)[]) => {
@@ -2896,6 +2967,7 @@ async function main(): Promise<void> {
   }
 
   const repoRoot = getRepoRoot();
+  const invocationRoot = getInvocationWorktreeRoot();
   const state = readState(stateFile);
   const logDir = dirname(stateFile);
   const runNum = state.run + 1;
@@ -2930,6 +3002,7 @@ async function main(): Promise<void> {
       runNum,
       logFile,
       repoRoot,
+      invocationRoot,
       stateFile,
     );
   } finally {


### PR DESCRIPTION
## Story

Once upon a time, auto-dent kept durable batch state and logs in the harness checkout while individual issue work happened in case worktrees. Every day, that looked fine because prompts often included absolute case paths, so edits could still land in the intended worktree.

One day, the `immense-cow` run for #1164 exposed the boundary leak: the run had a fresh case worktree bound to #1164, but the Codex subprocess was launched with `--cd /home/aviad/projects/kaizen`, whose `kaizen.issue` belonged to another issue. That meant provider-relative operations, hooks, and git config could silently use the wrong checkout.

Because of that, this PR separates the harness root from the provider workspace root. The harness still uses the common repo root for state/log/finalization, but provider launch now resolves an assigned issue worktree, validates its `kaizen.issue`, and fails before spawning if the binding is missing or mismatched.

Because of that, Codex and Claude now share the same validated provider root. Codex receives it in both argv (`--cd`) and spawn `cwd`; Claude receives it as spawn `cwd` plus explicit provider workspace env for traceability.

Until finally, a temp-git proof reproduces the incident shape: main is bound to #1586, the case worktree is bound to #1164, and the resolver selects the case root from main, accepts the case invocation, and rejects the wrong assignment before provider launch.

And ever since, planned auto-dent issue runs have a fail-closed subprocess boundary instead of relying on prompt text to keep providers in the right checkout.

Fixes Garsson-io/kaizen#1592
Related: Garsson-io/kaizen#254

## Architecture

```text
main/common repo root
  ├─ state.json, logs, progress issue, finalizer state
  └─ auto-dent-run.ts
        ├─ getRepoRoot()                 -> harness root
        ├─ getInvocationWorktreeRoot()   -> actual launch worktree
        ├─ resolveProviderWorkspaceRoot()
        │     ├─ assigned issue? no -> harness root for synthetic/unassigned modes
        │     ├─ invocation case binding matches -> provider root
        │     ├─ matching worktree-list case binding matches -> provider root
        │     └─ missing/mismatch -> fail before spawn
        └─ spawn provider with validated provider root
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep `getRepoRoot()` as the harness root | State, logs, progress issue, rescue, and final aggregation already belong to the durable batch root | Requires a second explicit provider-root concept |
| Add `scripts/auto-dent-provider-workspace.ts` | Keeps git worktree parsing and binding validation testable without spawning providers | One new small helper module |
| Fail assigned runs on missing/mismatched case binding | Wrong-checkout edits are worse than an early deterministic stop | A planned issue run needs a real bound case worktree before provider launch |
| Leave unassigned/synthetic runs on harness root | Avoids over-correcting generic auto-dent modes that do not have an assigned issue | The strict worktree contract applies only after assignment |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-provider-workspace.ts` | Resolves provider root from assigned issue, invocation root, known cases, and `git worktree list`; validates `kaizen.issue` through existing binding primitives |
| `scripts/auto-dent-run.ts` | Threads validated provider root into Codex argv/cwd and Claude cwd/env; returns a fail-closed provider result before spawn on mismatch |
| `scripts/auto-dent-run.test.ts` | Covers matching invocation worktree, mismatch failure, worktree-list selection, missing worktree failure, prefix-token safety, unassigned modes, and provider wiring source checks |

## Impact (goal -> before/after -> match)

- Goal (#1592): Auto-dent provider subprocess cwd and git issue binding follow the assigned issue worktree.
- Acceptance signal: Synthetic assigned issue/case root produces provider args/cwd from the case worktree; mismatch fails before spawning.
- BEFORE: `runCodex()` rendered `buildCodexExecArgs(input.repoRoot)` and spawned with `cwd: input.repoRoot`, so the incident shape produced `--cd /home/aviad/projects/kaizen` while the intended case was `.claude/worktrees/260629-0120-k1164-cross-pr-dry-sweep`.
- AFTER: `runCodex()` renders `buildCodexExecArgs(input.providerRoot)` and spawns with `cwd: input.providerRoot`; Claude spawn uses `cwd: providerWorkspace.providerRoot`; resolver rejects missing/mismatched bindings before either provider can spawn.
- Delta: Provider launch root changed from implicit common repo root to explicit validated provider workspace root; wrong issue binding now returns exit code 1 before subprocess launch.
- Goal met?: yes.
- Residual scan: no remaining `buildCodexExecArgs(input.repoRoot)`, `cwd: input.repoRoot`, or `cwd: repoRoot` provider launch paths in `scripts/auto-dent-run.ts`; adjacent provider runtime switching remains tracked by open PR #1588 and is not closed here.

## Test Plan (Behaviors × Levels)

| # | Behavior | Level | Coverage |
|---|---|---|---|
| 1 | Assigned issue resolves to matching case worktree provider root | Unit | Tested in `provider workspace contract` |
| 2 | Missing or mismatched `kaizen.issue` fails closed before spawn | Unit | Tested in resolver mismatch and missing-worktree cases |
| 3 | Codex argv and spawn cwd use the same validated provider root | Unit/source-shape | Tested by source-shape assertion over `runCodex()` |
| 4 | Claude and Codex share the same workspace contract | Source-shape/unit | Tested by resolver-before-spawn and Claude cwd assertions |
| 5 | Batch state/log/rescue paths stay harness-root based | Regression | Existing focused runner tests plus `check:fast`; implementation only changes provider launch cwd |
| 6 | Direct temp-git proof reproduces original incident shape | Reality | Ran temp repo with main `kaizen.issue=1586`, case worktree `kaizen.issue=1164` |

## Validation

- [x] RED: focused workspace tests initially failed because the resolver/import did not exist.
- [x] `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-codex.test.ts` - 381 passed.
- [x] `npm run check:fast` - typecheck plus 676 passed, 2 skipped.
- [x] `npm test` - 4104 passed, 14 skipped.
- [x] Temp-git proof: `from-main` selected the #1164 case worktree, `from-case` accepted the #1164 invocation worktree, `wrong-case` failed with `binding-mismatch` before provider launch.
- [x] Review hardening: known case paths outside `.claude/worktrees` are ignored even if they report a matching `kaizen.issue`.

## Known Limitations

- This PR does not merge or replace the adjacent provider-runtime switching work in #1588.
- Assigned runs without a discoverable bound case worktree now stop early by design; that is the intended fail-closed behavior for #1592.