### PR TITLE
test: harden post-hook harness timeouts

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -34,7 +34,7 @@ Kaizen provides enforcement hooks, reflection workflows, and dev workflow skills
 | `.agents/kaizen/verification.md` | Verification discipline |
 | `.claude/hooks/` | All enforcement hooks (kaizen- prefixed) |
 | `.claude/hooks/lib/` | Shared hook libraries |
-| `.claude/hooks/tests/` | Hook test infrastructure |
+| `.claude/hooks/tests/` | Hook test infrastructure. In Python `test_hooks.py`, PostToolUse hook tests use `HookHarness.run_post_hook()` plus `assert_post_hook_stdout_contains()` so slow advisory hooks fail with timeout diagnostics instead of ambiguous missing-output assertions. |
 | `src/hooks/` | TypeScript hooks |
 | `src/hooks/lib/gate-manager.ts` | Unified stop gate — read/format/clear all pending gates |
 | `src/hooks/stop-gate.ts` | Unified stop hook entry point (replaces 3 bash stop hooks) |

--- a/.claude/hooks/tests/harness.py
+++ b/.claude/hooks/tests/harness.py
@@ -40,7 +40,7 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-DEFAULT_HOOK_TIMEOUT_SECONDS = _env_int("KAIZEN_HOOK_TEST_TIMEOUT_SECONDS", 10)
+DEFAULT_HOOK_TIMEOUT_SECONDS = 10
 DEFAULT_POST_TOOL_USE_TIMEOUT_SECONDS = _env_int("KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS", 30)
 
 
@@ -272,7 +272,7 @@ class HookHarness:
         """Set an environment variable override for all hook runs."""
         self.env_overrides[key] = value
 
-    def run_hook(self, hook_name: str, input_data, timeout: Optional[int] = None) -> HookResult:
+    def run_hook(self, hook_name: str, input_data, timeout: Optional[float] = None) -> HookResult:
         """Run a single hook with given input."""
         timeout = timeout if timeout is not None else DEFAULT_HOOK_TIMEOUT_SECONDS
         hook_path = self.hooks_dir / hook_name
@@ -309,12 +309,12 @@ class HookHarness:
                 timed_out=True,
             )
 
-    def run_post_hook(self, hook_name: str, input_data, timeout: Optional[int] = None) -> HookResult:
+    def run_post_hook(self, hook_name: str, input_data, timeout: Optional[float] = None) -> HookResult:
         """Run a PostToolUse hook with the post-hook budget used by fleet-sensitive tests."""
         timeout = timeout if timeout is not None else DEFAULT_POST_TOOL_USE_TIMEOUT_SECONDS
         return self.run_hook(hook_name, input_data, timeout=timeout)
 
-    def run_all_hooks(self, event: str, tool_name: str, input_data, timeout: Optional[int] = None) -> MultiHookResult:
+    def run_all_hooks(self, event: str, tool_name: str, input_data, timeout: Optional[float] = None) -> MultiHookResult:
         """Run all configured hooks for event+tool (sequentially, unlike Claude Code's parallel)."""
         timeout = timeout if timeout is not None else DEFAULT_HOOK_TIMEOUT_SECONDS
         hooks = self._get_hooks_for_event(event, tool_name)

--- a/.claude/hooks/tests/harness.py
+++ b/.claude/hooks/tests/harness.py
@@ -33,6 +33,17 @@ SETTINGS_PATH = HOOKS_DIR.parent / "settings.json"
 REPO_ROOT = HOOKS_DIR.parent.parent
 
 
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+DEFAULT_HOOK_TIMEOUT_SECONDS = _env_int("KAIZEN_HOOK_TEST_TIMEOUT_SECONDS", 10)
+DEFAULT_POST_TOOL_USE_TIMEOUT_SECONDS = _env_int("KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS", 30)
+
+
 def resolve_tsx_bin() -> Optional[str]:
     helper = HOOKS_DIR / "lib" / "resolve-tsx-bin.sh"
     try:
@@ -207,6 +218,21 @@ class MultiHookResult:
         return [r for r in self.results if r.exit_code not in (0, 2)]
 
 
