### PR TITLE
fix(structured-data): reject unknown cli flags

### DIFF
--- a/src/cli-structured-data.test.ts
+++ b/src/cli-structured-data.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { openSync, readFileSync, writeFileSync } from 'node:fs';
-import { handlers, parseArgs, resolveContent, resolveRound, type CliArgs } from './cli-structured-data.js';
+import {
+  handlers,
+  parseArgs,
+  resolveContent,
+  resolveRound,
+  unknownFlagsForCommand,
+  validateKnownFlags,
+  type CliArgs,
+} from './cli-structured-data.js';
 import {
   nextReviewRound,
   storePlan,
@@ -120,6 +128,19 @@ describe('handler registry', () => {
     expect(Object.keys(handlers).length).toBe(24);
   });
 
+  it('has unknown-flag validation coverage for every registered handler', () => {
+    for (const cmd of Object.keys(handlers)) {
+      expect(
+        unknownFlagsForCommand({
+          command: cmd,
+          repo: 'Garsson-io/kaizen',
+          'definitely-unknown': 'true',
+        } as CliArgs),
+        `missing flag allowlist for '${cmd}'`,
+      ).toEqual(['definitely-unknown']);
+    }
+  });
+
   it('registers the attach-transcript handler (#1508)', () => {
     expect(handlers['attach-transcript']).toBeTypeOf('function');
   });
@@ -179,6 +200,56 @@ describe('parseArgs — boolean flag handling', () => {
     const a = parseArgs(['store-review-finding', '--pr', '1060', '--round', '2']);
     expect(a.pr).toBe('1060');
     expect(a.round).toBe('2');
+  });
+});
+
+describe('command flag validation (#1163)', () => {
+  function spyExit() {
+    return vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
+      throw new Error(`process.exit(${code})`);
+    });
+  }
+
+  it('treats --json as an explicit content alias for payload-bearing commands', () => {
+    const a = parseArgs([
+      'store-review-summary',
+      '--repo', 'Garsson-io/kaizen',
+      '--pr', '903',
+      '--round', '5',
+      '--json', '{"summary":"kept"}',
+    ]);
+
+    expect(unknownFlagsForCommand(a)).toEqual([]);
+    expect(resolveContent(a)).toBe('{"summary":"kept"}');
+  });
+
+  it('reports command-scoped unknown flags instead of silently accepting them', () => {
+    const a = parseArgs([
+      'store-review-summary',
+      '--repo', 'Garsson-io/kaizen',
+      '--pr', '903',
+      '--round', '5',
+      '--json', '{"summary":"kept"}',
+      '--bogus', 'dropped',
+    ]);
+
+    expect(unknownFlagsForCommand(a)).toEqual(['bogus']);
+  });
+
+  it('exits non-zero with an actionable unknown-option error before dispatch', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exit = spyExit();
+    const a = parseArgs([
+      'store-review-summary',
+      '--repo', 'Garsson-io/kaizen',
+      '--pr', '903',
+      '--bogus',
+    ]);
+
+    expect(() => validateKnownFlags(a)).toThrow('process.exit(1)');
+    expect(err).toHaveBeenCalledWith('store-review-summary: unknown option: --bogus');
+    err.mockRestore();
+    exit.mockRestore();
   });
 });
 

--- a/src/cli-structured-data.ts
+++ b/src/cli-structured-data.ts
@@ -85,6 +85,33 @@ type Handler = (a: CliArgs) => Promise<void>;
  * Keeps `--stdin` usable without the trap of consuming the next arg.
  */
 const BOOLEAN_FLAGS = new Set(['stdin']);
