### PR TITLE
Fix opaque missing-tsx hook failures

### DIFF
--- a/.claude/hooks/kaizen-enforce-worktree-writes.sh
+++ b/.claude/hooks/kaizen-enforce-worktree-writes.sh
@@ -96,10 +96,10 @@ REASON="Cannot write to '$FILE_PATH' — it's source code in the main checkout (
 source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || true
 WORKTREE_HINT=""
 if [ -n "${KAIZEN_DIR:-}" ] && [ -f "$KAIZEN_DIR/src/hooks/worktree-integrity.ts" ]; then
-  if [ -x "$KAIZEN_DIR/node_modules/.bin/tsx" ]; then
-    WORKTREE_HINT=$("$KAIZEN_DIR/node_modules/.bin/tsx" "$KAIZEN_DIR/src/hooks/worktree-integrity.ts" main-edit-hint --main-root "$MAIN_ROOT" --rel-path "$REL_PATH" 2>/dev/null || true)
-  elif command -v npx >/dev/null 2>&1; then
-    WORKTREE_HINT=$(npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/worktree-integrity.ts" main-edit-hint --main-root "$MAIN_ROOT" --rel-path "$REL_PATH" 2>/dev/null || true)
+  source "$(dirname "$0")/lib/resolve-tsx-bin.sh" 2>/dev/null || true
+  TSX_BIN="$(resolve_tsx_bin "$KAIZEN_DIR" 2>/dev/null || true)"
+  if [ -n "$TSX_BIN" ]; then
+    WORKTREE_HINT=$("$TSX_BIN" "$KAIZEN_DIR/src/hooks/worktree-integrity.ts" main-edit-hint --main-root "$MAIN_ROOT" --rel-path "$REL_PATH" 2>/dev/null || true)
   fi
 fi
 

--- a/.claude/hooks/kaizen-session-snapshot.sh
+++ b/.claude/hooks/kaizen-session-snapshot.sh
@@ -13,16 +13,16 @@
 
 set -u
 source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || exit 0
+source "$(dirname "$0")/lib/resolve-tsx-bin.sh" 2>/dev/null || exit 0
 
-# Resolve tsx from the kaizen repo's node_modules, then fall back to npx.
-# Stay silent if neither is available — this hook must never break startup.
+# Resolve tsx through the same shell contract used by TS hook shims. Stay
+# fail-open if unavailable — this hook must never break startup — but do not
+# shell through `npx ... 2>/dev/null`, which recreates #1131's empty-stderr
+# diagnostic black hole.
 TS="${KAIZEN_DIR}/scripts/kaizen-doctor.ts"
-LOCAL_TSX="${KAIZEN_DIR}/node_modules/.bin/tsx"
-if [ -x "${LOCAL_TSX}" ]; then
-  "${LOCAL_TSX}" "${TS}" snapshot >/dev/null 2>&1 || true
-  "${LOCAL_TSX}" "${TS}" hook-syntax --quiet || true
-elif command -v npx >/dev/null 2>&1; then
-  npx --prefix "${KAIZEN_DIR}" tsx "${TS}" snapshot >/dev/null 2>&1 || true
-  npx --prefix "${KAIZEN_DIR}" tsx "${TS}" hook-syntax --quiet || true
+TSX_BIN="$(resolve_tsx_bin "$KAIZEN_DIR" || true)"
+if [ -n "$TSX_BIN" ]; then
+  "$TSX_BIN" "$TS" snapshot >/dev/null 2>&1 || true
+  "$TSX_BIN" "$TS" hook-syntax --quiet || true
 fi
 exit 0

--- a/.claude/hooks/kaizen-worktree-setup.sh
+++ b/.claude/hooks/kaizen-worktree-setup.sh
@@ -47,10 +47,10 @@ done
 # and binding contracts stay shared with the plan gate and issue-binding CLI.
 source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || true
 if [ -n "${KAIZEN_DIR:-}" ] && [ -f "$KAIZEN_DIR/src/hooks/worktree-integrity.ts" ]; then
-  if [ -x "$KAIZEN_DIR/node_modules/.bin/tsx" ]; then
-    "$KAIZEN_DIR/node_modules/.bin/tsx" "$KAIZEN_DIR/src/hooks/worktree-integrity.ts" session-setup >/dev/null || true
-  elif command -v npx >/dev/null 2>&1; then
-    npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/worktree-integrity.ts" session-setup >/dev/null || true
+  source "$(dirname "$0")/lib/resolve-tsx-bin.sh" 2>/dev/null || true
+  TSX_BIN="$(resolve_tsx_bin "$KAIZEN_DIR" 2>/dev/null || true)"
+  if [ -n "$TSX_BIN" ]; then
+    "$TSX_BIN" "$KAIZEN_DIR/src/hooks/worktree-integrity.ts" session-setup >/dev/null || true
   fi
 fi
 

--- a/.claude/hooks/lib/run-tsx.sh
+++ b/.claude/hooks/lib/run-tsx.sh
@@ -2,9 +2,10 @@
 # Part of kAIzen Agent Control Flow
 # run-tsx.sh — Reliable tsx execution for TS hook shims
 #
-# Resolves tsx from KAIZEN_DIR/node_modules, then global npx, then gives up
-# gracefully (exit 0). Prevents hook errors when node_modules is missing
-# (e.g., plugin installations without npm install).
+# Resolves tsx from KAIZEN_DIR/node_modules, parent/worktree installs, or the
+# git common dir, then gives up loudly but fail-open. Prevents opaque hook
+# errors when node_modules is missing (e.g., plugin installations without npm
+# install) while keeping hooks non-blocking.
 #
 # Usage (in a TS shim):
 #   source "$(dirname "$0")/lib/run-tsx.sh"
@@ -35,11 +36,10 @@ run_tsx() {
     exec "$resolved_tsx" "$ts_file"
   fi
 
-  # 2. npx with --prefix — finds tsx in kaizen's node_modules
-  if command -v npx &>/dev/null; then
-    exec npx --prefix "$kaizen_dir" tsx "$ts_file" 2>/dev/null
-  fi
-
-  # 3. tsx not available — exit gracefully instead of crashing
+  # 2. tsx not available — exit gracefully instead of crashing. Do not shell
+  # through `npx --prefix ... 2>/dev/null`: when the bound plugin/worktree root
+  # lacks node_modules, npx exits non-zero with empty stderr and Claude reports
+  # only "Failed with non-blocking status code: No stderr output" (#1131).
+  echo "kaizen hook: tsx not found for $kaizen_dir — run npm install there or symlink node_modules from the main checkout; skipping $ts_file" >&2
   exit 0
 }

--- a/.claude/hooks/tests/test-run-tsx.sh
+++ b/.claude/hooks/tests/test-run-tsx.sh
@@ -52,4 +52,26 @@ resolved=$(
 )
 assert_eq "resolve_tsx_bin finds parent worktree tsx" "$TMP_DIR/parent/node_modules/.bin/tsx" "$resolved"
 
+mkdir -p "$TMP_DIR/missing-deps-root"
+cat > "$TMP_DIR/npx" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$TMP_DIR/npx"
+
+result=$(
+  PATH="$TMP_DIR:$PATH" bash -c "
+    source '$RUN_TSX'
+    run_tsx '$TMP_DIR/missing-deps-root' '$TMP_DIR/hook.ts'
+  " 2>&1
+)
+exit_code=$?
+
+assert_eq "missing tsx exits 0 instead of opaque non-blocking failure" "0" "$exit_code"
+assert_contains "missing tsx emits actionable diagnostic" "kaizen hook: tsx not found" "$result"
+assert_contains "missing tsx diagnostic names root" "$TMP_DIR/missing-deps-root" "$result"
+
+legacy_fallbacks=$(grep -R -nE 'npx --prefix .+tsx.+2>/dev/null' "$REPO_ROOT/.claude/hooks" --exclude-dir=tests || true)
+assert_eq "runtime hooks avoid silent npx tsx fallbacks" "" "$legacy_fallbacks"
+
 print_results

--- a/scripts/kaizen-doctor.test.ts
+++ b/scripts/kaizen-doctor.test.ts
@@ -10,6 +10,7 @@ import {
   checkStalePluginCache,
   checkRestartNeeded,
   checkHookExecSmoke,
+  checkHookDependencyRoots,
   checkHookSyntaxSmoke,
   checkDevLinkOverride,
   checkSingleRegistrationPath,
@@ -381,6 +382,68 @@ describe('checkHookExecSmoke', () => {
   });
 });
 
