### PR TITLE
test(batch): cover artifact upload entrypoint

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -209,6 +209,17 @@ describe('closeBatchProgressIssue maintenance wiring', () => {
     expect(closeSection).toContain('runBacklogHealthMaintenance');
     expect(closeSection).toContain('[backlog-health]');
   });
+
+  it('uploads raw batch artifacts during batch finalize', () => {
+    const closeSection = AUTO_DENT_RUN_SOURCE.slice(
+      AUTO_DENT_RUN_SOURCE.indexOf('export function closeBatchProgressIssue'),
+      AUTO_DENT_RUN_SOURCE.indexOf('// Execute Claude'),
+    );
+
+    expect(closeSection).toContain('uploadBatchArtifacts(m[1], kaizenRepo, batchDir');
+    expect(closeSection).toContain('[intelligence] uploaded raw batch artifacts');
+    expect(closeSection).toContain('[intelligence] no raw artifacts on disk to upload');
+  });
 });
 
 describe('buildTemplateVars', () => {

--- a/scripts/batch-artifacts-upload.test.ts
+++ b/scripts/batch-artifacts-upload.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { makeIgnoredTestDir } from '../src/lib/test-dirs.js';
 import {
   buildArtifactsComment,
   parseArtifactsComment,
   readArtifactParts,
+  uploadBatchArtifacts,
   type ArtifactParts,
   BATCH_ARTIFACTS_ATTACHMENT,
   ARTIFACTS_BODY_BUDGET,
@@ -144,7 +145,7 @@ describe('readArtifactParts', () => {
     writeFileSync(join(dir, 'batch-summary.txt'), 'all good');
 
     const parts = readArtifactParts(dir);
-    expect(parts.batchId).toBe(dir.split('/').pop());
+    expect(parts.batchId).toBe(basename(dir));
     expect(parts.stateJson).toBe('{"run":2}');
     expect(parts.eventsJsonl).toBe('{"kind":"run_start"}');
     expect(parts.summary).toBe('all good');
@@ -163,6 +164,47 @@ describe('readArtifactParts', () => {
     const dir = freshBatchDir();
     writeFileSync(join(dir, 'batch-summary-report.md'), '# report');
     expect(readArtifactParts(dir).summary).toBe('# report');
+  });
+});
+
+describe('uploadBatchArtifacts', () => {
+  it('returns null and does not write when a batch dir has no artifacts', () => {
+    const dir = freshBatchDir();
+    const writes: Array<{ name: string; body: string }> = [];
+
+    const url = uploadBatchArtifacts('1183', 'owner/repo', dir, NOW, (_target, name, body) => {
+      writes.push({ name, body });
+      return 'https://github.com/owner/repo/issues/1183#issuecomment-1';
+    });
+
+    expect(url).toBeNull();
+    expect(writes).toEqual([]);
+  });
+
+  it('reads a batch dir and writes the stable batch-artifacts attachment body', () => {
+    const dir = freshBatchDir();
+    writeFileSync(join(dir, 'state.json'), JSON.stringify({ batch_id: 'fixture-batch', run: 2 }));
+    writeFileSync(join(dir, 'events.jsonl'), [
+      JSON.stringify({ timestamp: NOW, event: { type: 'run.start', batch_id: 'fixture-batch', run_num: 1 } }),
+      JSON.stringify({ timestamp: NOW, event: { type: 'run.complete', batch_id: 'fixture-batch', run_num: 1 } }),
+    ].join('\n'));
+    writeFileSync(join(dir, 'batch-summary-report.md'), 'Fixture batch summary');
+    const calls: Array<{ target: unknown; name: string; body: string }> = [];
+
+    const url = uploadBatchArtifacts('1183', 'owner/repo', dir, NOW, (target, name, body) => {
+      calls.push({ target, name, body });
+      return 'https://github.com/owner/repo/issues/1183#issuecomment-2';
+    });
+
+    expect(url).toContain('issuecomment-2');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].target).toEqual({ kind: 'issue', number: '1183', repo: 'owner/repo' });
+    expect(calls[0].name).toBe(BATCH_ARTIFACTS_ATTACHMENT);
+    const parts = parseArtifactsComment(calls[0].body);
+    expect(parts.batchId).toBe(dir.split('/').pop());
+    expect(parts.eventsJsonl).toContain('"run.complete"');
+    expect(parts.stateJson).toContain('"fixture-batch"');
+    expect(parts.summary).toBe('Fixture batch summary');
   });
 });
 

--- a/scripts/batch-artifacts-upload.ts
+++ b/scripts/batch-artifacts-upload.ts
@@ -220,10 +220,11 @@ export function uploadBatchArtifacts(
   repo: string,
   batchDir: string,
   nowIso: string,
+  write: typeof writeAttachment = writeAttachment,
 ): string | null {
   const parts = readArtifactParts(batchDir);
   if (!parts.stateJson && !parts.eventsJsonl && !parts.summary) return null;
 
   const body = buildArtifactsComment(parts, nowIso);
-  return writeAttachment({ kind: 'issue', number: issueNumber, repo }, BATCH_ARTIFACTS_ATTACHMENT, body);
+  return write({ kind: 'issue', number: issueNumber, repo }, BATCH_ARTIFACTS_ATTACHMENT, body);
 }


### PR DESCRIPTION
## Summary
- add a small writer injection point to `uploadBatchArtifacts()` while preserving the production default `writeAttachment` path
- directly cover the empty-artifact guard and populated-dir upload body/target contract
- add a close-path invariant that batch finalize still calls `uploadBatchArtifacts()` and logs both upload/no-artifact outcomes

## Why
`uploadBatchArtifacts()` was the production finalize entrypoint for raw batch artifact uploads, but existing coverage only exercised helpers and adjacent finalize wiring. A regression could have left finalize unable to upload artifacts while the helper tests stayed green.

## DRY / Refactor Sweep
- kept all size cap, scrub, parse, and marker behavior in the existing shared artifact/comment helpers
- reused the existing `writeAttachment` primitive rather than adding a second GitHub transport
- reused the ignored test-dir helper for filesystem fixtures

## Evidence
- RED: the first focused test attempted a real `gh issue comment 1183` against `owner/repo`, proving the entrypoint had no observable writer seam
- `npx vitest run scripts/batch-artifacts-upload.test.ts scripts/auto-dent-run.test.ts` -> 2 files, 399 tests passed
- `npm run typecheck` -> passed
- `npm run test:fast` -> 11 files, 768 passed, 2 skipped
- `npm test` -> 175 files passed, 2 skipped; 4184 passed, 14 skipped. The `Unknown option: --bogus` line is from an existing negative-path CLI test and the command exited 0.

Closes #1183