+const CONTENT_FLAGS = ['file', 'payload-file', 'text', 'payload', 'json', 'stdin'] as const;
+const COMMAND_ALLOWED_FLAGS: Record<string, readonly string[]> = {
+  'next-round': ['pr'],
+  'store-review-finding': ['pr', 'round', 'dimension', ...CONTENT_FLAGS],
+  'store-review-batch': ['pr', 'round', ...CONTENT_FLAGS],
+  'quick-pass': ['pr', 'round', 'dimension', 'summary', 'requirements'],
+  'store-review-summary': ['pr', 'round', 'note', ...CONTENT_FLAGS],
+  'list-review-rounds': ['pr'],
+  'list-review-dims': ['pr', 'round'],
+  'read-review-finding': ['pr', 'round', 'dimension'],
+  'read-review-summary': ['pr', 'round'],
+  'store-plan': ['issue', ...CONTENT_FLAGS],
+  'retrieve-plan': ['issue'],
+  'store-testplan': ['issue', ...CONTENT_FLAGS],
+  'retrieve-testplan': ['issue'],
+  'attach-transcript': ['pr', 'issue', 'file', 'label', 'source-path'],
+  'mine-transcripts': ['prs', 'pr'],
+  'store-friction-candidates': ['prs', 'pr', 'issue', 'pr-target'],
+  'store-metadata': ['issue', ...CONTENT_FLAGS],
+  'retrieve-metadata': ['issue'],
+  'query-connected': ['issue'],
+  'query-pr': ['issue'],
+  'update-pr-section': ['pr', 'name', 'section', ...CONTENT_FLAGS],
+  'store-iteration': ['pr', 'issue', ...CONTENT_FLAGS],
+  'retrieve-iteration': ['pr', 'issue'],
+  'emit-test-review-sentinel': ['pr', 'round'],
+};
 
 export function parseArgs(argv?: string[]): CliArgs {
   const args = argv ?? process.argv.slice(2);
@@ -104,6 +131,21 @@ export function parseArgs(argv?: string[]): CliArgs {
   return { command, ...flags } as CliArgs;
 }
 
+export function unknownFlagsForCommand(a: CliArgs): string[] {
+  const commandFlags = COMMAND_ALLOWED_FLAGS[a.command];
+  if (!commandFlags) return [];
+  const allowed = new Set(['repo', ...commandFlags]);
+  return Object.keys(a).filter((name) => name !== 'command' && !allowed.has(name));
+}
+
+export function validateKnownFlags(a: CliArgs): void {
+  const unknown = unknownFlagsForCommand(a);
+  if (unknown.length === 0) return;
+  const options = unknown.map((name) => `--${name}`).join(', ');
+  console.error(`${a.command}: unknown option${unknown.length === 1 ? '' : 's'}: ${options}`);
+  process.exit(1);
+}
+
 /**
  * Read content from --file / --payload-file, --text / --payload, or stdin.
  *
@@ -117,7 +159,7 @@ export function parseArgs(argv?: string[]): CliArgs {
 export function resolveContent(a: CliArgs): string {
   const file = a.file ?? a['payload-file'];
   if (file) return readFileSync(file, 'utf8');
-  const text = a.text ?? a.payload;
+  const text = a.text ?? a.payload ?? a.json;
   if (text) return text;
 
   if ('stdin' in a) {
@@ -525,6 +567,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  validateKnownFlags(a);
   await handler(a);
 }
 


### PR DESCRIPTION
## Summary
- add command-specific flag validation for `cli-structured-data.ts` before handler dispatch
- accept `--json` as an explicit content alias for payload-bearing commands, alongside `--text` and `--payload`
- add tests for the #1163 incident shape, non-zero unknown-option validation, and allowlist drift across registered handlers

## Why
#1163 came from `store-review-summary --json ...` reporting success while silently dropping the payload because unknown flags were parsed and ignored. The CLI now either recognizes `--json` as content or rejects truly unknown flags before any storage handler runs.

## Evidence
- `npx vitest run src/cli-structured-data.test.ts` -> 1 file, 40 tests passed
- `npm run typecheck` -> passed
- `npm run test:fast` -> 1 file, 40 tests passed
- `npm test` -> 175 files passed, 2 skipped; 4192 passed, 14 skipped. The `Unknown option: --bogus` line is from an existing negative-path CLI test and the command exited 0.

Closes #1163