### PR TITLE
fix(telemetry): rotate interactive jsonl logs

### DIFF
--- a/src/hooks/reflection-persistence.test.ts
+++ b/src/hooks/reflection-persistence.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
@@ -13,9 +13,15 @@ const REFLECTION_PERSISTENCE_SOURCE = readFileSync(
   'utf-8',
 );
 
+function makeReflectionTestDir(suffix: string): string {
+  const base = join(process.cwd(), 'data', 'test-tmp');
+  mkdirSync(base, { recursive: true });
+  return mkdtempSync(join(base, `reflection-${suffix}-`));
+}
+
 describe('json-lines helper source invariant', () => {
-  it('routes reflection JSONL appends through appendJsonLine', () => {
-    expect(REFLECTION_PERSISTENCE_SOURCE).toContain('appendJsonLine');
+  it('routes reflection JSONL appends through the bounded append helper', () => {
+    expect(REFLECTION_PERSISTENCE_SOURCE).toContain('appendBoundedJsonLine');
     expect(REFLECTION_PERSISTENCE_SOURCE).toContain("from '../lib/json-lines.js'");
     expect(REFLECTION_PERSISTENCE_SOURCE).not.toContain('appendFileSync(filePath, JSON.stringify');
   });
@@ -86,7 +92,7 @@ describe('buildReflectionRecord', () => {
 
 describe('persistReflection', () => {
   it('writes reflection record to reflections.jsonl', () => {
-    const dir = `/tmp/.test-rp-${Date.now()}-a`;
+    const dir = makeReflectionTestDir('a');
     const record = buildReflectionRecord({
       prUrl: 'https://github.com/Garsson-io/kaizen/pull/77',
       branch: 'test-branch',
@@ -111,7 +117,7 @@ describe('persistReflection', () => {
   });
 
   it('appends multiple records', () => {
-    const dir = `/tmp/.test-rp-${Date.now()}-b`;
+    const dir = makeReflectionTestDir('b');
     const base = {
       branch: 'b',
       clearType: 'impediments' as const,
@@ -133,6 +139,30 @@ describe('persistReflection', () => {
     expect(lines).toHaveLength(2);
     expect((JSON.parse(lines[0]) as ReflectionRecord).pr_url).toBe('url1');
     expect((JSON.parse(lines[1]) as ReflectionRecord).pr_url).toBe('url2');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rotates reflection telemetry when the next record would exceed the local cap', () => {
+    const dir = makeReflectionTestDir('rotate');
+    const base = {
+      branch: 'b',
+      clearType: 'impediments' as const,
+      clearReason: 'ok',
+      quality: 'medium' as const,
+      impediments: [{ impediment: 'long enough to force a small cap rollover', disposition: 'filed' }],
+    };
+
+    persistReflection(
+      buildReflectionRecord({ ...base, prUrl: 'url1' }),
+      { telemetryDir: dir, maxBytes: 180, maxBackups: 2 },
+    );
+    persistReflection(
+      buildReflectionRecord({ ...base, prUrl: 'url2' }),
+      { telemetryDir: dir, maxBytes: 180, maxBackups: 2 },
+    );
+
+    expect(readFileSync(join(dir, 'reflections.jsonl'), 'utf-8')).toContain('url2');
+    expect(readFileSync(join(dir, 'reflections.jsonl.1'), 'utf-8')).toContain('url1');
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/src/hooks/reflection-persistence.ts
+++ b/src/hooks/reflection-persistence.ts
@@ -3,7 +3,7 @@
  *
  * Closes the observability gap where KAIZEN_IMPEDIMENTS data was only in
  * PR comments and flat audit logs. Stores full structured reflection records
- * in data/telemetry/reflections.jsonl, enabling:
+ * in bounded data/telemetry/reflections.jsonl, enabling:
  *   - Gap analysis: aggregate by category, find recurring friction
  *   - Quality trends: track filed vs no-action ratio over time
  *   - Cross-session learning: future agents can query past reflections
@@ -12,8 +12,12 @@
  */
 
 import { resolve } from 'node:path';
-import { appendJsonLine } from '../lib/json-lines.js';
-import { resolveTelemetryDir } from './session-telemetry.js';
+import { appendBoundedJsonLine } from '../lib/json-lines.js';
+import {
+  INTERACTIVE_TELEMETRY_MAX_BACKUPS,
+  INTERACTIVE_TELEMETRY_MAX_BYTES,
+  resolveTelemetryDir,
+} from './session-telemetry.js';
 
 export interface ReflectionImpediment {
   impediment?: string;
@@ -82,12 +86,15 @@ export function buildReflectionRecord(options: {
  */
 export function persistReflection(
   record: ReflectionRecord,
-  options?: { telemetryDir?: string },
+  options?: { telemetryDir?: string; maxBytes?: number; maxBackups?: number },
 ): void {
   try {
     const dir = options?.telemetryDir ?? resolveTelemetryDir();
     const filePath = resolve(dir, 'reflections.jsonl');
-    appendJsonLine(filePath, record);
+    appendBoundedJsonLine(filePath, record, {
+      maxBytes: options?.maxBytes ?? INTERACTIVE_TELEMETRY_MAX_BYTES,
+      maxBackups: options?.maxBackups ?? INTERACTIVE_TELEMETRY_MAX_BACKUPS,
+    });
   } catch {
     // Best-effort — never break the hook
   }

--- a/src/hooks/session-telemetry.test.ts
+++ b/src/hooks/session-telemetry.test.ts
@@ -1,5 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
@@ -15,12 +14,14 @@ import {
 const SESSION_TELEMETRY_SOURCE = readFileSync(new URL('./session-telemetry.ts', import.meta.url), 'utf-8');
 
 function makeTelemetryTestDir(suffix: string): string {
-  return mkdtempSync(join(tmpdir(), `.test-st-${suffix}-`));
+  const base = join(process.cwd(), 'data', 'test-tmp');
+  mkdirSync(base, { recursive: true });
+  return mkdtempSync(join(base, `session-${suffix}-`));
 }
 
 describe('json-lines helper source invariant', () => {
-  it('routes telemetry JSONL appends through appendJsonLine', () => {
-    expect(SESSION_TELEMETRY_SOURCE).toContain('appendJsonLine');
+  it('routes telemetry JSONL appends through the bounded append helper', () => {
+    expect(SESSION_TELEMETRY_SOURCE).toContain('appendBoundedJsonLine');
     expect(SESSION_TELEMETRY_SOURCE).toContain("from '../lib/json-lines.js'");
     expect(SESSION_TELEMETRY_SOURCE).not.toContain('appendFileSync(filePath, JSON.stringify');
   });
@@ -76,6 +77,24 @@ describe('emitSessionEvent', () => {
       { telemetryDir: nested },
     );
     expect(existsSync(join(nested, 'events.jsonl'))).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rotates interactive telemetry when the next event would exceed the local cap', () => {
+    const dir = makeTelemetryTestDir('rotate');
+    emitSessionEvent(
+      { type: 'session.pr_created', session_id: 's1', pr_url: 'u', branch: 'b', changed_files_count: 0 },
+      { telemetryDir: dir, now: new Date('2026-03-23T08:00:00Z'), maxBytes: 140, maxBackups: 2 },
+    );
+    emitSessionEvent(
+      { type: 'session.pr_merged', session_id: 's2', pr_url: 'u', branch: 'b', changed_files_count: 1 },
+      { telemetryDir: dir, now: new Date('2026-03-23T08:01:00Z'), maxBytes: 140, maxBackups: 2 },
+    );
+
+    const current = readFileSync(join(dir, 'events.jsonl'), 'utf-8');
+    const previous = readFileSync(join(dir, 'events.jsonl.1'), 'utf-8');
+    expect(current).toContain('session.pr_merged');
+    expect(previous).toContain('session.pr_created');
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -138,8 +157,29 @@ describe('countSessionEvents', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it('counts matching telemetry events across retained rotation backups', () => {
+    const dir = makeTelemetryTestDir('count-rotated');
+    writeFileSync(
+      join(dir, 'events.jsonl'),
+      JSON.stringify({ timestamp: 't3', source: 'interactive', event: { type: 'session.pr_merged' } }),
+    );
+    writeFileSync(
+      join(dir, 'events.jsonl.1'),
+      JSON.stringify({ timestamp: 't2', source: 'interactive', event: { type: 'session.pr_merged' } }),
+    );
+    writeFileSync(
+      join(dir, 'events.jsonl.2'),
+      JSON.stringify({ timestamp: 't1', source: 'interactive', event: { type: 'session.pr_created' } }),
+    );
+
+    expect(countSessionEvents('session.pr_merged', { telemetryDir: dir, maxBackups: 2 })).toBe(2);
+    expect(countSessionEvents('session.pr_created', { telemetryDir: dir, maxBackups: 2 })).toBe(1);
+    expect(countSessionEvents('session.pr_created', { telemetryDir: dir, maxBackups: 1 })).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it('returns zero when the telemetry file is missing or unreadable', () => {
-    expect(countSessionEvents('session.pr_merged', { telemetryDir: '/tmp/does-not-exist-kaizen-st' })).toBe(0);
+    expect(countSessionEvents('session.pr_merged', { telemetryDir: join(process.cwd(), 'data', 'does-not-exist-kaizen-st') })).toBe(0);
     expect(countSessionEvents('session.pr_merged', { telemetryDir: '/dev/null/impossible' })).toBe(0);
   });
 });

--- a/src/hooks/session-telemetry.ts
+++ b/src/hooks/session-telemetry.ts
@@ -8,7 +8,7 @@
  * Design:
  *   - Reuses the EventEnvelope wrapper format from auto-dent-events.ts
  *   - Defines session-specific event types (session.pr_created, session.pr_merged)
- *   - Writes JSONL to data/telemetry/events.jsonl (gitignored via data/)
+ *   - Writes bounded JSONL to data/telemetry/events.jsonl (gitignored via data/)
  *   - Best-effort: never blocks or crashes the hook
  *
  * Part of horizon #249 (Observability), issue #671.
@@ -16,7 +16,7 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { appendJsonLine } from '../lib/json-lines.js';
+import { appendBoundedJsonLine } from '../lib/json-lines.js';
 
 // Session event types — lightweight versions of auto-dent events
 
@@ -67,6 +67,9 @@ export interface SessionEventEnvelope {
   event: SessionEvent;
 }
 
+export const INTERACTIVE_TELEMETRY_MAX_BYTES = 10 * 1024 * 1024;
+export const INTERACTIVE_TELEMETRY_MAX_BACKUPS = 3;
+
 /**
  * Resolve the telemetry directory for the current project.
  * Uses KAIZEN_TELEMETRY_DIR env var if set, otherwise data/telemetry
@@ -86,7 +89,7 @@ export function resolveTelemetryDir(projectDir?: string): string {
  */
 export function emitSessionEvent(
   event: SessionEvent,
-  options?: { telemetryDir?: string; now?: Date },
+  options?: { telemetryDir?: string; now?: Date; maxBytes?: number; maxBackups?: number },
 ): void {
   try {
     const dir = options?.telemetryDir ?? resolveTelemetryDir();
@@ -96,7 +99,10 @@ export function emitSessionEvent(
       source: 'interactive',
       event,
     };
-    appendJsonLine(filePath, envelope);
+    appendBoundedJsonLine(filePath, envelope, {
+      maxBytes: options?.maxBytes ?? INTERACTIVE_TELEMETRY_MAX_BYTES,
+      maxBackups: options?.maxBackups ?? INTERACTIVE_TELEMETRY_MAX_BACKUPS,
+    });
   } catch {
     // Telemetry is best-effort — never break the hook
   }
@@ -109,13 +115,24 @@ export function emitSessionEvent(
  */
 export function countSessionEvents(
   type: SessionEvent['type'],
-  options?: { telemetryDir?: string },
+  options?: { telemetryDir?: string; maxBackups?: number },
 ): number {
-  try {
-    const dir = options?.telemetryDir ?? resolveTelemetryDir();
-    const filePath = resolve(dir, 'events.jsonl');
-    const content = readFileSync(filePath, 'utf-8');
-    let count = 0;
+  const dir = options?.telemetryDir ?? resolveTelemetryDir();
+  const filePath = resolve(dir, 'events.jsonl');
+  const maxBackups = Math.max(0, Math.floor(options?.maxBackups ?? INTERACTIVE_TELEMETRY_MAX_BACKUPS));
+  const paths = [
+    filePath,
+    ...Array.from({ length: maxBackups }, (_, index) => `${filePath}.${index + 1}`),
+  ];
+  let count = 0;
+
+  for (const path of paths) {
+    let content: string;
+    try {
+      content = readFileSync(path, 'utf-8');
+    } catch {
+      continue;
+    }
     for (const line of content.split('\n')) {
       if (!line.trim()) continue;
       try {
@@ -125,10 +142,8 @@ export function countSessionEvents(
         // Ignore partial/corrupt rows; telemetry is advisory.
       }
     }
-    return count;
-  } catch {
-    return 0;
   }
+  return count;
 }
 
 /**

--- a/src/lib/json-lines.test.ts
+++ b/src/lib/json-lines.test.ts
@@ -1,7 +1,18 @@
-import { readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { appendJsonLine, parseJsonLines, parseJsonLinesWithMalformedRows } from './json-lines.js';
+import {
+  appendBoundedJsonLine,
+  appendJsonLine,
+  parseJsonLines,
+  parseJsonLinesWithMalformedRows,
+} from './json-lines.js';
+
+function makeJsonLinesTestDir(suffix: string): string {
+  const base = join(process.cwd(), 'data', 'test-tmp');
+  mkdirSync(base, { recursive: true });
+  return mkdtempSync(join(base, `json-lines-${suffix}-`));
+}
 
 describe('parseJsonLines', () => {
   it('parses valid JSON lines while skipping blanks and malformed rows', () => {
@@ -30,7 +41,7 @@ describe('parseJsonLines', () => {
 
 describe('appendJsonLine', () => {
   it('creates parent directories and appends one JSON value per line', () => {
-    const dir = `/tmp/.test-json-lines-${Date.now()}-a`;
+    const dir = makeJsonLinesTestDir('append-a');
     const filePath = join(dir, 'nested', 'events.jsonl');
 
     try {
@@ -41,6 +52,92 @@ describe('appendJsonLine', () => {
       expect(lines).toHaveLength(2);
       expect(JSON.parse(lines[0])).toEqual({ a: 1 });
       expect(JSON.parse(lines[1])).toEqual({ b: 2 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('appendBoundedJsonLine', () => {
+  it('creates parent directories and appends one JSON value per line', () => {
+    const dir = makeJsonLinesTestDir('bounded-a');
+    const filePath = join(dir, 'nested', 'events.jsonl');
+
+    try {
+      appendBoundedJsonLine(filePath, { a: 1 }, { maxBytes: 1024, maxBackups: 3 });
+      appendBoundedJsonLine(filePath, { b: 2 }, { maxBytes: 1024, maxBackups: 3 });
+
+      const lines = readFileSync(filePath, 'utf-8').trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0])).toEqual({ a: 1 });
+      expect(JSON.parse(lines[1])).toEqual({ b: 2 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rotates before the write that would exceed the active file cap', () => {
+    const dir = makeJsonLinesTestDir('bounded-b');
+    const filePath = join(dir, 'events.jsonl');
+
+    try {
+      appendBoundedJsonLine(filePath, { value: 'first' }, { maxBytes: 20, maxBackups: 3 });
+      appendBoundedJsonLine(filePath, { value: 'second' }, { maxBytes: 20, maxBackups: 3 });
+
+      expect(readFileSync(`${filePath}.1`, 'utf-8')).toContain('first');
+      expect(readFileSync(filePath, 'utf-8')).toContain('second');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps only the configured number of backup generations', () => {
+    const dir = makeJsonLinesTestDir('bounded-c');
+    const filePath = join(dir, 'events.jsonl');
+
+    try {
+      appendBoundedJsonLine(filePath, { value: 'one' }, { maxBytes: 1, maxBackups: 2 });
+      appendBoundedJsonLine(filePath, { value: 'two' }, { maxBytes: 1, maxBackups: 2 });
+      appendBoundedJsonLine(filePath, { value: 'three' }, { maxBytes: 1, maxBackups: 2 });
+      appendBoundedJsonLine(filePath, { value: 'four' }, { maxBytes: 1, maxBackups: 2 });
+
+      expect(readFileSync(filePath, 'utf-8')).toContain('four');
+      expect(readFileSync(`${filePath}.1`, 'utf-8')).toContain('three');
+      expect(readFileSync(`${filePath}.2`, 'utf-8')).toContain('two');
+      expect(existsSync(`${filePath}.3`)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('deletes the previous active file when zero backups are configured', () => {
+    const dir = makeJsonLinesTestDir('bounded-d');
+    const filePath = join(dir, 'events.jsonl');
+
+    try {
+      appendBoundedJsonLine(filePath, { value: 'old' }, { maxBytes: 1, maxBackups: 0 });
+      appendBoundedJsonLine(filePath, { value: 'new' }, { maxBytes: 1, maxBackups: 0 });
+
+      expect(readFileSync(filePath, 'utf-8')).toContain('new');
+      expect(readFileSync(filePath, 'utf-8')).not.toContain('old');
+      expect(existsSync(`${filePath}.1`)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fills the active file exactly to the cap, then rotates on the next append', () => {
+    const dir = makeJsonLinesTestDir('bounded-e');
+    const filePath = join(dir, 'events.jsonl');
+    const line = `${JSON.stringify({ a: 1 })}\n`;
+
+    try {
+      appendBoundedJsonLine(filePath, { a: 1 }, { maxBytes: line.length * 2, maxBackups: 3 });
+      appendBoundedJsonLine(filePath, { b: 2 }, { maxBytes: line.length * 2, maxBackups: 3 });
+      appendBoundedJsonLine(filePath, { c: 3 }, { maxBytes: line.length * 2, maxBackups: 3 });
+
+      expect(readFileSync(`${filePath}.1`, 'utf-8')).toBe(`${line}${JSON.stringify({ b: 2 })}\n`);
+      expect(readFileSync(filePath, 'utf-8')).toBe(`${JSON.stringify({ c: 3 })}\n`);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/lib/json-lines.ts
+++ b/src/lib/json-lines.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync } from 'node:fs';
+import { appendFileSync, closeSync, fstatSync, mkdirSync, openSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 export interface ParsedJsonLines<T = unknown> {
@@ -28,7 +28,92 @@ export function parseJsonLines<T = unknown>(text: string): T[] {
   return parseJsonLinesWithMalformedRows<T>(text).rows;
 }
 
+function appendLineWithDescriptor(filepath: string, line: string): void {
+  const fd = openSync(filepath, 'a');
+  try {
+    writeFileSync(fd, line);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 export function appendJsonLine(filepath: string, value: unknown): void {
   mkdirSync(dirname(filepath), { recursive: true });
   appendFileSync(filepath, JSON.stringify(value) + '\n');
+}
+
+export interface BoundedJsonLineOptions {
+  /** Maximum active-file size before a new line rolls the file to `.1`. */
+  maxBytes: number;
+  /** Number of numeric backup generations to keep (`.1`, `.2`, ...). */
+  maxBackups: number;
+}
+
+function normalizeBoundedOptions(options: BoundedJsonLineOptions): BoundedJsonLineOptions {
+  return {
+    maxBytes: Math.max(1, Math.floor(options.maxBytes)),
+    maxBackups: Math.max(0, Math.floor(options.maxBackups)),
+  };
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function renameIfPresent(from: string, to: string): void {
+  try {
+    renameSync(from, to);
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
+  }
+}
+
+function rotateFile(filepath: string, maxBackups: number): void {
+  if (maxBackups === 0) {
+    rmSync(filepath, { force: true });
+    return;
+  }
+
+  rmSync(`${filepath}.${maxBackups}`, { force: true });
+  for (let generation = maxBackups - 1; generation >= 1; generation -= 1) {
+    const from = `${filepath}.${generation}`;
+    renameIfPresent(from, `${filepath}.${generation + 1}`);
+  }
+  renameIfPresent(filepath, `${filepath}.1`);
+}
+
+/**
+ * Append one JSON line while bounding local append-only telemetry growth.
+ *
+ * Rotation happens before the write when the active file is already at/over the
+ * cap or the next line would exceed it. Backup names are deterministic so hook
+ * telemetry stays easy to inspect and test.
+ */
+export function appendBoundedJsonLine(
+  filepath: string,
+  value: unknown,
+  options: BoundedJsonLineOptions,
+): void {
+  const normalized = normalizeBoundedOptions(options);
+  mkdirSync(dirname(filepath), { recursive: true });
+
+  const line = JSON.stringify(value) + '\n';
+  const lineBytes = Buffer.byteLength(line, 'utf-8');
+  let fd: number | undefined = openSync(filepath, 'a');
+  try {
+    const currentSize = fstatSync(fd).size;
+    if (
+      currentSize >= normalized.maxBytes ||
+      (currentSize > 0 && currentSize + lineBytes > normalized.maxBytes)
+    ) {
+      closeSync(fd);
+      fd = undefined;
+      rotateFile(filepath, normalized.maxBackups);
+      appendLineWithDescriptor(filepath, line);
+    } else {
+      writeFileSync(fd, line);
+    }
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
 }


### PR DESCRIPTION
## Summary

Closes #687 by finishing the remaining immediate repo-overflow prevention slice for local interactive telemetry.

Prior merged work already moved batch artifacts into progress issue attachments (#688/#695 and #696/#1118). This PR leaves batch `logs/auto-dent/<batch>/events.jsonl` unchanged so progress issue forensic uploads remain complete, and instead caps the still-local interactive telemetry files under `data/telemetry/`.

## Changes

- Adds `appendBoundedJsonLine()` in `src/lib/json-lines.ts` with deterministic numeric rotation (`.1`, `.2`, `.3`).
- Uses descriptor-based append/fstat/write inside the bounded helper and exception-driven backup renames, avoiding CodeQL path check/use race patterns.
- Leaves the legacy `appendJsonLine()` helper unchanged so existing batch and hook-trace append semantics do not widen in this PR.
- Routes `src/hooks/session-telemetry.ts` `events.jsonl` through bounded append.
- Routes `src/hooks/reflection-persistence.ts` `reflections.jsonl` through the same bounded append policy.
- Keeps a 10 MiB active file and 3 backup generations by default for interactive telemetry.
- Updates `countSessionEvents()` to count retained `events.jsonl.N` backups so periodic advisory behavior does not reset on rotation.
- Moves touched filesystem tests to repo-local ignored `data/test-tmp/` scratch directories instead of OS temp paths.
- Adds tests for rotation, retention pruning, zero-backup behavior, exact cap boundary behavior, both hook writers, and counts across retained backups.

## Review

- Round 1 structured review: https://github.com/Garsson-io/kaizen/pull/1632#issuecomment-4828099986
- Round 1 fix: `countSessionEvents()` now reads active + retained backups.
- Final round 2 structured review: https://github.com/Garsson-io/kaizen/pull/1632#issuecomment-4828111335
- Round 2 fixes: CodeQL file-safety alerts addressed with bounded-helper descriptor writes, exception-driven renames, repo-local ignored test scratch directories, and no legacy append helper widening.

## Verification

- `npx vitest run src/lib/json-lines.test.ts src/hooks/session-telemetry.test.ts src/hooks/reflection-persistence.test.ts`
- `npm run typecheck`
- `npm run test:fast`
- `npx tsx scripts/auto-dent-dry-sweep.ts --changed origin/main`
- Direct runtime proof: three bounded appends with `maxBytes: 1, maxBackups: 2` produced active `three`, backup `.1` `two`, backup `.2` `one`.
- `npm test` (passed; Vitest printed the existing `Unknown option: --bogus` line but exited 0 with 172 passed / 2 skipped files)
- `git diff --check`
