### PR TITLE
fix(hooks): require agent evidence for review gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -194,6 +194,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/pr-review-loop-ts.sh",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "Stop": [

--- a/.claude/hooks/tests/harness.py
+++ b/.claude/hooks/tests/harness.py
@@ -114,6 +114,12 @@ class PostToolUseInput:
         return cls(tool_name="Bash", tool_input={"command": command},
                    stdout=stdout, stderr=stderr, exit_code=exit_code, **kwargs)
 
+    @classmethod
+    def agent(cls, prompt: str = "Run /kaizen-review-pr dimension review", stdout: str = "review complete",
+              stderr: str = "", exit_code: str = "0", **kwargs) -> "PostToolUseInput":
+        return cls(tool_name="Agent", tool_input={"prompt": prompt},
+                   stdout=stdout, stderr=stderr, exit_code=exit_code, **kwargs)
+
 
 @dataclass
 class StopInput:

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -256,7 +256,8 @@ class TestPRLifecycle:
         r = review_harness.run_hook("kaizen-enforce-pr-review-ts.sh", PreToolUseInput.bash("gh pr diff 55"))
         assert r.allows(), "Should allow gh pr diff"
 
-        # Phase 3: Review outcome persisted (store-review-summary/store-review-batch sentinel)
+        # Phase 3: Review agents ran and outcome persisted.
+        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.agent())
         state.create_review_sentinel(self.PR_URL, 1)
 
         # gh pr diff → review passed
@@ -276,7 +277,7 @@ class TestPRLifecycle:
         assert s["ROUND"] == "2", "Round should be incremented after push"
 
     def test_diff_requires_review_sentinel(self, review_harness, state):
-        """gh pr diff alone must not clear gate; sentinel is required (#920)."""
+        """gh pr diff alone must not clear gate; sentinel and Agent evidence are required."""
         state.create_state(self.PR_URL, round_num=1, status="needs_review", branch="wt/test-branch")
 
         # No sentinel yet -> stays blocked
@@ -288,8 +289,15 @@ class TestPRLifecycle:
         # "no valid review sentinel stored" message.
         assert "no valid review sentinel stored" in r.stdout
 
-        # Sentinel present -> clears
+        # Sentinel without Agent evidence still stays blocked (#455).
         state.create_review_sentinel(self.PR_URL, 1)
+        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
+        s = state.read_state(self.PR_URL)
+        assert s["STATUS"] == "needs_review"
+        assert "no observed Agent reviewer activity" in r.stdout
+
+        # Sentinel plus Agent evidence -> clears.
+        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.agent())
         r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "passed"

--- a/src/e2e/plugin-lifecycle.test.ts
+++ b/src/e2e/plugin-lifecycle.test.ts
@@ -191,6 +191,18 @@ describe("Part 2: All hooks are registered and executable", () => {
     expect(matchers).toContain("Agent");
   });
 
