### PR TITLE
test: route three-state doctor through shared runner

### DIFF
--- a/src/e2e/three-state-activation.test.ts
+++ b/src/e2e/three-state-activation.test.ts
@@ -25,15 +25,23 @@ import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
 import { enablePlugin } from '../kaizen-setup.js';
+import { buildTypeScriptSubprocess } from '../../scripts/test-typescript-runner.js';
 
 const DOCTOR = resolve(__dirname, '../../scripts/kaizen-doctor.ts');
+const DOCTOR_RUNNER = buildTypeScriptSubprocess(DOCTOR, {
+  startDir: __dirname,
+});
+const TEST_SOURCE = readFileSync(
+  resolve(__dirname, 'three-state-activation.test.ts'),
+  'utf-8',
+);
 
 function runDoctor(projectRoot: string, homeDir: string): {
   exitCode: number;
   results: Array<{ name: string; status: string; detail: string }>;
 } {
   try {
-    const out = execFileSync('npx', ['tsx', DOCTOR, '--json'], {
+    const out = execFileSync(DOCTOR_RUNNER.command, [...DOCTOR_RUNNER.args, '--json'], {
       cwd: projectRoot,
       env: { ...process.env, HOME: homeDir },
       encoding: 'utf-8',
@@ -81,6 +89,12 @@ describe('#1063 three-state matrix — host project activation', () => {
   afterEach(() => {
     rmSync(project, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
+  });
+
+  it('test runtime invariant: doctor subprocesses use the shared TypeScript runner', () => {
+    expect(runDoctor.toString()).toContain('DOCTOR_RUNNER');
+    expect(TEST_SOURCE).toContain('buildTypeScriptSubprocess');
+    expect(TEST_SOURCE).not.toMatch(/execFileSync\(['"]npx['"]/);
   });
 
   it('State 1: enabled — enabledPlugins present, doctor all-PASS, activation switch works', () => {


### PR DESCRIPTION
## Summary

Closes #1618. Part of #1532.

This keeps the three-state activation E2E coverage but routes the doctor CLI subprocess through the shared TypeScript runner contract:

- Replaces direct `execFileSync('npx', ['tsx', DOCTOR, '--json'], ...)` with `buildTypeScriptSubprocess(DOCTOR, { startDir: __dirname })`.
- Keeps the real `scripts/kaizen-doctor.ts --json` boundary for enabled / not-enabled / marketplace-only state interpretation.
- Adds a regression invariant so this test does not drift back to direct `npx` TypeScript subprocess construction.

## Proof

Baseline on `main`:

```text
/usr/bin/time -p npx vitest run src/e2e/three-state-activation.test.ts --reporter=verbose --coverage.enabled=false
Test Files 1 passed
Tests 5 passed
Duration 6.33s
real 6.98

State 1: 2029ms
State 2: 2005ms
State 3: 1998ms
```

After this PR:

```text
/usr/bin/time -p npx vitest run src/e2e/three-state-activation.test.ts --reporter=verbose --coverage.enabled=false
Test Files 1 passed
Tests 6 passed
Duration 4.42s
real 5.30

State 1: 1355ms
State 2: 1341ms
State 3: 1301ms
```

## Verification

```text
npm run typecheck
npm run check:fast
/usr/bin/time -p npx vitest run src/e2e/three-state-activation.test.ts --reporter=verbose --coverage.enabled=false
git diff --check
```

Note: `check:fast` correctly found no changed non-E2E test files because this slice only touches `src/e2e/**`; the focused E2E run is the behavior proof.