+def assert_post_hook_stdout_contains(result: HookResult, expected: str, context: str) -> None:
+    if result.timed_out:
+        raise AssertionError(
+            f"{context} timed out before emitting {expected!r}. "
+            f"hook={result.name}, exit={result.exit_code}, stderr={result.stderr!r}. "
+            "PostToolUse hooks are advisory and can be slow under fleet load; "
+            "set KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS to adjust the bounded test budget."
+        )
+    assert expected in result.stdout, (
+        f"{context} did not emit {expected!r}. "
+        f"hook={result.name}, exit={result.exit_code}, "
+        f"stdout={result.stdout[:500]!r}, stderr={result.stderr[:500]!r}"
+    )
+
+
 # Main harness
 
 class HookHarness:
@@ -246,8 +272,9 @@ class HookHarness:
         """Set an environment variable override for all hook runs."""
         self.env_overrides[key] = value
 
-    def run_hook(self, hook_name: str, input_data, timeout: int = 10) -> HookResult:
+    def run_hook(self, hook_name: str, input_data, timeout: Optional[int] = None) -> HookResult:
         """Run a single hook with given input."""
+        timeout = timeout if timeout is not None else DEFAULT_HOOK_TIMEOUT_SECONDS
         hook_path = self.hooks_dir / hook_name
         if not hook_path.exists():
             raise FileNotFoundError(f"Hook not found: {hook_path}")
@@ -282,8 +309,14 @@ class HookHarness:
                 timed_out=True,
             )
 
-    def run_all_hooks(self, event: str, tool_name: str, input_data, timeout: int = 10) -> MultiHookResult:
+    def run_post_hook(self, hook_name: str, input_data, timeout: Optional[int] = None) -> HookResult:
+        """Run a PostToolUse hook with the post-hook budget used by fleet-sensitive tests."""
+        timeout = timeout if timeout is not None else DEFAULT_POST_TOOL_USE_TIMEOUT_SECONDS
+        return self.run_hook(hook_name, input_data, timeout=timeout)
+
+    def run_all_hooks(self, event: str, tool_name: str, input_data, timeout: Optional[int] = None) -> MultiHookResult:
         """Run all configured hooks for event+tool (sequentially, unlike Claude Code's parallel)."""
+        timeout = timeout if timeout is not None else DEFAULT_HOOK_TIMEOUT_SECONDS
         hooks = self._get_hooks_for_event(event, tool_name)
         results = []
         for hook_cmd in hooks:

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -164,8 +164,8 @@ class TestRealWorldCommands:
             "gh pr create --title test --body test",
             stderr="https://github.com/Garsson-io/kaizen/pull/88",
         )
-        result = review_harness.run_hook("pr-review-loop-ts.sh", inp)
-        assert "SELF-REVIEW" in result.stdout
+        result = review_harness.run_post_hook("pr-review-loop-ts.sh", inp)
+        assert_post_hook_stdout_contains(result, "SELF-REVIEW", "PostToolUse pr-review-loop")
 
     def test_multiline_command(self, harness, mocks):
         mocks.add_git_mock()
@@ -240,10 +240,10 @@ class TestPRLifecycle:
         assert r.allows(), "Should allow before any PR"
 
         # Phase 2: PR create → gate activates
-        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
+        r = review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
             "gh pr create --title test --body test",
             stdout=self.PR_URL))
-        assert "SELF-REVIEW" in r.stdout
+        assert_post_hook_stdout_contains(r, "SELF-REVIEW", "PostToolUse pr-review-loop")
         assert state.state_exists(self.PR_URL)
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "needs_review"
@@ -258,11 +258,11 @@ class TestPRLifecycle:
         assert r.allows(), "Should allow gh pr diff"
 
         # Phase 3: Review agents ran and outcome persisted.
-        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.agent())
+        review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.agent())
         state.create_review_sentinel(self.PR_URL, 1)
 
         # gh pr diff → review passed
-        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
+        r = review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "passed"
 
