### PR TITLE
fix(hooks): guard shared default state writes

### DIFF
--- a/.claude/hooks/lib/run-tsx.sh
+++ b/.claude/hooks/lib/run-tsx.sh
@@ -17,6 +17,10 @@ run_tsx() {
   local kaizen_dir="$1"
   local ts_file="$2"
 
+  # This trampoline is a real hook entrypoint. Direct TS hook smoke tests must
+  # set STATE_DIR explicitly; wrappers mark production dispatch as trusted.
+  export KAIZEN_TRUST_DEFAULT_STATE_DIR=1
+
   # Test harnesses may execute hooks from a worktree whose source is current but
   # whose node_modules is absent or incomplete. Let them provide a known-good
   # tsx binary while still running the source file from this kaizen_dir.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -38,6 +38,8 @@ fi
 # ── Dispatch ───────────────────────────────────────────────────────────
 # Pass stdin (git's pre-push refs) straight through; forward exit code.
 # PATH may not include tsx on first run — fall back to node_modules/.bin.
+export KAIZEN_TRUST_DEFAULT_STATE_DIR=1
+
 if command -v npx >/dev/null 2>&1; then
   exec npx --no-install tsx "$HOOK_TS" "$@"
 fi

--- a/docs/hooks-design.md
+++ b/docs/hooks-design.md
@@ -200,6 +200,26 @@ When a gate blocks commands, it needs an allowlist of commands that ARE permitte
 - **Cross-branch lookup:** Active declarations (KAIZEN_IMPEDIMENTS) use `_any_branch` variants since the agent may submit from a different worktree
 - **Staleness:** Files older than `MAX_STATE_AGE` (2 hours) are ignored
 
+### Direct Hook Smoke Tests
+
+Directly invoking a TS hook binary is not the same as running through the real
+hook wrapper. State-writing hooks refuse to write to the shared default
+`/tmp/.pr-review-state` unless one of these is true:
+
+- `STATE_DIR` is set explicitly, preferably `STATE_DIR=$(mktemp -d)` for smoke
+  tests and local repros.
+- A real wrapper has exported `KAIZEN_TRUST_DEFAULT_STATE_DIR=1` before
+  dispatching the TS hook.
+- An operator deliberately sets `KAIZEN_ALLOW_DEFAULT_STATE_DIR=1` for an
+  emergency manual write.
+
+Use an isolated state dir in every direct smoke:
+
+```bash
+STATE_DIR=$(mktemp -d) CLAUDECODE=1 \
+  npx tsx src/hooks/pre-push.ts origin https://github.com/Garsson-io/kaizen
+```
+
 ### Testing Hooks
 
 **TypeScript hooks (preferred):**

--- a/src/hooks/pre-push.test.ts
+++ b/src/hooks/pre-push.test.ts
@@ -29,8 +29,41 @@ import {
   type PrQueryResult,
   type PrePushDecision,
 } from './pre-push.js';
+import {
+  ALLOW_DEFAULT_STATE_DIR_ENV,
+  SHARED_DEFAULT_STATE_DIR,
+  TRUSTED_DEFAULT_STATE_DIR_ENV,
+} from './state-utils.js';
 
 const PRE_PUSH_SOURCE = fs.readFileSync(new URL('./pre-push.ts', import.meta.url), 'utf-8');
+
+function withPrePushDefaultStateEnv<T>(
+  env: Record<string, string | undefined>,
+  fn: () => T,
+): T {
+  const keys = ['STATE_DIR', TRUSTED_DEFAULT_STATE_DIR_ENV, ALLOW_DEFAULT_STATE_DIR_ENV];
+  const previous = new Map(keys.map((key) => [key, process.env[key]]));
+  for (const key of keys) {
+    const value = env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
 
 // ── detectAgentEnv ────────────────────────────────────────────────────
 
@@ -476,6 +509,35 @@ describe('applyDecision — idempotent gate write', () => {
 
     expect(secondFiles).toEqual(firstFiles);
     expect(secondContent).toBe(firstContent);
+  });
+
+  it('refuses direct default-state writes without an explicit STATE_DIR or wrapper marker (#1072)', () => {
+    const prNum = String(Date.now());
+    const prUrl = `https://github.com/owner/repo/pull/${prNum}`;
+    const filename = `owner_repo_${prNum}`;
+    const leakedFile = path.join(SHARED_DEFAULT_STATE_DIR, filename);
+    const decision: PrePushDecision = {
+      action: 'allow_gate',
+      reason: 'open_pr_push',
+      message: null,
+      gateSignal: {
+        gate: 'needs_review',
+        action: 'set',
+        pr: prUrl,
+        round: 1,
+        reason: 'test direct default-state write refusal',
+      },
+    };
+
+    try {
+      withPrePushDefaultStateEnv({}, () => {
+        expect(() => applyDecision(decision, 'feat/foo')).toThrow(/Direct hook invocation would write/);
+      });
+
+      expect(fs.existsSync(leakedFile)).toBe(false);
+    } finally {
+      fs.rmSync(leakedFile, { force: true });
+    }
   });
 });
 

--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -27,7 +27,7 @@
 
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { DEFAULT_STATE_DIR, ensureStateDir, prUrlToStateKey, readStateFile, writeStateFile } from './state-utils.js';
+import { DEFAULT_STATE_DIR, prUrlToStateKey, readStateFile, writeStateFile } from './state-utils.js';
 import { currentHookBranch } from './lib/current-branch.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
@@ -307,7 +307,6 @@ export function applyDecision(
   if (!decision.gateSignal?.pr) return;
 
   const stateDir = options.stateDir ?? DEFAULT_STATE_DIR;
-  ensureStateDir(stateDir);
   const filename = prUrlToStateKey(decision.gateSignal.pr);
   const filepath = join(stateDir, filename);
 

--- a/src/hooks/state-utils.test.ts
+++ b/src/hooks/state-utils.test.ts
@@ -8,6 +8,7 @@ import {
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  ALLOW_DEFAULT_STATE_DIR_ENV,
   clearAllStatesWithStatus,
   clearStateWithStatus,
   clearStateWithStatusAnyBranch,
@@ -22,6 +23,8 @@ import {
   parseStateFile,
   prUrlToStateKey,
   serializeStateFile,
+  SHARED_DEFAULT_STATE_DIR,
+  TRUSTED_DEFAULT_STATE_DIR_ENV,
   writeStateFile,
 } from './state-utils.js';
 
@@ -30,6 +33,34 @@ const STATE_UTILS_SOURCE = readFileSync(
   new URL('./state-utils.ts', import.meta.url),
   'utf-8',
 );
+
+function withDefaultStateEnv<T>(
+  env: Record<string, string | undefined>,
+  fn: () => T,
+): T {
+  const keys = ['STATE_DIR', TRUSTED_DEFAULT_STATE_DIR_ENV, ALLOW_DEFAULT_STATE_DIR_ENV];
+  const previous = new Map(keys.map((key) => [key, process.env[key]]));
+  for (const key of keys) {
+    const value = env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
 
 beforeEach(() => {
   if (existsSync(TEST_STATE_DIR)) {
@@ -132,6 +163,58 @@ describe('writeStateFile', () => {
       BRANCH: 'branch',
     });
     expect(existsSync(join(subDir, 'test'))).toBe(true);
+  });
+
+  it('refuses untrusted writes to the shared default state dir', () => {
+    const leakedFile = join(SHARED_DEFAULT_STATE_DIR, 'kaizen-1072-untrusted-write');
+
+    withDefaultStateEnv({}, () => {
+      expect(() => writeStateFile(SHARED_DEFAULT_STATE_DIR, 'kaizen-1072-untrusted-write', {
+        PR_URL: 'https://github.com/Garsson-io/kaizen/pull/1072',
+        STATUS: 'needs_review',
+        BRANCH: 'case/1072',
+      })).toThrow(/STATE_DIR=.*mktemp -d/);
+    });
+
+    expect(existsSync(leakedFile)).toBe(false);
+  });
+
+  it('allows shared default writes from trusted hook wrappers', () => {
+    const filename = `kaizen-1072-trusted-${Date.now()}`;
+    const filepath = join(SHARED_DEFAULT_STATE_DIR, filename);
+
+    try {
+      withDefaultStateEnv({ [TRUSTED_DEFAULT_STATE_DIR_ENV]: '1' }, () => {
+        expect(writeStateFile(SHARED_DEFAULT_STATE_DIR, filename, {
+          PR_URL: 'https://github.com/Garsson-io/kaizen/pull/1072',
+          STATUS: 'needs_review',
+          BRANCH: 'case/1072',
+        })).toBe(filepath);
+      });
+
+      expect(existsSync(filepath)).toBe(true);
+    } finally {
+      rmSync(filepath, { force: true });
+    }
+  });
+
+  it('allows explicit emergency override for default state writes', () => {
+    const filename = `kaizen-1072-override-${Date.now()}`;
+    const filepath = join(SHARED_DEFAULT_STATE_DIR, filename);
+
+    try {
+      withDefaultStateEnv({ [ALLOW_DEFAULT_STATE_DIR_ENV]: '1' }, () => {
+        expect(writeStateFile(SHARED_DEFAULT_STATE_DIR, filename, {
+          PR_URL: 'https://github.com/Garsson-io/kaizen/pull/1072',
+          STATUS: 'needs_review',
+          BRANCH: 'case/1072',
+        })).toBe(filepath);
+      });
+
+      expect(existsSync(filepath)).toBe(true);
+    } finally {
+      rmSync(filepath, { force: true });
+    }
   });
 });
 

--- a/src/hooks/state-utils.ts
+++ b/src/hooks/state-utils.ts
@@ -16,7 +16,10 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 
-export const DEFAULT_STATE_DIR = process.env.STATE_DIR || '/tmp/.pr-review-state';
+export const SHARED_DEFAULT_STATE_DIR = '/tmp/.pr-review-state';
+export const DEFAULT_STATE_DIR = process.env.STATE_DIR || SHARED_DEFAULT_STATE_DIR;
+export const TRUSTED_DEFAULT_STATE_DIR_ENV = 'KAIZEN_TRUST_DEFAULT_STATE_DIR';
+export const ALLOW_DEFAULT_STATE_DIR_ENV = 'KAIZEN_ALLOW_DEFAULT_STATE_DIR';
 const DEFAULT_MAX_STATE_AGE = 7200; // 2 hours
 
 // Default audit directory. Override via AUDIT_DIR env var for test isolation (kaizen #429).
@@ -89,6 +92,21 @@ export function ensureStateDir(stateDir: string = DEFAULT_STATE_DIR): void {
   }
 }
 
+/** Refuse accidental writes to the shared production default from direct hook smokes. */
+export function assertStateDirWritable(stateDir: string): void {
+  if (stateDir !== SHARED_DEFAULT_STATE_DIR) return;
+  if (process.env.STATE_DIR) return;
+  if (process.env[TRUSTED_DEFAULT_STATE_DIR_ENV] === '1') return;
+  if (process.env[ALLOW_DEFAULT_STATE_DIR_ENV] === '1') return;
+
+  throw new Error([
+    `Direct hook invocation would write to shared default STATE_DIR ${SHARED_DEFAULT_STATE_DIR}.`,
+    'For smoke tests, run with STATE_DIR=$(mktemp -d) so hook state is isolated.',
+    `Real hook wrappers set ${TRUSTED_DEFAULT_STATE_DIR_ENV}=1 before dispatch.`,
+    `For emergency manual writes only, set ${ALLOW_DEFAULT_STATE_DIR_ENV}=1 explicitly.`,
+  ].join(' '));
+}
+
 /**
  * Write a state file atomically.
  * Creates the state directory if needed.
@@ -98,6 +116,7 @@ export function writeStateFile(
   filename: string,
   state: StateFile,
 ): string {
+  assertStateDirWritable(stateDir);
   ensureStateDir(stateDir);
   const filepath = join(stateDir, filename);
   writeFileSync(filepath, serializeStateFile(state), { mode: 0o600 });

--- a/src/hooks/wrapper-smoke.test.ts
+++ b/src/hooks/wrapper-smoke.test.ts
@@ -17,6 +17,9 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 
 const HOOKS_DIR = path.resolve(__dirname, '../../.claude/hooks');
+const GIT_PRE_PUSH = path.resolve(__dirname, '../../.githooks/pre-push');
+const HOOKS_DESIGN = path.resolve(__dirname, '../../docs/hooks-design.md');
+const TRUSTED_DEFAULT_STATE_DIR_ENV = 'KAIZEN_TRUST_DEFAULT_STATE_DIR';
 
 interface SmokeContext {
   tmpDir: string;
@@ -148,6 +151,27 @@ describe('wrapper smoke: bash wrappers exist and are executable', () => {
       expect(stats.mode & 0o100).toBeGreaterThan(0);
     });
   }
+});
+
+describe('wrapper smoke: default state trust boundary', () => {
+  it('marks Claude TS hook trampolines as trusted default-state writers (#1072)', () => {
+    const source = fs.readFileSync(path.join(HOOKS_DIR, 'lib/run-tsx.sh'), 'utf-8');
+
+    expect(source).toContain(`export ${TRUSTED_DEFAULT_STATE_DIR_ENV}=1`);
+  });
+
+  it('marks the git pre-push wrapper as a trusted default-state writer (#1072)', () => {
+    const source = fs.readFileSync(GIT_PRE_PUSH, 'utf-8');
+
+    expect(source).toContain(`export ${TRUSTED_DEFAULT_STATE_DIR_ENV}=1`);
+  });
+
+  it('documents isolated STATE_DIR for direct hook smoke tests (#1072)', () => {
+    const source = fs.readFileSync(HOOKS_DESIGN, 'utf-8');
+
+    expect(source).toContain('STATE_DIR=$(mktemp -d)');
+    expect(source).toContain(TRUSTED_DEFAULT_STATE_DIR_ENV);
+  });
 });
 
 describe('wrapper smoke: pr-review-loop-ts.sh', () => {


### PR DESCRIPTION
## Story

Once upon a time, kaizen hook state lived in `$STATE_DIR`, defaulting to `/tmp/.pr-review-state`, and direct hook smokes used the same default as real review gates.

Every day, that was tolerable as long as tests and manual repros remembered to set an isolated `STATE_DIR`.

One day, #1072 showed the failure mode: a direct `npx tsx src/hooks/pre-push.ts ...` smoke with `CLAUDECODE=1` wrote `ROUND=1` into the shared state file for PR #1060, corrupting the live review-loop state that was already at round 5.

Because of that, this PR makes shared-default writes an explicit trust boundary. `writeStateFile()` now refuses `/tmp/.pr-review-state` when `STATE_DIR` is unset unless the process came through a real hook wrapper or an operator set an emergency override.

Because of that, real wrappers export `KAIZEN_TRUST_DEFAULT_STATE_DIR=1` before dispatching TS hooks, while direct smokes get an actionable error telling them to use `STATE_DIR=$(mktemp -d)`.

Until finally, the focused red tests now prove the old silent write path is blocked, and the full hook suite still passes through the trusted wrapper path.

And ever since, direct hook binaries are safe by default, while production hook invocations keep using the shared state directory intentionally.

Fixes Garsson-io/kaizen#1072

## Impact (goal -> before/after -> match)

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Prevent direct hook smokes from silently writing shared production state | #1072 reports `npx tsx src/hooks/pre-push.ts ...` wrote `/tmp/.pr-review-state/Garsson-io_kaizen_1060` with `ROUND=1` | `src/hooks/state-utils.test.ts` now asserts untrusted `writeStateFile('/tmp/.pr-review-state', ...)` throws and creates no file | Shared-default write changed from silent success to explicit refusal with `STATE_DIR=$(mktemp -d)` guidance | yes |
| Keep real hook wrappers functional | Wrappers had no trust marker, so a central guard would block production dispatch | `.claude/hooks/lib/run-tsx.sh` and `.githooks/pre-push` export `KAIZEN_TRUST_DEFAULT_STATE_DIR=1`; wrapper smoke tests pass | Real wrapper path remains allowed while direct TS binary path is blocked | yes |
| Make the safe smoke contract discoverable | `docs/hooks-design.md` only said tests should override `STATE_DIR`; direct smokes were not covered | New `Direct Hook Smoke Tests` section documents isolated `STATE_DIR`, wrapper marker, and emergency override | Operators get the exact command contract before running hook binaries directly | yes |

- Acceptance signal: untrusted shared-default write is blocked; explicit temp `STATE_DIR` and trusted wrappers still work.
- Residual scan: #477 is adjacent broader test-isolation work and remains open; this PR closes the direct hook binary contamination path from #1072, not the broader test isolation epic.

## Architecture

```text
real hook wrapper
  exports KAIZEN_TRUST_DEFAULT_STATE_DIR=1
  -> TS hook
     -> writeStateFile(stateDir, ...)
        -> assertStateDirWritable(stateDir)
           -> allow shared default only if STATE_DIR, wrapper marker, or override exists

direct TS hook smoke
  no STATE_DIR, no marker
  -> writeStateFile('/tmp/.pr-review-state', ...)
     -> throws before mkdir/write
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Guard in `writeStateFile()` | It is the canonical state write seam for review/reflection/post-merge gates, so callers inherit the safety rule without per-hook drift | Existing callers that intentionally write the shared default must come through wrappers or set an explicit env override |
| Wrapper marker: `KAIZEN_TRUST_DEFAULT_STATE_DIR=1` | Distinguishes real hook dispatch from direct TS binary smokes without relying on TTY heuristics | Bash wrappers become part of the state-write contract |
| Emergency override: `KAIZEN_ALLOW_DEFAULT_STATE_DIR=1` | Keeps manual recovery possible while making unsafe shared writes explicit | Operators can still bypass protection if they choose to |
| Remove early `ensureStateDir()` from `pre-push.applyDecision()` | The writer now owns the safety check and directory creation; pre-push should not create the default dir before refusal | No behavior loss because `writeStateFile()` already creates the directory |

## Files Changed

| File | Purpose |
|---|---|
| `src/hooks/state-utils.ts` | Adds shared default constants and write guard |
| `src/hooks/pre-push.ts` | Lets `writeStateFile()` own state-dir creation/refusal |
| `.claude/hooks/lib/run-tsx.sh` | Marks Claude TS hook wrapper dispatch as trusted |
| `.githooks/pre-push` | Marks git pre-push wrapper dispatch as trusted |
| `docs/hooks-design.md` | Documents direct smoke-test safety contract |
| `src/hooks/state-utils.test.ts` | Covers blocked untrusted writes and allowed trusted/override writes |
| `src/hooks/pre-push.test.ts` | Covers `applyDecision()` inheriting the guard |
| `src/hooks/wrapper-smoke.test.ts` | Pins wrapper marker and docs invariants |

## Test Plan (Behaviors x Levels)

| # | Behavior | Perspective | Level | Coverage |
|---|---|---|---|---|
| 1 | Untrusted code cannot write gate state into `/tmp/.pr-review-state` when `STATE_DIR` is unset | code | Unit | tested in `src/hooks/state-utils.test.ts` |
| 2 | Explicitly isolated smoke/test state dirs remain writable | code | Unit | tested in existing and new `state-utils` write tests |
| 3 | Real hook wrappers are allowed to use the shared default state dir | session | Integration | tested by trusted-marker unit check plus wrapper smoke suite |
| 4 | Direct `pre-push` decision application inherits the state guard | session | Integration | tested in `src/hooks/pre-push.test.ts` |
| 5 | Operators can discover the safe smoke-test contract | user | Unit | tested by docs invariant in `src/hooks/wrapper-smoke.test.ts` |

## Validation

- [x] RED focused suite failed before implementation: 7 planned failures across `state-utils`, `pre-push`, and wrapper/docs invariants
- [x] `npx vitest run src/hooks/state-utils.test.ts src/hooks/pre-push.test.ts src/hooks/wrapper-smoke.test.ts` -> 131 passed
- [x] `npm run check:fast` -> typecheck passed, 519 changed tests passed
- [x] `npm run test:hooks` -> 435 passed
- [x] `npm test` -> 4,138 passed, 14 skipped
- [x] `git diff --check` -> clean

## Known Limitations

The legacy bash fallback `kaizen-pr-kaizen-clear-fallback.sh` can rewrite an already-active kaizen gate in the shared state directory when invoked as a real wrapper and `dist/` is missing. It does not create review-loop state and is outside #1072's direct TS binary smoke path; the main state-writing hooks now route through `writeStateFile()` and the trusted wrapper contract.
