### PR TITLE
feat(hooks): add kaizen dev link override

### DIFF
--- a/docs/plugin-lifecycle.md
+++ b/docs/plugin-lifecycle.md
@@ -71,6 +71,23 @@ scripts/kaizen-uninstall-plugin.sh --plugin x@y   # other plugin
 
 The script is idempotent — safe to run multiple times. It removes the `enabledPlugins` entry, the `installed_plugins.json` record, and the cache dir; then prints a loud restart banner. **Always restart Claude Code after running it.**
 
+## Contributing to kaizen
+
+Kaizen contributors sometimes need to edit a hook in this working tree and test it through the same plugin-loaded path that Claude Code already registered. Use the dev-link helper for that loop:
+
+```bash
+scripts/kaizen-dev-link.sh status
+scripts/kaizen-dev-link.sh enable
+# edit .claude/hooks/foo.sh, then trigger the same tool call again
+scripts/kaizen-dev-link.sh disable
+```
+
+`enable` moves the active `kaizen@kaizen` install directory from `~/.claude/plugins/cache/kaizen/kaizen/<version>` to a backup next to it, then replaces that install path with a symlink to the current working tree. Claude Code keeps invoking the already-registered cache path, but the files underneath now come from your checkout, so hook body edits hot-reload on the next invocation without publishing, `/plugin update`, or restart.
+
+Run `disable` before normal user testing. It removes the symlink and restores the backed-up cache directory. `kaizen-doctor` reports `[WARN] dev-link-override` while the override is active so it does not get left on accidentally.
+
+Do not use dev-link to test plugin manifest changes, hook path renames, marketplace changes, or install/uninstall behavior. Those still require the normal plugin lifecycle and a Claude Code restart because the in-memory hook registry is loaded at session start.
+
 ## Why the error message is so unhelpful
 
 `Failed with non-blocking status code: No stderr output` is emitted by the Claude Code harness when a registered hook exits non-zero and produces no stderr. When the registered path is missing, the shell's `file not found` diagnostic is suppressed, so the harness has nothing to display. The result is an unactionable error on every tool call. A fix for this belongs upstream in `anthropics/claude-code`; until then, `kaizen-doctor` is the mechanical substitute.

--- a/scripts/kaizen-dev-link.sh
+++ b/scripts/kaizen-dev-link.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Thin shim for contributor local hook development. Real logic lives in
+# kaizen-dev-link.ts so path safety and state transitions are testable.
+set -eu
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec npx tsx "${DIR}/kaizen-dev-link.ts" "$@"