@@ -272,7 +272,7 @@ class TestPRLifecycle:
 
         # Phase 4: git push → re-gate
         # The push handler finds "passed" state and increments to next round.
-        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("git push", stdout="ok"))
+        r = review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("git push", stdout="ok"))
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "needs_review", "Push after passed should re-engage gate"
         assert s["ROUND"] == "2", "Round should be incremented after push"
@@ -282,7 +282,7 @@ class TestPRLifecycle:
         state.create_state(self.PR_URL, round_num=1, status="needs_review", branch="wt/test-branch")
 
         # No sentinel yet -> stays blocked
-        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
+        r = review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "needs_review"
         # The gate now reports the structured sentinel reason (#920); the old
@@ -292,21 +292,21 @@ class TestPRLifecycle:
 
         # Sentinel without Agent evidence still stays blocked (#455).
         state.create_review_sentinel(self.PR_URL, 1)
-        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
+        r = review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "needs_review"
         assert "no observed Agent reviewer activity" in r.stdout
 
         # Sentinel plus Agent evidence -> clears.
-        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.agent())
-        r = review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
+        review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.agent())
+        r = review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash("gh pr diff 55", stdout="diff..."))
         s = state.read_state(self.PR_URL)
         assert s["STATUS"] == "passed"
 
     def test_merge_cleans_up(self, review_harness, state):
         state.create_state(self.PR_URL, round_num=2, status="needs_review", branch="wt/test-branch")
 
-        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
+        review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
             "gh pr merge 55 --squash",
             stdout=f"✓ Merged {self.PR_URL}"))
 
@@ -317,23 +317,23 @@ class TestPRLifecycle:
         url_b = "https://github.com/Garsson-io/garsson-prints/pull/10"
 
         # Create PRs for both repos
-        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
+        review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
             "gh pr create --repo Garsson-io/kaizen", stdout=url_a))
-        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
+        review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
             "gh pr create --repo Garsson-io/garsson-prints", stdout=url_b))
 
         assert state.state_exists(url_a)
         assert state.state_exists(url_b)
 
         # Merge A shouldn't affect B
-        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
+        review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
             "gh pr merge 60", stdout=f"✓ Merged {url_a}"))
 
         assert not state.state_exists(url_a)
         assert state.state_exists(url_b), "Merging A should not touch B's state"
 
     def test_failed_command_no_state(self, review_harness, state):
-        review_harness.run_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
+        review_harness.run_post_hook("pr-review-loop-ts.sh", PostToolUseInput.bash(
             "gh pr create --title test", exit_code="1"))
         assert state.state_count() == 0, "Failed command should not create state"
 
@@ -407,6 +407,27 @@ class TestPostToolUseFormat:
         )
 
         with pytest.raises(AssertionError, match="PostToolUse kaizen-reflect timed out.*KAIZEN"):
+            assert_post_hook_stdout_contains(result, "KAIZEN", "PostToolUse kaizen-reflect")
+
+    def test_post_hook_stdout_helper_accepts_expected_output(self):
+        result = HookResult(
+            hook_path="kaizen-reflect-ts.sh",
+            stdout="KAIZEN: consider filing a process improvement",
+            stderr="",
+            exit_code=0,
+        )
+
+        assert_post_hook_stdout_contains(result, "KAIZEN", "PostToolUse kaizen-reflect")
+
+    def test_post_hook_stdout_helper_reports_missing_output_without_timeout(self):
+        result = HookResult(
+            hook_path="kaizen-reflect-ts.sh",
+            stdout="SELF-REVIEW: run review",
+            stderr="",
+            exit_code=0,
+        )
+
+        with pytest.raises(AssertionError, match="did not emit 'KAIZEN'.*stdout="):
             assert_post_hook_stdout_contains(result, "KAIZEN", "PostToolUse kaizen-reflect")
 
     def test_run_post_hook_timeout_reports_real_subprocess_diagnostic(self, tmp_path):

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -23,7 +23,8 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from harness import (
     HookHarness, PreToolUseInput, PostToolUseInput, StopInput,
-    PRReviewState, MockBinDir, REAL_COMMANDS,
+    PRReviewState, MockBinDir, HookResult, REAL_COMMANDS,
+    assert_post_hook_stdout_contains,
 )
 
 
