### PR TITLE
fix(hook-gym): support self dogfood runs

### DIFF
--- a/scripts/hook-gym-cli.test.ts
+++ b/scripts/hook-gym-cli.test.ts
@@ -11,9 +11,11 @@
  * would always pass — this is why the level is Integration not Unit.
  */
 
-import { beforeAll, describe, it, expect } from 'vitest';
+import { afterEach, beforeAll, describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { buildTypeScriptSubprocess } from './test-typescript-runner.js';
 
 const REPO_ROOT = resolve(__dirname, '..');
@@ -22,9 +24,18 @@ const CLI_RUNNER = buildTypeScriptSubprocess(CLI, { startDir: __dirname });
 
 type CliResult = { stdout: string; stderr: string; status: number };
 
-function runCli(args: string[]): CliResult {
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function runCli(args: string[], env: NodeJS.ProcessEnv = {}): CliResult {
   const result = spawnSync(CLI_RUNNER.command, [...CLI_RUNNER.args, ...args], {
     cwd: REPO_ROOT,
+    env: { ...process.env, ...env },
     encoding: 'utf-8',
     timeout: 30000,
   });
@@ -33,6 +44,21 @@ function runCli(args: string[]): CliResult {
     stderr: result.stderr ?? '',
     status: result.status ?? -1,
   };
+}
+
+function fakeClaudePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hook-gym-fake-claude-'));
+  tempDirs.push(dir);
+  const script = join(dir, 'claude');
+  writeFileSync(script, `#!/usr/bin/env bash
+cat <<'JSON'
+{"type":"system","subtype":"hook_started","hook_id":"h1","hook_name":"SessionStart:startup","hook_event":"SessionStart","uuid":"u1","session_id":"s1"}
+{"type":"system","subtype":"hook_response","hook_id":"h1","hook_name":"SessionStart:startup","hook_event":"SessionStart","output":"","stdout":"","stderr":"","exit_code":0,"outcome":"success","uuid":"u1","session_id":"s1"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"fake claude completed"}]}}
+JSON
+`, { mode: 0o755 });
+  chmodSync(script, 0o755);
+  return dir;
 }
 
 describe('hook-gym CLI — --list (B8)', () => {
@@ -152,6 +178,32 @@ describe('hook-gym CLI — implemented commands reject bad input', () => {
   });
 });
 
+describe('hook-gym CLI — self-dogfood live dispatch (#1179)', () => {
+  it('default self --run reaches the runner instead of the unsupported self-mode exit', () => {
+    const fakeBin = fakeClaudePath();
+    const { stdout, stderr } = runCli(
+      ['--run', 'probe-hooks', '--model', 'haiku'],
+      { PATH: `${fakeBin}:${process.env.PATH ?? ''}` },
+    );
+
+    expect(stderr).not.toContain('Self-dogfood mode not yet supported');
+    expect(stdout).toContain('[run] probe-hooks');
+    expect(stdout).toContain(`cwd=${REPO_ROOT}`);
+  });
+
+  it('default self --run-all reaches scenario execution instead of the unsupported self-mode exit', () => {
+    const fakeBin = fakeClaudePath();
+    const { stdout, stderr } = runCli(
+      ['--run-all', '--model', 'haiku'],
+      { PATH: `${fakeBin}:${process.env.PATH ?? ''}` },
+    );
+
+    expect(stderr).not.toContain('Self-dogfood mode not yet supported');
+    expect(stdout).toContain('[run] Running');
+    expect(stdout).toContain(`cwd=${REPO_ROOT}`);
+  });
+});
+
 describe('hook-gym CLI — --help', () => {
   it('prints usage and exits 0', () => {
     const { stdout, status } = runCli(['--help']);
@@ -160,5 +212,6 @@ describe('hook-gym CLI — --help', () => {
     expect(stdout).toContain('--list');
     expect(stdout).toContain('--run');
     expect(stdout).toContain('--validate-fixture');
+    expect(stdout).toContain('[--host-repo');
   });
 });

--- a/scripts/hook-gym.ts
+++ b/scripts/hook-gym.ts
@@ -4,9 +4,9 @@
  *
  * Usage:
  *   npx tsx scripts/hook-gym.ts --list
- *   npx tsx scripts/hook-gym.ts --run probe-hooks --host-repo Garsson-io/kaizen-test-fixture
+ *   npx tsx scripts/hook-gym.ts --run probe-hooks [--host-repo Garsson-io/kaizen-test-fixture]
  *   npx tsx scripts/hook-gym.ts --run probe-hooks --dry-run
- *   npx tsx scripts/hook-gym.ts --run-all --host-repo Garsson-io/kaizen-test-fixture
+ *   npx tsx scripts/hook-gym.ts --run-all [--host-repo Garsson-io/kaizen-test-fixture]
  *   npx tsx scripts/hook-gym.ts --validate-fixture <path> --scenario <name>
  *   npx tsx scripts/hook-gym.ts --replay <fixture> --scenario <name>
  *   npx tsx scripts/hook-gym.ts --replay-hooks <fixture> --scenario <name>
@@ -17,7 +17,7 @@ import { writeFileSync } from 'node:fs';
 import { SCENARIOS, getScenario, renderPrompt } from './hook-gym-scenarios.js';
 import { SEVERITY_WEIGHT } from './hook-gym-schema.js';
 import { validateFixtureFile, formatValidationReport } from './hook-gym-validate.js';
-import { FixtureRepo, getHostRepo, type RunResult } from './hook-gym-harness.js';
+import { FixtureRepo, getHostRepo, runAll, runScenario, type RunResult } from './hook-gym-harness.js';
 import { extractToolActionsFromFile, replayFixture, formatFixture } from './hook-gym-replay.js';
 
 function getFlag(flag: string): string | undefined {
@@ -72,6 +72,15 @@ function cmdDryRun(scenarioName: string, hostRepo: string): void {
   console.log(rendered);
 }
 
+function selfRunOpts(hostRepo: string, model?: string, debug?: boolean) {
+  return {
+    model,
+    debug,
+    cwd: process.cwd(),
+    hostRepo,
+  };
+}
+
 async function cmdRun(scenarioName: string, hostRepo: string, model?: string, debug?: boolean): Promise<void> {
   const scenario = getScenario(scenarioName);
   if (!scenario) {
@@ -84,17 +93,14 @@ async function cmdRun(scenarioName: string, hostRepo: string, model?: string, de
   let result: RunResult;
 
   if (isSelf) {
-    // Self-dogfood: run in CWD, no clone needed
-    // TODO: implement self-dogfood path via harness
-    console.error('Self-dogfood mode not yet supported via harness. Use --host-repo.');
-    process.exit(1);
-  }
-
-  const fixture = await FixtureRepo.create(hostRepo);
-  try {
-    result = await fixture.run(scenario, { model, debug });
-  } finally {
-    await fixture.cleanup();
+    result = await runScenario(scenario, selfRunOpts(hostRepo, model, debug));
+  } else {
+    const fixture = await FixtureRepo.create(hostRepo);
+    try {
+      result = await fixture.run(scenario, { model, debug });
+    } finally {
+      await fixture.cleanup();
+    }
   }
   process.exit(result.passed ? 0 : 1);
 }
@@ -102,8 +108,8 @@ async function cmdRun(scenarioName: string, hostRepo: string, model?: string, de
 async function cmdRunAll(hostRepo: string, model?: string, debug?: boolean): Promise<void> {
   const isSelf = hostRepo === getHostRepo();
   if (isSelf) {
-    console.error('Self-dogfood mode not yet supported via harness. Use --host-repo.');
-    process.exit(1);
+    const { allPassed } = await runAll(SCENARIOS, selfRunOpts(hostRepo, model, debug));
+    process.exit(allPassed ? 0 : 1);
   }
 
   const fixture = await FixtureRepo.create(hostRepo);
@@ -139,9 +145,9 @@ async function main(): Promise<void> {
 
 Usage:
   npx tsx scripts/hook-gym.ts --list
-  npx tsx scripts/hook-gym.ts --run <name> --host-repo <owner/repo>
+  npx tsx scripts/hook-gym.ts --run <name> [--host-repo <owner/repo>]
   npx tsx scripts/hook-gym.ts --run <name> --dry-run
-  npx tsx scripts/hook-gym.ts --run-all --host-repo <owner/repo>
+  npx tsx scripts/hook-gym.ts --run-all [--host-repo <owner/repo>]
   npx tsx scripts/hook-gym.ts --validate-fixture <path> --scenario <name>
   npx tsx scripts/hook-gym.ts --replay <fixture> --scenario <name>
   npx tsx scripts/hook-gym.ts --replay-hooks <fixture> --scenario <name>
@@ -155,7 +161,7 @@ Replay layers (PR 5):
 
 Options:
   --model <model>    Override scenario model (haiku, sonnet, opus)
-  --host-repo <r>    Target repo (default: kaizen.config.json)
+  --host-repo <r>    Target repo (default: kaizen.config.json; self runs use the current checkout)
   --debug            Print raw hook event JSON
   --dry-run          Show prompt without spawning agent
   --output <path>    Output path for --extract (default: stdout)`);


### PR DESCRIPTION
Once upon a time, Hook Gym had the runner machinery to execute scenarios with a chosen `cwd`, but the CLI refused to use it when the target repo was kaizen itself. Every day, local hook debugging still had to go through `--host-repo` and a cloned fixture even though the code comment promised "run in CWD, no clone needed."

One day, #1179 captured the mismatch: the self-dogfood branch hard-exited before hooks could run. Because of that, this PR removes the self-mode dead end and routes default self-host `--run` through `runScenario()` with `cwd: process.cwd()`, and routes default self-host `--run-all` through the existing `runAll()` helper. Because of that, external host repos still keep the fixture path, including `FixtureRepo.create()`, per-scenario setup seeding, and cleanup.

Until finally, the direct smoke now reaches `[run] probe-hooks ... cwd=<current checkout>` with a fake `claude` binary instead of printing the unsupported self-mode error. And ever since, Hook Gym can be used as the fast local black-box harness for the actual kaizen checkout, while fixture repos remain available when the scenario needs an isolated host.

Fixes #1179
Refs #1532

## Impact (goal -> before/after -> match)
- Goal (#1179): hook-gym can exercise hooks against the current kaizen checkout itself, not only against a cloned external fixture.
- Acceptance signal: default self-host `--run` and `--run-all` route into runner logic instead of printing `Self-dogfood mode not yet supported`.
- BEFORE: `npx tsx scripts/hook-gym.ts --run probe-hooks --model haiku` and `--run-all --model haiku` both exited 1 with `Self-dogfood mode not yet supported via harness. Use --host-repo.`
- AFTER: with a fake `claude` executable on `PATH`, `npx tsx scripts/hook-gym.ts --run probe-hooks --model haiku` reaches `[run] probe-hooks (model=haiku, timeout=180s, cwd=/home/aviad/projects/kaizen/.claude/worktrees/260629-0445-k1179-hook-gym-self)` and writes normal validation output. It exits 1 only because the fake stream intentionally contains one hook event, not the full expected lifecycle.
- Delta: immediate unsupported self-mode exit removed for both single-scenario and run-all dispatch; current-checkout `cwd` is observable in subprocess output.
- Goal met?: yes.
- Residual scan: no remaining production `Self-dogfood mode not yet supported` text; #1532 remains broader local/CI check optimization work and is not closed here.

## Architecture
```
hook-gym CLI
  --run self host     -> runScenario(scenario, { cwd: process.cwd(), hostRepo })
  --run-all self host -> runAll(SCENARIOS, { cwd: process.cwd(), hostRepo })
  --host-repo other   -> FixtureRepo.create(hostRepo) -> fixture.run(...) -> cleanup()
```

## Design Decisions
| Decision | Why | Tradeoff |
|---|---|---|
| Reuse `runScenario()` for self-dogfood | The harness already accepts `cwd` and `hostRepo`; the bug was CLI dispatch, not missing runner machinery | Self-runs act on the current checkout, which is the advertised behavior |
| Keep external fixture flow separate | `FixtureRepo.run()` still owns setup-file seeding and cleanup for cloned hosts | A little branching remains so setup files are not accidentally committed into self checkouts |
| Use fake `claude` in CLI tests | Proves real subprocess dispatch without live model cost or API nondeterminism | Fake stream only proves dispatch, not a complete live hook scenario |

## What's In This PR
| File | Purpose |
|---|---|
| `scripts/hook-gym.ts` | Remove self-mode hard exits, route self runs through existing runner helpers, clarify `--host-repo` is optional |
| `scripts/hook-gym-cli.test.ts` | Add subprocess regression tests with a fake `claude` binary for self `--run` and `--run-all` dispatch |

## Test Plan (Behaviors x Levels)
| # | Behavior | Level | Coverage |
|---|---|---|---|
| 1 | Self-dogfood single-scenario dispatch uses the current checkout instead of rejecting | System | `scripts/hook-gym-cli.test.ts` fake-claude subprocess checks stdout contains `[run] probe-hooks` and `cwd=<repo>` |
| 2 | Self-dogfood run-all dispatch reuses the same no-clone target | System | `scripts/hook-gym-cli.test.ts` fake-claude subprocess checks stdout contains `[run] Running` and `cwd=<repo>` |
| 3 | External host repo behavior still clones and cleans up | Unit/structural | Production branch remains `FixtureRepo.create(hostRepo) -> fixture.run(...) -> fixture.cleanup()`; existing hook-gym fixture tests continue passing |
| 4 | CLI help and dry-run remain stable and do not require `--host-repo` for self mode | Integration | Existing CLI tests plus updated help assertion for `[--host-repo <owner/repo>]` |
| 5 | Original #1179 unsupported self-mode failure is gone | System | RED tests failed on the unsupported message; GREEN tests and direct fake-claude smoke show runner output instead |

## Validation
- [x] RED: `npx vitest run scripts/hook-gym-cli.test.ts` failed on both self-mode unsupported exits and help text requiring `--host-repo`.
- [x] GREEN focused: `npx vitest run scripts/hook-gym-cli.test.ts` — 17 passed.
- [x] Hook-gym cluster: `npx vitest run scripts/hook-gym*.test.ts` — 12 files, 159 passed.
- [x] `npm run check:fast` — typecheck plus changed tests passed.
- [x] `npm run test:hooks` — 435 passed.
- [x] `npm test` — 175 files passed, 2 skipped; 4181 passed, 14 skipped.
- [x] `git diff --check`.
- [x] Dogfood smoke with fake `claude`: self `--run probe-hooks` reached runner output with case worktree `cwd` and no unsupported-message stderr.

## Known Limitations
- This PR proves the self-dogfood dispatch path without a live model call. A full live Hook Gym scenario still depends on the local `claude` runtime, credentials, and scenario behavior.
- `--run-all` in self mode can execute scenarios whose setup assumptions were originally designed for fixtures. This PR removes the categorical hard exit; scenario suitability remains part of Hook Gym scenario design.
