### PR TITLE
test: share ignored scratch directory helper

### DIFF
--- a/src/hooks/reflection-persistence.test.ts
+++ b/src/hooks/reflection-persistence.test.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { makeIgnoredTestDir } from '../lib/test-dirs.js';
 import {
   buildReflectionRecord,
   persistReflection,
@@ -14,9 +15,7 @@ const REFLECTION_PERSISTENCE_SOURCE = readFileSync(
 );
 
 function makeReflectionTestDir(suffix: string): string {
-  const base = join(process.cwd(), 'data', 'test-tmp');
-  mkdirSync(base, { recursive: true });
-  return mkdtempSync(join(base, `reflection-${suffix}-`));
+  return makeIgnoredTestDir(`reflection-${suffix}`);
 }
 
 describe('json-lines helper source invariant', () => {

--- a/src/hooks/session-telemetry.test.ts
+++ b/src/hooks/session-telemetry.test.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { makeIgnoredTestDir } from '../lib/test-dirs.js';
 import {
   countChangedFiles,
   countSessionEvents,
@@ -14,9 +15,7 @@ import {
 const SESSION_TELEMETRY_SOURCE = readFileSync(new URL('./session-telemetry.ts', import.meta.url), 'utf-8');
 
 function makeTelemetryTestDir(suffix: string): string {
-  const base = join(process.cwd(), 'data', 'test-tmp');
-  mkdirSync(base, { recursive: true });
-  return mkdtempSync(join(base, `session-${suffix}-`));
+  return makeIgnoredTestDir(`session-${suffix}`);
 }
 
 describe('json-lines helper source invariant', () => {

--- a/src/lib/json-lines.test.ts
+++ b/src/lib/json-lines.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
@@ -7,12 +7,7 @@ import {
   parseJsonLines,
   parseJsonLinesWithMalformedRows,
 } from './json-lines.js';
-
-function makeJsonLinesTestDir(suffix: string): string {
-  const base = join(process.cwd(), 'data', 'test-tmp');
-  mkdirSync(base, { recursive: true });
-  return mkdtempSync(join(base, `json-lines-${suffix}-`));
-}
+import { makeIgnoredTestDir } from './test-dirs.js';
 
 describe('parseJsonLines', () => {
   it('parses valid JSON lines while skipping blanks and malformed rows', () => {
@@ -41,7 +36,7 @@ describe('parseJsonLines', () => {
 
 describe('appendJsonLine', () => {
   it('creates parent directories and appends one JSON value per line', () => {
-    const dir = makeJsonLinesTestDir('append-a');
+    const dir = makeIgnoredTestDir('json-lines-append-a');
     const filePath = join(dir, 'nested', 'events.jsonl');
 
     try {
@@ -60,7 +55,7 @@ describe('appendJsonLine', () => {
 
 describe('appendBoundedJsonLine', () => {
   it('creates parent directories and appends one JSON value per line', () => {
-    const dir = makeJsonLinesTestDir('bounded-a');
+    const dir = makeIgnoredTestDir('json-lines-bounded-a');
     const filePath = join(dir, 'nested', 'events.jsonl');
 
     try {
@@ -77,7 +72,7 @@ describe('appendBoundedJsonLine', () => {
   });
 
   it('rotates before the write that would exceed the active file cap', () => {
-    const dir = makeJsonLinesTestDir('bounded-b');
+    const dir = makeIgnoredTestDir('json-lines-bounded-b');
     const filePath = join(dir, 'events.jsonl');
 
     try {
@@ -92,7 +87,7 @@ describe('appendBoundedJsonLine', () => {
   });
 
   it('keeps only the configured number of backup generations', () => {
-    const dir = makeJsonLinesTestDir('bounded-c');
+    const dir = makeIgnoredTestDir('json-lines-bounded-c');
     const filePath = join(dir, 'events.jsonl');
 
     try {
@@ -111,7 +106,7 @@ describe('appendBoundedJsonLine', () => {
   });
 
   it('deletes the previous active file when zero backups are configured', () => {
-    const dir = makeJsonLinesTestDir('bounded-d');
+    const dir = makeIgnoredTestDir('json-lines-bounded-d');
     const filePath = join(dir, 'events.jsonl');
 
     try {
@@ -127,7 +122,7 @@ describe('appendBoundedJsonLine', () => {
   });
 
   it('fills the active file exactly to the cap, then rotates on the next append', () => {
-    const dir = makeJsonLinesTestDir('bounded-e');
+    const dir = makeIgnoredTestDir('json-lines-bounded-e');
     const filePath = join(dir, 'events.jsonl');
     const line = `${JSON.stringify({ a: 1 })}\n`;
 

--- a/src/lib/test-dirs.test.ts
+++ b/src/lib/test-dirs.test.ts
@@ -1,0 +1,60 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  IGNORED_TEST_TMP_RELATIVE_DIR,
+  ignoredTestTmpRoot,
+  makeIgnoredTestDir,
+} from './test-dirs.js';
+
+function makeProjectRoot(prefix: string): string {
+  const base = join(process.cwd(), 'data', 'test-tmp-roots');
+  mkdirSync(base, { recursive: true });
+  return mkdtempSync(join(base, `${prefix}-`));
+}
+
+describe('ignored test directories', () => {
+  it('creates scratch directories under data/test-tmp for a project root', () => {
+    const projectRoot = makeProjectRoot('placement');
+
+    try {
+      const dir = makeIgnoredTestDir('json-lines', { projectRoot });
+
+      expect(existsSync(dir)).toBe(true);
+      expect(relative(projectRoot, dir)).toMatch(/^data[/\\]test-tmp[/\\]json-lines-/);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a unique directory on each call', () => {
+    const projectRoot = makeProjectRoot('unique');
+
+    try {
+      const first = makeIgnoredTestDir('case', { projectRoot });
+      const second = makeIgnoredTestDir('case', { projectRoot });
+
+      expect(first).not.toBe(second);
+      expect(existsSync(first)).toBe(true);
+      expect(existsSync(second)).toBe(true);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('sanitizes prefixes so callers cannot add path segments', () => {
+    const projectRoot = makeProjectRoot('sanitize');
+
+    try {
+      const dir = makeIgnoredTestDir('../bad prefix', { projectRoot });
+      const relativePath = relative(ignoredTestTmpRoot({ projectRoot }), dir);
+
+      expect(relativePath).toMatch(/^bad-prefix-/);
+      expect(relativePath).not.toContain('/');
+      expect(relativePath).not.toContain('\\');
+      expect(IGNORED_TEST_TMP_RELATIVE_DIR).toBe(join('data', 'test-tmp'));
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/test-dirs.ts
+++ b/src/lib/test-dirs.ts
@@ -1,0 +1,30 @@
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const IGNORED_TEST_TMP_RELATIVE_DIR = join('data', 'test-tmp');
+
+export interface IgnoredTestDirOptions {
+  /** Repo/project root. Defaults to the current test process cwd. */
+  projectRoot?: string;
+}
+
+export function ignoredTestTmpRoot(options?: IgnoredTestDirOptions): string {
+  return join(options?.projectRoot ?? process.cwd(), IGNORED_TEST_TMP_RELATIVE_DIR);
+}
+
+function sanitizePrefix(prefix: string): string {
+  return prefix.replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'test';
+}
+
+/**
+ * Create a unique scratch directory under the repo-ignored `data/test-tmp/`.
+ *
+ * Use this for tests that exercise shared filesystem helpers but do not need
+ * OS temp-directory semantics. It keeps CodeQL from tracing generic helper
+ * writes back to insecure-temp-file test paths while still isolating each test.
+ */
+export function makeIgnoredTestDir(prefix: string, options?: IgnoredTestDirOptions): string {
+  const base = ignoredTestTmpRoot(options);
+  mkdirSync(base, { recursive: true });
+  return mkdtempSync(join(base, `${sanitizePrefix(prefix)}-`));
+}


### PR DESCRIPTION
## Summary

Closes #1635 by making the PR #1632 CodeQL workaround reusable instead of copied across test files.

Shared filesystem helper tests should not default to OS temp paths when temp semantics are irrelevant, because CodeQL can trace those paths into changed helper code and report high-severity temp-file alerts on the helper. This PR adds a small repo-local ignored scratch-directory helper and moves the three #1632 test files to it.

## Changes

- Adds `src/lib/test-dirs.ts` with:
  - `makeIgnoredTestDir(prefix)`,
  - `ignoredTestTmpRoot()`,
  - `IGNORED_TEST_TMP_RELATIVE_DIR`.
- Creates scratch directories under ignored `data/test-tmp/`.
- Sanitizes caller prefixes so they cannot add path segments.
- Replaces duplicated local `data/test-tmp` helpers in:
  - `src/lib/json-lines.test.ts`,
  - `src/hooks/session-telemetry.test.ts`,
  - `src/hooks/reflection-persistence.test.ts`.
- Leaves unrelated `tmpdir()` tests alone; some tests intentionally need OS-temp behavior.

## Review

- Round 1 structured review: https://github.com/Garsson-io/kaizen/pull/1636#issuecomment-4828181338

## Verification

- `npx vitest run src/lib/test-dirs.test.ts src/lib/json-lines.test.ts src/hooks/session-telemetry.test.ts src/hooks/reflection-persistence.test.ts`
- `npm run typecheck`
- `npm run test:fast`
- `npm test` (passed; Vitest printed the existing `Unknown option: --bogus` line but exited 0 with 174 passed / 2 skipped files)
- `npx tsx scripts/auto-dent-dry-sweep.ts --changed origin/main`
- `git diff --check`
