### PR TITLE
fix(review): honor active review round for verdict gates

### DIFF
--- a/.github/workflows/review-verdict-gate.yml
+++ b/.github/workflows/review-verdict-gate.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - name: Check latest stored review verdict
+      - name: Check authoritative stored review verdict
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}

--- a/scripts/review-verdict-status.test.ts
+++ b/scripts/review-verdict-status.test.ts
@@ -6,9 +6,10 @@ import {
 } from './review-verdict-status.js';
 
 describe('decideReviewVerdictStatus', () => {
-  it('fails when the latest stored review round derives FAIL', () => {
+  it('fails when the authoritative stored review round derives FAIL', () => {
     const status = decideReviewVerdictStatus(2, 'FAIL');
     expect(status.outcome).toBe('fail');
+    expect(status.message.toLowerCase()).toContain('authoritative');
     expect(status.message).toContain('r2');
   });
 
@@ -54,26 +55,41 @@ describe('resolveTarget', () => {
 });
 
 describe('getReviewVerdictStatus', () => {
-  it('reads the latest stored review round and fails when it derives FAIL', () => {
-    const latest = vi.fn(() => 2);
+  it('reads the authoritative stored review round and fails when it derives FAIL', () => {
+    const authoritative = vi.fn(() => 2);
     const derive = vi.fn(() => 'FAIL' as const);
 
     const status = getReviewVerdictStatus('Garsson-io/kaizen', '1498', {
-      latestReviewRound: latest,
+      authoritativeReviewRound: authoritative,
       deriveStoredRoundVerdict: derive,
     });
 
     expect(status.outcome).toBe('fail');
-    expect(latest).toHaveBeenCalledWith({ kind: 'pr', number: '1498', repo: 'Garsson-io/kaizen' });
+    expect(authoritative).toHaveBeenCalledWith({ kind: 'pr', number: '1498', repo: 'Garsson-io/kaizen' });
+    expect(derive).toHaveBeenCalledWith({ kind: 'pr', number: '1498', repo: 'Garsson-io/kaizen' }, 2);
+  });
+
+  it('uses active r2 instead of stale higher r3 when deriving the gate verdict', () => {
+    const authoritative = vi.fn(() => 2);
+    const derive = vi.fn((_target, round: number) => round === 2 ? 'PASS' as const : 'FAIL' as const);
+
+    const status = getReviewVerdictStatus('Garsson-io/kaizen', '1498', {
+      authoritativeReviewRound: authoritative,
+      deriveStoredRoundVerdict: derive,
+    });
+
+    expect(status.outcome).toBe('pass');
+    expect(status.round).toBe(2);
+    expect(derive).toHaveBeenCalledTimes(1);
     expect(derive).toHaveBeenCalledWith({ kind: 'pr', number: '1498', repo: 'Garsson-io/kaizen' }, 2);
   });
 
   it('does not read a round verdict when no review rounds exist', () => {
-    const latest = vi.fn(() => 0);
+    const authoritative = vi.fn(() => 0);
     const derive = vi.fn(() => 'FAIL' as const);
 
     const status = getReviewVerdictStatus('Garsson-io/kaizen', '1498', {
-      latestReviewRound: latest,
+      authoritativeReviewRound: authoritative,
       deriveStoredRoundVerdict: derive,
     });
 

--- a/scripts/review-verdict-status.ts
+++ b/scripts/review-verdict-status.ts
@@ -3,14 +3,14 @@
  * CI status check for stored PR review verdicts.
  *
  * This is the non-Claude backstop for #1220: when branch protection requires
- * the "Review verdict gate" check, a PR whose latest stored review round
+ * the "Review verdict gate" check, a PR whose authoritative stored review round
  * derives FAIL cannot land even outside an interactive Claude session.
  */
 
 import { parseGithubPrUrl } from '../src/lib/github-pr.js';
 import {
+  authoritativeReviewRound,
   deriveStoredRoundVerdict,
-  latestReviewRound,
   prTarget,
 } from '../src/structured-data.js';
 import type { RoundVerdict } from '../src/review-finding-contract.js';
@@ -34,14 +34,14 @@ export function decideReviewVerdictStatus(round: number, verdict: RoundVerdict |
   if (verdict === 'FAIL') {
     return {
       outcome: 'fail',
-      message: `Latest stored review round r${round} derives FAIL; merge is blocked.`,
+      message: `Authoritative stored review round r${round} derives FAIL; merge is blocked.`,
       round,
       verdict,
     };
   }
   return {
     outcome: 'pass',
-    message: `Latest stored review round r${round} derives ${verdict}.`,
+    message: `Authoritative stored review round r${round} derives ${verdict}.`,
     round,
     verdict,
   };
@@ -69,7 +69,7 @@ export function resolveTarget(): { repo: string; pr: string } {
 }
 
 export interface ReviewVerdictReaders {
-  latestReviewRound?: typeof latestReviewRound;
+  authoritativeReviewRound?: typeof authoritativeReviewRound;
   deriveStoredRoundVerdict?: typeof deriveStoredRoundVerdict;
 }
 
@@ -79,9 +79,9 @@ export function getReviewVerdictStatus(
   readers: ReviewVerdictReaders = {},
 ): ReviewVerdictStatus {
   const target = prTarget(pr, repo);
-  const readLatestRound = readers.latestReviewRound ?? latestReviewRound;
+  const readRound = readers.authoritativeReviewRound ?? authoritativeReviewRound;
   const readVerdict = readers.deriveStoredRoundVerdict ?? deriveStoredRoundVerdict;
-  const round = readLatestRound(target);
+  const round = readRound(target);
   const verdict = round === 0 ? null : readVerdict(target, round);
   return decideReviewVerdictStatus(round, verdict);
 }

--- a/src/hooks/enforce-merge-verdict.test.ts
+++ b/src/hooks/enforce-merge-verdict.test.ts
@@ -1,12 +1,30 @@
-import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   checkMergeVerdict,
   decideMergeGate,
+  defaultVerdictReader,
   inferGithubRepoFromCommandTarget,
   MERGE_OVERRIDE_ENV,
   parseMergeTarget,
   type VerdictReader,
 } from './enforce-merge-verdict.js';
+import { clearCommentCache } from '../section-editor.js';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+const mockGh = vi.mocked(spawnSync);
+
+function ghReturns(stdout: string) {
+  mockGh.mockReturnValueOnce({ status: 0, stdout, stderr: '', signal: null, pid: 0, output: [null, stdout, ''] } as any);
+}
+
+beforeEach(() => {
+  mockGh.mockReset();
+  clearCommentCache();
+});
 
 const gitRunner = (remoteUrl = 'https://github.com/Garsson-io/kaizen.git') => (args: readonly string[]) => {
   if (args.join(' ').includes('remote get-url origin')) {
@@ -149,5 +167,28 @@ describe('checkMergeVerdict', () => {
     expect(checkMergeVerdict('gh pr create --title x', { readVerdict: failReader }).action).toBe('allow');
     expect(checkMergeVerdict('git push origin HEAD', { readVerdict: failReader }).action).toBe('allow');
     expect(checkMergeVerdict('echo gh pr merge 1', { readVerdict: failReader }).action).toBe('allow');
+  });
+});
+
+describe('defaultVerdictReader', () => {
+  it('permits active r2 PASS even when stale higher r3 findings fail', () => {
+    ghReturns(JSON.stringify({
+      url: 'u',
+      body: '<!-- kaizen:review/active-round -->\n<!-- meta:{"round":2} -->\nActive review round: r2',
+    }));
+    ghReturns([
+      JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r2/correctness -->' }),
+      JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r2/summary -->' }),
+      JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r3/security -->' }),
+      JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r3/summary -->' }),
+    ].join('\n'));
+    const r2Finding = JSON.stringify({
+      url: 'u',
+      body: '<!-- kaizen:review/r2/correctness -->\n<!-- meta:{"round":2,"dimension":"correctness","verdict":"pass","done":2,"partial":0,"missing":0} -->',
+    });
+    ghReturns(r2Finding);
+    ghReturns(r2Finding);
+
+    expect(defaultVerdictReader({ pr: '1212', repo: 'Garsson-io/kaizen' })).toBe('PASS');
   });
 });

--- a/src/hooks/enforce-merge-verdict.ts
+++ b/src/hooks/enforce-merge-verdict.ts
@@ -3,14 +3,14 @@
  *
  * Auto-dent now blocks unsafe auto-merge queueing before it asks GitHub to merge.
  * This hook covers the sibling L2 path: a direct interactive `gh pr merge` must
- * not bypass a latest review round that derives FAIL.
+ * not bypass an authoritative review round that derives FAIL.
  */
 
 import { parseGithubPrUrl } from '../lib/github-pr.js';
 import type { RoundVerdict } from '../review-finding-contract.js';
 import {
+  authoritativeReviewRound,
   deriveStoredRoundVerdict,
-  latestReviewRound,
   prTarget,
 } from '../structured-data.js';
 import { readHookInput, traceHookEvent, traceNullInput } from './hook-io.js';
@@ -86,7 +86,7 @@ export function parseMergeTarget(
 
 export const defaultVerdictReader: VerdictReader = (target) => {
   const t = prTarget(target.pr, target.repo);
-  const round = latestReviewRound(t);
+  const round = authoritativeReviewRound(t);
   if (round === 0) return null;
   return deriveStoredRoundVerdict(t, round);
 };
@@ -109,9 +109,9 @@ export function decideMergeGate(
     }
     return {
       action: 'deny',
-      message: `MERGE BLOCKED: ${prRef}'s latest review round derives FAIL.
+      message: `MERGE BLOCKED: ${prRef}'s authoritative review round derives FAIL.
 
-Fix the findings and re-run the review until the latest round derives PASS, or
+Fix the findings and re-run the review until the authoritative round derives PASS, or
 use an explicit logged human override:
 
   ${MERGE_OVERRIDE_ENV}=1 gh pr merge ...

--- a/src/structured-data.test.ts
+++ b/src/structured-data.test.ts
@@ -13,6 +13,8 @@ import {
   parseFindingMeta,
   nextReviewRound,
   latestReviewRound,
+  authoritativeReviewRound,
+  readActiveReviewRound,
   listReviewRounds,
   listReviewDimensions,
   readReviewFinding,
@@ -190,6 +192,8 @@ describe('storeReviewBatch — multiple findings + auto-summary', () => {
     ghReturns(stored2);
     // writeAttachment for summary: readAttachment (no existing) + createComment
     ghReturns(''); ghReturns('https://...#issuecomment-12');
+    // writeAttachment for active marker: readAttachment (no existing) + createComment
+    ghReturns(''); ghReturns('https://...#issuecomment-active');
 
     const result = storeReviewBatch(pr, 5, [passFinding, failFinding]);
     expect(result.urls).toHaveLength(2);
@@ -224,6 +228,41 @@ describe('nextReviewRound + latestReviewRound', () => {
       JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r3/summary -->' }),
     ].join('\n'));
     expect(nextReviewRound(pr)).toBe(4);
+  });
+
+  it('uses a stored active round instead of a stale higher-numbered round when it has review data', () => {
+    ghReturns(JSON.stringify({
+      url: 'u',
+      body: '<!-- kaizen:review/active-round -->\n<!-- meta:{"round":2} -->\nActive review round: r2',
+    }));
+    ghReturns([
+      JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r2/summary -->' }),
+      JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r3/security -->' }),
+    ].join('\n'));
+
+    expect(authoritativeReviewRound(pr)).toBe(2);
+  });
+
+  it('reads the stored active review round marker', () => {
+    ghReturns(JSON.stringify({
+      url: 'u',
+      body: '<!-- kaizen:review/active-round -->\n<!-- meta:{"round":2} -->\nActive review round: r2',
+    }));
+
+    expect(readActiveReviewRound(pr)).toBe(2);
+  });
+
+  it('falls back to latest review round when the active marker points at a missing round', () => {
+    ghReturns(JSON.stringify({
+      url: 'u',
+      body: '<!-- kaizen:review/active-round -->\n<!-- meta:{"round":9} -->\nActive review round: r9',
+    }));
+    ghReturns([
+      JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r2/summary -->' }),
+      JSON.stringify({ url: 'u', body: '<!-- kaizen:review/r3/security -->' }),
+    ].join('\n'));
+
+    expect(authoritativeReviewRound(pr)).toBe(3);
   });
 });
 
@@ -270,12 +309,11 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
       body: `<!-- kaizen:review/r${round}/${dim} -->\n<!-- meta:{"round":${round},"dimension":"${dim}","verdict":"${verdict}","done":${done},"partial":${partial},"missing":${missing}} -->`,
     });
 
-  const bodyOfLastCreate = (): string => {
-    // createComment is the final gh call; its args carry body=<content>.
+  const bodyOfLastSummaryWrite = (): string => {
     for (let i = mockGh.mock.calls.length - 1; i >= 0; i--) {
       const args = mockGh.mock.calls[i][1] as string[];
       const body = args?.find?.(a => typeof a === 'string' && a.startsWith('body='));
-      if (body) return body;
+      if (body?.includes('## Review Round')) return body;
     }
     return '';
   };
@@ -298,9 +336,11 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     ghReturns(sec); // compose: read
     ghReturns(''); // writeAttachment: readAttachment (no existing summary) → create
     ghReturns('https://...#issuecomment-sum');
+    ghReturns(''); // active marker write: readAttachment (no existing)
+    ghReturns('https://...#issuecomment-active');
 
     storeReviewSummary(pr, 5);
-    const body = bodyOfLastCreate();
+    const body = bodyOfLastSummaryWrite();
     expect(body).toContain('## Review Round 5 — FAIL');
     expect(body).toContain('| security | ❌ FAIL | 1 | 0 | 2 |');
   });
@@ -311,12 +351,32 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     ghReturns(ok); // compose: read
     ghReturns(''); // writeAttachment: readAttachment (no existing)
     ghReturns('https://...#issuecomment-sum');
+    ghReturns(''); // active marker write: readAttachment (no existing)
+    ghReturns('https://...#issuecomment-active');
 
     storeReviewSummary(pr, 2, 'rebased onto main, re-ran the 3 test files, no changes');
-    const body = bodyOfLastCreate();
+    const body = bodyOfLastSummaryWrite();
     expect(body).toContain('## Review Round 2 — PASS');
     expect(body).toContain('### Reviewer notes (non-authoritative');
     expect(body).toContain('rebased onto main');
+  });
+
+  it('updates the active review round marker when a summary is stored', () => {
+    const ok = dimComment(2, 'correctness', 'pass', 3, 0, 0);
+    ghReturns(ok); // compose: list
+    ghReturns(ok); // compose: read
+    ghReturns(''); // summary write: readAttachment
+    ghReturns('https://...#issuecomment-sum');
+    ghReturns(''); // active marker write: readAttachment
+    ghReturns('https://...#issuecomment-active');
+
+    storeReviewSummary(pr, 2);
+
+    const activeBody = mockGh.mock.calls
+      .map(([, args]) => (args as string[])?.find?.(a => typeof a === 'string' && a.startsWith('body=')) ?? '')
+      .find(body => body.includes('<!-- kaizen:review/active-round -->')) ?? '';
+    expect(activeBody).toContain('<!-- meta:{"round":2} -->');
+    expect(activeBody).toContain('Active review round: r2');
   });
 
   // The #1070 CI-proof gate that previously lived here was reverted (#1225): storing a derived PASS
@@ -329,10 +389,12 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     ghReturns(ok); // compose: read
     ghReturns(''); // writeAttachment: readAttachment (no existing) — only storage calls, no pr view/checks
     ghReturns('https://...#issuecomment-sum');
+    ghReturns(''); // active marker write: readAttachment (no existing)
+    ghReturns('https://...#issuecomment-active');
 
     storeReviewSummary(pr, 4);
 
-    const body = bodyOfLastCreate();
+    const body = bodyOfLastSummaryWrite();
     expect(body).toContain('## Review Round 4 — PASS');
 
     // The reverted #1070 gate shelled out to `gh pr view --json headRefOid`, `gh pr checks`,
@@ -356,6 +418,8 @@ describe('storeReviewSummary — derived verdict is authoritative (#1019)', () =
     ghReturns(ok); // compose: read
     ghReturns(''); // writeAttachment: readAttachment (no existing)
     ghReturns('https://...#issuecomment-sum'); // createComment
+    ghReturns(''); // active marker write: readAttachment (no existing)
+    ghReturns('https://...#issuecomment-active');
 
     // Pre-revert this threw via `if (target.kind !== 'pr') throw`; now it stores like any target.
     expect(() => storeReviewSummary(issue, 3)).not.toThrow();

--- a/src/structured-data.ts
+++ b/src/structured-data.ts
@@ -7,6 +7,7 @@
  * Naming conventions (attachment names):
  *   review/r{N}/{dimension}  — per-dimension findings for round N
  *   review/r{N}/summary      — overall round N assessment
+ *   review/active-round      — authoritative review round pointer
  *   plan                     — implementation plan
  *   testplan                 — test plan
  *   metadata                 — YAML structured metadata (connected issues, PR number, etc.)
@@ -113,6 +114,7 @@ export function extractPlanText(text: string): string | undefined {
 export type { ReviewFinding, ReviewFindingData } from './review-finding-contract.js';
 
 const STATUS_ICON: Record<string, string> = { DONE: '✅', PARTIAL: '⚠️', MISSING: '❌' };
+const ACTIVE_REVIEW_ROUND_ATTACHMENT = 'review/active-round';
 
 function extractSummaryRoundVerdict(summary: string): RoundVerdict | null {
   const meta = parseJsonMetaComment(summary);
@@ -312,7 +314,35 @@ export function storeReviewSummary(
     content = `${derived}\n\n### Reviewer notes (non-authoritative — verdict above is derived from findings)\n\n${trimmed}`;
   }
 
-  return writeAttachment(target, `review/r${round}/summary`, content);
+  const summaryUrl = writeAttachment(target, `review/r${round}/summary`, content);
+  storeActiveReviewRound(target, round);
+  return summaryUrl;
+}
+
+/**
+ * Store the active review round marker used by verdict consumers.
+ */
+export function storeActiveReviewRound(target: AttachmentTarget, round: number): string {
+  if (!Number.isSafeInteger(round) || round < 1) {
+    throw new Error(`store-active-review-round: expected a positive integer round, got ${round}`);
+  }
+  return writeAttachment(
+    target,
+    ACTIVE_REVIEW_ROUND_ATTACHMENT,
+    `<!-- meta:${JSON.stringify({ round })} -->\nActive review round: r${round}`,
+  );
+}
+
+/**
+ * Read the active review round marker, or null when absent/malformed.
+ */
+export function readActiveReviewRound(target: AttachmentTarget): number | null {
+  const attachment = readAttachment(target, ACTIVE_REVIEW_ROUND_ATTACHMENT);
+  if (!attachment) return null;
+
+  const meta = parseJsonMetaComment(attachment.content);
+  const round = meta && typeof meta === 'object' ? (meta as { round?: unknown }).round : undefined;
+  return typeof round === 'number' && Number.isSafeInteger(round) && round >= 1 ? round : null;
 }
 
 /**
@@ -360,6 +390,20 @@ export function readReviewSummary(target: AttachmentTarget, round: number): stri
  */
 export function latestReviewRound(target: AttachmentTarget): number {
   const rounds = listReviewRounds(target);
+  return rounds.length > 0 ? rounds[rounds.length - 1] : 0;
+}
+
+/**
+ * Get the authoritative review round for verdict consumers.
+ *
+ * A newer clean active round can intentionally supersede an older higher-numbered
+ * failed round. If the marker is missing or points at data that is no longer
+ * present, fall back to the numeric latest round.
+ */
+export function authoritativeReviewRound(target: AttachmentTarget): number {
+  const active = readActiveReviewRound(target);
+  const rounds = listReviewRounds(target);
+  if (active !== null && rounds.includes(active)) return active;
   return rounds.length > 0 ? rounds[rounds.length - 1] : 0;
 }
 


### PR DESCRIPTION
## Summary
- store a durable `review/active-round` marker whenever a review summary is stored
- add `authoritativeReviewRound()` so verdict consumers prefer the active round when it has stored review data and fall back to numeric latest otherwise
- switch the review verdict status check and direct merge hook to the authoritative round

Fixes #1634

## Validation
- `npx vitest run src/structured-data.test.ts scripts/review-verdict-status.test.ts src/hooks/enforce-merge-verdict.test.ts`
- `npm run check:fast`
- `npm run test:hooks`
- `npm test`
- `git diff --check`