### PR TITLE
feat(batch): analyze progress issue artifacts

### DIFF
--- a/scripts/batch-artifacts-cli.test.ts
+++ b/scripts/batch-artifacts-cli.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { parseBatchArtifactCliArgs } from './batch-artifacts-cli.js';
+
+describe('parseBatchArtifactCliArgs', () => {
+  it('extracts positional dirs, json mode, repo, and repeated progress issues', () => {
+    const parsed = parseBatchArtifactCliArgs([
+      'logs/auto-dent',
+      '--progress-issue',
+      '100',
+      '--json',
+      '--repo',
+      'owner/repo',
+      '--progress-issue',
+      '101',
+    ]);
+
+    expect(parsed).toEqual({
+      jsonMode: true,
+      positional: ['logs/auto-dent'],
+      progressIssues: ['100', '101'],
+      repo: 'owner/repo',
+    });
+  });
+
+  it('falls back to GITHUB_REPOSITORY when --repo is absent', () => {
+    const previous = process.env.GITHUB_REPOSITORY;
+    process.env.GITHUB_REPOSITORY = 'env/repo';
+    try {
+      expect(parseBatchArtifactCliArgs(['--progress-issue', '100']).repo).toBe('env/repo');
+    } finally {
+      if (previous === undefined) delete process.env.GITHUB_REPOSITORY;
+      else process.env.GITHUB_REPOSITORY = previous;
+    }
+  });
+});

--- a/scripts/batch-artifacts-cli.ts
+++ b/scripts/batch-artifacts-cli.ts
@@ -1,0 +1,29 @@
+export interface BatchArtifactCliArgs {
+  jsonMode: boolean;
+  positional: string[];
+  progressIssues: string[];
+  repo: string | undefined;
+}
+export function parseBatchArtifactCliArgs(args: string[]): BatchArtifactCliArgs {
+  const valueAfter = (flag: string): string | undefined => {
+    const idx = args.indexOf(flag);
+    return idx >= 0 ? args[idx + 1] : undefined;
+  };
+  const valuesAfter = (flag: string): string[] => {
+    const values: string[] = [];
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === flag && args[i + 1]) values.push(args[i + 1]);
+    }
+    return values;
+  };
+
+  return {
+    jsonMode: args.includes('--json'),
+    progressIssues: valuesAfter('--progress-issue'),
+    repo: valueAfter('--repo') ?? process.env.GITHUB_REPOSITORY,
+    positional: args.filter((arg, idx) => {
+      if (arg === '--json' || arg === '--progress-issue' || arg === '--repo') return false;
+      return args[idx - 1] !== '--progress-issue' && args[idx - 1] !== '--repo';
+    }),
+  };
+}

--- a/scripts/batch-artifacts-upload.test.ts
+++ b/scripts/batch-artifacts-upload.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { makeIgnoredTestDir } from '../src/lib/test-dirs.js';
 import {
   buildArtifactsComment,
+  parseArtifactsComment,
   readArtifactParts,
   type ArtifactParts,
   BATCH_ARTIFACTS_ATTACHMENT,
@@ -29,7 +30,7 @@ afterEach(() => {
   while (tmpDirs.length) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
 });
 function freshBatchDir(): string {
-  const d = mkdtempSync(join(tmpdir(), 'batch-artifacts-'));
+  const d = makeIgnoredTestDir('batch-artifacts');
   tmpDirs.push(d);
   return d;
 }
@@ -110,6 +111,28 @@ describe('buildArtifactsComment', () => {
     );
     expect(body.length).toBeLessThanOrEqual(ARTIFACTS_BODY_BUDGET);
     expect(body).toContain('## Batch Artifacts: `sticky-lark`'); // header always survives
+  });
+});
+
+describe('parseArtifactsComment', () => {
+  it('round-trips generated artifact comments into raw parts', () => {
+    const body = buildArtifactsComment(makeParts(), NOW);
+
+    const parts = parseArtifactsComment(body);
+
+    expect(parts.batchId).toBe('sticky-lark');
+    expect(parts.eventsJsonl).toContain('{"kind":"run_complete","run":1}');
+    expect(parts.stateJson).toContain('"batch_id": "sticky-lark"');
+    expect(parts.summary).toBe('Runs: 3\nPRs: 1');
+  });
+
+  it('rejects truncated events.jsonl instead of returning partial telemetry', () => {
+    const huge = Array.from({ length: 4000 }, (_, i) => `{"kind":"run_complete","run":${i}}`).join(
+      '\n',
+    );
+    const body = buildArtifactsComment(makeParts({ eventsJsonl: huge }), NOW);
+
+    expect(() => parseArtifactsComment(body)).toThrow(/truncated events\.jsonl/);
   });
 });
 

