### PR TITLE
fix(analyze): explain progress issue artifact limits

### DIFF
--- a/scripts/auto-dent-analyze.test.ts
+++ b/scripts/auto-dent-analyze.test.ts
@@ -5,10 +5,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { basename, join } from 'path';
-import { tmpdir } from 'os';
+import { makeIgnoredTestDir } from '../src/lib/test-dirs.js';
 import {
   analyzeRunLog,
   analyzeBatch,
@@ -18,6 +18,7 @@ import {
   generateRecommendations,
   detectRunRegression,
   detectBatchRegressions,
+  formatProgressIssueAnalysisDiagnostic,
   formatRegressionReports,
   formatRunAnalysis,
   formatBatchAnalysis,
@@ -71,14 +72,14 @@ function initMsg(): string {
 // Helpers
 
 function createTmpLog(lines: string[]): string {
-  const dir = mkdtempSync(join(tmpdir(), 'analyze-test-'));
+  const dir = makeIgnoredTestDir('auto-dent-analyze-log');
   const logPath = join(dir, 'run-1-test.log');
   writeFileSync(logPath, lines.join('\n') + '\n');
   return logPath;
 }
 
 function createTmpBatch(runLogs: string[][]): string {
-  const dir = mkdtempSync(join(tmpdir(), 'analyze-batch-'));
+  const dir = makeIgnoredTestDir('auto-dent-analyze-batch');
   for (let i = 0; i < runLogs.length; i++) {
     const logPath = join(dir, `run-${i + 1}-test.log`);
     writeFileSync(logPath, runLogs[i].join('\n') + '\n');
@@ -326,6 +327,39 @@ describe('analyzeBatch', () => {
 
     const result = analyzeBatch(batchDir);
     expect(result.batchId).toBe(basename(batchDir));
+  });
+});
+
+describe('progress issue artifact diagnostic', () => {
+  it('explains why uploaded JSONL artifacts are insufficient for transcript analysis', () => {
+    const output = formatProgressIssueAnalysisDiagnostic({
+      issueNumber: '1641',
+      repo: 'Garsson-io/kaizen',
+      parts: {
+        batchId: 'cloud-batch',
+        eventsJsonl: '{"event":{"type":"run.complete"}}\n{"event":{"type":"run.start"}}',
+        stateJson: '{"batch_id":"cloud-batch"}',
+        summary: 'Batch summary',
+      },
+    });
+
+    expect(output).toContain('cannot analyze progress issue #1641 directly');
+    expect(output).toContain('run transcript logs');
+    expect(output).toContain('events.jsonl (2 events)');
+    expect(output).toContain('state.json');
+    expect(output).toContain('batch-summary.ts --progress-issue 1641 --repo Garsson-io/kaizen');
+    expect(output).toContain('upload compressed run logs');
+  });
+
+  it('reports missing batch-artifacts attachment distinctly', () => {
+    const output = formatProgressIssueAnalysisDiagnostic({
+      issueNumber: '1641',
+      repo: 'Garsson-io/kaizen',
+      parts: null,
+    });
+
+    expect(output).toContain('No batch-artifacts attachment was found');
+    expect(output).toContain('batch-trends.ts --progress-issue 1641 --repo Garsson-io/kaizen');
   });
 });
 

--- a/scripts/auto-dent-analyze.ts
+++ b/scripts/auto-dent-analyze.ts
@@ -21,6 +21,11 @@ import { execSync } from 'child_process';
 import { readState, type BatchState } from './auto-dent-run.js';
 import { renderToolInputSummary } from './auto-dent-display.js';
 import { parseJsonLines } from '../src/lib/json-lines.js';
+import { parseBatchArtifactCliArgs } from './batch-artifacts-cli.js';
+import {
+  readArtifactPartsFromProgressIssue,
+  type ArtifactParts,
+} from './batch-artifacts-upload.js';
 import {
   computeHookActivationCounts,
   formatHookActivationDistribution,
@@ -970,8 +975,79 @@ export function formatBatchAnalysis(batch: BatchAnalysis): string {
 
 // CLI
 
+export interface ProgressIssueAnalysisDiagnosticInput {
+  issueNumber: string;
+  repo: string;
+  parts: ArtifactParts | null;
+}
+
+export function formatProgressIssueAnalysisDiagnostic(
+  input: ProgressIssueAnalysisDiagnosticInput,
+): string {
+  const { issueNumber, repo, parts } = input;
+  const lines = [
+    `auto-dent-analyze cannot analyze progress issue #${issueNumber} directly.`,
+    '',
+    'This tool analyzes run transcript logs (`run-*.log`) to compute cold-start, tool-pattern, and waste metrics.',
+  ];
+
+  if (!parts) {
+    lines.push(
+      '',
+      `No batch-artifacts attachment was found on ${repo}#${issueNumber}.`,
+    );
+  } else {
+    const eventCount = parts.eventsJsonl
+      ? parts.eventsJsonl.split('\n').filter(l => l.trim()).length
+      : 0;
+    const available = [
+      parts.eventsJsonl ? `events.jsonl (${eventCount} events)` : null,
+      parts.stateJson ? 'state.json' : null,
+      parts.summary ? 'batch summary' : null,
+    ].filter(Boolean);
+    lines.push(
+      '',
+      `Found batch-artifacts for batch \`${parts.batchId}\`: ${available.length ? available.join(', ') : 'no analyzable artifacts'}.`,
+      'Those artifacts do not include the run transcript logs required by auto-dent-analyze.',
+    );
+  }
+
+  lines.push(
+    '',
+    'Use the JSONL artifact analyzers for progress-issue data:',
+    `- npx tsx scripts/batch-summary.ts --progress-issue ${issueNumber} --repo ${repo}`,
+    `- npx tsx scripts/batch-trends.ts --progress-issue ${issueNumber} --repo ${repo}`,
+    '',
+    'To make auto-dent-analyze cloud-backed, upload compressed run logs to the progress issue and teach this tool to read them.',
+  );
+
+  return lines.join('\n');
+}
+
 function main(): void {
-  const target = process.argv[2];
+  const args = parseBatchArtifactCliArgs(process.argv.slice(2));
+  const progressIssue = args.progressIssues[0];
+
+  if (progressIssue) {
+    if (!args.repo) {
+      console.error('Usage: --progress-issue requires --repo <owner/repo> or GITHUB_REPOSITORY');
+      process.exit(1);
+    }
+    try {
+      const parts = readArtifactPartsFromProgressIssue(progressIssue, args.repo);
+      console.error(formatProgressIssueAnalysisDiagnostic({
+        issueNumber: progressIssue,
+        repo: args.repo,
+        parts,
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Could not read batch-artifacts from ${args.repo}#${progressIssue}: ${message}`);
+    }
+    process.exit(1);
+  }
+
+  const target = args.positional[0];
 
   if (!target || target === '--help') {
     console.log(`auto-dent-analyze — Cold-start and efficiency analysis
@@ -980,11 +1056,15 @@ Usage:
   auto-dent-analyze.ts <batch-dir>         Analyze all runs in a batch
   auto-dent-analyze.ts <log-file>          Analyze a single run log
   auto-dent-analyze.ts --all               Analyze all batches
+  auto-dent-analyze.ts --progress-issue N --repo owner/repo
+                                           Explain why progress-issue artifacts
+                                           are not sufficient for transcript analysis
 
 Examples:
   npx tsx scripts/auto-dent-analyze.ts logs/auto-dent/batch-260323-0003-072b
   npx tsx scripts/auto-dent-analyze.ts logs/auto-dent/batch-260323-0003-072b/run-1-260322220305.log
-  npx tsx scripts/auto-dent-analyze.ts --all`);
+  npx tsx scripts/auto-dent-analyze.ts --all
+  npx tsx scripts/auto-dent-analyze.ts --progress-issue 688 --repo Garsson-io/kaizen`);
     process.exit(0);
   }
 


### PR DESCRIPTION
## Problem

After #1639, JSONL batch analysis can consume progress-issue `batch-artifacts`, but `auto-dent-analyze.ts` still behaved like every input was a local path. Running it with a progress issue would fail as a generic missing-file error even though the real limitation is more specific: this tool needs run transcript logs, while `batch-artifacts` currently contains `events.jsonl` and `state.json`.

## Solution

- Add explicit `--progress-issue <issue> --repo <owner/repo>` handling to `auto-dent-analyze.ts`.
- Read the progress issue's `batch-artifacts` attachment when possible and report which artifacts are available.
- Explain that transcript logs are required for cold-start/tool-pattern/waste analysis.
- Point users to `batch-summary.ts` and `batch-trends.ts` for JSONL artifact analysis.
- Migrate touched analyzer test fixtures to the repo-ignored test temp helper.

## Evidence

- `npx vitest run scripts/auto-dent-analyze.test.ts scripts/batch-artifacts-cli.test.ts scripts/batch-artifacts-upload.test.ts` -> 3 files, 72 tests passed
- `npx vitest run scripts/auto-dent-analyze.test.ts` -> 57 tests passed
- `npm run typecheck` -> pass
- `npm run test:fast` -> 57 tests passed
- `npm test` -> 175 passed, 2 skipped; 4179 passed, 14 skipped

Note: the full suite prints `Unknown option: --bogus` from an existing negative-path CLI test while exiting 0.

Closes #1641