@@ -377,17 +378,29 @@ class TestParallelExecution:
             "gh pr create --title test --body test",
             stdout="https://github.com/Garsson-io/kaizen/pull/99")
 
-        review_result = review_harness.run_hook("pr-review-loop-ts.sh", inp)
-        kaizen_result = review_harness.run_hook("kaizen-reflect-ts.sh", inp)
+        review_result = review_harness.run_post_hook("pr-review-loop-ts.sh", inp)
+        kaizen_result = review_harness.run_post_hook("kaizen-reflect-ts.sh", inp)
 
-        assert "SELF-REVIEW" in review_result.stdout, "pr-review-loop should fire"
-        assert "KAIZEN" in kaizen_result.stdout, "kaizen-reflect should fire"
+        assert_post_hook_stdout_contains(review_result, "SELF-REVIEW", "PostToolUse pr-review-loop")
+        assert_post_hook_stdout_contains(kaizen_result, "KAIZEN", "PostToolUse kaizen-reflect")
 
 
 # PostToolUse format tests
 
 class TestPostToolUseFormat:
     """INVARIANT: PostToolUse hooks output advisory text, not deny JSON."""
+
+    def test_post_hook_timeout_reports_diagnostic(self):
+        result = HookResult(
+            hook_path="kaizen-reflect-ts.sh",
+            stdout="",
+            stderr="TIMEOUT after 1s",
+            exit_code=124,
+            timed_out=True,
+        )
+
+        with pytest.raises(AssertionError, match="PostToolUse kaizen-reflect timed out.*KAIZEN"):
+            assert_post_hook_stdout_contains(result, "KAIZEN", "PostToolUse kaizen-reflect")
 
     @pytest.mark.parametrize("hook", ["pr-review-loop-ts.sh", "kaizen-reflect-ts.sh"])
     def test_no_deny_json_in_post_hooks(self, review_harness, hook):
@@ -396,7 +409,7 @@ class TestPostToolUseFormat:
             "gh pr create --title test --body test",
             stdout="https://github.com/Garsson-io/kaizen/pull/70")
 
-        result = review_harness.run_hook(hook, inp)
+        result = review_harness.run_post_hook(hook, inp)
         assert result.exit_code == 0, f"{hook} should always exit 0"
 
         # Should not produce deny JSON

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from harness import (
     HookHarness, PreToolUseInput, PostToolUseInput, StopInput,
     PRReviewState, MockBinDir, HookResult, REAL_COMMANDS,
-    assert_post_hook_stdout_contains,
+    _env_int, assert_post_hook_stdout_contains,
 )
 
 
@@ -390,6 +390,13 @@ class TestParallelExecution:
 class TestPostToolUseFormat:
     """INVARIANT: PostToolUse hooks output advisory text, not deny JSON."""
 