--- a/scripts/kaizen-dev-link.test.ts
+++ b/scripts/kaizen-dev-link.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  checkDevLinkStatus,
+  resolvePluginInstall,
+  runDevLink,
+} from './kaizen-dev-link.ts';
+
+function makeTemp(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function writeInstalled(home: string, projectRoot: string, installPath: string): void {
+  mkdirSync(join(home, '.claude/plugins'), { recursive: true });
+  writeFileSync(
+    join(home, '.claude/plugins/installed_plugins.json'),
+    JSON.stringify({
+      version: 2,
+      plugins: {
+        'kaizen@kaizen': [
+          {
+            scope: 'project',
+            projectPath: projectRoot,
+            installPath,
+            version: '1.2.3',
+          },
+        ],
+      },
+    }),
+  );
+}
+
+function writeHook(root: string, text: string): string {
+  const hook = join(root, '.claude/hooks/foo.sh');
+  mkdirSync(join(root, '.claude/hooks'), { recursive: true });
+  writeFileSync(hook, `#!/bin/bash\nprintf '${text}\\n'\n`);
+  chmodSync(hook, 0o755);
+  return hook;
+}
+
+describe('kaizen-dev-link install resolution', () => {
+  let home: string;
+  let project: string;
+
+  beforeEach(() => {
+    home = makeTemp('kai-devlink-home-');
+    project = makeTemp('kai-devlink-project-');
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  });
+
+  it('resolves the kaizen install path for the current project', () => {
+    const installPath = join(home, '.claude/plugins/cache/kaizen/kaizen/1.2.3');
+    mkdirSync(installPath, { recursive: true });
+    writeInstalled(home, project, installPath);
+
+    const resolved = resolvePluginInstall({ homeDir: home, projectRoot: project });
+
+    expect(resolved).toMatchObject({
+      plugin: 'kaizen@kaizen',
+      installPath,
+      projectPath: project,
+    });
+  });
+
+  it('rejects install paths outside the kaizen plugin cache', () => {
+    const outside = makeTemp('kai-devlink-outside-');
+    writeInstalled(home, project, outside);
+
+    expect(() => resolvePluginInstall({ homeDir: home, projectRoot: project }))
+      .toThrow(/outside the kaizen plugin cache/);
+
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('rejects the cache versions root itself as an install path', () => {
+    const versionsRoot = join(home, '.claude/plugins/cache/kaizen/kaizen');
+    mkdirSync(versionsRoot, { recursive: true });
+    writeInstalled(home, project, versionsRoot);
+
+    expect(() => resolvePluginInstall({ homeDir: home, projectRoot: project }))
+      .toThrow(/outside the kaizen plugin cache/);
+  });
+});
+
+describe('kaizen-dev-link enable/disable', () => {
+  let home: string;
+  let project: string;
+  let installPath: string;
+
+  beforeEach(() => {
+    home = makeTemp('kai-devlink-home-');
+    project = makeTemp('kai-devlink-project-');
+    installPath = join(home, '.claude/plugins/cache/kaizen/kaizen/1.2.3');
+    mkdirSync(installPath, { recursive: true });
+    writeFileSync(join(installPath, 'CACHE_SENTINEL'), 'cache\n');
+    writeInstalled(home, project, installPath);
+    writeHook(project, 'one');
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  });
+
+  it('enables a symlink from active plugin install path to the worktree and restores it on disable', () => {
+    const enabled = runDevLink({ command: 'enable', homeDir: home, projectRoot: project });
+
+    expect(enabled.status).toBe('enabled');
+    expect(lstatSync(installPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(installPath)).toBe(project);
+
+    const status = checkDevLinkStatus({ homeDir: home, projectRoot: project });
+    expect(status.active).toBe(true);
+    expect(status.targetPath).toBe(project);
+
+    const disabled = runDevLink({ command: 'disable', homeDir: home, projectRoot: project });
+
+    expect(disabled.status).toBe('disabled');
+    expect(lstatSync(installPath).isDirectory()).toBe(true);
+    expect(existsSync(join(installPath, 'CACHE_SENTINEL'))).toBe(true);
+  });
+
+  it('makes a fixed cache hook path observe edited worktree hook content without changing the command path', () => {
+    const cacheHook = join(installPath, '.claude/hooks/foo.sh');
+
+    runDevLink({ command: 'enable', homeDir: home, projectRoot: project });
+    expect(execFileSync(cacheHook, { encoding: 'utf8' })).toBe('one\n');
+
+    writeHook(project, 'two');
+
+    expect(execFileSync(cacheHook, { encoding: 'utf8' })).toBe('two\n');
+    expect(resolve(cacheHook)).toBe(join(installPath, '.claude/hooks/foo.sh'));
+  });
+
+  it('the shell wrapper delegates to the TypeScript CLI', () => {
+    const out = execFileSync(
+      'bash',
+      [
+        join(process.cwd(), 'scripts/kaizen-dev-link.sh'),
+        'status',
+        '--home',
+        home,
+        '--project',
+        project,
+      ],
+      { encoding: 'utf8' },
+    );
+
+    expect(out).toContain('kaizen-dev-link');
+    expect(out).toContain('inactive');
+  });
+});

--- a/scripts/kaizen-dev-link.ts
+++ b/scripts/kaizen-dev-link.ts
@@ -1,0 +1,317 @@
+#!/usr/bin/env npx tsx
+/**
+ * kaizen-dev-link — contributor-only local hook development override.
+ *
+ * Claude Code registers plugin hook command paths at session start. This tool
+ * keeps the registered install path stable and swaps the cache version dir for
+ * a symlink to a kaizen working tree, so hook body edits hot-reload without a
+ * plugin publish/update/restart cycle.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
+import { homedir } from 'node:os';
+import { readJsonValueFile } from '../src/lib/json-file.js';
+import { KAIZEN_PLUGIN_SOURCE } from '../src/kaizen-plugin-identity.js';
+
+export type DevLinkCommand = 'status' | 'enable' | 'disable';
+
+export interface DevLinkOpts {
+  command: DevLinkCommand;
+  homeDir: string;
+  projectRoot: string;
+  plugin?: string;
+}
+
+export interface PluginInstall {
+  plugin: string;
+  installPath: string;
+  projectPath: string | null;
+  version: string | null;
+}
+
+export interface DevLinkStatus {
+  plugin: string;
+  installPath: string | null;
+  active: boolean;
+  state: 'not-installed' | 'missing' | 'inactive' | 'active' | 'foreign-link';
+  targetPath: string | null;
+  backupPath: string | null;
+  detail: string;
+}
+
+export interface DevLinkResult extends DevLinkStatus {
+  status: 'enabled' | 'disabled' | 'unchanged' | 'status';
+}
+
+const DEFAULT_PLUGIN = KAIZEN_PLUGIN_SOURCE;
+const PLUGIN_RE = /^[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+$/;
+
+function validatePlugin(plugin: string): string {
+  if (!PLUGIN_RE.test(plugin)) {
+    throw new Error(`invalid plugin "${plugin}" (must match ${PLUGIN_RE.source})`);
+  }
+  return plugin;
+}
+
+function shortNameOf(plugin: string): string {
+  return plugin.split('@')[0] ?? plugin;
+}
+
+function ownerOf(plugin: string): string {
+  return plugin.split('@')[1] ?? '';
+}
+
+function normalizePath(path: string): string {
+  try { return realpathSync(path); } catch { return resolve(path); }
+}
+
+function pathWithSep(path: string): string {
+  return path.endsWith(sep) ? path : path + sep;
+}
+
+export function isPathUnderOrEqual(child: string, parent: string): boolean {
+  const c = pathWithSep(resolve(child));
+  const p = pathWithSep(resolve(parent));
+  return c === p || c.startsWith(p);
+}
+
+function cacheVersionsRoot(homeDir: string, plugin: string): string {
+  return join(homeDir, '.claude/plugins/cache', ownerOf(plugin), shortNameOf(plugin));
+}
+
+function backupPathFor(installPath: string): string {
+  return `${installPath}.kaizen-dev-link-backup`;
+}
+
+function readInstalledEntries(homeDir: string, plugin: string): Array<Record<string, unknown>> {
+  const installedPath = join(homeDir, '.claude/plugins/installed_plugins.json');
+  const data = readJsonValueFile(installedPath) as
+    | { plugins?: Record<string, unknown> }
+    | null;
+  const entry = data?.plugins?.[plugin];
+  if (Array.isArray(entry)) return entry.filter(e => e && typeof e === 'object') as Array<Record<string, unknown>>;
+  if (entry && typeof entry === 'object') return [entry as Record<string, unknown>];
+  return [];
+}
+
+function validateInstallPath(homeDir: string, plugin: string, installPath: string): string {
+  const resolvedInstall = resolve(installPath);
+  const versionsRoot = cacheVersionsRoot(homeDir, plugin);
+  if (resolvedInstall === resolve(versionsRoot) || !isPathUnderOrEqual(resolvedInstall, versionsRoot)) {
+    throw new Error(
+      `installed_plugins installPath is outside the kaizen plugin cache: ${resolvedInstall} (expected under ${versionsRoot})`,
+    );
+  }
+  return resolvedInstall;
+}
+
+export function resolvePluginInstall(opts: {
+  homeDir: string;
+  projectRoot: string;
+  plugin?: string;
+}): PluginInstall | null {
+  const plugin = validatePlugin(opts.plugin ?? DEFAULT_PLUGIN);
+  const normalizedProject = normalizePath(opts.projectRoot);
+  const entries = readInstalledEntries(opts.homeDir, plugin);
+  const matching = entries.find(entry => {
+    const projectPath = entry.projectPath;
+    return typeof projectPath === 'string' && normalizePath(projectPath) === normalizedProject;
+  }) ?? (entries.length === 1 ? entries[0] : undefined);
+
+  if (!matching) return null;
+  const rawInstallPath = matching.installPath;
+  if (typeof rawInstallPath !== 'string' || rawInstallPath.trim() === '') {
+    throw new Error(`installed_plugins record for ${plugin} has no installPath`);
+  }
+  const rawProjectPath = matching.projectPath;
+  const rawVersion = matching.version;
+  return {
+    plugin,
+    installPath: validateInstallPath(opts.homeDir, plugin, rawInstallPath),
+    projectPath: typeof rawProjectPath === 'string' ? rawProjectPath : null,
+    version: typeof rawVersion === 'string' ? rawVersion : null,
+  };
+}
+
+export function checkDevLinkStatus(opts: {
+  homeDir: string;
+  projectRoot: string;
+  plugin?: string;
+}): DevLinkStatus {
+  const plugin = validatePlugin(opts.plugin ?? DEFAULT_PLUGIN);
+  const install = resolvePluginInstall({ ...opts, plugin });
+  if (!install) {
+    return {
+      plugin,
+      installPath: null,
+      active: false,
+      state: 'not-installed',
+      targetPath: null,
+      backupPath: null,
+      detail: `${plugin} is not installed for this project; no dev override active.`,
+    };
+  }
+
+  const backupPath = backupPathFor(install.installPath);
+  if (!existsSync(install.installPath)) {
+    return {
+      plugin,
+      installPath: install.installPath,
+      active: false,
+      state: 'missing',
+      targetPath: null,
+      backupPath,
+      detail: `install path missing (${install.installPath}); no dev override active.`,
+    };
+  }
+
+  const stat = lstatSync(install.installPath);
+  if (!stat.isSymbolicLink()) {
+    return {
+      plugin,
+      installPath: install.installPath,
+      active: false,
+      state: 'inactive',
+      targetPath: null,
+      backupPath,
+      detail: `dev override inactive; install path is a normal cache directory (${install.installPath}).`,
+    };
+  }
+
+  const rawTarget = readlinkSync(install.installPath);
+  const target = normalizePath(resolve(dirname(install.installPath), rawTarget));
+  const project = normalizePath(opts.projectRoot);
+  const active = target === project;
+  return {
+    plugin,
+    installPath: install.installPath,
+    active,
+    state: active ? 'active' : 'foreign-link',
+    targetPath: target,
+    backupPath,
+    detail: active
+      ? `dev override active: ${install.installPath} -> ${target}`
+      : `install path is a symlink to ${target}, not this project (${project}).`,
+  };
+}
+
+function enable(opts: DevLinkOpts): DevLinkResult {
+  const install = resolvePluginInstall(opts);
+  if (!install) {
+    throw new Error(`${opts.plugin ?? DEFAULT_PLUGIN} is not installed for this project`);
+  }
+  const current = checkDevLinkStatus(opts);
+  if (current.active) return { ...current, status: 'unchanged' };
+  if (current.state === 'foreign-link') {
+    throw new Error(`refusing to replace foreign symlink at ${install.installPath}: ${current.targetPath}`);
+  }
+  if (current.state === 'missing') {
+    throw new Error(`refusing to enable dev link because install path is missing: ${install.installPath}`);
+  }
+  const backupPath = backupPathFor(install.installPath);
+  if (existsSync(backupPath)) {
+    throw new Error(`backup already exists (${backupPath}); run disable or inspect before enabling`);
+  }
+
+  mkdirSync(dirname(install.installPath), { recursive: true });
+  renameSync(install.installPath, backupPath);
+  symlinkSync(normalizePath(opts.projectRoot), install.installPath, 'dir');
+  return { ...checkDevLinkStatus(opts), status: 'enabled' };
+}
+
+function disable(opts: DevLinkOpts): DevLinkResult {
+  const current = checkDevLinkStatus(opts);
+  if (!current.installPath) return { ...current, status: 'unchanged' };
+  if (!current.active && current.state !== 'foreign-link') return { ...current, status: 'unchanged' };
+  if (current.state === 'foreign-link') {
+    throw new Error(`refusing to remove foreign symlink at ${current.installPath}: ${current.targetPath}`);
+  }
+
+  rmSync(current.installPath, { force: true });
+  if (current.backupPath && existsSync(current.backupPath)) {
+    renameSync(current.backupPath, current.installPath);
+  }
+  return { ...checkDevLinkStatus(opts), status: 'disabled' };
+}
+
+export function runDevLink(opts: DevLinkOpts): DevLinkResult {
+  const normalized: DevLinkOpts = {
+    ...opts,
+    plugin: validatePlugin(opts.plugin ?? DEFAULT_PLUGIN),
+    homeDir: resolve(opts.homeDir),
+    projectRoot: resolve(opts.projectRoot),
+  };
+  switch (normalized.command) {
+    case 'status': return { ...checkDevLinkStatus(normalized), status: 'status' };
+    case 'enable': return enable(normalized);
+    case 'disable': return disable(normalized);
+  }
+}
+
+function parseArgv(argv: string[]): DevLinkOpts {
+  const first = argv[0];
+  const command: DevLinkCommand =
+    first === 'enable' || first === 'disable' || first === 'status'
+      ? first
+      : 'status';
+  const rest = first === command ? argv.slice(1) : argv;
+  let homeDir = homedir();
+  let projectRoot = process.cwd();
+  let plugin = DEFAULT_PLUGIN;
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    switch (arg) {
+      case '--home': homeDir = rest[++i] ?? ''; break;
+      case '--project': projectRoot = rest[++i] ?? ''; break;
+      case '--plugin': plugin = rest[++i] ?? ''; break;
+      case '-h':
+      case '--help':
+        process.stdout.write([
+          'kaizen-dev-link [status|enable|disable] [--home PATH] [--project PATH] [--plugin kaizen@kaizen]',
+          '',
+          'Contributor-only override: replace the active plugin install path with a symlink to this worktree.',
+        ].join('\n') + '\n');
+        process.exit(0);
+      default:
+        throw new Error(`unknown arg: ${arg}`);
+    }
+  }
+  return { command, homeDir, projectRoot, plugin };
+}
+
+function format(result: DevLinkResult): string {
+  const lines = [
+    `kaizen-dev-link: ${result.state}`,
+    `plugin: ${result.plugin}`,
+    `installPath: ${result.installPath ?? '(none)'}`,
+    `target: ${result.targetPath ?? '(none)'}`,
+    `detail: ${result.detail}`,
+  ];
+  if (result.backupPath) lines.push(`backup: ${result.backupPath}`);
+  return lines.join('\n') + '\n';
+}
+
+const isMain = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}`; } catch { return false; }
+})();
+
+if (isMain) {
+  try {
+    const result = runDevLink(parseArgv(process.argv.slice(2)));
+    process.stdout.write(format(result));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`kaizen-dev-link: ${message}\n`);
+    process.exit(2);
+  }
+}

--- a/scripts/kaizen-doctor.test.ts
+++ b/scripts/kaizen-doctor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync, symlinkSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -11,6 +11,7 @@ import {
   checkRestartNeeded,
   checkHookExecSmoke,
   checkHookSyntaxSmoke,
+  checkDevLinkOverride,
   checkSingleRegistrationPath,
   checkCodexReadiness,
   runAllChecks,
@@ -192,6 +193,50 @@ describe('checkStalePluginCache', () => {
     writeFileSync(join(home, '.claude/plugins/installed_plugins.json'), JSON.stringify({ plugins: {} }));
     const r = checkStalePluginCache({ projectRoot: proj, homeDir: home });
     expect(r.status).toBe('PASS');
+  });
+});
+
+describe('checkDevLinkOverride (#1064)', () => {
+  let proj: string, home: string;
+  beforeEach(() => { proj = makeProject(); home = makeHome(); });
+  afterEach(() => { rmSync(proj, { recursive: true, force: true }); rmSync(home, { recursive: true, force: true }); });
+
+  function installRecord(installPath: string): void {
+    writeFileSync(join(home, '.claude/plugins/installed_plugins.json'),
+      JSON.stringify({ plugins: { 'kaizen@kaizen': [{ installPath, projectPath: proj }] } }));
+  }
+
+  it('PASS when kaizen is not installed for this project', () => {
+    writeFileSync(join(home, '.claude/plugins/installed_plugins.json'), JSON.stringify({ plugins: {} }));
+
+    const r = checkDevLinkOverride({ projectRoot: proj, homeDir: home });
+
+    expect(r.status).toBe('PASS');
+    expect(r.detail).toContain('no dev override active');
+  });
+
+  it('PASS when install path is a normal cache directory', () => {
+    const installPath = join(home, '.claude/plugins/cache/kaizen/kaizen/1.2.3');
+    mkdirSync(installPath, { recursive: true });
+    installRecord(installPath);
+
+    const r = checkDevLinkOverride({ projectRoot: proj, homeDir: home });
+
+    expect(r.status).toBe('PASS');
+    expect(r.detail).toContain('inactive');
+  });
+
+  it('WARN when install path is symlinked to this worktree', () => {
+    const installPath = join(home, '.claude/plugins/cache/kaizen/kaizen/1.2.3');
+    mkdirSync(join(installPath, '..'), { recursive: true });
+    symlinkSync(proj, installPath);
+    installRecord(installPath);
+
+    const r = checkDevLinkOverride({ projectRoot: proj, homeDir: home });
+
+    expect(r.status).toBe('WARN');
+    expect(r.detail).toContain('dev override active');
+    expect(r.detail).toContain(proj);
   });
 });
 
@@ -688,6 +733,7 @@ describe('runAllChecks + exitCodeFor', () => {
       'plugin-double-install',
       'dangling-hook-paths',
       'stale-plugin-cache',
+      'dev-link-override',
       'restart-needed',
       'hook-exec-smoke',
       'hook-syntax-smoke',

--- a/scripts/kaizen-doctor.ts
+++ b/scripts/kaizen-doctor.ts
@@ -33,6 +33,7 @@ import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { readJsonValueFile } from '../src/lib/json-file.js';
 import { KAIZEN_PLUGIN_SOURCE } from '../src/kaizen-plugin-identity.js';
+import { checkDevLinkStatus } from './kaizen-dev-link.js';
 
 export type CheckStatus = 'PASS' | 'WARN' | 'FAIL';
 
@@ -284,6 +285,42 @@ export function checkStalePluginCache(opts: DoctorOpts): CheckResult {
       ? `installed_plugins and cache consistent for "${plugin}".`
       : `"${plugin}" not installed, no cache.`,
   };
+}
+
+/** Check: contributor dev-link override is visible so it is not left on
+ * accidentally. This is WARN, not FAIL: active dev links are intentional local
+ * development state, but they should be loud in doctor output. */
+export function checkDevLinkOverride(opts: DoctorOpts): CheckResult {
+  try {
+    const status = checkDevLinkStatus({
+      homeDir: opts.homeDir,
+      projectRoot: opts.projectRoot,
+      plugin: opts.pluginName ?? DEFAULT_PLUGIN,
+    });
+    if (status.active) {
+      return {
+        name: 'dev-link-override',
+        status: 'WARN',
+        detail: `dev override active: ${status.installPath} -> ${status.targetPath}. Run scripts/kaizen-dev-link.sh disable before normal user testing.`,
+        data: status,
+      };
+    }
+    return {
+      name: 'dev-link-override',
+      status: 'PASS',
+      detail: status.state === 'inactive'
+        ? `inactive for "${status.plugin}".`
+        : `no dev override active for "${status.plugin}" (${status.state}).`,
+      data: status,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      name: 'dev-link-override',
+      status: 'WARN',
+      detail: `could not inspect dev override state: ${message}`,
+    };
+  }
 }
 
 /** Normalize a project root for snapshot-keying. Uses realpath when possible
@@ -685,6 +722,7 @@ export function runAllChecks(opts: DoctorOpts): CheckResult[] {
     checkPluginDoubleInstall(opts),
     checkDanglingHookPaths(opts),
     checkStalePluginCache(opts),
+    checkDevLinkOverride(opts),
     checkRestartNeeded(opts),
     checkHookExecSmoke(opts),
     checkHookSyntaxSmoke(opts),


### PR DESCRIPTION
## Story

Once upon a time, kaizen hook registrations came from `.claude-plugin/plugin.json`, and Claude Code resolved `${CLAUDE_PLUGIN_ROOT}` to the installed plugin cache at session start. Every day, that was the right user path: stable plugin install state, no duplicate hook registration, and hook script bodies hot-reload when the registered file path stays put.

One day, #1064 captured the contributor gap left by that design: if a kaizen maintainer edited `.claude/hooks/foo.sh` in the working tree, the registered session still invoked the cached copy. Testing the edit meant publish, `/plugin update`, and restart, which is the wrong loop for hook development.

Because of that, this PR adds a contributor-only `scripts/kaizen-dev-link.sh` helper backed by testable TypeScript. It resolves the active `kaizen@kaizen` install path from `installed_plugins.json`, backs up that version directory, and replaces it with a symlink to the current worktree. The registered cache path stays the same, but the files underneath are now the working tree.

Because of that, `kaizen-doctor` now reports an active dev override as a WARN. The override is intentional local state, not a failure, but it should be loud enough that contributors disable it before normal user testing.

Until finally, a temp-home smoke proved the actual acceptance path: after `enable`, executing the same cache hook path printed `one`; after editing the worktree hook body, executing the same cache hook path printed `two`; after `disable`, the original cache directory was restored.

And ever since, hook contributors get a documented fast loop without changing plugin manifest registrations or asking all users to go through a dispatcher.

Fixes Garsson-io/kaizen#1064

## Architecture

```text
installed_plugins.json
  kaizen@kaizen record for this project
        |
        v
~/.claude/plugins/cache/kaizen/kaizen/<version>  -- normal state: cache dir
        |
        | scripts/kaizen-dev-link.sh enable
        v
<version>.kaizen-dev-link-backup                -- original cache dir
<version> -> /path/to/kaizen-worktree           -- active dev override
        |
        v
Claude Code keeps invoking the same registered cache path
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Symlink the active install path instead of rewriting hook registrations | Existing Claude sessions already call the cache path; keeping that path stable enables immediate hook-body reloads | Contributor-only filesystem state must be restored with `disable` |
| Resolve install path from `installed_plugins.json` | Avoids guessing the current version directory | If the plugin is not installed for the project, the script refuses to enable |
| Require install path under `~/.claude/plugins/cache/kaizen/kaizen/<version>` | Prevents replacing arbitrary filesystem paths from malformed registry data | The helper is intentionally scoped to kaizen’s plugin layout |
| Doctor emits WARN, not FAIL | Active dev-link is intentional while developing | It still appears in normal doctor output so it is not left on silently |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/kaizen-dev-link.ts` | Testable dev-link resolver, status, enable, and disable logic |
| `scripts/kaizen-dev-link.sh` | Executable wrapper for contributor usage |
| `scripts/kaizen-dev-link.test.ts` | Temp-home tests for resolution, path safety, enable/disable restore, wrapper delegation, and hot-edit behavior |
| `scripts/kaizen-doctor.ts` | Adds `dev-link-override` doctor check |
| `scripts/kaizen-doctor.test.ts` | Verifies doctor PASS/WARN states and runAllChecks order |
| `docs/plugin-lifecycle.md` | Adds “Contributing to kaizen” dev-link workflow and caveats |

## Impact (goal -> before/after -> match)

- Goal (#1064): contributors can test local hook edits through the plugin-loaded hook path without publishing, reinstalling, or restarting Claude Code.
- Acceptance signal: a fixed command path under a fake plugin cache install path executes a working-tree hook, then executes newly edited hook content without changing the command path.
- BEFORE: no `kaizen-dev-link` script, no doctor dev-override check, and no contributor docs; cache install paths were ordinary directories.
- AFTER: standalone smoke returned `before=one after=two restored=restored` using the same `$install/.claude/hooks/foo.sh` command path before and after editing the worktree hook.
- Delta: publish/update/restart loop replaced by `scripts/kaizen-dev-link.sh enable`, edit hook, trigger tool call, `scripts/kaizen-dev-link.sh disable`.
- Goal met?: yes.
- Residual scan: no related open issue beyond #1064; docs explicitly state manifest changes/path renames still require normal restart lifecycle.

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration/System | Manual Smoke |
|---|---:|---:|---:|
| Resolve current kaizen install path from `installed_plugins.json` | ✅ `scripts/kaizen-dev-link.test.ts` | ✅ temp filesystem registry | n/a |
| Reject unsafe/non-kaizen install paths | ✅ `scripts/kaizen-dev-link.test.ts` | ✅ temp filesystem path checks | n/a |
| Enable symlink and restore original cache on disable | ✅ `scripts/kaizen-dev-link.test.ts` | ✅ real temp symlink/rename operations | ✅ `before=one after=two restored=restored` |
| Fixed cache hook path observes edited worktree hook content | ✅ `scripts/kaizen-dev-link.test.ts` | ✅ executes temp cache path before/after edit | ✅ same command path smoke |
| Doctor reports active dev override | ✅ `scripts/kaizen-doctor.test.ts` | ✅ temp installed plugin record + symlink | n/a |
| Contributor workflow is documented | n/a | ✅ docs diff | n/a |

No deferred behaviors.

## Validation

- [x] RED confirmed: focused suite initially failed because `kaizen-dev-link.ts`, `checkDevLinkOverride()`, and the runAllChecks entry did not exist.
- [x] `npx vitest run scripts/kaizen-dev-link.test.ts scripts/kaizen-doctor.test.ts` — 60 passed.
- [x] `npm run check:fast` — typecheck passed; changed tests 60 passed.
- [x] `npm run test:hooks` — 435 passed.
- [x] `npm test` — 4117 passed, 14 skipped.
- [x] Standalone temp-home smoke — `before=one after=two restored=restored`.

## Known Limitations

- Dev-link does not test plugin manifest edits, hook path renames, marketplace updates, install/uninstall behavior, or any other registry-level change. Those still require the normal plugin lifecycle and a Claude Code restart.
- The helper requires a project-scoped `kaizen@kaizen` install record. If no record exists, it reports status and refuses to enable rather than guessing a version directory.