+describe('checkHookDependencyRoots (#1131)', () => {
+  let proj: string, home: string;
+  beforeEach(() => { proj = makeProject(); home = makeHome(); });
+  afterEach(() => { rmSync(proj, { recursive: true, force: true }); rmSync(home, { recursive: true, force: true }); });
+
+  function writeTsHookRegistration(): void {
+    writeHook(proj, '.claude/hooks/kaizen-enforce-plan-stored-ts.sh', true, [
+      '#!/bin/bash',
+      'source "$(dirname "$0")/lib/run-tsx.sh"',
+      'run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/enforce-plan-stored.ts"',
+      '',
+    ].join('\n'));
+    writePluginJson(proj, {
+      hooks: {
+        PreToolUse: [{
+          matcher: 'Write',
+          hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/.claude/hooks/kaizen-enforce-plan-stored-ts.sh' }],
+        }],
+      },
+    });
+  }
+
+  it('FAILS when a registered TS hook root has no runnable tsx dependency', () => {
+    writeTsHookRegistration();
+
+    const result = checkHookDependencyRoots({ projectRoot: proj, homeDir: home });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.name).toBe('hook-dependency-roots');
+    expect(result.detail).toContain('tsx not found');
+    expect(result.detail).toContain(proj);
+  });
+
+  it('PASSES when the registered TS hook root has a local tsx binary', () => {
+    writeTsHookRegistration();
+    mkdirSync(join(proj, 'node_modules/.bin'), { recursive: true });
+    writeFileSync(join(proj, 'node_modules/.bin/tsx'), '#!/bin/bash\nexit 0\n', { mode: 0o755 });
+
+    const result = checkHookDependencyRoots({ projectRoot: proj, homeDir: home });
+
+    expect(result.status).toBe('PASS');
+    expect(result.detail).toContain('all 1 TS hook root');
+  });
+
+  it('PASSES when no registered hooks use the TS trampoline', () => {
+    writeHook(proj, '.claude/hooks/plain.sh', true, '#!/bin/bash\nexit 0\n');
+    writePluginJson(proj, {
+      hooks: {
+        PreToolUse: [{
+          matcher: 'Write',
+          hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/.claude/hooks/plain.sh' }],
+        }],
+      },
+    });
+
+    const result = checkHookDependencyRoots({ projectRoot: proj, homeDir: home });
+
+    expect(result.status).toBe('PASS');
+    expect(result.detail).toContain('no TS hook roots');
+  });
+});
+
 describe('checkHookSyntaxSmoke', () => {
   let proj: string, home: string;
   beforeEach(() => { proj = makeProject(); home = makeHome(); });
@@ -735,6 +798,7 @@ describe('runAllChecks + exitCodeFor', () => {
       'stale-plugin-cache',
       'dev-link-override',
       'restart-needed',
+      'hook-dependency-roots',
       'hook-exec-smoke',
       'hook-syntax-smoke',
       'codex-readiness',

--- a/scripts/kaizen-doctor.ts
+++ b/scripts/kaizen-doctor.ts
@@ -34,6 +34,7 @@ import { homedir } from 'node:os';
 import { readJsonValueFile } from '../src/lib/json-file.js';
 import { KAIZEN_PLUGIN_SOURCE } from '../src/kaizen-plugin-identity.js';
 import { checkDevLinkStatus } from './kaizen-dev-link.js';
+import { resolveTsxBin } from '../src/lib/typescript-runner.js';
 
 export type CheckStatus = 'PASS' | 'WARN' | 'FAIL';
 
@@ -487,6 +488,65 @@ export function checkHookExecSmoke(opts: DoctorOpts): CheckResult {
   };
 }
 
+function hookRootFor(hook: ReferencedHook, projectRoot: string): string {
+  if (hook.command.includes('${CLAUDE_PLUGIN_ROOT}')) return projectRoot;
+  const marker = '/.claude/hooks/';
+  const idx = hook.path.indexOf(marker);
+  if (idx >= 0) return hook.path.slice(0, idx);
+  return dirname(dirname(hook.path));
+}
+
+function hookUsesTypeScriptTrampoline(path: string): boolean {
+  try {
+    const body = readFileSync(path, 'utf8');
+    return body.includes('run-tsx.sh') || /\brun_tsx\b/.test(body);
+  } catch {
+    return false;
+  }
+}
+
+/** Check: registered TypeScript hook roots must have a runnable tsx dependency.
+ *
+ * Path/executable/syntax checks can all pass while TS hook shims still fail at
+ * runtime because the bound plugin/worktree root lacks node_modules. This is the
+ * #1131 diagnostic black hole: hooks look installed but every TS dispatch skips
+ * or fails. Check roots, not individual files, because many hooks share one
+ * dependency contract.
+ */
+export function checkHookDependencyRoots(opts: DoctorOpts): CheckResult {
+  const roots = new Set<string>();
+  for (const hook of collectReferencedHooks(opts)) {
+    if (!existsSync(hook.path)) continue;
+    if (!hookUsesTypeScriptTrampoline(hook.path)) continue;
+    roots.add(hookRootFor(hook, opts.projectRoot));
+  }
+
+  if (roots.size === 0) {
+    return {
+      name: 'hook-dependency-roots',
+      status: 'PASS',
+      detail: 'no TS hook roots to check.',
+    };
+  }
+
+  const missing = [...roots].filter(root => !resolveTsxBin(root));
+  if (missing.length > 0) {
+    return {
+      name: 'hook-dependency-roots',
+      status: 'FAIL',
+      detail: `tsx not found for ${missing.length}/${roots.size} TS hook root(s): ${missing.slice(0, 3).join('; ')}${missing.length > 3 ? ` (+${missing.length - 3} more)` : ''}. Run npm install there or symlink node_modules from the main checkout.`,
+    };
+  }
+
+  return {
+    name: 'hook-dependency-roots',
+    status: 'PASS',
+    detail: roots.size === 1
+      ? 'all 1 TS hook root has runnable tsx dependencies.'
+      : `all ${roots.size} TS hook roots have runnable tsx dependencies.`,
+  };
+}
+
 function bounded(text: string, max = 240): string {
   const compact = text.replace(/\s+/g, ' ').trim();
   if (compact.length <= max) return compact;
@@ -724,6 +784,7 @@ export function runAllChecks(opts: DoctorOpts): CheckResult[] {
     checkStalePluginCache(opts),
     checkDevLinkOverride(opts),
     checkRestartNeeded(opts),
+    checkHookDependencyRoots(opts),
     checkHookExecSmoke(opts),
     checkHookSyntaxSmoke(opts),
     checkCodexReadiness(opts.codexReadiness),

--- a/src/lib/typescript-runner.ts
+++ b/src/lib/typescript-runner.ts
@@ -94,7 +94,7 @@ export function resolveTsxBin(repoRoot: string): string | undefined {
     // Not every synthetic fixture is a git worktree.
   }
 
-  return candidates.find(existsSync);
+  return candidates.map(executableFile).find((path): path is string => path !== null);
 }
 
 export function resolveTypeScriptHookRunner(


### PR DESCRIPTION
Once upon a time, kaizen TS hook shims had healthy registration checks: doctor could confirm hook paths existed, were executable, and passed shell syntax. Every day, that looked sufficient for plugin/worktree health.

One day, issue #1131 showed the missing layer: a mid-session `EnterWorktree` produced a root without `node_modules`, and `run-tsx.sh` fell through to `npx --prefix ... tsx ... 2>/dev/null`. The observable result was `Failed with non-blocking status code: No stderr output` on every tool call.

Because of that, this PR removes the silent `npx` fallback from the TS hook trampoline, makes missing `tsx` fail-open with a one-line actionable stderr naming the root, and adds a doctor check for registered TS hook roots. Because of that, related SessionStart/worktree hint callers now use the same shared resolver instead of preserving bespoke silent dispatch paths.

Until finally, the original fake failing-`npx` repro now exits 0 with `kaizen hook: tsx not found for /tmp/.../plugin ...`, and doctor reports `hook-dependency-roots` before executable/syntax smoke.

Closes #1131

## Impact (goal -> before/after -> match)
- Goal (#1131): hooks must not fail opaquely when a mid-session worktree or plugin root lacks runnable TypeScript dependencies.
- Acceptance signal: missing `tsx`/`node_modules` emits actionable hook stderr with exit 0, and doctor fails registered TS hook roots without a runnable `tsx` while passing runnable roots.
- BEFORE: fake failing `npx` with an empty plugin root returned `exit=1` and empty output; `runAllChecks()` had no dependency-readiness check.
- AFTER: same repro returns `exit=0` and `kaizen hook: tsx not found for /tmp/.../plugin — run npm install there or symlink node_modules from the main checkout; skipping /tmp/.../hook.ts`.
- Delta: opaque non-zero/empty hook dispatch becomes visible non-blocking remediation; doctor gains `hook-dependency-roots` before `hook-exec-smoke` and `hook-syntax-smoke`.
- Goal met?: yes.
- Residual scan: direct `npx --prefix ... tsx ... 2>/dev/null` runtime hook fallbacks removed from `.claude/hooks`; docs/setup examples remain intentionally unchanged.

## Architecture
```
registered hook shim
  -> .claude/hooks/lib/run-tsx.sh
       -> resolve-tsx-bin.sh
            -> local node_modules/.bin/tsx
            -> ancestor/worktree node_modules/.bin/tsx
            -> git-common main checkout node_modules/.bin/tsx
       -> missing: stderr remediation + exit 0

kaizen-doctor
  -> collect referenced hooks
  -> identify hooks using run-tsx.sh/run_tsx
  -> derive unique hook roots
  -> resolveTsxBin(root)
  -> PASS/FAIL hook-dependency-roots
```

## Design Decisions
| Decision | Why | Tradeoff |
|---|---|---|
| Remove the `npx --prefix ... 2>/dev/null` fallback from `run-tsx.sh` | It is the exact empty-stderr failure path from #1131. | Hooks still skip enforcement when deps are absent, but the skip is visible and non-blocking. |
| Add doctor root readiness instead of per-hook readiness | Many TS hooks share one root dependency contract. | Doctor reports by root, not by every individual hook file. |
| Use shared resolver behavior in SessionStart/worktree helper callers | Prevents competing TS dispatch contracts from preserving the silent path. | These helper calls remain fail-open if the resolver cannot find `tsx`. |
| Require executable `tsx` in the TS resolver | Matches shell `-x` semantics and avoids false PASS on non-runnable files. | A present but non-executable file now correctly counts as unavailable. |

## What's In This PR
| File | Purpose |
|---|---|
| `.claude/hooks/lib/run-tsx.sh` | Emits actionable missing-`tsx` diagnostics and exits 0 instead of silent `npx` failure. |
| `.claude/hooks/kaizen-session-snapshot.sh` | Uses the shared resolver for doctor snapshot/syntax dispatch. |
| `.claude/hooks/kaizen-worktree-setup.sh` | Uses the shared resolver before worktree integrity setup. |
| `.claude/hooks/kaizen-enforce-worktree-writes.sh` | Uses the shared resolver for worktree hint generation. |
| `scripts/kaizen-doctor.ts` | Adds `hook-dependency-roots` doctor check and ordering. |
| `src/lib/typescript-runner.ts` | Aligns TypeScript resolver with executable-only shell semantics. |
| Tests | Cover missing deps, root readiness PASS/FAIL, aggregate ordering, and silent fallback regression. |

## Test Plan (Behaviors × Levels)
| # | Behavior | Level | Coverage |
|---|---|---|---|
| 1 | `run_tsx` with no resolvable TS runner does not produce empty non-zero hook failure. | System | ✅ `.claude/hooks/tests/test-run-tsx.sh` plus direct fake-`npx` repro. |
| 2 | `run_tsx` still honors `KAIZEN_TSX_BIN` and shared parent/worktree resolver before falling back. | System | ✅ `.claude/hooks/tests/test-run-tsx.sh`. |
| 3 | Doctor fails when registered TS hook roots cannot run `tsx`. | Unit | ✅ `scripts/kaizen-doctor.test.ts`. |
| 4 | Doctor passes dependency readiness when hook roots have a local or resolvable TS runner. | Unit | ✅ `scripts/kaizen-doctor.test.ts`. |
| 5 | Doctor aggregate output includes the dependency-root check before hook exec/syntax smoke. | Unit | ✅ `scripts/kaizen-doctor.test.ts`. |
| 6 | The fixed behavior is proven against the original opaque failure repro. | System | ✅ direct shell repro in validation. |

No deferred behaviors.

## Validation
- [x] `bash .claude/hooks/tests/test-run-tsx.sh` -> 7 passed, 0 failed.
- [x] `npx vitest run scripts/kaizen-doctor.test.ts scripts/test-typescript-runner.test.ts src/hooks/worktree-setup.test.ts --reporter=verbose` -> 71 passed.
- [x] `npm run typecheck` -> pass.
- [x] Direct fake failing-`npx` repro -> `exit=0`, actionable `kaizen hook: tsx not found...` output.
- [x] `npm run check:fast` -> 7 files passed, 203 tests passed.
- [x] `npm run test:hooks` -> 439 passed, 0 failed.
- [x] `npm test` -> 176 files passed, 2 skipped; 4,207 passed, 14 skipped.
- [x] `npx tsx scripts/kaizen-doctor.ts --json` -> `hook-dependency-roots` PASS. Existing environment warnings: orphan plugin cache and missing session-start snapshot.

## Known Limitations
This PR intentionally does not mutate plugin/cache roots from hooks to self-heal `node_modules`. The chosen fix removes the diagnostic black hole and gives doctor an explicit readiness check without writing into installed plugin caches during hook execution.
