### PR TITLE
fix(auto-dent): require explore dedup evidence

### DIFF
--- a/prompts/explore-gaps.md
+++ b/prompts/explore-gaps.md
@@ -45,8 +45,8 @@ Rotate through these focus areas based on run number ({{run_num}} mod 6):
 | 5 | "Recursive self-improvement" — LessWrong, alignment forum, research papers |
 
 Use WebSearch to find 2-3 relevant repos or articles for your assigned topic.
-For each discovery: assess relevance to kaizen. If high-relevance, file an issue
-with labels `source:ecosystem-research` and `kaizen`.
+For each discovery: assess relevance to kaizen. If high-relevance, put it
+through the Search-before-file gate below before filing or commenting.
 
 ## Exploration Tasks
 
@@ -84,14 +84,36 @@ Rules:
 - Include every promising candidate you discovered, including candidates you did
   not file as issues.
 - Use `suggested_mode` to describe how the next run should approach the candidate.
+- Fill `dedup` for every candidate. A candidate without `dedup.query`,
+  `dedup.matches`, `dedup.decision`, and `dedup.reason` is incomplete scouting.
 - If no candidates exist, write `"candidates": []` and explain why in the run
   summary.
 - A run that only files issues but writes no manifest is incomplete scouting.
 
+### Search-before-file gate
+
+Before filing any issue, run a targeted duplicate search using
+`gh issue list --search` or `gh search issues`. Record the exact query and
+relevant matches in the candidate's `dedup` object.
+
+Use exactly one dedup decision per candidate:
+- `file_new` - no strong existing match; file a new issue.
+- `comment_existing` - a strong match exists; comment on the existing issue
+  with the new evidence instead of filing a duplicate.
+- `candidate_only` - promising but not worth filing or commenting yet; keep it
+  in the manifest for future planning.
+
+At most 2 candidates may use `file_new` in one explore run. Prioritize the two
+highest-value genuinely new gaps. Extra discoveries should be `comment_existing`
+or `candidate_only`.
+
 For each discovery:
-1. File a GitHub issue in {{kaizen_repo}} with clear title and context
-2. Label it `source:auto-dent-explore` and `kaizen`
-3. Reference this exploration run in the issue body
+1. Search first and record the `dedup` decision in the manifest.
+2. If `decision=file_new`, file a GitHub issue in {{kaizen_repo}} with clear
+   title and context, label it `source:auto-dent-explore` and `kaizen`, and
+   reference this exploration run in the issue body.
+3. If `decision=comment_existing`, add the new evidence to the existing issue
+   and do not file a duplicate.
 
 Post a summary of all discoveries to the batch progress issue.
 

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -281,6 +281,8 @@ describe('buildTemplateVars', () => {
     expect(vars.candidate_manifest_path).toBe(join(tmpDir, 'run-4-candidate-tasks-manifest.json'));
     expect(vars.candidate_manifest_schema).toContain('candidates');
     expect(vars.candidate_manifest_schema).toContain('suggested_mode');
+    expect(vars.candidate_manifest_schema).toContain('"dedup"');
+    expect(vars.candidate_manifest_schema).toContain('"decision": "file_new|comment_existing|candidate_only"');
   });
 
   it('renders explore prompt with required candidate manifest artifact path', () => {
@@ -293,6 +295,10 @@ describe('buildTemplateVars', () => {
     expect(meta.prompt).toContain('Required artifact');
     expect(meta.prompt).toContain(join(tmpDir, 'run-2-candidate-tasks-manifest.json'));
     expect(meta.prompt).toContain('candidate-task manifest');
+    expect(meta.prompt).toContain('Search-before-file gate');
+    expect(meta.prompt).toContain('gh issue list --search');
+    expect(meta.prompt).toContain('comment_existing');
+    expect(meta.prompt).toContain('At most 2 candidates may use');
   });
 
   it('exposes the shared goal forcing contract as a template variable', () => {
@@ -312,14 +318,126 @@ describe('parseCandidateTaskManifest', () => {
       runTag: 'batch/run-1',
       generatedAt: '2026-06-29T00:00:00.000Z',
       candidates: [
-        { id: 'a', title: 'First', rationale: 'why', refs: ['#1'], suggested_mode: 'exploit' },
-        { id: 'b', title: 'Second', rationale: 'why', refs: [], suggested_mode: 'subtract' },
+        {
+          id: 'a',
+          title: 'First',
+          rationale: 'why',
+          refs: ['#1'],
+          suggested_mode: 'exploit',
+          dedup: {
+            query: 'First in:title repo:Garsson-io/kaizen',
+            matches: [],
+            decision: 'file_new',
+            reason: 'No existing issue matched this specific gap',
+          },
+        },
+        {
+          id: 'b',
+          title: 'Second',
+          rationale: 'why',
+          refs: ['#2'],
+          suggested_mode: 'subtract',
+          dedup: {
+            query: 'Second in:title repo:Garsson-io/kaizen',
+            matches: ['#2'],
+            decision: 'comment_existing',
+            reason: 'Existing issue covers the candidate',
+          },
+        },
       ],
     }));
 
     const parsed = parseCandidateTaskManifest(path);
 
-    expect(parsed).toEqual({ path, count: 2, warnings: [] });
+    expect(parsed).toEqual({
+      path,
+      count: 2,
+      dedupCheckedCount: 2,
+      fileNewCount: 1,
+      warnings: [],
+    });
+  });
+
+  it('warns when candidates omit dedup evidence', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-no-dedup-'));
+    const path = join(tmpDir, 'run-1-candidate-tasks-manifest.json');
+    writeFileSync(path, JSON.stringify({
+      version: 1,
+      candidates: [
+        { id: 'a', title: 'First', rationale: 'why', refs: ['#1'], suggested_mode: 'exploit' },
+      ],
+    }));
+
+    const parsed = parseCandidateTaskManifest(path);
+
+    expect(parsed).toMatchObject({
+      path,
+      count: 1,
+      dedupCheckedCount: 0,
+      fileNewCount: 0,
+      warnings: [expect.stringContaining('missing dedup evidence')],
+    });
+  });
+
+  it('warns when a dedup decision is invalid', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-bad-decision-'));
+    const path = join(tmpDir, 'run-1-candidate-tasks-manifest.json');
+    writeFileSync(path, JSON.stringify({
+      version: 1,
+      candidates: [
+        {
+          id: 'a',
+          title: 'First',
+          rationale: 'why',
+          refs: ['#1'],
+          suggested_mode: 'exploit',
+          dedup: {
+            query: 'First',
+            matches: [],
+            decision: 'maybe',
+            reason: 'bad',
+          },
+        },
+      ],
+    }));
+
+    const parsed = parseCandidateTaskManifest(path);
+
+    expect(parsed).toMatchObject({
+      count: 1,
+      dedupCheckedCount: 0,
+      warnings: [expect.stringContaining('invalid dedup decision')],
+    });
+  });
+
+  it('warns when an explore manifest exceeds the file-new budget', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-budget-'));
+    const path = join(tmpDir, 'run-1-candidate-tasks-manifest.json');
+    writeFileSync(path, JSON.stringify({
+      version: 1,
+      candidates: [1, 2, 3].map((n) => ({
+        id: `c${n}`,
+        title: `Candidate ${n}`,
+        rationale: 'why',
+        refs: [],
+        suggested_mode: 'exploit',
+        dedup: {
+          query: `Candidate ${n}`,
+          matches: [],
+          decision: 'file_new',
+          reason: 'No duplicate found',
+        },
+      })),
+    }));
+
+    const parsed = parseCandidateTaskManifest(path);
+
+    expect(parsed).toMatchObject({
+      count: 3,
+      dedupCheckedCount: 3,
+      fileNewCount: 3,
+      warnings: [expect.stringContaining('file_new budget exceeded')],
+    });
   });
 
   it('returns zero with warning for missing or malformed manifests', () => {
@@ -2777,7 +2895,7 @@ describe('computeBanditWeights', () => {
     expect(result.explorationC).toBe(DEFAULT_BANDIT_C);
   });
 
-  it('reward semantics: explore credited by issues_filed, subtract by lines/pruned', () => {
+  it('reward semantics: explore issue-filing reward is capped, subtract uses lines/pruned', () => {
     const history: RunMetrics[] = [];
     for (let i = 0; i < 8; i++) history.push(makeRunMetrics({ run: i, mode: 'exploit', prs: [], cost_usd: 1 }));
     // explore files lots of issues (its reward), subtract deletes lines.
@@ -2786,8 +2904,9 @@ describe('computeBanditWeights', () => {
     history.push(makeRunMetrics({ run: 10, mode: 'subtract', lines_deleted: 400, issues_pruned: 2, cost_usd: 1 }));
     const result = computeBanditWeights(history, { minRuns: 10 })!;
     const byMode = Object.fromEntries(result.details.map(d => [d.mode, d]));
-    // explore's mean reward reflects issues filed (3/play), not its zero PRs.
-    expect(byMode.explore.meanReward).toBeCloseTo(3, 5);
+    // explore's issue-filing reward is capped at 2/play so over-filing does not
+    // train the bandit to prefer backlog inflation.
+    expect(byMode.explore.meanReward).toBeCloseTo(2, 5);
     expect(byMode.subtract.meanReward).toBeGreaterThan(0);
     // exploit produced zero PRs ⇒ zero mean reward.
     expect(byMode.exploit.meanReward).toBe(0);
@@ -2827,10 +2946,15 @@ describe('modeSuccess', () => {
     expect(modeSuccess('exploit', makeRunMetrics({ prs: [] }))).toBe(0);
   });
 
-  it('explore uses candidate manifest count plus issues_filed', () => {
-    expect(modeSuccess('explore', makeRunMetrics({ issues_filed: ['#1', '#2', '#3'] }))).toBe(3);
+  it('explore uses dedup-checked candidate manifests plus capped issues_filed', () => {
+    expect(modeSuccess('explore', makeRunMetrics({ issues_filed: ['#1', '#2', '#3'] }))).toBe(2);
     expect(modeSuccess('explore', makeRunMetrics({ issues_filed: [], candidate_manifest_count: 4 }))).toBe(4);
     expect(modeSuccess('explore', makeRunMetrics({ issues_filed: ['#1'], candidate_manifest_count: 2 }))).toBe(3);
+    expect(modeSuccess('explore', makeRunMetrics({
+      issues_filed: ['#1', '#2', '#3'],
+      candidate_manifest_count: 4,
+      candidate_manifest_dedup_checked_count: 2,
+    }))).toBe(4);
     expect(modeSuccess('explore', makeRunMetrics({ prs: ['pr1'], issues_filed: [] }))).toBe(0);
   });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -296,6 +296,10 @@ export interface RunMetrics {
   candidate_manifest_path?: string;
   /** Number of candidates parsed from the explore-mode candidate-task manifest (#1196). */
   candidate_manifest_count?: number;
+  /** Number of manifest candidates with complete duplicate-search evidence (#735). */
+  candidate_manifest_dedup_checked_count?: number;
+  /** Number of manifest candidates that chose to file a new issue (#735). */
+  candidate_manifest_file_new_count?: number;
   /** Non-fatal candidate manifest parse/read warnings (#1196). */
   candidate_manifest_warnings?: string[];
   /** Durable UCB1 decision breakdown used for mode selection (#1178). */
@@ -370,6 +374,10 @@ export interface RunResult {
   candidateManifestPath?: string;
   /** Number of candidates parsed from the explore-mode candidate-task manifest (#1196). */
   candidateManifestCount?: number;
+  /** Number of manifest candidates with complete duplicate-search evidence (#735). */
+  candidateManifestDedupCheckedCount?: number;
+  /** Number of manifest candidates that chose to file a new issue (#735). */
+  candidateManifestFileNewCount?: number;
   /** Non-fatal candidate manifest parse/read warnings (#1196). */
   candidateManifestWarnings?: string[];
   /** Structured failure classification */
@@ -458,6 +466,8 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     issues_pruned: result.issuesPruned,
     candidate_manifest_path: result.candidateManifestPath,
     candidate_manifest_count: result.candidateManifestCount,
+    candidate_manifest_dedup_checked_count: result.candidateManifestDedupCheckedCount,
+    candidate_manifest_file_new_count: result.candidateManifestFileNewCount,
     candidate_manifest_warnings: result.candidateManifestWarnings,
     bandit_decision: buildBanditDecisionTelemetry(runMode, modeReason, bandit),
     final_claim_status: result.finalClaimStatus,
@@ -472,6 +482,8 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
 export interface CandidateTaskManifestParseResult {
   path: string;
   count: number;
+  dedupCheckedCount: number;
+  fileNewCount: number;
   warnings: string[];
 }
 
@@ -490,7 +502,13 @@ export const CANDIDATE_TASK_MANIFEST_SCHEMA = [
   '      "title": "<candidate task title>",',
   '      "rationale": "<why this should be worked>",',
   '      "refs": ["#123", "path/to/file.ts"],',
-  '      "suggested_mode": "exploit|subtract|reflect|contemplate"',
+  '      "suggested_mode": "exploit|subtract|reflect|contemplate",',
+  '      "dedup": {',
+  '        "query": "<gh issue search/list query used before filing>",',
+  '        "matches": ["#123 existing related issue, if any"],',
+  '        "decision": "file_new|comment_existing|candidate_only",',
+  '        "reason": "<why this decision does not duplicate the backlog>"',
+  '      }',
   '    }',
   '  ]',
   '}',
@@ -498,27 +516,78 @@ export const CANDIDATE_TASK_MANIFEST_SCHEMA = [
 
 export function parseCandidateTaskManifest(path: string): CandidateTaskManifestParseResult {
   if (!existsSync(path)) {
-    return { path, count: 0, warnings: [`candidate task manifest missing: ${path}`] };
+    return { path, count: 0, dedupCheckedCount: 0, fileNewCount: 0, warnings: [`candidate task manifest missing: ${path}`] };
   }
 
   const raw = readFileSync(path, 'utf8');
   const parsed = parseJsonObject(raw);
   if (!parsed) {
-    return { path, count: 0, warnings: [`candidate task manifest malformed JSON: ${path}`] };
+    return { path, count: 0, dedupCheckedCount: 0, fileNewCount: 0, warnings: [`candidate task manifest malformed JSON: ${path}`] };
   }
 
   const candidates = (parsed as { candidates?: unknown }).candidates;
   if (!Array.isArray(candidates)) {
-    return { path, count: 0, warnings: [`candidate task manifest candidates must be an array: ${path}`] };
+    return { path, count: 0, dedupCheckedCount: 0, fileNewCount: 0, warnings: [`candidate task manifest candidates must be an array: ${path}`] };
   }
 
-  return { path, count: candidates.length, warnings: [] };
+  const warnings: string[] = [];
+  let dedupCheckedCount = 0;
+  let fileNewCount = 0;
+  const validDecisions = new Set(['file_new', 'comment_existing', 'candidate_only']);
+
+  candidates.forEach((candidate, index) => {
+    const label = `candidate[${index}]`;
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      warnings.push(`candidate task manifest ${label} must be an object with dedup evidence: ${path}`);
+      return;
+    }
+
+    const dedup = (candidate as Record<string, unknown>).dedup;
+    if (!dedup || typeof dedup !== 'object' || Array.isArray(dedup)) {
+      warnings.push(`candidate task manifest ${label} missing dedup evidence: ${path}`);
+      return;
+    }
+
+    const rawDedup = dedup as Record<string, unknown>;
+    const query = typeof rawDedup.query === 'string' ? rawDedup.query.trim() : '';
+    const matches = rawDedup.matches;
+    const decision = typeof rawDedup.decision === 'string' ? rawDedup.decision.trim() : '';
+    const reason = typeof rawDedup.reason === 'string' ? rawDedup.reason.trim() : '';
+
+    if (!query) {
+      warnings.push(`candidate task manifest ${label} missing dedup query: ${path}`);
+      return;
+    }
+    if (!Array.isArray(matches) || !matches.every((match) => typeof match === 'string')) {
+      warnings.push(`candidate task manifest ${label} dedup matches must be a string array: ${path}`);
+      return;
+    }
+    if (!validDecisions.has(decision)) {
+      warnings.push(`candidate task manifest ${label} invalid dedup decision: ${decision || '<empty>'}`);
+      return;
+    }
+    if (!reason) {
+      warnings.push(`candidate task manifest ${label} missing dedup reason: ${path}`);
+      return;
+    }
+
+    dedupCheckedCount += 1;
+    if (decision === 'file_new') fileNewCount += 1;
+  });
+
+  if (fileNewCount > 2) {
+    warnings.push(`candidate task manifest file_new budget exceeded: ${fileNewCount} decisions (max 2)`);
+  }
+
+  return { path, count: candidates.length, dedupCheckedCount, fileNewCount, warnings };
 }
 
 function attachCandidateTaskManifest(result: RunResult, path: string): void {
   const parsed = parseCandidateTaskManifest(path);
   result.candidateManifestPath = parsed.path;
   result.candidateManifestCount = parsed.count;
+  result.candidateManifestDedupCheckedCount = parsed.dedupCheckedCount;
+  result.candidateManifestFileNewCount = parsed.fileNewCount;
   result.candidateManifestWarnings = parsed.warnings;
 }
 
@@ -1183,7 +1252,7 @@ function learnedSignalMode(
  * Compute mode-appropriate success metric for a run.
  * Each mode has its own definition of "success":
  *   - exploit: PRs produced
- *   - explore: candidate-task manifest entries + issues filed (durable scouting)
+ *   - explore: dedup-checked candidate-task entries + capped issues filed (durable scouting)
  *   - reflect: issues filed (insights that become actionable issues)
  *   - subtract: lines deleted + issues pruned (reduction, not addition)
  *   - contemplate: fixed baseline (strategic value not measurable per-run)
@@ -1192,8 +1261,10 @@ export function modeSuccess(mode: string, metrics: RunMetrics): number {
   switch (mode) {
     case 'exploit':
       return metrics.prs.length;
-    case 'explore':
-      return metrics.issues_filed.length + (metrics.candidate_manifest_count ?? 0);
+    case 'explore': {
+      const manifestReward = metrics.candidate_manifest_dedup_checked_count ?? metrics.candidate_manifest_count ?? 0;
+      return Math.min(metrics.issues_filed.length, 2) + manifestReward;
+    }
     case 'reflect':
       return metrics.issues_filed.length;
     case 'subtract':


### PR DESCRIPTION
## Story

Once upon a time, explore runs were supposed to scout useful future work. Every day, the harness rewarded durable scouting by counting filed issues and candidate manifest entries.

One day, #735 pointed out that this can become net-negative: an explore run can rediscover known gaps, file duplicate issues, and then get rewarded for inflating the backlog it just complained about.

Because of that, this PR makes duplicate-search evidence part of the explore contract. Every candidate in the durable manifest now has to record the search query, matches, filing decision, and reason.

Because of that, the parser can surface old/no-evidence manifests and over-budget filing decisions instead of silently counting everything as clean scouting. Explore scoring also caps raw issue-filing reward at two and prefers dedup-checked manifest candidates when the new metrics exist.

Until finally, the direct parser proof shows three concrete outcomes: the old manifest shape warns, a dedup-checked manifest is clean, and a manifest with three `file_new` decisions warns that the file-new budget was exceeded. The score proof shows three filed issues produce reward `2`, not `3`.

And ever since, explore can still discover and preserve candidates, but duplicate filing is no longer an invisible or self-reinforcing success path.

Fixes Garsson-io/kaizen#735
Related: Garsson-io/kaizen#598
Related: Garsson-io/kaizen#940

## Architecture

```text
explore-gaps.md prompt
  -> requires Search-before-file gate
  -> writes candidate manifest with per-candidate dedup evidence

parseCandidateTaskManifest()
  -> count candidates
  -> count dedup-checked candidates
  -> count file_new decisions
  -> warn on missing/malformed dedup evidence
  -> warn when file_new decisions > 2

modeSuccess('explore')
  -> reward min(issues_filed, 2)
  -> reward candidate_manifest_dedup_checked_count when present
  -> fall back to candidate_manifest_count for old history
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Require manifest-level dedup evidence | The harness needs durable evidence it can inspect after the run | It does not intercept `gh issue create` before execution |
| Warn on more than two `file_new` decisions | Makes the proposed budget cap observable and testable without disabling exploration | The warning is post-run; scoring carries the harder consequence |
| Cap explore issue-filing reward at two | Stops the bandit from learning that backlog inflation is high reward | Runs can still file more than two issues, but they do not get extra reward |
| Keep fallback to `candidate_manifest_count` | Old run history should remain interpretable | New manifests with missing dedup evidence report zero dedup-checked candidates |

## What's In This PR

| File | Purpose |
|---|---|
| `prompts/explore-gaps.md` | Adds the Search-before-file gate, `file_new`/`comment_existing`/`candidate_only` decisions, and max-two file-new instruction |
| `scripts/auto-dent-run.ts` | Extends manifest schema/parser metrics and updates explore reward semantics |
| `scripts/auto-dent-run.test.ts` | Covers schema/prompt text, valid/missing/invalid/over-budget manifests, metric threading, and scoring cap |

## Impact (goal -> before/after -> match)

- Goal (#735): Explore runs should not silently rediscover known gaps, file duplicates, and inflate backlog while being rewarded for it.
- Acceptance signal: Dedup-search evidence and file-new decisions are durable in the manifest; missing evidence and >2 file-new decisions surface warnings; over-filing stops increasing explore reward.
- BEFORE: Manifest schema only recorded `id/title/rationale/refs/suggested_mode`; `parseCandidateTaskManifest()` returned only count/warnings; `modeSuccess('explore')` rewarded all `issues_filed` plus raw manifest count.
- AFTER: Manifest schema includes `dedup.query/matches/decision/reason`; parser returns `dedupCheckedCount` and `fileNewCount`; old manifests warn; >2 `file_new` warns; explore reward uses `min(issues_filed, 2)` plus dedup-checked candidates when present.
- Delta: Duplicate decision evidence moved from prompt hope to durable harness-readable data, and raw issue spam is no longer a linear reward signal.
- Goal met?: yes for the dedup + budget-cap enforcement slice; long-term cross-run memory remains related #598/#940 work.
- Residual scan: #598 remains the broader accumulative-memory issue; #940 remains broader cross-batch intelligence steering.

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Coverage |
|---|---|---|---|
| 1 | Manifest schema advertises required dedup fields | Unit/source | `buildTemplateVars` schema assertion |
| 2 | Explore prompt tells agents to search first and comment existing matches | Source/prompt | `buildPromptWithMetadata` prompt assertion |
| 3 | Valid dedup manifest records checked/file-new counts | Unit | `parseCandidateTaskManifest` valid manifest test |
| 4 | Missing/malformed dedup data creates warnings | Unit | missing dedup and invalid decision tests |
| 5 | More than two `file_new` decisions creates warning | Unit | over-budget manifest test |
| 6 | Explore scoring caps raw issue filing and prefers dedup-checked candidates | Unit | `modeSuccess` and bandit reward semantics tests |

## Validation

- [x] RED: focused prompt/schema tests failed before implementation because schema/prompt did not mention dedup decisions.
- [x] `npx vitest run scripts/auto-dent-run.test.ts` - 374 passed.
- [x] `npm run check:fast` - typecheck plus 679 passed, 2 skipped.
- [x] `npm test` - 4111 passed, 14 skipped.
- [x] Direct parser proof: old manifest warns for missing dedup evidence; new manifest is clean; 3x `file_new` manifest warns `file_new budget exceeded`.
- [x] Direct score proof: explore run with 3 filed issues returns reward `2`.
- [x] Review fix: prompt now names valid duplicate-search commands (`gh issue list --search`, `gh search issues`) and has a regression assertion.

## Known Limitations

- This PR does not implement a pre-command `gh issue create` block; it makes dedup evidence durable and changes the reward signal.
- Cross-run explore memory is still tracked by related #598/#940 rather than solved here.