### PR TITLE
fix(review): add manual review state CLI

### DIFF
--- a/scripts/review-fix.test.ts
+++ b/scripts/review-fix.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync as spawnRaw } from 'node:child_process';
@@ -606,6 +606,30 @@ describe('parseArgs', () => {
       '--repo', 'org/repo',
       '--fix-provider', 'api-token',
     ])).toThrow('exit');
+  });
+
+  it('parses --transition without requiring --issue for the full fix loop (#929)', () => {
+    vi.spyOn(process, 'exit').mockImplementation((_code?: number | string) => { throw new Error('exit'); });
+    const result = parseArgs([
+      'node', 'review-fix.ts',
+      '--transition', 'needs_review',
+      '--pr', 'https://github.com/org/repo/pull/1',
+      '--repo', 'org/repo',
+    ]);
+    expect(result.transition).toBe('needs_review');
+    expect(result.prUrl).toBe('https://github.com/org/repo/pull/1');
+    expect(result.repo).toBe('org/repo');
+  });
+
+  it('parses --clear-review-gate without requiring full-loop args (#961)', () => {
+    vi.spyOn(process, 'exit').mockImplementation((_code?: number | string) => { throw new Error('exit'); });
+    const result = parseArgs([
+      'node', 'review-fix.ts',
+      '--clear-review-gate', 'feat/manual-review',
+      '--state-dir', '/tmp/review-state',
+    ]);
+    expect(result.clearReviewGate).toBe('feat/manual-review');
+    expect(result.stateDir).toBe('/tmp/review-state');
   });
 });
 