--- a/scripts/batch-artifacts-upload.ts
+++ b/scripts/batch-artifacts-upload.ts
@@ -24,7 +24,7 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { join, basename } from 'node:path';
-import { writeAttachment } from '../src/section-editor.js';
+import { readAttachment, writeAttachment } from '../src/section-editor.js';
 import {
   buildCappedBody,
   GITHUB_COMMENT_LIMIT,
@@ -51,6 +51,17 @@ export interface ArtifactParts {
   summary: string | null;
 }
 
+interface DetailsBlock {
+  summary: string;
+  fence: string;
+  content: string;
+}
+
+const DETAILS_BLOCK_RE =
+  /<details>\s*<summary>([^<]*)<\/summary>\s*```([^\n`]*)\n([\s\S]*?)\n```\s*<\/details>/g;
+const TRUNCATION_MARKER_RE =
+  /\[(?:\d+ lines truncated|comment truncated) — full data on disk at [^\]]+\]/;
+
 function readIfExists(path: string): string | null {
   try {
     return existsSync(path) ? readFileSync(path, 'utf8') : null;
@@ -73,6 +84,70 @@ export function readArtifactParts(batchDir: string): ArtifactParts {
       readIfExists(join(batchDir, 'batch-summary.txt')) ??
       readIfExists(join(batchDir, 'batch-summary-report.md')),
   };
+}
+
+function detailsBlocks(body: string): DetailsBlock[] {
+  return [...body.matchAll(DETAILS_BLOCK_RE)].map((match) => ({
+    summary: match[1],
+    fence: match[2],
+    content: match[3],
+  }));
+}
+
+function findDetailsBlock(
+  body: string,
+  summaryPrefix: string,
+  expectedFence: string,
+): DetailsBlock | null {
+  return detailsBlocks(body).find((block) =>
+    block.summary.startsWith(summaryPrefix) && block.fence === expectedFence,
+  ) ?? null;
+}
+
+function blockWasTruncated(block: DetailsBlock): boolean {
+  return block.summary.includes('(truncated)') || TRUNCATION_MARKER_RE.test(block.content);
+}
+
+/**
+ * Parse the idempotent progress-issue `batch-artifacts` attachment back into
+ * raw artifact parts. This is the cloud-reader counterpart to
+ * {@link buildArtifactsComment}, used by analysis tooling when local batch
+ * directories are unavailable.
+ */
+export function parseArtifactsComment(body: string): ArtifactParts {
+  const batchId = body.match(/^## Batch Artifacts: `([^`]+)`/m)?.[1] ?? 'unknown';
+  const eventBlock = findDetailsBlock(body, 'events.jsonl', 'jsonl');
+  const stateBlock = findDetailsBlock(body, 'state.json', 'json');
+
+  if (eventBlock && blockWasTruncated(eventBlock)) {
+    throw new Error(
+      `Batch artifacts for ${batchId} contain a truncated events.jsonl block; analysis requires the complete artifact.`,
+    );
+  }
+
+  const summary = body.match(/### Batch Summary\s+```\n([\s\S]*?)\n```/)?.[1] ?? null;
+
+  return {
+    batchId,
+    eventsJsonl: eventBlock?.content ?? null,
+    stateJson: stateBlock?.content ?? null,
+    summary,
+  };
+}
+
+/**
+ * Read and parse the `batch-artifacts` attachment from a progress issue.
+ * Returns `null` when the attachment has not been posted yet.
+ */
+export function readArtifactPartsFromProgressIssue(
+  issueNumber: string,
+  repo: string,
+): ArtifactParts | null {
+  const attachment = readAttachment(
+    { kind: 'issue', number: issueNumber, repo },
+    BATCH_ARTIFACTS_ATTACHMENT,
+  );
+  return attachment ? parseArtifactsComment(attachment.content) : null;
 }
 
 /**

--- a/scripts/batch-summary.test.ts
+++ b/scripts/batch-summary.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from 'fs';
+import { writeFileSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
+import { makeIgnoredTestDir } from '../src/lib/test-dirs.js';
 import type { EventEnvelope } from './auto-dent-events.js';
-import { parseEventsFile, summarizeEvents, formatPlainLanguage } from './batch-summary.js';
+import { buildArtifactsComment, parseArtifactsComment } from './batch-artifacts-upload.js';
+import {
+  parseEventsFile,
+  parseEventsJsonl,
+  summarizeEvents,
+  formatPlainLanguage,
+} from './batch-summary.js';
 
 function makeEnvelope(event: EventEnvelope['event'], timestamp?: string): EventEnvelope {
   return {
@@ -37,7 +43,7 @@ describe('parseEventsFile', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'batch-summary-'));
+    tmpDir = makeIgnoredTestDir('batch-summary');
   });
 
   it('returns empty array for non-existent file', () => {
@@ -88,6 +94,40 @@ describe('parseEventsFile', () => {
     const source = readFileSync(new URL('./batch-summary.ts', import.meta.url), 'utf8');
 
     expect(source).not.toContain('JSON.parse(line)');
+  });
+});
+
+describe('progress issue artifact event parsing', () => {
+  it('summarizes events from a generated batch-artifacts comment without a local events file', () => {
+    const events = [
+      makeCompleteEvent({ batch_id: 'cloud-batch', run_num: 1, cost_usd: 2, prs_created: 1 }),
+      makeEnvelope({
+        type: 'run.issue_picked',
+        run_id: 'cloud-batch/run-1',
+        batch_id: 'cloud-batch',
+        run_num: 1,
+        issue: '#688',
+        title: 'Cloud artifacts',
+        labels: ['horizon/observability'],
+      }),
+    ];
+    const body = buildArtifactsComment(
+      {
+        batchId: 'cloud-batch',
+        eventsJsonl: events.map(e => JSON.stringify(e)).join('\n'),
+        stateJson: null,
+        summary: null,
+      },
+      '2026-06-29T00:00:00Z',
+    );
+
+    const parts = parseArtifactsComment(body);
+    const summary = summarizeEvents(parseEventsJsonl(parts.eventsJsonl!));
+
+    expect(summary.batch_id).toBe('cloud-batch');
+    expect(summary.total_runs).toBe(1);
+    expect(summary.total_prs).toBe(1);
+    expect(summary.horizon_distribution).toEqual({ 'horizon/observability': 1 });
   });
 });
 
@@ -472,7 +512,7 @@ describe('process verdict distribution (#1149)', () => {
   });
 
   it('CLI output includes hook activation health for a synthetic batch with bounded subprocess cost', () => {
-    const tmpDir = mkdtempSync(join(tmpdir(), 'batch-summary-cli-'));
+    const tmpDir = makeIgnoredTestDir('batch-summary-cli');
     const hook = (status: string, degraded: boolean) => ({
       provider: 'claude',
       expected: true,

--- a/scripts/batch-summary.ts
+++ b/scripts/batch-summary.ts
@@ -18,6 +18,8 @@ import { resolve } from 'path';
 import { parseJsonLines } from '../src/lib/json-lines.js';
 import type { EventEnvelope, RunCompleteEvent, RunIssuePickedEvent, RunPrCreatedEvent } from './auto-dent-events.js';
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
+import { parseBatchArtifactCliArgs } from './batch-artifacts-cli.js';
+import { readArtifactPartsFromProgressIssue } from './batch-artifacts-upload.js';
 import {
   computeHookActivationCounts,
   hookActivationDistributionEntries,
@@ -97,7 +99,28 @@ export function parseEventsFile(eventsPath: string): EventEnvelope[] {
   const content = readFileSync(eventsPath, 'utf8').trim();
   if (!content) return [];
 
-  return parseJsonLines<EventEnvelope>(content);
+  return parseEventsJsonl(content);
+}
+
+/**
+ * Parse events.jsonl content into typed event envelopes.
+ * Silently skips malformed lines through the shared JSONL helper.
+ */
+export function parseEventsJsonl(content: string): EventEnvelope[] {
+  const trimmed = content.trim();
+  if (!trimmed) return [];
+  return parseJsonLines<EventEnvelope>(trimmed);
+}
+
+export function parseEventsFromProgressIssue(issueNumber: string, repo: string): EventEnvelope[] {
+  const parts = readArtifactPartsFromProgressIssue(issueNumber, repo);
+  if (!parts) {
+    throw new Error(`No batch-artifacts attachment found on issue #${issueNumber}`);
+  }
+  if (!parts.eventsJsonl) {
+    throw new Error(`No events.jsonl artifact found on issue #${issueNumber}`);
+  }
+  return parseEventsJsonl(parts.eventsJsonl);
 }
 
 /**
@@ -398,19 +421,32 @@ export function formatPlainLanguage(summary: BatchSummary): string {
 
 // CLI entry point
 if (process.argv[1]?.endsWith('batch-summary.ts') || process.argv[1]?.endsWith('batch-summary.js')) {
-  const batchDir = process.argv[2];
-  const jsonMode = process.argv.includes('--json');
+  const { positional, progressIssues, repo, jsonMode } = parseBatchArtifactCliArgs(process.argv.slice(2));
+  const progressIssue = progressIssues[0];
+  const batchDir = positional[0];
 
-  if (!batchDir) {
+  if (!batchDir && !progressIssue) {
     console.error('Usage: npx tsx scripts/batch-summary.ts <batch-dir> [--json]');
+    console.error('   or: npx tsx scripts/batch-summary.ts --progress-issue <issue> --repo <owner/repo> [--json]');
+    process.exit(1);
+  }
+  if (progressIssue && !repo) {
+    console.error('Usage: --progress-issue requires --repo <owner/repo> or GITHUB_REPOSITORY');
     process.exit(1);
   }
 
-  const eventsPath = resolve(batchDir, 'events.jsonl');
-  const envelopes = parseEventsFile(eventsPath);
+  const eventsPath = batchDir ? resolve(batchDir, 'events.jsonl') : '';
+  let envelopes: EventEnvelope[];
+  try {
+    envelopes = progressIssue ? parseEventsFromProgressIssue(progressIssue, repo!) : parseEventsFile(eventsPath);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 
   if (envelopes.length === 0) {
-    console.error(`No events found at ${eventsPath}`);
+    const source = progressIssue ? `progress issue #${progressIssue}` : eventsPath;
+    console.error(`No events found at ${source}`);
     process.exit(1);
   }
 

--- a/scripts/batch-trends.test.ts
+++ b/scripts/batch-trends.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
+import { makeIgnoredTestDir } from '../src/lib/test-dirs.js';
 import type { EventEnvelope } from './auto-dent-events.js';
+import { buildArtifactsComment, parseArtifactsComment } from './batch-artifacts-upload.js';
 import {
   discoverBatchDirs,
   toDataPoint,
   computeTrend,
+  analyzeEventSources,
   analyzeTrends,
+  eventSourceFromArtifactParts,
   formatTrendReport,
 } from './batch-trends.js';
 import { summarizeEvents } from './batch-summary.js';
@@ -44,7 +47,7 @@ describe('discoverBatchDirs', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'batch-trends-'));
+    tmpDir = makeIgnoredTestDir('batch-trends');
   });
 
   it('returns empty array for non-existent directory', () => {
@@ -142,7 +145,7 @@ describe('analyzeTrends', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'batch-trends-analyze-'));
+    tmpDir = makeIgnoredTestDir('batch-trends-analyze');
   });
 
   it('produces report from multiple batch directories', () => {
@@ -208,6 +211,39 @@ describe('analyzeTrends', () => {
   });
 });
 
+describe('analyzeEventSources with uploaded artifacts', () => {
+  it('produces trends from batch-artifacts comments without local events files', () => {
+    const firstEvents = [
+      makeCompleteEnvelope({ batch_id: 'cloud-001', cost_usd: 4, prs_created: 1 }, '2026-06-28T10:00:00Z'),
+    ];
+    const secondEvents = [
+      makeCompleteEnvelope({ batch_id: 'cloud-002', cost_usd: 2, prs_created: 2 }, '2026-06-29T10:00:00Z'),
+    ];
+    const first = parseArtifactsComment(buildArtifactsComment({
+      batchId: 'cloud-001',
+      eventsJsonl: firstEvents.map(e => JSON.stringify(e)).join('\n'),
+      stateJson: null,
+      summary: null,
+    }, '2026-06-28T12:00:00Z'));
+    const second = parseArtifactsComment(buildArtifactsComment({
+      batchId: 'cloud-002',
+      eventsJsonl: secondEvents.map(e => JSON.stringify(e)).join('\n'),
+      stateJson: null,
+      summary: null,
+    }, '2026-06-29T12:00:00Z'));
+
+    const report = analyzeEventSources([
+      eventSourceFromArtifactParts(first),
+      eventSourceFromArtifactParts(second),
+    ]);
+
+    expect(report.batch_count).toBe(2);
+    expect(report.datapoints.map(d => d.batch_id)).toEqual(['cloud-001', 'cloud-002']);
+    expect(report.totals.total_prs).toBe(3);
+    expect(report.trends.cost_per_pr.direction).toBe('improving');
+  });
+});
+
 describe('toDataPoint mode_distribution', () => {
   it('includes mode_distribution from summary', () => {
     const summary = summarizeEvents([
@@ -224,7 +260,7 @@ describe('analyzeTrends mode_diversity', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'batch-trends-mode-'));
+    tmpDir = makeIgnoredTestDir('batch-trends-mode');
   });
 
   it('tracks mode diversity trend across batches', () => {
@@ -256,7 +292,7 @@ describe('formatTrendReport', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'batch-trends-format-'));
+    tmpDir = makeIgnoredTestDir('batch-trends-format');
   });
 
   it('produces readable markdown output', () => {

--- a/scripts/batch-trends.ts
+++ b/scripts/batch-trends.ts
@@ -16,7 +16,18 @@
 
 import { readdirSync, statSync, existsSync } from 'fs';
 import { resolve, basename } from 'path';
-import { parseEventsFile, summarizeEvents, type BatchSummary } from './batch-summary.js';
+import type { EventEnvelope } from './auto-dent-events.js';
+import { parseBatchArtifactCliArgs } from './batch-artifacts-cli.js';
+import {
+  readArtifactPartsFromProgressIssue,
+  type ArtifactParts,
+} from './batch-artifacts-upload.js';
+import {
+  parseEventsFile,
+  parseEventsJsonl,
+  summarizeEvents,
+  type BatchSummary,
+} from './batch-summary.js';
 
 export interface BatchDataPoint {
   batch_id: string;
@@ -60,6 +71,11 @@ export interface TrendDirection {
   first_half_avg: number;
   second_half_avg: number;
   change_pct: number;
+}
+
+export interface BatchEventSource {
+  label: string;
+  envelopes: EventEnvelope[];
 }
 
 /**
@@ -157,14 +173,52 @@ export function computeTrend(
 }
 
 /**
- * Build a TrendReport from multiple batch directories.
+ * Read a local batch directory into an in-memory trend source.
  */
-export function analyzeTrends(batchDirs: string[]): TrendReport {
+export function eventSourceFromBatchDir(dir: string): BatchEventSource {
+  const eventsPath = resolve(dir, 'events.jsonl');
+  return {
+    label: basename(dir),
+    envelopes: parseEventsFile(eventsPath),
+  };
+}
+
+/**
+ * Convert parsed uploaded batch artifacts into an in-memory trend source.
+ */
+export function eventSourceFromArtifactParts(
+  parts: ArtifactParts,
+  label = parts.batchId,
+): BatchEventSource {
+  if (!parts.eventsJsonl) {
+    throw new Error(`No events.jsonl artifact found for ${label}`);
+  }
+  return {
+    label,
+    envelopes: parseEventsJsonl(parts.eventsJsonl),
+  };
+}
+
+/**
+ * Read a progress issue's uploaded `batch-artifacts` attachment into an
+ * in-memory trend source.
+ */
+export function eventSourceFromProgressIssue(issueNumber: string, repo: string): BatchEventSource {
+  const parts = readArtifactPartsFromProgressIssue(issueNumber, repo);
+  if (!parts) {
+    throw new Error(`No batch-artifacts attachment found on issue #${issueNumber}`);
+  }
+  return eventSourceFromArtifactParts(parts, `issue #${issueNumber}`);
+}
+
+/**
+ * Build a TrendReport from in-memory event sources.
+ */
+export function analyzeEventSources(sources: BatchEventSource[]): TrendReport {
   const datapoints: BatchDataPoint[] = [];
 
-  for (const dir of batchDirs) {
-    const eventsPath = resolve(dir, 'events.jsonl');
-    const envelopes = parseEventsFile(eventsPath);
+  for (const source of sources) {
+    const envelopes = source.envelopes;
     if (envelopes.length === 0) continue;
 
     const summary = summarizeEvents(envelopes);
@@ -196,6 +250,13 @@ export function analyzeTrends(batchDirs: string[]): TrendReport {
   };
 
   return { batch_count: datapoints.length, date_range: dateRange, datapoints, trends, totals };
+}
+
+/**
+ * Build a TrendReport from multiple local batch directories.
+ */
+export function analyzeTrends(batchDirs: string[]): TrendReport {
+  return analyzeEventSources(batchDirs.map(eventSourceFromBatchDir));
 }
 
 /**
@@ -258,16 +319,22 @@ function formatTrendLine(label: string, trend: TrendDirection, unit: string): st
 
 // CLI entry point
 if (process.argv[1]?.endsWith('batch-trends.ts') || process.argv[1]?.endsWith('batch-trends.js')) {
-  const args = process.argv.slice(2).filter(a => !a.startsWith('--'));
-  const jsonMode = process.argv.includes('--json');
+  const { positional: args, progressIssues, repo, jsonMode } = parseBatchArtifactCliArgs(process.argv.slice(2));
 
-  if (args.length === 0) {
+  if (args.length === 0 && progressIssues.length === 0) {
     console.error('Usage: npx tsx scripts/batch-trends.ts <parent-dir|batch-dir...> [--json]');
+    console.error('   or: npx tsx scripts/batch-trends.ts --progress-issue <issue> --repo <owner/repo> [--json]');
+    process.exit(1);
+  }
+  if (progressIssues.length > 0 && !repo) {
+    console.error('Usage: --progress-issue requires --repo <owner/repo> or GITHUB_REPOSITORY');
     process.exit(1);
   }
 
   let batchDirs: string[];
-  if (args.length === 1) {
+  if (args.length === 0) {
+    batchDirs = [];
+  } else if (args.length === 1) {
     // Single arg: could be a parent dir containing batch subdirs, or a single batch dir
     const resolved = resolve(args[0]);
     const discovered = discoverBatchDirs(resolved);
@@ -283,10 +350,20 @@ if (process.argv[1]?.endsWith('batch-trends.ts') || process.argv[1]?.endsWith('b
     batchDirs = args.map(a => resolve(a));
   }
 
-  const report = analyzeTrends(batchDirs);
+  let report: TrendReport;
+  try {
+    const sources = [
+      ...batchDirs.map(eventSourceFromBatchDir),
+      ...progressIssues.map((issue) => eventSourceFromProgressIssue(issue, repo!)),
+    ];
+    report = analyzeEventSources(sources);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 
   if (report.batch_count === 0) {
-    console.error('No events found in any batch directory');
+    console.error('No events found in any batch directory or progress issue artifact');
     process.exit(1);
   }
 


### PR DESCRIPTION
## Problem

`batch-artifacts` upload now exists on progress issues, but the JSONL analysis tools still assumed local `events.jsonl` files. That left #688 only half-done: the durable cloud copy existed, but the analysis path did not consume it.

## Solution

- Add a parser/reader for the idempotent `batch-artifacts` attachment.
- Reject truncated `events.jsonl` blocks rather than analyzing partial telemetry.
- Add `--progress-issue <issue> --repo <owner/repo>` support to `batch-summary.ts`.
- Add repeated `--progress-issue` support to `batch-trends.ts`, sharing the same in-memory trend path as local directories.
- Extract shared batch artifact CLI parsing so summary/trends do not drift.
- Move touched filesystem tests to the repo-ignored `data/test-tmp` helper.

## Evidence

- `npx vitest run scripts/batch-artifacts-cli.test.ts scripts/batch-artifacts-upload.test.ts scripts/batch-summary.test.ts scripts/batch-trends.test.ts` -> 4 files, 77 tests passed
- `npm run typecheck` -> pass
- `npm run test:fast` -> 12 files, 765 passed, 2 skipped
- `npm test` -> 175 passed, 2 skipped; 4170 passed, 14 skipped

Note: the full test run prints `Unknown option: --bogus` from an existing CLI-negative-path test while still exiting 0.

## Closeout

#1118 already made batch finalize upload raw artifacts to the progress issue. #1632 bounded the local telemetry JSONL accumulation risk. This PR completes the remaining JSONL analysis-consumption path from the progress issue attachment.

Closes #688
