### PR TITLE
fix(hooks): require post-merge workflow checks

### DIFF
--- a/src/hooks/lib/gate-manager.test.ts
+++ b/src/hooks/lib/gate-manager.test.ts
@@ -94,6 +94,7 @@ describe('readAllPendingGates', () => {
     const report = readAllPendingGates(TEST_BRANCH, TEST_STATE_DIR);
     expect(report.gates).toHaveLength(1);
     expect(report.gates[0].type).toBe('post_merge');
+    expect(report.gates[0].detail).toContain('gh run list --repo org/repo --branch main --commit <merge-sha>');
     expect(report.gates[0].detail).toContain('git fetch origin main');
   });
 
@@ -107,9 +108,12 @@ describe('readAllPendingGates', () => {
     expect(detail.toLowerCase()).toMatch(/kaizen/);
     // Kaizen must appear before git sync in the detail text
     const kaizenPos = detail.toLowerCase().indexOf('kaizen');
+    const workflowPos = detail.indexOf('gh run list');
     const gitPos = detail.toLowerCase().indexOf('git fetch');
     expect(kaizenPos).toBeGreaterThanOrEqual(0);
+    expect(workflowPos).toBeGreaterThan(kaizenPos);
     expect(kaizenPos).toBeLessThan(gitPos);
+    expect(workflowPos).toBeLessThan(gitPos);
   });
 
   it('reads multiple gates of different types', () => {

--- a/src/hooks/lib/gate-manager.ts
+++ b/src/hooks/lib/gate-manager.ts
@@ -28,6 +28,7 @@ import {
   readStateFile,
 } from '../state-utils.js';
 import { readJsonValueFile, writeJsonValueFile } from '../../lib/json-file.js';
+import { postMergeWorkflowVerificationLines } from './post-merge-workflows.js';
 
 export interface PendingGate {
   type: 'review' | 'reflection' | 'post_merge';
@@ -99,7 +100,11 @@ export function readAllPendingGates(
       type: 'post_merge',
       prUrl: r.prUrl,
       label: `POST-MERGE SYNC (${r.prUrl})`,
-      detail: '1. Run /kaizen to reflect on this PR\n   2. Then: git fetch origin main && git merge origin/main',
+      detail: [
+        '1. Run /kaizen to reflect on this PR',
+        `   2. ${postMergeWorkflowVerificationLines(r.prUrl)}`,
+        '   3. Then: git fetch origin main && git merge origin/main',
+      ].join('\n'),
       action: 'git fetch origin main && git merge origin/main',
       filepath: r.filepath,
     });

--- a/src/hooks/lib/post-merge-workflows.test.ts
+++ b/src/hooks/lib/post-merge-workflows.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { postMergeWorkflowVerificationLines } from './post-merge-workflows.js';
+
+describe('postMergeWorkflowVerificationLines', () => {
+  it('builds a concrete main workflow verification command from a PR URL', () => {
+    const lines = postMergeWorkflowVerificationLines('https://github.com/org/repo/pull/42');
+
+    expect(lines).toContain('org/repo');
+    expect(lines).toContain('main');
+    expect(lines).toContain('gh run list --repo org/repo --branch main --commit <merge-sha>');
+    expect(lines).toContain('If any run failed');
+  });
+
+  it('falls back to the current repository when the PR URL is malformed', () => {
+    const lines = postMergeWorkflowVerificationLines('not-a-pr-url');
+
+    expect(lines).toContain('gh run list --branch main --commit <merge-sha>');
+    expect(lines).not.toContain('--repo');
+  });
+});

--- a/src/hooks/lib/post-merge-workflows.ts
+++ b/src/hooks/lib/post-merge-workflows.ts
@@ -1,0 +1,21 @@
+import { parseGithubPrUrl } from '../../lib/github-pr.js';
+
+function repoArg(prUrl: string): string {
+  const parsed = parseGithubPrUrl(prUrl);
+  return parsed ? `--repo ${parsed.repo} ` : '';
+}
+
+/**
+ * Instructions for checking workflows that run only after the merge commit
+ * lands on main. The hook cannot know the merge SHA synchronously, so it gives
+ * the agent the exact command shape and a placeholder to fill after merge.
+ */
+export function postMergeWorkflowVerificationLines(prUrl: string): string {
+  const repo = repoArg(prUrl);
+  return [
+    '**Verify workflows on main** — check runs triggered by the merge commit:',
+    `   - Merge SHA: \`gh pr view ${repo}--json mergeCommit --jq '.mergeCommit.oid'\``,
+    `   - Workflow runs: \`gh run list ${repo}--branch main --commit <merge-sha>\``,
+    '   - If any run failed, investigate and report or fix it before declaring the work done.',
+  ].join('\n');
+}

--- a/src/hooks/post-merge-clear.test.ts
+++ b/src/hooks/post-merge-clear.test.ts
@@ -140,6 +140,8 @@ describe('processPostMergeClear — Bash trigger (MERGED detection)', () => {
 
     expect(output).toContain('PR merge confirmed');
     expect(output).toContain('pull/50');
+    expect(output).toContain('gh run list --repo org/repo --branch main --commit <merge-sha>');
+    expect(output).toContain('If any run failed');
 
     // awaiting_merge should be cleared, needs_post_merge should be written
     const stateFile = join(TEST_STATE_DIR, 'post-merge-org_repo_50');

--- a/src/hooks/post-merge-clear.ts
+++ b/src/hooks/post-merge-clear.ts
@@ -18,6 +18,7 @@
 import { getCurrentBranch, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
+import { postMergeWorkflowVerificationLines } from './lib/post-merge-workflows.js';
 import { isGhPrCommand, stripHeredocBody } from './parse-command.js';
 import {
   DEFAULT_STATE_DIR,
@@ -87,7 +88,7 @@ export function processPostMergeClear(
 
     const mc = resolveMainCheckout();
     return formatGateSignal({ hook: 'post-merge-clear', type: 'gate-set', gate: 'needs_post_merge', pr: prUrl, reason: 'Merge confirmed — run /kaizen to reflect' }) +
-      `\n🎉 PR merge confirmed: ${prUrl}\n\nNow complete the post-merge workflow:\n1. **Kaizen reflection (REQUIRED)** — Run \`/kaizen\` NOW to reflect on impediments and process friction\n2. **Mark case done** — if a case exists for this work\n3. **Sync main** — \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n4. **Update linked issue** — close the kaizen/tracking issue with lessons learned\n\n⛔ You will NOT be able to finish until /kaizen is run.`;
+      `\n🎉 PR merge confirmed: ${prUrl}\n\nNow complete the post-merge workflow:\n1. **Kaizen reflection (REQUIRED)** — Run \`/kaizen\` NOW to reflect on impediments and process friction\n2. ${postMergeWorkflowVerificationLines(prUrl)}\n3. **Mark case done** — if a case exists for this work\n4. **Sync main** — \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n5. **Update linked issue** — close the kaizen/tracking issue with lessons learned\n\n⛔ You will NOT be able to finish until /kaizen is run.`;
   }
 
   return '';

--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -612,6 +612,8 @@ describe('pr-review-loop: gh pr merge', () => {
     expect(output).toContain('Update linked issue');
     expect(output).toContain('Spec update');
     expect(output).toContain('Post-merge action needed');
+    expect(output).toContain('gh run list --repo Garsson-io/kaizen --branch main --commit <merge-sha>');
+    expect(output).toContain('If any run failed');
     expect(output).toContain('Sync main');
   });
 

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -34,6 +34,7 @@ import { type HookInput, readHookInput, traceHookEvent, writeHookOutput } from '
 import { currentHookBranch } from './lib/current-branch.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
+import { postMergeWorkflowVerificationLines } from './lib/post-merge-workflows.js';
 import {
   isGhPrCommand,
   isGitCommand,
@@ -357,7 +358,7 @@ export function processHookInput(
       STATUS: 'needs_post_merge',
       BRANCH: branch,
     });
-    const mergeMsg = `\n\ud83c\udf89 PR merged: ${mergeUrl}\n\nNow complete the post-merge workflow:\n1. **Kaizen reflection (REQUIRED)** \u2014 Run \`/kaizen\` NOW.\n2. **Post-merge action needed** \u2014 classify per CLAUDE.md deploy policy.\n3. **Sync main** \u2014 \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n4. **Update linked issue** \u2014 Close with lessons learned.\n5. **Spec update** \u2014 Move completed work to "Already Solved".\n\n\u26d4 You will NOT be able to finish until /kaizen is run.\n`;
+    const mergeMsg = `\n\ud83c\udf89 PR merged: ${mergeUrl}\n\nNow complete the post-merge workflow:\n1. **Kaizen reflection (REQUIRED)** \u2014 Run \`/kaizen\` NOW.\n2. **Post-merge action needed** \u2014 classify per CLAUDE.md deploy policy.\n3. ${postMergeWorkflowVerificationLines(mergeUrl)}\n4. **Sync main** \u2014 \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n5. **Update linked issue** \u2014 Close with lessons learned.\n6. **Spec update** \u2014 Move completed work to "Already Solved".\n\n\u26d4 You will NOT be able to finish until /kaizen is run.\n`;
     return decide('post_merge', 'merge_completed', mergeMsg, { mergeUrl });
   }
 


### PR DESCRIPTION
Once upon a time, the kaizen post-merge gate could prove that a PR reached `MERGED` and could force `/kaizen` plus local main sync. Every day, that made the end of a PR look complete even though some workflows only start after the merge commit lands on `main`.

One day, #101 captured the concrete failure mode: after PRs #144/#145/#147, a main-push workflow failure was missed until a human asked whether it worked. A later incident on 2026-03-19 showed the same class of gap around explicit merge-state verification.

Because of that, this PR makes the existing `needs_post_merge` gate carry the missing workflow verification step. Direct `gh pr merge`, auto-merge confirmation via `gh pr view ... MERGED`, and the stop gate now all show the concrete command shape:

`gh run list --repo <owner/repo> --branch main --commit <merge-sha>`

Because of that, the instruction is no longer a one-off advisory that can scroll away. It is part of the same post-merge gate that blocks stopping until the workflow is handled or honestly deferred.

Until finally, focused RED tests first failed against the old prompts, then passed after the shared formatter was wired into all live post-merge paths. The manual smoke output now shows `/kaizen` first, workflow-run verification second, and local main sync after that.

And ever since, the next agent reaching post-merge state gets a direct main-workflow check before declaring work done.

Fixes Garsson-io/kaizen#101

## Architecture

```
gh pr merge / gh pr view MERGED
        |
        v
needs_post_merge state
        |
        +--> pr-review-loop direct merge prompt
        +--> post-merge-clear auto-merge confirmation prompt
        +--> stop-gate via gate-manager detail
                    |
                    v
        shared postMergeWorkflowVerificationLines()
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Reuse the existing `needs_post_merge` gate | #101 is about the post-merge completion contract, and this gate already blocks stop | Does not yet execute or validate `gh run list`; it makes the required check unavoidable in the gate UX |
| Add one shared formatter | Prevents direct merge, auto-merge confirmation, and stop-gate wording from drifting | Small new helper module |
| Keep `/kaizen` first | Preserves the #936 invariant that reflection remains the first post-merge action | Workflow verification becomes second rather than first |

## What Changed

| File | Purpose |
|---|---|
| `src/hooks/lib/post-merge-workflows.ts` | Shared post-merge workflow verification wording |
| `src/hooks/pr-review-loop.ts` | Direct merge prompt includes main workflow verification |
| `src/hooks/post-merge-clear.ts` | Auto-merge confirmation prompt includes main workflow verification |
| `src/hooks/lib/gate-manager.ts` | Stop gate detail includes workflow verification before local main sync |
| `*.test.ts` updates | Lock the command text and ordering across all paths |

## Impact (goal -> before/after -> match)

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Post-merge gate must direct agents to verify workflows triggered on `main` | Existing prompt/gate tests only asserted `/kaizen`, issue update, and `git fetch origin main`; RED run failed 5 checks for missing `gh run list` | Focused tests pass 86/86, and smoke output shows `gh run list --repo Garsson-io/kaizen --branch main --commit <merge-sha>` between `/kaizen` and sync | Live post-merge paths now render main workflow verification | yes |

- Acceptance signal: `needs_post_merge` paths display `gh run list --branch main --commit <merge-sha>` and failure-handling wording.
- Residual scan: #1037 remains separate post-merge branch/worktree cleanup; #149 remains separate merge-wait prevention analysis. Neither is closed by this PR.

## Test Plan (Behaviors x Levels)

| Behavior | Level | Status | Evidence |
|---|---|---|---|
| Formatter emits main workflow-run command from PR URL | Unit | tested | `src/hooks/lib/post-merge-workflows.test.ts` |
| Direct `gh pr merge` prompt includes workflow-run verification | Unit/System seam | tested | `src/hooks/pr-review-loop.test.ts` |
| Auto-merge `MERGED` confirmation includes workflow-run verification | Unit/System seam | tested | `src/hooks/post-merge-clear.test.ts` |
| Stop-gate detail preserves `/kaizen` first and places workflow check before local sync | Unit/System seam | tested | `src/hooks/lib/gate-manager.test.ts` |

## Validation

- [x] RED: focused tests failed on current behavior for missing `gh run list` in direct merge, auto-merge confirmation, and stop gate.
- [x] GREEN: `npx vitest run src/hooks/lib/post-merge-workflows.test.ts src/hooks/pr-review-loop.test.ts src/hooks/post-merge-clear.test.ts src/hooks/lib/gate-manager.test.ts` -> 4 files, 86 tests passed.
- [x] `npm run check:fast` -> typecheck plus changed-file tests, 11 files and 243 tests passed.
- [x] `npm run test:hooks` -> 435/435 hook tests passed.
- [x] `npm test` -> 171 files passed, 2 skipped; 4096 tests passed, 14 skipped.
- [x] Manual smoke: rendered direct merge prompt shows `/kaizen`, then `gh run list --repo Garsson-io/kaizen --branch main --commit <merge-sha>`, then local main sync.

## Known Limitations

This PR makes workflow verification part of the blocking post-merge UX. It does not poll GitHub Actions or parse run conclusions automatically; that would be a stronger L3 merge procedure/tooling step.