@@ -1274,7 +1298,12 @@ describe('resume state machine E2E (#917)', () => {
 // These tests verify the invariant: review state must live in the MAIN repo,
 // never inside a worktree. Worktrees are ephemeral; state must survive deletion.
 
-import { resolveStateDir, validateTransition } from './review-fix.js';
+import {
+  clearReviewGate,
+  resolveStateDir,
+  transitionReviewFixState,
+  validateTransition,
+} from './review-fix.js';
 
 describe('resolveStateDir', () => {
   it('returns main-repo-rooted path when git-common-dir is .git (main checkout)', () => {
@@ -1372,5 +1401,136 @@ describe('validateTransition', () => {
     const findings = [{ status: 'PARTIAL' as const, requirement: 'req', detail: 'minor gap', confidence: 79 }];
     const result = validateTransition('needs_review', baseState, findings);
     expect(result.allowed).toBe(true);
+  });
+});
+
+describe('manual review-fix transitions (#929)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'review-fix-transition-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function stateWithFindings(findings: ReviewFixState['rounds'][number]['findings']): ReviewFixState {
+    return {
+      prUrl: 'https://github.com/org/repo/pull/1',
+      issueNum: '1',
+      repo: 'org/repo',
+      maxRounds: 3,
+      budgetCap: 5,
+      currentRound: 1,
+      totalCostUsd: 0,
+      startedAt: '2026-01-01T00:00:00.000Z',
+      phase: 'needs_fix',
+      rounds: [{
+        round: 1,
+        phase: 'review',
+        verdict: 'pass',
+        gaps: 0,
+        reviewCost: 0,
+        fixCost: 0,
+        findings,
+      }],
+    };
+  }
+
+  it('updates state and appends a transition audit record when findings are safe', () => {
+    const state = stateWithFindings([{ status: 'DONE', requirement: 'review done', detail: 'ok', confidence: 90 }]);
+    saveState(state, dir);
+
+    const result = transitionReviewFixState({
+      prUrl: state.prUrl,
+      targetPhase: 'needs_review',
+      stateDir: dir,
+      actor: 'test',
+      now: () => '2026-06-29T01:00:00.000Z',
+    });
+
+    expect(result.changed).toBe(true);
+    const loaded = loadState(state.prUrl, dir)!;
+    expect(loaded.phase).toBe('needs_review');
+    expect(loaded.manualTransitions).toEqual([
+      expect.objectContaining({
+        from: 'needs_fix',
+        to: 'needs_review',
+        actor: 'test',
+        at: '2026-06-29T01:00:00.000Z',
+      }),
+    ]);
+  });
+
+  it('blocks transition when the current round has no findings', () => {
+    const state = stateWithFindings([]);
+    saveState(state, dir);
+
+    const result = transitionReviewFixState({
+      prUrl: state.prUrl,
+      targetPhase: 'needs_review',
+      stateDir: dir,
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.reason).toMatch(/no findings/i);
+    expect(loadState(state.prUrl, dir)!.phase).toBe('needs_fix');
+  });
+});
+
+describe('manual review gate clear (#961)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'review-gate-clear-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeNeedsReview(branch: string): string {
+    const statePath = join(dir, 'pr-review-test');
+    writeFileSync(statePath, [
+      'PR_URL=https://github.com/org/repo/pull/1',
+      'STATUS=needs_review',
+      `BRANCH=${branch}`,
+      'ROUND=1',
+      '',
+    ].join('\n'));
+    return statePath;
+  }
+
+  it('clears a needs_review hook state for the requested branch', () => {
+    const branch = 'feat/manual-review';
+    const statePath = writeNeedsReview(branch);
+
+    expect(clearReviewGate({ branch, stateDir: dir })).toEqual({
+      cleared: true,
+      branch,
+    });
+    expect(existsSync(statePath)).toBe(false);
+  });
+
+  it('CLI smoke clears a real temp state file without MODULE_NOT_FOUND', () => {
+    const branch = 'feat/manual-review';
+    const statePath = writeNeedsReview(branch);
+
+    const result = spawnRaw('npx', [
+      'tsx',
+      'scripts/review-fix.ts',
+      '--clear-review-gate', branch,
+      '--state-dir', dir,
+    ], {
+      cwd: new URL('..', import.meta.url),
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain('MODULE_NOT_FOUND');
+    expect(result.stderr).not.toContain('Cannot find module');
+    expect(result.stdout).toContain('Cleared needs_review gate');
+    expect(existsSync(statePath)).toBe(false);
   });
 });

--- a/scripts/review-fix.ts
+++ b/scripts/review-fix.ts
@@ -47,6 +47,7 @@ import {
   type ProviderCapability,
   type PlanValidation,
 } from './auto-dent-provider.js';
+import { clearStateWithStatus } from '../src/hooks/state-utils.js';
 
 // ── Stream-JSON parsing ─────────────────────────────────────────────
 
@@ -288,6 +289,13 @@ export interface ReviewFixState {
   outcome?: string;
   prBranch?: string;
   isMerged?: boolean;
+  manualTransitions?: Array<{
+    from: ReviewFixState['phase'];
+    to: ReviewFixState['phase'];
+    round: number;
+    at: string;
+    actor: string;
+  }>;
 }
 
 /**
@@ -382,6 +390,67 @@ export function validateTransition(
   return { allowed: true };
 }
 
+export interface TransitionReviewFixStateOptions {
+  prUrl: string;
+  targetPhase: string;
+  stateDir?: string;
+  actor?: string;
+  now?: () => string;
+}
+
+export interface TransitionReviewFixStateResult {
+  changed: boolean;
+  reason?: string;
+  from?: ReviewFixState['phase'];
+  to?: ReviewFixState['phase'];
+}
+
+function latestTransitionFindings(state: ReviewFixState): ReviewFinding[] {
+  const matchingRound = [...state.rounds]
+    .reverse()
+    .find(round => round.phase === 'review' && round.round === state.currentRound);
+  const latestReview = matchingRound ?? [...state.rounds].reverse().find(round => round.phase === 'review');
+  return latestReview?.findings ?? [];
+}
+
+export function transitionReviewFixState(
+  opts: TransitionReviewFixStateOptions,
+): TransitionReviewFixStateResult {
+  const state = loadState(opts.prUrl, opts.stateDir);
+  if (!state) return { changed: false, reason: `No review-fix state found for ${opts.prUrl}` };
+
+  const validation = validateTransition(opts.targetPhase, state, latestTransitionFindings(state));
+  if (!validation.allowed) return { changed: false, reason: validation.reason };
+
+  const from = state.phase;
+  const to = opts.targetPhase as ReviewFixState['phase'];
+  state.phase = to;
+  state.manualTransitions = [
+    ...(state.manualTransitions ?? []),
+    {
+      from,
+      to,
+      round: state.currentRound,
+      at: opts.now?.() ?? new Date().toISOString(),
+      actor: opts.actor ?? process.env.USER ?? 'unknown',
+    },
+  ];
+  saveState(state, opts.stateDir);
+  return { changed: true, from, to };
+}
+
+export interface ClearReviewGateOptions {
+  branch: string;
+  stateDir?: string;
+}
+
+export function clearReviewGate(opts: ClearReviewGateOptions): { cleared: boolean; branch: string } {
+  return {
+    branch: opts.branch,
+    cleared: clearStateWithStatus('needs_review', opts.branch, opts.stateDir),
+  };
+}
+
 // ── CLI ─────────────────────────────────────────────────────────────
 
 export interface CliArgs {
@@ -394,12 +463,18 @@ export interface CliArgs {
   maxRounds: number;
   budgetCap: number;
   resume: boolean;
+  transition?: string;
+  clearReviewGate?: string;
+  stateDir?: string;
 }
 
 export function parseArgs(argv = process.argv): CliArgs {
   const args = argv.slice(2);
   let prUrl = '', issueNum = '', repo = '';
   let dryRun = false, resume = false, maxRounds = MAX_FIX_ROUNDS, budgetCap = BUDGET_CAP_USD;
+  let transition: string | undefined;
+  let clearReviewGateBranch: string | undefined;
+  let stateDirArg: string | undefined;
   const defaults = defaultReviewFixProviders();
   let reviewProvider = defaults.reviewProvider;
   let fixProvider = defaults.fixProvider;
@@ -415,7 +490,42 @@ export function parseArgs(argv = process.argv): CliArgs {
       case '--resume': resume = true; break;
       case '--max-rounds': maxRounds = parseInt(args[++i] ?? '3', 10); break;
       case '--budget': budgetCap = parseFloat(args[++i] ?? '2'); break;
+      case '--transition': transition = args[++i] ?? ''; break;
+      case '--clear-review-gate': clearReviewGateBranch = args[++i] ?? ''; break;
+      case '--state-dir': stateDirArg = args[++i] ?? ''; break;
     }
+  }
+
+  if (clearReviewGateBranch) {
+    return {
+      prUrl,
+      issueNum,
+      repo,
+      reviewProvider,
+      fixProvider,
+      dryRun,
+      maxRounds,
+      budgetCap,
+      resume,
+      clearReviewGate: clearReviewGateBranch,
+      stateDir: stateDirArg,
+    };
+  }
+
+  if (transition && prUrl && repo) {
+    return {
+      prUrl,
+      issueNum,
+      repo,
+      reviewProvider,
+      fixProvider,
+      dryRun,
+      maxRounds,
+      budgetCap,
+      resume,
+      transition,
+      stateDir: stateDirArg,
+    };
   }
 
   if (!prUrl || !issueNum || !repo) {
@@ -423,12 +533,18 @@ export function parseArgs(argv = process.argv): CliArgs {
 
 Usage:
   npx tsx scripts/review-fix.ts --pr <url> --issue <num> --repo <owner/repo> [options]
+  npx tsx scripts/review-fix.ts --transition <needs_review|needs_fix|fix_running> --pr <url> --repo <owner/repo> [--state-dir <dir>]
+  npx tsx scripts/review-fix.ts --clear-review-gate <branch> [--state-dir <dir>]
 
 Options:
   --dry-run       Review only, show fix prompt, don't execute
   --resume        Resume from last saved state (skips completed rounds)
   --max-rounds N  Max review-fix rounds (default: ${MAX_FIX_ROUNDS})
   --budget N      Budget cap in USD (default: ${BUDGET_CAP_USD})
+  --transition P  Manually transition review-fix state after validating stored findings
+  --clear-review-gate BRANCH
+                  Clear the hook needs_review gate for a branch without raw tsx -e imports
+  --state-dir DIR State directory for manual transition/gate-clear commands
   --review-provider claude|codex
                   Review provider to record/pass to the review battery (default: claude)
   --fix-provider claude|codex
@@ -862,6 +978,29 @@ export async function runFixLoop(opts: CliArgs, deps: RunFixLoopDeps = {}): Prom
 
 async function main() {
   const opts = parseArgs();
+  if (opts.clearReviewGate) {
+    const result = clearReviewGate({ branch: opts.clearReviewGate, stateDir: opts.stateDir });
+    if (result.cleared) {
+      console.log(`Cleared needs_review gate for ${result.branch}`);
+      process.exit(0);
+    }
+    console.log(`No needs_review gate found for ${result.branch}`);
+    process.exit(1);
+  }
+  if (opts.transition) {
+    const result = transitionReviewFixState({
+      prUrl: opts.prUrl,
+      targetPhase: opts.transition,
+      stateDir: opts.stateDir,
+      actor: process.env.USER ?? 'review-fix',
+    });
+    if (result.changed) {
+      console.log(`Transitioned review-fix state for ${opts.prUrl}: ${result.from} -> ${result.to}`);
+      process.exit(0);
+    }
+    console.error(result.reason ?? `Transition blocked for ${opts.prUrl}`);
+    process.exit(1);
+  }
   const startTime = Date.now();
   const state = await runFixLoop(opts);
   finish(state, startTime);

--- a/src/hooks/lib/allowlist.test.ts
+++ b/src/hooks/lib/allowlist.test.ts
@@ -109,6 +109,11 @@ describe('isReviewCommand', () => {
     expect(isReviewCommand('npm test')).toBe(true);
   });
 
+  it('allows manual review-fix state commands during needs_review (#929/#961)', () => {
+    expect(isReviewCommand('npx tsx scripts/review-fix.ts --transition needs_review --pr https://github.com/org/repo/pull/1 --repo org/repo')).toBe(true);
+    expect(isReviewCommand('npx tsx scripts/review-fix.ts --clear-review-gate feat/manual-review --state-dir /tmp/state')).toBe(true);
+  });
+
   it('blocks non-review commands', () => {
     expect(isReviewCommand('gh pr create --title "test"')).toBe(false);
     expect(isReviewCommand('git push')).toBe(false);


### PR DESCRIPTION
## Summary
- add `review-fix.ts --transition <phase>` to safely advance review-fix state using the existing `validateTransition()` guard
- add `review-fix.ts --clear-review-gate <branch>` to clear hook `needs_review` state via `clearStateWithStatus()` instead of raw `tsx -e` imports
- pin both manual review commands in parse, state, subprocess smoke, and review allowlist tests

Fixes #929
Fixes #961
Related: #1010

## Validation
- RED: focused tests failed on missing CLI/export paths before implementation
- `npx vitest run scripts/review-fix.test.ts src/hooks/lib/allowlist.test.ts`
- `npm run check:fast`
- `npm run test:hooks`
- `npm test`
- `git diff --check`

## Dogfood
- `npx tsx scripts/review-fix.ts --clear-review-gate feat/manual-review --state-dir <tmp>` deleted a real temp `needs_review` state file
- `npx tsx scripts/review-fix.ts --transition needs_review --pr https://github.com/org/repo/pull/1 --repo org/repo --state-dir <tmp>` updated review-fix state and appended `manualTransitions` audit data