### PR TITLE
fix(auto-dent): post strategic run output fallback

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -4642,13 +4642,15 @@ describe('mode-output progress fallback (#702)', () => {
     expect(logs.some((msg) => msg.includes('no progress issue'))).toBe(true);
   });
 
-  it('wires the fallback after runLog is available and before metrics progress update', () => {
-    const runLogIndex = AUTO_DENT_RUN_SOURCE.indexOf('const runLog = existsSync(logFile) ? readFileSync(logFile,');
+  it('wires the fallback immediately after run metadata and before review/metrics updates', () => {
+    const metadataIndex = AUTO_DENT_RUN_SOURCE.indexOf("'--- auto-dent metadata ---'");
     const fallbackIndex = AUTO_DENT_RUN_SOURCE.indexOf('postModeOutputToProgressIssue({');
+    const reviewIndex = AUTO_DENT_RUN_SOURCE.indexOf('runReviewWiring(', fallbackIndex);
     const metricsIndex = AUTO_DENT_RUN_SOURCE.indexOf('updateBatchProgressIssue(', fallbackIndex);
 
-    expect(runLogIndex).toBeGreaterThan(-1);
-    expect(fallbackIndex).toBeGreaterThan(runLogIndex);
+    expect(metadataIndex).toBeGreaterThan(-1);
+    expect(fallbackIndex).toBeGreaterThan(metadataIndex);
+    expect(reviewIndex).toBeGreaterThan(fallbackIndex);
     expect(metricsIndex).toBeGreaterThan(fallbackIndex);
   });
 });

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -54,6 +54,8 @@ import {
   findExistingProgressIssue,
   ensureBatchProgressIssue,
   updateBatchProgressIssue,
+  extractModeOutput,
+  postModeOutputToProgressIssue,
   extractPlanText,
   populateCrossBatchSteering,
   shouldRunCodexProvider,
@@ -4477,6 +4479,177 @@ describe('updateBatchProgressIssue', () => {
     expect(body).toContain('| CLEANUP | not observed | - | - |');
     expect(body.indexOf('| PICK |')).toBeLessThan(body.indexOf('| REVIEW |'));
     expect(body.indexOf('| REVIEW |')).toBeLessThan(body.indexOf('| STOP |'));
+  });
+});
+
+describe('mode-output progress fallback (#702)', () => {
+  const exploreLog = [
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"Candidate analysis\\n\\n- #10 duplicate of #9\\n- File #11 for missing fallback"}]}}',
+    '',
+    '--- auto-dent metadata ---',
+    'exit_code=0',
+  ].join('\n');
+
+  it('extracts assistant analysis text from a completed stream log without metadata noise', () => {
+    const output = extractModeOutput(exploreLog);
+
+    expect(output).toContain('Candidate analysis');
+    expect(output).toContain('File #11 for missing fallback');
+    expect(output).not.toContain('auto-dent metadata');
+  });
+
+  it('posts harness-owned explore output to the progress issue', () => {
+    const commands: string[] = [];
+
+    postModeOutputToProgressIssue({
+      progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
+      repo: 'Garsson-io/kaizen',
+      mode: 'explore',
+      runNum: 3,
+      logFile: '/logs/run-3.log',
+      readLog: () => exploreLog,
+      gh: (cmd) => {
+        commands.push(cmd);
+        return 'https://github.com/Garsson-io/kaizen/issues/7020#issuecomment-1';
+      },
+      log: () => {},
+    });
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain('gh issue comment 7020 --repo Garsson-io/kaizen');
+    const body = JSON.parse(commands[0].match(/--body (.+)$/)![1]);
+    expect(body).toContain('### explore run #3 — analysis fallback');
+    expect(body).toContain('Candidate analysis');
+    expect(body).toContain('File #11 for missing fallback');
+  });
+
+  it('posts reflect output from codex final text blocks', () => {
+    const commands: string[] = [];
+    const reflectLog = [
+      '[provider] codex subscription-cli',
+      '--- codex final text ---',
+      'REFLECTION_INSIGHT: progress issue fallback is missing',
+      '',
+      'Detailed reflection body.',
+      '--- codex lifecycle markers ---',
+      'AUTO_DENT_PHASE: REFLECT | issues_filed=1',
+    ].join('\n');
+
+    postModeOutputToProgressIssue({
+      progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
+      repo: 'Garsson-io/kaizen',
+      mode: 'reflect',
+      runNum: 4,
+      logFile: '/logs/run-4.log',
+      readLog: () => reflectLog,
+      gh: (cmd) => {
+        commands.push(cmd);
+        return '';
+      },
+      log: () => {},
+    });
+
+    const body = JSON.parse(commands[0].match(/--body (.+)$/)![1]);
+    expect(body).toContain('### reflect run #4 — analysis fallback');
+    expect(body).toContain('REFLECTION_INSIGHT: progress issue fallback is missing');
+    expect(body).toContain('Detailed reflection body.');
+    expect(body).not.toContain('codex lifecycle markers');
+  });
+
+  it('does not post for exploit mode', () => {
+    const commands: string[] = [];
+
+    postModeOutputToProgressIssue({
+      progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
+      repo: 'Garsson-io/kaizen',
+      mode: 'exploit',
+      runNum: 5,
+      logFile: '/logs/run-5.log',
+      readLog: () => exploreLog,
+      gh: (cmd) => {
+        commands.push(cmd);
+        return '';
+      },
+      log: () => {},
+    });
+
+    expect(commands).toHaveLength(0);
+  });
+
+  it('deduplicates contemplate when the agent already posted to the progress issue', () => {
+    const commands: string[] = [];
+    const logs: string[] = [];
+
+    postModeOutputToProgressIssue({
+      progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
+      repo: 'Garsson-io/kaizen',
+      mode: 'contemplate',
+      runNum: 6,
+      logFile: '/logs/run-6.log',
+      readLog: () => 'Strategic output\nReflection complete (posted to progress issue).',
+      gh: (cmd) => {
+        commands.push(cmd);
+        return '';
+      },
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(commands).toHaveLength(0);
+    expect(logs.some((msg) => msg.includes('already posted'))).toBe(true);
+  });
+
+  it('fails open when the log cannot be read', () => {
+    const commands: string[] = [];
+    const logs: string[] = [];
+
+    expect(() => postModeOutputToProgressIssue({
+      progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
+      repo: 'Garsson-io/kaizen',
+      mode: 'reflect',
+      runNum: 7,
+      logFile: '/logs/missing.log',
+      readLog: () => { throw new Error('ENOENT'); },
+      gh: (cmd) => {
+        commands.push(cmd);
+        return '';
+      },
+      log: (msg) => logs.push(msg),
+    })).not.toThrow();
+
+    expect(commands).toHaveLength(0);
+    expect(logs.some((msg) => msg.includes('skipped'))).toBe(true);
+  });
+
+  it('fails open without a progress issue or repository', () => {
+    const commands: string[] = [];
+    const logs: string[] = [];
+
+    postModeOutputToProgressIssue({
+      progressIssue: '',
+      repo: '',
+      mode: 'reflect',
+      runNum: 8,
+      logFile: '/logs/run-8.log',
+      readLog: () => exploreLog,
+      gh: (cmd) => {
+        commands.push(cmd);
+        return '';
+      },
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(commands).toHaveLength(0);
+    expect(logs.some((msg) => msg.includes('no progress issue'))).toBe(true);
+  });
+
+  it('wires the fallback after runLog is available and before metrics progress update', () => {
+    const runLogIndex = AUTO_DENT_RUN_SOURCE.indexOf('const runLog = existsSync(logFile) ? readFileSync(logFile,');
+    const fallbackIndex = AUTO_DENT_RUN_SOURCE.indexOf('postModeOutputToProgressIssue({');
+    const metricsIndex = AUTO_DENT_RUN_SOURCE.indexOf('updateBatchProgressIssue(', fallbackIndex);
+
+    expect(runLogIndex).toBeGreaterThan(-1);
+    expect(fallbackIndex).toBeGreaterThan(runLogIndex);
+    expect(metricsIndex).toBeGreaterThan(fallbackIndex);
   });
 });
 

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -4499,7 +4499,7 @@ describe('mode-output progress fallback (#702)', () => {
   });
 
   it('posts harness-owned explore output to the progress issue', () => {
-    const commands: string[] = [];
+    const commands: string[][] = [];
 
     postModeOutputToProgressIssue({
       progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
@@ -4508,23 +4508,23 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 3,
       logFile: '/logs/run-3.log',
       readLog: () => exploreLog,
-      gh: (cmd) => {
-        commands.push(cmd);
+      gh: (args) => {
+        commands.push(args);
         return 'https://github.com/Garsson-io/kaizen/issues/7020#issuecomment-1';
       },
       log: () => {},
     });
 
     expect(commands).toHaveLength(1);
-    expect(commands[0]).toContain('gh issue comment 7020 --repo Garsson-io/kaizen');
-    const body = JSON.parse(commands[0].match(/--body (.+)$/)![1]);
+    expect(commands[0].slice(0, 5)).toEqual(['issue', 'comment', '7020', '--repo', 'Garsson-io/kaizen']);
+    const body = commands[0][commands[0].indexOf('--body') + 1];
     expect(body).toContain('### explore run #3 — analysis fallback');
     expect(body).toContain('Candidate analysis');
     expect(body).toContain('File #11 for missing fallback');
   });
 
   it('posts reflect output from codex final text blocks', () => {
-    const commands: string[] = [];
+    const commands: string[][] = [];
     const reflectLog = [
       '[provider] codex subscription-cli',
       '--- codex final text ---',
@@ -4542,14 +4542,14 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 4,
       logFile: '/logs/run-4.log',
       readLog: () => reflectLog,
-      gh: (cmd) => {
-        commands.push(cmd);
+      gh: (args) => {
+        commands.push(args);
         return '';
       },
       log: () => {},
     });
 
-    const body = JSON.parse(commands[0].match(/--body (.+)$/)![1]);
+    const body = commands[0][commands[0].indexOf('--body') + 1];
     expect(body).toContain('### reflect run #4 — analysis fallback');
     expect(body).toContain('REFLECTION_INSIGHT: progress issue fallback is missing');
     expect(body).toContain('Detailed reflection body.');
@@ -4557,7 +4557,7 @@ describe('mode-output progress fallback (#702)', () => {
   });
 
   it('does not post for exploit mode', () => {
-    const commands: string[] = [];
+    const commands: string[][] = [];
 
     postModeOutputToProgressIssue({
       progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
@@ -4566,8 +4566,8 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 5,
       logFile: '/logs/run-5.log',
       readLog: () => exploreLog,
-      gh: (cmd) => {
-        commands.push(cmd);
+      gh: (args) => {
+        commands.push(args);
         return '';
       },
       log: () => {},
@@ -4577,7 +4577,7 @@ describe('mode-output progress fallback (#702)', () => {
   });
 
   it('deduplicates contemplate when the agent already posted to the progress issue', () => {
-    const commands: string[] = [];
+    const commands: string[][] = [];
     const logs: string[] = [];
 
     postModeOutputToProgressIssue({
@@ -4587,8 +4587,8 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 6,
       logFile: '/logs/run-6.log',
       readLog: () => 'Strategic output\nReflection complete (posted to progress issue).',
-      gh: (cmd) => {
-        commands.push(cmd);
+      gh: (args) => {
+        commands.push(args);
         return '';
       },
       log: (msg) => logs.push(msg),
@@ -4599,7 +4599,7 @@ describe('mode-output progress fallback (#702)', () => {
   });
 
   it('fails open when the log cannot be read', () => {
-    const commands: string[] = [];
+    const commands: string[][] = [];
     const logs: string[] = [];
 
     expect(() => postModeOutputToProgressIssue({
@@ -4609,8 +4609,8 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 7,
       logFile: '/logs/missing.log',
       readLog: () => { throw new Error('ENOENT'); },
-      gh: (cmd) => {
-        commands.push(cmd);
+      gh: (args) => {
+        commands.push(args);
         return '';
       },
       log: (msg) => logs.push(msg),
@@ -4621,7 +4621,7 @@ describe('mode-output progress fallback (#702)', () => {
   });
 
   it('fails open without a progress issue or repository', () => {
-    const commands: string[] = [];
+    const commands: string[][] = [];
     const logs: string[] = [];
 
     postModeOutputToProgressIssue({
@@ -4631,8 +4631,8 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 8,
       logFile: '/logs/run-8.log',
       readLog: () => exploreLog,
-      gh: (cmd) => {
-        commands.push(cmd);
+      gh: (args) => {
+        commands.push(args);
         return '';
       },
       log: (msg) => logs.push(msg),

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -65,6 +65,7 @@ import { parseJsonObject } from '../src/lib/json-value.js';
 import { readDurableJsonValueFile, readJsonValueFile, writeDurableJsonValueFile } from '../src/lib/json-file.js';
 import { hasHardQualityFailure } from '../src/verdict-binding-policy.js';
 import { extractPlanText } from '../src/structured-data.js';
+import { gh } from '../src/lib/gh-exec.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -2828,7 +2829,7 @@ export function postModeOutputToProgressIssue(input: {
   runNum: number;
   logFile: string;
   readLog?: (path: string) => string;
-  gh?: typeof ghExec;
+  gh?: (args: string[]) => string;
   log?: (msg: string) => void;
 }): void {
   if (!MODE_OUTPUT_FALLBACK_MODES.has(input.mode)) return;
@@ -2872,9 +2873,9 @@ export function postModeOutputToProgressIssue(input: {
     '',
     output,
   ].join('\n');
-  const gh = input.gh ?? ghExec;
+  const runGh = input.gh ?? ((args) => gh(args));
   try {
-    const url = gh(`gh issue comment ${issueNum} --repo ${input.repo} --body ${JSON.stringify(body)}`);
+    const url = runGh(['issue', 'comment', issueNum, '--repo', input.repo, '--body', body]);
     log(`  [hygiene] posted ${input.mode} output fallback to progress issue${url ? `: ${url}` : ''}`);
   } catch (err) {
     log(`  [hygiene] ${input.mode} output fallback skipped: ${(err as Error).message}`);

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -3229,6 +3229,15 @@ async function main(): Promise<void> {
     ].join('\n'),
   );
 
+  const progressIssue = ensureBatchProgressIssue(state, stateFile);
+  postModeOutputToProgressIssue({
+    progressIssue,
+    repo: state.kaizen_repo,
+    mode: runMode,
+    runNum,
+    logFile,
+  });
+
   // Emit per-artifact events from stream results (#647)
   let pickedIssue = '';
   {
@@ -3625,16 +3634,8 @@ async function main(): Promise<void> {
   }
 
   // Post-run hygiene
-  const progressIssue = ensureBatchProgressIssue(state, stateFile);
   labelArtifacts(result, 'auto-dent');
   const runLog = existsSync(logFile) ? readFileSync(logFile, 'utf8') : undefined;
-  postModeOutputToProgressIssue({
-    progressIssue,
-    repo: state.kaizen_repo,
-    mode: runMode,
-    runNum,
-    logFile,
-  });
   const testHealth = deriveRunTestHealth({ runLog });
   const autoMergeDecision = decideAutoMergeSafety({
     prCount: result.prs.length,

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2778,6 +2778,109 @@ export function attachRunTranscripts(input: {
   }
 }
 
+const MODE_OUTPUT_FALLBACK_MODES = new Set(['explore', 'reflect', 'contemplate']);
+const MODE_OUTPUT_MAX_CHARS = 12_000;
+
+function cleanModeOutput(text: string): string {
+  return truncateAtWordBoundary(
+    text
+      .replace(/\n--- auto-dent metadata ---[\s\S]*$/m, '')
+      .replace(/\n--- codex lifecycle markers ---[\s\S]*$/m, '')
+      .trim(),
+    MODE_OUTPUT_MAX_CHARS,
+  );
+}
+
+function extractCodexFinalText(logText: string): string {
+  const marker = '--- codex final text ---';
+  const start = logText.indexOf(marker);
+  if (start < 0) return '';
+  return cleanModeOutput(logText.slice(start + marker.length));
+}
+
+function extractAssistantTextFromStream(logText: string): string {
+  const chunks: string[] = [];
+  for (const line of logText.split(/\r?\n/)) {
+    const msg = parseJsonObject(line);
+    if (!msg || msg.type !== 'assistant' || !Array.isArray(msg.message?.content)) continue;
+    for (const block of msg.message.content) {
+      if (block?.type === 'text' && typeof block.text === 'string' && block.text.trim()) {
+        chunks.push(block.text.trim());
+      }
+    }
+  }
+  return cleanModeOutput(chunks.join('\n\n'));
+}
+
+export function extractModeOutput(logText: string): string {
+  return extractCodexFinalText(logText) || extractAssistantTextFromStream(logText);
+}
+
+function contemplateAlreadyPosted(logText: string): boolean {
+  return /\bposted to (?:the )?progress issue\b/i.test(logText)
+    || /\bprogress issue\b[\s\S]{0,120}\bposted\b/i.test(logText);
+}
+
+export function postModeOutputToProgressIssue(input: {
+  progressIssue: string;
+  repo: string;
+  mode: string;
+  runNum: number;
+  logFile: string;
+  readLog?: (path: string) => string;
+  gh?: typeof ghExec;
+  log?: (msg: string) => void;
+}): void {
+  if (!MODE_OUTPUT_FALLBACK_MODES.has(input.mode)) return;
+
+  const log = input.log ?? ((m) => console.log(m));
+  if (!input.progressIssue || !input.repo) {
+    log(`  [hygiene] ${input.mode} output fallback skipped: no progress issue`);
+    return;
+  }
+
+  const issueNum = input.progressIssue.match(/issues\/(\d+)/)?.[1];
+  if (!issueNum) {
+    log(`  [hygiene] ${input.mode} output fallback skipped: invalid progress issue`);
+    return;
+  }
+
+  const readLog = input.readLog ?? ((p) => readFileSync(p, 'utf8'));
+  let logText = '';
+  try {
+    logText = readLog(input.logFile);
+  } catch (err) {
+    log(`  [hygiene] ${input.mode} output fallback skipped: ${(err as Error).message}`);
+    return;
+  }
+
+  if (input.mode === 'contemplate' && contemplateAlreadyPosted(logText)) {
+    log(`  [hygiene] contemplate output fallback skipped: already posted to progress issue`);
+    return;
+  }
+
+  const output = extractModeOutput(logText);
+  if (!output) {
+    log(`  [hygiene] ${input.mode} output fallback skipped: no analysis text found`);
+    return;
+  }
+
+  const body = [
+    `### ${input.mode} run #${input.runNum} — analysis fallback`,
+    '',
+    `_Harness-posted from \`${input.logFile}\` so non-exploit analysis is durable even if the agent did not post it._`,
+    '',
+    output,
+  ].join('\n');
+  const gh = input.gh ?? ghExec;
+  try {
+    const url = gh(`gh issue comment ${issueNum} --repo ${input.repo} --body ${JSON.stringify(body)}`);
+    log(`  [hygiene] posted ${input.mode} output fallback to progress issue${url ? `: ${url}` : ''}`);
+  } catch (err) {
+    log(`  [hygiene] ${input.mode} output fallback skipped: ${(err as Error).message}`);
+  }
+}
+
 function printRunSummary(
   runNum: number,
   exitCode: number,
@@ -3524,6 +3627,13 @@ async function main(): Promise<void> {
   const progressIssue = ensureBatchProgressIssue(state, stateFile);
   labelArtifacts(result, 'auto-dent');
   const runLog = existsSync(logFile) ? readFileSync(logFile, 'utf8') : undefined;
+  postModeOutputToProgressIssue({
+    progressIssue,
+    repo: state.kaizen_repo,
+    mode: runMode,
+    runNum,
+    logFile,
+  });
   const testHealth = deriveRunTestHealth({ runLog });
   const autoMergeDecision = decideAutoMergeSafety({
     prCount: result.prs.length,


### PR DESCRIPTION
## Story

Once upon a time, auto-dent batches already had a GitHub progress issue and per-run metric comments. The harness could say a run cost `$0.13`, took 90 seconds, and produced no PR.

Every day, that was enough for exploit runs because the PR itself carried most of the useful output. For reflect, explore, and contemplate runs, the useful artifact is the analysis text itself. If the agent did not post that text, the progress issue only showed a bare metrics row.

One day, #702 captured the concrete failure: in `batch-260323-0003-072b`, reflect run analysis never appeared in the progress issue. The run had useful strategic output, but the cloud artifact did not preserve it.

Because of that, this PR adds a harness-owned fallback in `scripts/auto-dent-run.ts`. After a non-exploit run completes and metadata is appended to the run log, the harness extracts bounded analysis text and posts it to the batch progress issue before review and merge hygiene. The helper handles Claude stream JSON and Codex final-text logs, ignores exploit runs, and fails open when the progress issue or log is unavailable.

Because of that, contemplate gets the same safety net without duplicating the agent's existing post. If the completed log says the agent already posted to the progress issue, the harness skips the fallback for that contemplate run.

Until finally, the acceptance path is test-proven: synthetic explore and reflect logs produce a captured `gh issue comment` body with the mode/run heading and analysis text, while exploit and already-posted contemplate logs produce no comment.

And ever since, strategic auto-dent runs have a harness-level path to make their analysis durable within the batch progress issue even when the agent never posts it.

Fixes Garsson-io/kaizen#702
Related: Garsson-io/kaizen#842
Related: Garsson-io/kaizen#691

## Architecture

```text
completed run log
  -> extractModeOutput()
       - Codex: --- codex final text --- block
       - Claude: assistant text blocks from stream JSON
  -> postModeOutputToProgressIssue()
       - eligible modes: explore, reflect, contemplate
       - contemplate dedup: skip if already posted
       - gh issue comment <progress issue>
  -> existing updateBatchProgressIssue() metrics table
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Post from the existing post-run hygiene path | It has `runMode`, `logFile`, `progressIssue`, and repo context immediately after completion. | A live GitHub outage only logs a skip; it does not block the batch. |
| Use argv-style `gh()` for the new comment path | Matches `updateBatchProgressIssue()` and avoids a second GitHub wrapper. | This remains a direct issue comment rather than a named attachment. |
| Extract from completed logs, not state metrics | The missing artifact is prose analysis, not PR/issue metrics. | Extraction is intentionally bounded and best-effort. |
| Dedup only `contemplate` by posted-signal text | #702 says contemplate may already post by prompt; reflect/explore need the harness fallback. | If a contemplate post uses completely different wording, the fallback may still post once. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-run.ts` | Adds `extractModeOutput()` and `postModeOutputToProgressIssue()`, then wires the fallback immediately after run metadata is appended. |
| `scripts/auto-dent-run.test.ts` | Adds RED/GREEN coverage for extraction, posting, skip/dedup, fail-open behavior, and call-site placement. |

## Impact (goal -> before/after -> match)

- Goal (#702): non-exploit run analysis should be visible on the batch progress issue even if the agent does not post it.
- Acceptance signal: a unit-level post-run fallback can extract analysis from a representative completed log and emit a `gh issue comment` body containing the mode/run heading and analysis text.
- BEFORE: no `postModeOutputToProgressIssue()` or equivalent existed; the first RED run failed with `TypeError: postModeOutputToProgressIssue is not a function`.
- AFTER: `npx vitest run scripts/auto-dent-run.test.ts -t "mode-output progress fallback"` passes 8 tests, including captured argv and comment-body assertions for explore and reflect logs plus contemplate dedup.
- Delta: the harness now has a post-run comment path for `explore`, `reflect`, and `contemplate`; `exploit` stays unchanged.
- Goal met?: yes.
- Residual scan: related progress/artifact paths checked (`updateBatchProgressIssue`, `attachRunTranscripts`, `batch-artifacts-upload`); no competing GitHub wrapper or raw-artifact overlap added. Larger dashboard/memory epics remain open as Related #842 and Related #691.

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Coverage |
|---|---|---|
| 1 | Extract bounded human-readable analysis from a completed non-exploit run log | Unit | Tested in `scripts/auto-dent-run.test.ts` via assistant stream JSON and Codex final-text logs. |
| 2 | Post harness-owned fallback comments for `explore` and `reflect` modes | Unit | Tested by capturing the exact `gh issue comment` command and parsing the JSON body. |
| 3 | Avoid duplicate fallback comments for `contemplate` when the agent already posted | Unit | Tested with a log containing `posted to progress issue`; no command is emitted. |
| 4 | Fail open on missing issue URL, repo, or unreadable log | Unit | Tested with empty progress/repo inputs and a throwing `readLog`; no command is emitted. |
| 5 | Invoke fallback after run metadata is appended and before review/metrics updates | Unit/source invariant | Tested by source-order assertion in `scripts/auto-dent-run.test.ts` against metadata, review, and metrics call sites. |

No deferred behaviors.

## Validation

- [x] RED observed: targeted test failed before implementation because `postModeOutputToProgressIssue` did not exist.
- [x] `npx vitest run scripts/auto-dent-run.test.ts -t "mode-output progress fallback"` -> 8 passed.
- [x] `npx vitest run scripts/auto-dent-run.test.ts` -> 381 passed before the final added fail-open test; changed-test fast path covers the final state.
- [x] `npm run typecheck` -> pass.
- [x] `npm run test:fast` -> 8 files passed, 687 passed, 2 skipped.
- [x] `git diff --check` -> pass.

## Known Limitations

This PR does not close the larger observability dashboard or cross-batch memory work in #842/#691. It implements the scope-matched #702 fallback: strategic run output reaches the existing progress issue promptly and reliably.