+  it("PostToolUse observes Agent reviewers for the PR review loop", () => {
+    const agentEntry = (pluginJson.hooks.PostToolUse as any[]).find(
+      (e: any) => e.matcher === "Agent",
+    );
+    expect(agentEntry).toBeDefined();
+    expect(
+      agentEntry.hooks.some((hook: any) =>
+        String(hook.command ?? "").endsWith("/.claude/hooks/pr-review-loop-ts.sh"),
+      ),
+    ).toBe(true);
+  });
+
   // Reverse check: every .sh hook file on disk must be registered in plugin.json
   const registeredFilenames = new Set(
     allHookCommands.map((cmd) => cmd.split("/").pop()!),

--- a/src/hooks/enforce-pr-review.test.ts
+++ b/src/hooks/enforce-pr-review.test.ts
@@ -85,12 +85,13 @@ describe('enforce-pr-review PreToolUse — Bash commands', () => {
     expect(result.reason).toContain('round 3');
   });
 
-  it('gives the concrete store-review-summary + second diff sequence (#1085)', () => {
+  it('points to /kaizen-review-pr and does not document manual gate clearing', () => {
     createReviewGate('https://github.com/org/repo/pull/42', '3');
     const result = processPreToolUse('git push origin feature', TEST_BRANCH, TEST_STATE_DIR);
     expect(result.allowed).toBe(false);
-    expect(result.reason).toContain('store-review-summary');
-    expect(result.reason).toContain('--pr 42 --repo org/repo --round 3');
+    expect(result.reason).not.toContain('store-review-summary');
+    expect(result.reason).not.toContain('store-review-batch');
+    expect(result.reason).not.toContain('--pr 42 --repo org/repo --round 3');
     expect(result.reason).toContain('gh pr diff https://github.com/org/repo/pull/42');
     expect(result.reason).toContain('/kaizen-review-pr 42');
   });

--- a/src/hooks/enforce-pr-review.ts
+++ b/src/hooks/enforce-pr-review.ts
@@ -27,7 +27,6 @@ const BLOCKED_TOOLS = new Set(['Edit', 'Write']);
 
 function buildDenyMessage(toolLabel: string, prUrl: string, round: string): string {
   const prNum = prUrl.match(/\/pull\/(\d+)/)?.[1] ?? '<N>';
-  const repo = prUrl.match(/github\.com\/([^/]+\/[^/]+)/)?.[1] ?? '<owner/repo>';
 
   return `BLOCKED: ${toolLabel} is not allowed during PR review.
 
@@ -37,14 +36,11 @@ You have an active PR review that must be completed first:
 Use the review skill for the normal path:
   /kaizen-review-pr ${prNum}
 
-If you already performed the review manually, clearing this gate is a two-step
-mechanism:
-  1. Store a real review summary:
-     npx tsx src/cli-structured-data.ts store-review-summary --pr ${prNum} --repo ${repo} --round ${round} --text "REVIEW: <summary>"
-  2. Re-run the diff command so the PostToolUse hook observes the stored summary:
-     gh pr diff ${prUrl}
+The review gate clears only after /kaizen-review-pr launches reviewer agents,
+stores structured findings for every PR dimension, and you re-run:
+  gh pr diff ${prUrl}
 
-The summary must describe what was reviewed. A placeholder defeats the gate.
+Manual checklists or direct review-summary storage do not satisfy this gate.
 
 Allowed commands during review:
   gh pr diff, gh pr view, gh pr comment, gh pr edit

--- a/src/hooks/pr-review-loop-scenarios.test.ts
+++ b/src/hooks/pr-review-loop-scenarios.test.ts
@@ -35,6 +35,14 @@ function input(command: string, stdout = ''): HookInput {
   return { tool_name: 'Bash', tool_input: { command }, tool_response: { stdout, stderr: '', exit_code: '0' } };
 }
 
+function agentInput(): HookInput {
+  return {
+    tool_name: 'Agent',
+    tool_input: { prompt: 'Run /kaizen-review-pr dimension review' },
+    tool_response: { stdout: 'review complete', stderr: '', exit_code: '0' },
+  };
+}
+
 function opts(diffFn?: (sha: string) => number): ProcessOptions {
   return {
     stateDir: TEST_DIR,
@@ -62,6 +70,7 @@ function runAndReadState(hookInput: HookInput, options: ProcessOptions): { decis
 describe('Scenario: cumulative diff cap prevents auto-pass bypass', () => {
   it('small incremental (5 lines) but large cumulative (150 lines) triggers needs_review', () => {
     processHookInput(input('gh pr create --title "test"', PR_URL), opts());
+    processHookInput(agentInput(), opts());
     processHookInput(input('gh pr diff 42'), opts());
 
     // The hook calls getDiffLines twice: once for incremental (lastPushSha), once for cumulative (lastFullReviewSha).
@@ -79,6 +88,7 @@ describe('Scenario: cumulative diff cap prevents auto-pass bypass', () => {
 
   it('small push after review (STATUS=passed) requires review, not auto-pass', () => {
     processHookInput(input('gh pr create --title "test"', PR_URL), opts());
+    processHookInput(agentInput(), opts());
     processHookInput(input('gh pr diff 42'), opts()); // → STATUS=passed
 
     const pushOpts = opts(() => 8); // both incremental and cumulative = 8
@@ -99,6 +109,7 @@ describe('Scenario: cumulative diff cap prevents auto-pass bypass', () => {
 
   it('large incremental (50 lines) triggers needs_review regardless of cumulative', () => {
     processHookInput(input('gh pr create --title "test"', PR_URL), opts());
+    processHookInput(agentInput(), opts());
     processHookInput(input('gh pr diff 42'), opts());
 
     const pushOpts = opts(() => 50);
@@ -136,6 +147,7 @@ describe('Scenario: LAST_FULL_REVIEW_SHA lifecycle', () => {
 
   it('full review (gh pr diff) resets LAST_FULL_REVIEW_SHA', () => {
     processHookInput(input('gh pr create --title "test"', PR_URL), opts());
+    processHookInput(agentInput(), opts());
     processHookInput(input('gh pr diff 42'), opts());
 
     // Read SHA after first review
@@ -147,6 +159,7 @@ describe('Scenario: LAST_FULL_REVIEW_SHA lifecycle', () => {
     processHookInput(input('git push'), opts(() => 500));
 
     // Do second review
+    processHookInput(agentInput(), opts());
     processHookInput(input('gh pr diff 42'), opts());
 
     // LAST_FULL_REVIEW_SHA should be updated
@@ -164,6 +177,7 @@ describe('Scenario: LAST_FULL_REVIEW_SHA lifecycle', () => {
 describe('Scenario: invalid SHA graceful degradation', () => {
   it('rebased SHA → conservative needs_review (not crash or auto-pass)', () => {
     processHookInput(input('gh pr create --title "test"', PR_URL), opts());
+    processHookInput(agentInput(), opts());
     processHookInput(input('gh pr diff 42'), opts());
 
     const pushOpts = opts(() => 0); // can't compute diff

--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -200,6 +200,18 @@ function prDiffInput(prUrl: string): object {
   };
 }
 
+function agentReviewInput(): object {
+  return {
+    tool_name: 'Agent',
+    tool_input: { prompt: 'Run /kaizen-review-pr dimension review' },
+    tool_response: {
+      stdout: 'review complete',
+      stderr: '',
+      exit_code: '0',
+    },
+  };
+}
+
 function prMergeInput(prUrl: string, options: string = '--squash'): object {
   return {
     tool_input: { command: `gh pr merge ${prUrl} ${options}` },
@@ -392,7 +404,50 @@ describe('pr-review-loop: gh pr diff', () => {
     });
   }
 
-  it('outputs checklist and transitions to passed (with sentinel)', () => {
+  function createAgentReviewedState(
+    prNumber: string,
+    round: string = '1',
+    evidenceRound: string = round,
+  ): void {
+    const branch = TEST_BRANCH;
+    createState(`Garsson-io_kaizen_${prNumber}`, {
+      PR_URL: `https://github.com/Garsson-io/kaizen/pull/${prNumber}`,
+      ROUND: round,
+      STATUS: 'needs_review',
+      BRANCH: branch,
+      REVIEW_AGENT_ROUND: evidenceRound,
+      REVIEW_AGENT_OBSERVED_AT: '2026-06-29T00:00:00.000Z',
+    });
+  }
+
+  it('records Agent review evidence for the active review round', () => {
+    createPendingReviewState('4551', '2');
+
+    const output = runHookDecision(agentReviewInput());
+
+    expect(output).toBe('');
+    const state = readState('Garsson-io_kaizen_4551');
+    expect(state.STATUS).toBe('needs_review');
+    expect(state.REVIEW_AGENT_ROUND).toBe('2');
+    expect(state.REVIEW_AGENT_OBSERVED_AT).toBeTruthy();
+  });
+
+  it('keeps manual sentinel-only reviews blocked until /kaizen-review-pr runs Agent reviewers', () => {
+    createPendingReviewState('4552', '1');
+    writeSentinel('Garsson-io_kaizen_4552', '1');
+
+    const output = runHookDecision(
+      prDiffInput('https://github.com/Garsson-io/kaizen/pull/4552'),
+    );
+
+    expect(output).toContain('no observed Agent reviewer activity');
+    expect(output).toContain('/kaizen-review-pr https://github.com/Garsson-io/kaizen/pull/4552');
+    expect(output).not.toContain('REVIEW PASSED');
+    const state = readState('Garsson-io_kaizen_4552');
+    expect(state.STATUS).toBe('needs_review');
+  });
+
+  it('outputs checklist and transitions to passed (with Agent evidence and sentinel)', () => {
     const branch = TEST_BRANCH;
     createState('Garsson-io_kaizen_55', {
       PR_URL: 'https://github.com/Garsson-io/kaizen/pull/55',
@@ -400,13 +455,15 @@ describe('pr-review-loop: gh pr diff', () => {
       STATUS: 'needs_review',
       BRANCH: branch,
     });
+    runHookDecision(agentReviewInput());
     writeSentinel('Garsson-io_kaizen_55', '2');
 
     const output = runHookDecision(
       prDiffInput('https://github.com/Garsson-io/kaizen/pull/55'),
     );
     expect(output).toContain('REVIEW ROUND 2/4');
-    expect(output).toContain('/review-pr');
+    expect(output).toContain('/kaizen-review-pr');
+    expect(output).not.toContain('/review-pr');
     expect(output).toContain('REVIEW PASSED');
 
     const state = readState('Garsson-io_kaizen_55');
@@ -423,7 +480,7 @@ describe('pr-review-loop: gh pr diff', () => {
   });
 
   it('clears a stale local round when a later valid passing sentinel exists', () => {
-    createPendingReviewState('1559', '1');
+    createAgentReviewedState('1559', '1', '3');
     writeSentinel('Garsson-io_kaizen_1559', '3');
 
     const output = runHookDecision(
@@ -438,7 +495,7 @@ describe('pr-review-loop: gh pr diff', () => {
   });
 
   it('uses the newest valid later sentinel and skips invalid newer candidates', () => {
-    createPendingReviewState('1560', '1');
+    createAgentReviewedState('1560', '1', '2');
     writeSentinel('Garsson-io_kaizen_1560', '2');
     fs.writeFileSync(path.join(testStateDir, 'Garsson-io_kaizen_1560.reviewed-r4'), 'not json\n');
 
@@ -507,7 +564,7 @@ describe('pr-review-loop: gh pr diff', () => {
   });
 
   it('does not require non-PR dimensions to clear review gate', () => {
-    createPendingReviewState('1039', '1');
+    createAgentReviewedState('1039', '1');
     const prDimensions = expectedPrReviewDimensions();
     expect(prDimensions).not.toContain('plan-coverage');
     expect(prDimensions).not.toContain('multi-pr-spiral');
@@ -533,6 +590,8 @@ describe('pr-review-loop: gh pr diff', () => {
       ROUND: '1',
       STATUS: 'needs_review',
       BRANCH: branch,
+      REVIEW_AGENT_ROUND: '1',
+      REVIEW_AGENT_OBSERVED_AT: '2026-06-29T00:00:00.000Z',
     });
     writeSentinel('Garsson-io_kaizen_201', '1');
 
@@ -744,6 +803,7 @@ describe('INVARIANT: gate transitions verify outcome, not just trigger command',
         tool_response: { stdout: 'diff --git a/foo b/foo', stderr: '', exit_code: '0' },
       },
       provideOutcome: () => {
+        runHookDecision(agentReviewInput(), { branch });
         const dims = expectedPrReviewDimensions();
         writeReviewSentinel(PR_URL, '1', testStateDir, {
           dimensionsReviewed: dims,

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -8,7 +8,7 @@
  *                 full dimension coverage check tracked in #1038).
  *                 Canonical: docs/kaizen-invariants.md.
  *
- * PostToolUse hook on Bash — always exits 0 (advisory, not blocking).
+ * PostToolUse hook on Bash and Agent — always exits 0 (advisory, not blocking).
  *
  * Triggers:
  *   1. gh pr create  — starts review loop (round 1)
@@ -172,10 +172,10 @@ function printChecklist(
   maxRounds: number,
 ): string {
   return `
-Use the /review-pr skill for the full checklist. Run \`/review-pr ${prUrl}\` now.
+Use the /kaizen-review-pr skill for the full checklist. Run \`/kaizen-review-pr ${prUrl}\` now.
 
 PROCESS:
-1. Run \`/review-pr ${prUrl}\`
+1. Run \`/kaizen-review-pr ${prUrl}\`
 2. Walk through EVERY section
 3. If issues found: fix, commit, push
 4. If clean: state "REVIEW PASSED (round ${round}/${maxRounds})"
@@ -210,6 +210,14 @@ function reviewSentinelFailure(
     reason: result.reason === 'missing_sentinel' ? 'no_review_sentinel' : 'invalid_review_sentinel',
     message: `\n\ud83d\udccb REVIEW ROUND ${round}/${MAX_ROUNDS}\n${printChecklist(prUrl, round, MAX_ROUNDS)}\n\u26a0\ufe0f invalid review sentinel: no valid review sentinel stored for round ${round} (${result.reason}). Run \`/kaizen-review-pr ${prUrl}\` to spawn dimension agents.\n`,
   };
+}
+
+function reviewAgentFailure(prUrl: string, round: string): string {
+  return `\n\ud83d\udccb REVIEW ROUND ${round}/${MAX_ROUNDS}\n\u26a0\ufe0f review sentinel exists, but this round has no observed Agent reviewer activity.\nRun \`/kaizen-review-pr ${prUrl}\` so dimension agents review the diff, then store findings and re-run \`gh pr diff ${prUrl}\`.\nManual checklists or direct review-summary storage do not satisfy this gate.\n`;
+}
+
+function hasReviewAgentEvidence(state: Record<string, string | undefined>, round: string): boolean {
+  return state.REVIEW_AGENT_ROUND === round && !!state.REVIEW_AGENT_OBSERVED_AT;
 }
 
 /**
@@ -310,6 +318,25 @@ export function processHookInput(
   const isShaValid = options.checkShaExists ?? shaExists;
 
   ensureStateDir(stateDir);
+
+  if (input.tool_name === 'Agent') {
+    const found = findStateByStatuses(['needs_review'], branch, stateDir);
+    if (!found || !isValidPrUrl(found.prUrl)) {
+      return decide('ignore', 'no_pending_review_for_agent', null, { branch, hasState: !!found });
+    }
+
+    const state = readStateFile(found.filepath) as Record<string, string | undefined>;
+    writeStateFile(stateDir, prUrlToStateKey(found.prUrl), {
+      ...state,
+      PR_URL: found.prUrl,
+      STATUS: found.status,
+      BRANCH: state.BRANCH ?? branch,
+      ROUND: found.round,
+      REVIEW_AGENT_ROUND: found.round,
+      REVIEW_AGENT_OBSERVED_AT: new Date().toISOString(),
+    });
+    return decide('ignore', 'review_agent_observed', null, { prUrl: found.prUrl, round: found.round });
+  }
 
   const isPrCreate = isGhPrCommand(cmdLine, 'create');
   const isGitPush = isGitCommand(cmdLine, 'push');
@@ -512,6 +539,13 @@ export function processHookInput(
     }
 
     const passedRound = sentinelCheck.round;
+    const rawState = readStateFile(found.filepath) as Record<string, string | undefined>;
+    if (!hasReviewAgentEvidence(rawState, passedRound)) {
+      return decide('needs_review', 'missing_review_agent_evidence', reviewAgentFailure(found.prUrl, passedRound),
+        { prUrl: found.prUrl, round: passedRound, stateRound: found.round },
+        { hook: 'pr-review-loop', type: 'gate-set', gate: 'needs_review', pr: found.prUrl, round: parseInt(passedRound, 10), reason: 'missing_review_agent_evidence' });
+    }
+
     const sha = gitStdout(['rev-parse', 'HEAD']);
     writeStateFile(stateDir, prUrlToStateKey(found.prUrl), {
       PR_URL: found.prUrl,
@@ -542,6 +576,7 @@ async function main(): Promise<void> {
 
   // Trace every decision for observability
   const trigger = [
+    input.tool_name === 'Agent' && 'agent',
     isGhPrCommand(stripHeredocBody(input.tool_input?.command ?? ''), 'create') && 'pr_create',
     isGitCommand(stripHeredocBody(input.tool_input?.command ?? ''), 'push') && 'git_push',
     isGhPrCommand(stripHeredocBody(input.tool_input?.command ?? ''), 'diff') && 'pr_diff',


### PR DESCRIPTION
## Story

The PR review loop already had strong sentinel validation: signed summaries, all PR dimensions, and no MISSING findings. Every day, that made the gate look mechanically solid.

One day, issue #455 showed the gap: a manual checklist plus stored review comments could satisfy the letter of the gate without running `/kaizen-review-pr` and its reviewer agents. The state machine could prove that a summary existed, but not that the review method matched the intended workflow.

Because of that, this PR makes `pr-review-loop` observe `PostToolUse Agent` during an active `needs_review` round and record round-scoped evidence in the PR review state. A valid sentinel now clears the gate only when that same round has Agent evidence. Sentinel-only reviews stay blocked with a message that says to run `/kaizen-review-pr`.

Because of that, the user-facing gate copy now points at `/kaizen-review-pr` and no longer documents manual review-summary storage as a normal clearing path. Plugin installs also register `pr-review-loop-ts.sh` for `PostToolUse Agent`, so the evidence path works outside this repo.

Until finally, the test suite proves the before/after contract: valid sentinel without Agent evidence remains `needs_review`; Agent evidence plus sentinel transitions to `passed`; lifecycle and manifest tests cover the installed hook path.

Fixes Garsson-io/kaizen#455

## Architecture

```text
PostToolUse Agent
  -> pr-review-loop-ts.sh
  -> active needs_review state for current branch
  -> REVIEW_AGENT_ROUND=<round>
  -> REVIEW_AGENT_OBSERVED_AT=<iso timestamp>

PostToolUse Bash: gh pr diff
  -> validate signed review sentinel
  -> require REVIEW_AGENT_ROUND == sentinel round
  -> pass gate or keep needs_review
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Record Agent evidence in the existing review state file | Keeps the contract local to the gate state and branch/round scoping already in use | It proves Agent activity, not a full semantic parse of the skill transcript |
| Require evidence for the same round as the accepted sentinel | Prevents stale Agent activity from clearing later review rounds | Stale-local-round tests need explicit matching evidence |
| Remove manual clearing instructions from the pre-tool deny message | The old message taught the bypass this issue is closing | Users must use the review skill path instead of raw storage commands |
| Add manifest regression coverage | Plugin installs were missing the observation hook | Slightly broadens lifecycle test responsibility |

## What Changed

| File | Purpose |
|---|---|
| `.claude-plugin/plugin.json` | Registers `pr-review-loop-ts.sh` for `PostToolUse Agent` |
| `src/hooks/pr-review-loop.ts` | Records Agent evidence and requires it before accepting a valid sentinel |
| `src/hooks/enforce-pr-review.ts` | Removes manual clearing recipe and routes users to `/kaizen-review-pr` |
| `src/hooks/*test.ts`, `src/e2e/plugin-lifecycle.test.ts` | Unit, scenario, and manifest coverage for the new contract |
| `.claude/hooks/tests/*` | Python lifecycle harness/test coverage for sentinel-only blocked and Agent+sentinel passed |

## Impact (goal -> before/after -> match)

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Prevent manual checklist + stored sentinel from clearing PR review | Stored plan baseline: valid hand-created sentinel could clear `needs_review`; messages mentioned `/review-pr` and manual clearing | `src/hooks/pr-review-loop.test.ts` now asserts sentinel-only stays `needs_review`; Python lifecycle test asserts sentinel-only blocked before Agent evidence | Gate now requires valid sentinel plus same-round `PostToolUse Agent` evidence | yes |
| Make installed plugin observe the review-agent path | `.claude-plugin/plugin.json` only ran `pr-review-loop` for `PostToolUse Bash` | Manifest test asserts `PostToolUse Agent` includes `pr-review-loop-ts.sh` | Hook can record Agent review activity in host/plugin installs | yes |
| Remove stale/manual instructions | `enforce-pr-review` documented raw `store-review-summary` clearing | Message test forbids `store-review-summary` / `store-review-batch` recipe and requires `/kaizen-review-pr` | The visible gate path matches the enforced path | yes |

- Goal (#455): a PR review gate cannot be cleared by a manual checklist plus stored review comments.
- Acceptance signal: valid sentinel without recorded Agent activity keeps `STATUS=needs_review`; adding Agent evidence for the same round clears.
- Residual scan: searched hook/plugin surfaces for stale `/review-pr` instructions; none remain outside the negative assertion.

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Scenario / lifecycle | Manifest / plugin | Status |
|---|---|---|---|---|
| Sentinel-only review remains blocked | `src/hooks/pr-review-loop.test.ts` | `.claude/hooks/tests/test_hooks.py` | n/a | tested |
| Agent evidence is recorded for active review round | `src/hooks/pr-review-loop.test.ts` | `src/hooks/pr-review-loop-scenarios.test.ts` | n/a | tested |
| Agent evidence plus valid sentinel clears gate | `src/hooks/pr-review-loop.test.ts` | `.claude/hooks/tests/test_hooks.py` | n/a | tested |
| Gate copy uses `/kaizen-review-pr` and removes manual clearing recipe | `src/hooks/enforce-pr-review.test.ts` | n/a | n/a | tested |
| Plugin installs observe `PostToolUse Agent` | n/a | n/a | `src/e2e/plugin-lifecycle.test.ts` | tested |

## Validation

- [x] RED observed: focused tests failed on sentinel-only clearing, ignored Agent evidence, stale `/review-pr` copy, and manual clearing recipe.
- [x] `npx vitest run src/hooks/pr-review-loop.test.ts src/hooks/enforce-pr-review.test.ts src/e2e/plugin-lifecycle.test.ts` -> 174 passed, 2 skipped.
- [x] `npm run check:fast` -> typecheck passed, changed vitest tests 85 passed.
- [x] `pytest -q .claude/hooks/tests/test_hooks.py -vv` -> 38 passed.
- [x] `npm run test:hooks` -> 435 passed.
- [x] `npm test` -> 4123 passed, 14 skipped.
- [x] `git diff --check` -> clean.

## Known Limitations

This is an L2 method-evidence gate. It verifies same-round Agent activity plus structured review sentinel integrity; it does not parse the full Agent transcript to prove every spawned Agent came specifically from `/kaizen-review-pr`.