+    def test_post_hook_timeout_budget_env_parsing(self, monkeypatch):
+        monkeypatch.setenv("KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS", "45")
+        assert _env_int("KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS", 30) == 45
+
+        monkeypatch.setenv("KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS", "not-an-int")
+        assert _env_int("KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS", 30) == 30
+
     def test_post_hook_timeout_reports_diagnostic(self):
         result = HookResult(
             hook_path="kaizen-reflect-ts.sh",
@@ -401,6 +408,22 @@ class TestPostToolUseFormat:
 
         with pytest.raises(AssertionError, match="PostToolUse kaizen-reflect timed out.*KAIZEN"):
             assert_post_hook_stdout_contains(result, "KAIZEN", "PostToolUse kaizen-reflect")
+
+    def test_run_post_hook_timeout_reports_real_subprocess_diagnostic(self, tmp_path):
+        hook = tmp_path / "slow-post-hook.sh"
+        hook.write_text("#!/bin/bash\nsleep 1\necho KAIZEN\n")
+        hook.chmod(0o755)
+
+        h = HookHarness(hooks_dir=tmp_path, settings_path=tmp_path / "settings.json")
+        try:
+            result = h.run_post_hook("slow-post-hook.sh", PostToolUseInput.bash("gh pr create"), timeout=0.01)
+
+            assert result.timed_out
+            assert result.exit_code == 124
+            with pytest.raises(AssertionError, match="PostToolUse slow hook timed out.*KAIZEN.*slow-post-hook.sh"):
+                assert_post_hook_stdout_contains(result, "KAIZEN", "PostToolUse slow hook")
+        finally:
+            h.cleanup()
 
     @pytest.mark.parametrize("hook", ["pr-review-loop-ts.sh", "kaizen-reflect-ts.sh"])
     def test_no_deny_json_in_post_hooks(self, review_harness, hook):

--- a/docs/hook-test-dry-spec.md
+++ b/docs/hook-test-dry-spec.md
@@ -32,6 +32,7 @@ All environment setup, mock creation, state management helpers, and decision ext
 | Assertions | `test-helpers.sh`: assert_eq, assert_contains, assert_not_contains, assert_ok, assert_fails | Good — sourced by all bash tests |
 | Integration harness | `harness.sh`: run_single_hook, build_*_input, validate_deny_output | Good — used by integration tests |
 | Python harness | `harness.py`: HookHarness, MockBinDir, PRReviewState | Good — used by test_hooks.py |
+| Python PostToolUse timeout contract | `harness.py`: `run_post_hook()` plus `assert_post_hook_stdout_contains()` | Good — use for PostToolUse tests so slow advisory hooks report timeout diagnostics instead of ambiguous missing-output failures |
 | Mock creation (harness) | `harness.sh`: setup_gh_git_mocks, setup_mock_dir | Good — but only used by harness-based tests |
 
 ### Needs Building
@@ -189,6 +190,22 @@ bash .claude/hooks/tests/run-all-tests.sh
 ```
 
 **Pass criteria:** Same pass/fail counts as before. Zero regressions.
+
+### Python PostToolUse tests
+
+When adding Python lifecycle coverage for a PostToolUse hook, use:
+
+```python
+result = harness.run_post_hook("kaizen-reflect-ts.sh", post_tool_use_input)
+assert_post_hook_stdout_contains(result, "KAIZEN", "PostToolUse kaizen-reflect")
+```
+
+`run_post_hook()` uses `KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS` when set, or
+30 seconds by default. `assert_post_hook_stdout_contains()` checks
+`HookResult.timed_out` before checking stdout, so a slow advisory hook reports
+which hook timed out and what output was expected. Do not hand-roll
+`assert "KAIZEN" in result.stdout` for PostToolUse hooks; that reintroduces the
+#1120 false-red failure mode under fleet load.
 
 ## 8. Open Questions (Resolved)
 


### PR DESCRIPTION
## Story
Once upon a time, the Python hook harness treated every hook invocation the same way: one 10-second default and raw `stdout` assertions in the tests.

Every day, that was fine on a clean checkout. The #1120 incident showed the cost under fleet load: the post-hook tests for `pr-review-loop-ts.sh` and `kaizen-reflect-ts.sh` could time out and then fail as if the hooks stopped emitting `SELF-REVIEW` or `KAIZEN`.

One day, `test_hooks.py` failed during PR #1119 even though the hook worked on clean `main`. The failure was not a product regression; it was a trust-signal regression in the test harness.

Because of that, this PR gives PostToolUse tests their own bounded timeout path and a shared assertion helper. If a post-hook times out, the failure now names the hook, expected output, exit code, stderr, and the `KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS` knob.

Because of that, the two #1120 paths no longer duplicate raw `stdout` checks. They run through `run_post_hook()` and `assert_post_hook_stdout_contains()`, so timeout diagnostics and output checks share one contract.

Until finally, the original paths pass normally, and an intentionally forced timeout now fails with a diagnostic instead of an ambiguous missing-output assertion.

And ever since, slow PostToolUse startup under agent load should be triaged as a harness timeout with evidence, not confused with hook behavior drift.

Fixes Garsson-io/kaizen#1120
Refs Garsson-io/kaizen#1532
Refs Garsson-io/kaizen#451
Refs Garsson-io/kaizen#1076
Refs Garsson-io/kaizen#1601

## Architecture
```text
PostToolUse test
  -> HookHarness.run_post_hook(...)
       -> run_hook(..., timeout=KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS or 30s)
  -> assert_post_hook_stdout_contains(...)
       -> timed_out? diagnostic failure
       -> stdout missing expected text? behavior failure with stdout/stderr sample
```

## Design Decisions
| Decision | Why | Tradeoff |
|---|---|---|
| Keep `run_hook()` default at 10s | Preserve existing single-hook test behavior. | Generic hooks do not inherit the more generous post-hook budget. |
| Add `run_post_hook()` defaulting to 30s | PostToolUse hooks are advisory and can be slow under fleet load; #1120 was specifically a post-hook false red. | Slow real regressions still wait up to 30s before failing. |
| Add one shared stdout helper | Removes duplicated raw assertions and gives timeout failures a consistent diagnostic. | Tests that need richer semantic parsing still need their own assertions after this helper. |
| Use env vars for timeout budgets | Lets loaded CI/agent runs adjust bounded budgets without patching tests. | Env vars are read at module import time. |

## What's In This PR

| File | Purpose |
|---|---|
| `.claude/hooks/tests/harness.py` | Adds configurable PostToolUse hook timeout budget, `run_post_hook()`, and timeout-aware post-hook stdout assertion. Keeps generic hook tests on the existing 10s default. |
| `.claude/hooks/tests/test_hooks.py` | Adds timeout diagnostic regression tests, including a real subprocess timeout path, and routes the #1120 post-hook paths through the shared helper. |
| `.agents/AGENTS.md` | Documents the PostToolUse test contract in the canonical agent instructions. |
| `docs/hook-test-dry-spec.md` | Records the reusable Python PostToolUse test pattern in the hook-test DRY spec. |

## Test Plan (Behaviors x Levels)

| Behavior | Level | Status | Evidence |
|---|---|---|---|
| Timeout diagnostic contract exists | RED | tested | Before implementation: `python3 -m pytest .claude/hooks/tests/test_hooks.py::TestPostToolUseFormat::test_post_hook_timeout_reports_diagnostic -vv` failed at collection because `assert_post_hook_stdout_contains` did not exist. |
| #1120 post-hook paths use resilient contract | GREEN focused | tested | `python3 -m pytest .claude/hooks/tests/test_hooks.py::TestRealWorldCommands::test_pr_create_output_in_stderr .claude/hooks/tests/test_hooks.py::TestPRLifecycle .claude/hooks/tests/test_hooks.py::TestPostToolUseFormat .claude/hooks/tests/test_hooks.py::TestParallelExecution::test_both_post_hooks_fire_on_pr_create -vv` -> 14 passed. |
| Python hook harness remains green | Harness lane | tested | `python3 -m pytest .claude/hooks/tests/test_hooks.py -vv` -> 43 passed. |
| Full hook test lane remains green | Shell lane | tested | `npm run test:hooks` -> 444 tests, 444 passed. |
| Repo fast gate remains green | Fast gate | tested | `npm run check:fast` -> typecheck passed; changed-file Vitest path found no matching TS tests, exited 0. |

## Impact (goal -> before/after -> match)
| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Stop ambiguous #1120 post-hook false reds | Raw assertions such as `assert "KAIZEN" in kaizen_result.stdout`; a timeout produced empty stdout and looked like behavior drift. | `assert_post_hook_stdout_contains(...)` first checks `result.timed_out` and reports hook, expected text, exit, stderr, and timeout knob. | Timeout and behavior failures now have different messages. | yes |
| Make post-hook timeout budget explicit and bounded | `run_hook(..., timeout=10)` default was shared by all hook tests. | `run_post_hook()` uses `KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS` or 30s, while `run_hook()` stays at 10s by default. | PostToolUse tests get a fleet-load-aware budget without weakening all tests. | yes |
| DRY #1120 assertions | Two tests hand-rolled output assertions for `SELF-REVIEW` / `KAIZEN`. | Both tests use the shared helper and post-hook runner. | One contract owns timeout diagnostics and output evidence. | yes |

## Meet Reality
- Normal original path: `python3 -m pytest .claude/hooks/tests/test_hooks.py::TestParallelExecution::test_both_post_hooks_fire_on_pr_create .claude/hooks/tests/test_hooks.py::TestPostToolUseFormat::test_no_deny_json_in_post_hooks -vv` -> passed.
- Forced timeout path: `KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS=0 python3 -m pytest .claude/hooks/tests/test_hooks.py::TestParallelExecution::test_both_post_hooks_fire_on_pr_create -vv` -> expected failure with:

```text
AssertionError: PostToolUse pr-review-loop timed out before emitting 'SELF-REVIEW'. hook=pr-review-loop-ts.sh, exit=124, stderr='TIMEOUT after 0s'. PostToolUse hooks are advisory and can be slow under fleet load; set KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS to adjust the bounded test budget.
```

## Known Limitations

- This does not port the legacy Python hook harness to TypeScript. That remains broader #1076 / #1601 work.
- This does not isolate `test:hooks` from shared `dist/` contention under fleet load. Follow-up filed: #1654.
- This does not optimize `kaizen-check-wip` or the hook timing sentinel costs called out in #1120. Existing hook performance epic #451 now has the #1120 timing incident attached.

## Validation

- [x] `python3 -m pytest .claude/hooks/tests/test_hooks.py::TestRealWorldCommands::test_pr_create_output_in_stderr .claude/hooks/tests/test_hooks.py::TestPRLifecycle .claude/hooks/tests/test_hooks.py::TestPostToolUseFormat .claude/hooks/tests/test_hooks.py::TestParallelExecution::test_both_post_hooks_fire_on_pr_create -vv` -> 14 passed
- [x] `python3 -m pytest .claude/hooks/tests/test_hooks.py -vv` -> 43 passed
- [x] `npm run test:hooks` -> 444 tests, 444 passed
- [x] `npm run check:fast` -> typecheck passed; changed-file Vitest path exited 0
- [x] `git diff --check` -> passed
- [x] Bypass scan: no remaining `PostToolUseInput` path in `test_hooks.py` calls `run_hook()` directly
- [x] Forced-timeout dogfood: `KAIZEN_POST_TOOL_USE_TEST_TIMEOUT_SECONDS=0 ...test_both_post_hooks_fire_on_pr_create` fails with a hook-specific timeout diagnostic naming `pr-review-loop-ts.sh` and the budget knob.

## Kaizen

- **Root cause:** Python PostToolUse tests used ordinary `run_hook()` timeouts and raw stdout assertions, so slow advisory hooks under fleet load looked like behavior regressions.
- **Fix level:** L2 test infrastructure — `run_post_hook()` plus `assert_post_hook_stdout_contains()` make the right timeout/assertion contract reusable and tested.
- **Repeat failure?** Related to the broader #1532 local-check trust problem and #451 hook performance class; the specific Python harness assertion failure is fixed here.
- **Escalation needed?** Yes, for remaining infrastructure causes outside this PR: shared `dist/` contention is tracked by #1654, and slow `kaizen-check-wip` timing evidence was attached to #451.
- **Positive finding:** Review battery caught that documenting the helper only in a failure message was insufficient; the contract is now in `.agents/AGENTS.md` and `docs/hook-test-dry-spec.md`.
- **KAIZEN_IMPEDIMENTS:** `[{"finding":"test:hooks can still share contended dist under fleet load","type":"meta","disposition":"filed","ref":"#1654"},{"finding":"kaizen-check-wip remains a dominant hook timing cost in the #1120 incident","type":"meta","disposition":"incident","ref":"#451"},{"finding":"review found the PostToolUse helper needed full branch coverage and migration of existing lifecycle calls","type":"positive","disposition":"amplified","target":"docs/hook-test-dry-spec.md"}]`