### PR TITLE
fix(hooks): cover registered hook telemetry

### DIFF
--- a/.claude/hooks/kaizen-block-self-plugin-enable.sh
+++ b/.claude/hooks/kaizen-block-self-plugin-enable.sh
@@ -19,6 +19,7 @@
 source "$(dirname "$0")/lib/parse-command.sh" 2>/dev/null || { exit 0; }
 source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
 source "$(dirname "$0")/lib/hook-output.sh" 2>/dev/null || { exit 0; }
+source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true
 
 read_hook_input
 get_command

--- a/.claude/hooks/kaizen-pr-kaizen-clear-fallback.sh
+++ b/.claude/hooks/kaizen-pr-kaizen-clear-fallback.sh
@@ -15,11 +15,13 @@
 
 source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || exit 0
 source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || exit 0
+source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true
 
 # Use pre-compiled TS version if available (no tsx overhead)
 JS_PATH="$KAIZEN_DIR/dist/hooks/pr-kaizen-clear-fallback.js"
 if [ -f "$JS_PATH" ]; then
-  exec node "$JS_PATH"
+  node "$JS_PATH"
+  exit $?
 fi
 
 # Bash fallback when dist isn't built (CI, fresh checkout, pre-build)

--- a/.claude/hooks/kaizen-search-before-file.sh
+++ b/.claude/hooks/kaizen-search-before-file.sh
@@ -25,6 +25,7 @@ if [ -z "$COMMAND" ]; then
 fi
 
 source "$(dirname "$0")/lib/scope-guard.sh"
+source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true
 
 CMD_LINE=$(strip_heredoc_body "$COMMAND")
 

--- a/.claude/hooks/kaizen-session-snapshot.sh
+++ b/.claude/hooks/kaizen-session-snapshot.sh
@@ -14,6 +14,7 @@
 set -u
 source "$(dirname "$0")/lib/resolve-kaizen-dir.sh" 2>/dev/null || exit 0
 source "$(dirname "$0")/lib/resolve-tsx-bin.sh" 2>/dev/null || exit 0
+source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true
 
 # Resolve tsx through the same shell contract used by TS hook shims. Stay
 # fail-open if unavailable — this hook must never break startup — but do not

--- a/.claude/hooks/kaizen-worktree-setup.sh
+++ b/.claude/hooks/kaizen-worktree-setup.sh
@@ -12,6 +12,8 @@
 #
 # SessionStart hook — always exits 0 (advisory only, never blocks).
 
+source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true
+
 # Fix A (advisory) for #934/#939: warn when the .worktree-will-delete sentinel is present.
 # worktree-du.ts writes this sentinel before calling git worktree remove, giving sessions
 # a chance to notice the worktree is about to disappear.

--- a/.claude/hooks/lib/hook-telemetry.sh
+++ b/.claude/hooks/lib/hook-telemetry.sh
@@ -29,7 +29,7 @@ _hook_telemetry_now_ms() {
 
 _hook_telemetry_init() {
   _HOOK_TELEMETRY_START_MS=$(_hook_telemetry_now_ms)
-  _HOOK_TELEMETRY_NAME=$(basename "${BASH_SOURCE[2]:-${BASH_SOURCE[1]:-unknown}}" .sh)
+  _HOOK_TELEMETRY_NAME="${KAIZEN_HOOK_TELEMETRY_NAME:-$(basename "${BASH_SOURCE[2]:-${BASH_SOURCE[1]:-unknown}}" .sh)}"
 
   # Resolve telemetry dir if not set
   if [ -z "$_HOOK_TELEMETRY_DIR" ]; then

--- a/.claude/hooks/lib/run-tsx.sh
+++ b/.claude/hooks/lib/run-tsx.sh
@@ -14,6 +14,16 @@
 source "$(dirname "${BASH_SOURCE[0]}")/resolve-kaizen-dir.sh" || exit 0
 source "$(dirname "${BASH_SOURCE[0]}")/resolve-tsx-bin.sh" || exit 0
 
+# When sourced by a real hook shim, measure the outer shim once. Direct library
+# tests source run-tsx.sh without a caller script, so avoid writing telemetry
+# just for loading the helper.
+if [ -n "${BASH_SOURCE[1]:-}" ]; then
+  export KAIZEN_HOOK_TELEMETRY_NAME
+  KAIZEN_HOOK_TELEMETRY_NAME="$(basename "${BASH_SOURCE[1]}" .sh)"
+  source "$(dirname "${BASH_SOURCE[0]}")/hook-telemetry.sh" 2>/dev/null || true
+  unset KAIZEN_HOOK_TELEMETRY_NAME
+fi
+
 run_tsx() {
   local kaizen_dir="$1"
   local ts_file="$2"
@@ -26,14 +36,16 @@ run_tsx() {
   # whose node_modules is absent or incomplete. Let them provide a known-good
   # tsx binary while still running the source file from this kaizen_dir.
   if [ -n "${KAIZEN_TSX_BIN:-}" ] && [ -x "$KAIZEN_TSX_BIN" ]; then
-    exec "$KAIZEN_TSX_BIN" "$ts_file"
+    "$KAIZEN_TSX_BIN" "$ts_file"
+    exit $?
   fi
 
   # 1. Shared resolver — local node_modules, parent worktree installs, git common dir
   local resolved_tsx
   resolved_tsx="$(resolve_tsx_bin "$kaizen_dir" || true)"
   if [ -n "$resolved_tsx" ]; then
-    exec "$resolved_tsx" "$ts_file"
+    "$resolved_tsx" "$ts_file"
+    exit $?
   fi
 
   # 2. tsx not available — exit gracefully instead of crashing. Do not shell

--- a/.claude/hooks/tests/test-hook-telemetry.sh
+++ b/.claude/hooks/tests/test-hook-telemetry.sh
@@ -14,7 +14,7 @@ echo "=== Hook telemetry tests ==="
 
 # Setup: temp dir for telemetry output
 TELEMETRY_DIR=$(mktemp -d)
-trap 'rm -rf "$TELEMETRY_DIR"' EXIT
+trap 'rm -rf "$TELEMETRY_DIR" "${TS_TELEMETRY_DIR:-}" "${BASH_TELEMETRY_DIR:-}"' EXIT
 
 # Phase 1: Telemetry file is created on hook execution
 echo ""
@@ -138,6 +138,92 @@ else
   echo "  FAIL: invalid JSON found"
   echo "$INVALID"
   FAILED_NAMES+=("all lines valid JSON")
+  ((FAIL++))
+fi
+
+# Phase 10: TS shims emit telemetry through the shared run_tsx trampoline
+echo ""
+echo "--- Phase 10: TS shim telemetry via run_tsx ---"
+
+TS_TELEMETRY_DIR=$(mktemp -d)
+MOCK_TSX="$TS_TELEMETRY_DIR/mock-tsx"
+TS_FILE="$TS_TELEMETRY_DIR/hook.ts"
+TS_SHIM="$TS_TELEMETRY_DIR/sample-ts-hook.sh"
+cat > "$MOCK_TSX" <<'EOF'
+#!/bin/bash
+echo "tsx stdout:$1"
+echo "tsx stderr:$1" >&2
+exit 7
+EOF
+chmod +x "$MOCK_TSX"
+printf 'console.log("hook");\n' > "$TS_FILE"
+cat > "$TS_SHIM" <<EOF
+#!/bin/bash
+source "$HOOKS_DIR/lib/run-tsx.sh"
+run_tsx "$REPO_ROOT" "$TS_FILE"
+EOF
+chmod +x "$TS_SHIM"
+
+TS_OUTPUT=$(KAIZEN_TELEMETRY_DIR="$TS_TELEMETRY_DIR" KAIZEN_TSX_BIN="$MOCK_TSX" bash "$TS_SHIM" 2>&1)
+TS_EXIT=$?
+
+TS_LINE=$(tail -1 "$TS_TELEMETRY_DIR/hooks.jsonl" 2>/dev/null || true)
+TS_HOOK=$(echo "$TS_LINE" | jq -r '.hook // empty' 2>/dev/null)
+TS_EXIT_RECORDED=$(echo "$TS_LINE" | jq -r '.exit_code // empty' 2>/dev/null)
+assert_eq "run_tsx emits telemetry for the caller hook" "sample-ts-hook" "$TS_HOOK"
+assert_eq "run_tsx preserves TS runner exit status" "7" "$TS_EXIT"
+assert_eq "run_tsx records TS runner exit status" "7" "$TS_EXIT_RECORDED"
+assert_contains "run_tsx preserves TS runner stdout" "tsx stdout:$TS_FILE" "$TS_OUTPUT"
+assert_contains "run_tsx preserves TS runner stderr" "tsx stderr:$TS_FILE" "$TS_OUTPUT"
+
+# Phase 11: Previously missing non-TS hooks emit telemetry
+echo ""
+echo "--- Phase 11: Non-TS hook telemetry emission ---"
+
+BASH_TELEMETRY_DIR=$(mktemp -d)
+echo '{"tool_input":{"command":"echo noop"}}' | \
+  KAIZEN_TELEMETRY_DIR="$BASH_TELEMETRY_DIR" bash "$HOOKS_DIR/kaizen-search-before-file.sh" >/dev/null 2>&1
+
+BASH_LINE=$(tail -1 "$BASH_TELEMETRY_DIR/hooks.jsonl" 2>/dev/null || true)
+BASH_HOOK=$(echo "$BASH_LINE" | jq -r '.hook // empty' 2>/dev/null)
+BASH_EXIT_RECORDED=$(echo "$BASH_LINE" | jq -r '.exit_code // empty' 2>/dev/null)
+assert_eq "kaizen-search-before-file emits telemetry" "kaizen-search-before-file" "$BASH_HOOK"
+assert_eq "kaizen-search-before-file records exit status" "0" "$BASH_EXIT_RECORDED"
+
+# Phase 12: Every registered plugin hook has telemetry coverage
+echo ""
+echo "--- Phase 12: Registered hook telemetry coverage ---"
+
+REGISTERED_HOOKS=$(jq -r '
+  .. | objects | select(.type? == "command") | .command
+  | select(contains(".claude/hooks/"))
+  | sub("^.*\\.claude/hooks/"; ".claude/hooks/")
+  | split(" ")[0]
+' "$REPO_ROOT/.claude-plugin/plugin.json" | sort -u)
+
+RUN_TSX_HAS_TELEMETRY=0
+grep -q 'hook-telemetry.sh' "$HOOKS_DIR/lib/run-tsx.sh" && RUN_TSX_HAS_TELEMETRY=1
+
+MISSING_COVERAGE=()
+while IFS= read -r hook; do
+  [ -z "$hook" ] && continue
+  hook_path="$REPO_ROOT/$hook"
+  if grep -q 'hook-telemetry.sh' "$hook_path"; then
+    continue
+  fi
+  if [ "$RUN_TSX_HAS_TELEMETRY" -eq 1 ] && grep -qE '\brun_tsx\b' "$hook_path"; then
+    continue
+  fi
+  MISSING_COVERAGE+=("$hook")
+done <<< "$REGISTERED_HOOKS"
+
+if [ "${#MISSING_COVERAGE[@]}" -eq 0 ]; then
+  echo "  PASS: all registered plugin hooks have telemetry coverage"
+  ((PASS++))
+else
+  echo "  FAIL: registered plugin hooks missing telemetry coverage"
+  printf '    %s\n' "${MISSING_COVERAGE[@]}"
+  FAILED_NAMES+=("registered hook telemetry coverage")
   ((FAIL++))
 fi
 


### PR DESCRIPTION
Closes #1651
Parent: #451
Refs: #454, #930

## Story

Hook telemetry existed, and every day `scripts/hook-telemetry-summary.sh` could rank hook runtime from `.kaizen/telemetry/hooks.jsonl`. One day the #1651 audit compared that telemetry surface to `.claude-plugin/plugin.json` and found the report was only seeing 8 of 27 registered hook files.

Because of that, this PR makes the registered surface measurable. TypeScript hook shims now pick up telemetry through the shared `run_tsx` trampoline, and the remaining non-TS registered bash hooks source `hook-telemetry.sh` directly.

Because of that, the telemetry tests now parse plugin registrations and fail with the exact missing hook list when a registered `.claude/hooks/*.sh` entry lacks telemetry coverage. They also prove representative TS and bash hooks write JSONL rows with the expected hook name and exit status.

Until finally, the same coverage audit that started at `covered=8 missing=19` now reports `covered=27 missing=0`, and the full hook suite passes.

## Impact (goal -> before/after -> match)

- Goal (#1651): make hook execution telemetry cover every registered `.claude-plugin/plugin.json` hook command that resolves to `.claude/hooks/*.sh`, without copying timing logic into every TS shim.
- Acceptance signal: plugin registration audit has zero missing hook files, representative TS and bash hooks emit JSONL, and the hook suite passes.
- BEFORE: `registered_commands=32 unique_hook_files=27 covered=8 missing=19`; live telemetry summary had 4,257 rows but only 8 hook names.
- AFTER: `registered_commands=32 unique_hook_files=27 covered=27 missing=0`; temp JSONL rows include `kaizen-search-before-file` and `kaizen-prehook-no-verify`.
- Delta: +19 registered hook files covered; TS shims covered through one trampoline instead of per-shim telemetry boilerplate.
- Goal met?: yes.
- Residual scan: cross-session trends, anomaly detection, and Bun runtime benchmarking remain out of scope per #1651 and stay with the #451/#454/#930 backlog.

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Complete registered hook telemetry coverage | #1651 baseline audit: `covered=8 missing=19` | Local audit on this branch: `registered_commands=32 unique_hook_files=27 covered=27 missing=0` | All 27 registered hook files have direct or shared telemetry coverage | yes |
| TS shim telemetry without duplicated shim logic | Missing list included 14 TS-style shims such as `kaizen-prehook-no-verify.sh` | Temp JSONL sample: `{hook:"kaizen-prehook-no-verify", exit_code:0}` | TS wrappers are measured through `run_tsx` with wrapper hook names | yes |
| Previously invisible bash hooks become visible | Missing list included `kaizen-search-before-file.sh` | Temp JSONL sample: `{hook:"kaizen-search-before-file", exit_code:0}` | Representative non-TS hook writes telemetry | yes |

## Architecture

```text
.claude-plugin/plugin.json
  -> registered .claude/hooks/*.sh commands
      -> direct bash hook: source lib/hook-telemetry.sh
      -> TS shim: source lib/run-tsx.sh
            -> source lib/hook-telemetry.sh with outer shim name
            -> run tsx child, preserve stdout/stderr/status, exit same code

.claude/hooks/tests/test-hook-telemetry.sh
  -> parses plugin registrations
  -> verifies direct or run_tsx coverage
  -> exercises representative JSONL emission
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Put TS telemetry in `lib/run-tsx.sh` | All TS shims already share this trampoline, so one path covers the TS hook surface. | `run_tsx` must run the TS child and `exit $?` instead of `exec`, otherwise the telemetry `EXIT` trap cannot emit. Tests pin stdout, stderr, and exit status preservation. |
| Allow explicit `KAIZEN_HOOK_TELEMETRY_NAME` | Telemetry sourced from a shared helper should record the outer shim name, not `run-tsx`. | Adds one small override contract to `hook-telemetry.sh`. |
| Add direct telemetry only to remaining non-TS registered hooks | Non-TS hooks do not all share the TS trampoline. | A few one-line hook edits remain necessary. |
| Make plugin registration coverage a test invariant | The previous failure was silent drift between registration and telemetry. | The test parses `plugin.json`, so registration structure changes must keep the parser honest. |

## What's In This PR

| File | Purpose |
|---|---|
| `.claude/hooks/lib/run-tsx.sh` | Sources telemetry for TS hook shims and preserves child process output/status without `exec`. |
| `.claude/hooks/lib/hook-telemetry.sh` | Supports explicit hook-name override for shared trampoline attribution. |
| `.claude/hooks/kaizen-block-self-plugin-enable.sh` | Adds direct telemetry coverage. |
| `.claude/hooks/kaizen-pr-kaizen-clear-fallback.sh` | Adds direct telemetry coverage and replaces `exec node` with run-and-exit so telemetry can emit. |
| `.claude/hooks/kaizen-search-before-file.sh` | Adds direct telemetry coverage. |
| `.claude/hooks/kaizen-session-snapshot.sh` | Adds direct telemetry coverage. |
| `.claude/hooks/kaizen-worktree-setup.sh` | Adds direct telemetry coverage. |
| `.claude/hooks/tests/test-hook-telemetry.sh` | Adds TS shim emission, non-TS emission, and registered coverage invariant tests. |

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration/System | Reality Proof |
|---|---|---|---|
| Registered hook coverage cannot regress | `.claude/hooks/tests/test-hook-telemetry.sh` parses `.claude-plugin/plugin.json`, resolves unique `.claude/hooks/*.sh` commands, and fails with a missing list when any registered hook lacks direct telemetry or shared `run_tsx` coverage. | `npm run test:hooks` auto-discovers the telemetry test with the rest of the hook suite. | Coverage audit reports `registered_commands=32 unique_hook_files=27 covered=27 missing=0`. |
| TS hook shims emit telemetry through shared trampoline | Telemetry test creates a fake TS shim that sources `lib/run-tsx.sh` and asserts the JSONL hook name is the caller shim, not the trampoline. | Same test runs a fake `KAIZEN_TSX_BIN` and asserts stdout, stderr, nonzero exit code, and recorded `exit_code` are preserved. Existing `test-run-tsx.sh` keeps resolver/fail-open behavior pinned. | Temp telemetry run for `kaizen-prehook-no-verify.sh` writes `{hook:"kaizen-prehook-no-verify", exit_code:0}`. |
| Previously invisible non-TS hooks emit telemetry | Telemetry test runs `kaizen-search-before-file.sh` with benign input and asserts a JSONL row plus exit status. | `npm run test:hooks` runs existing tests for the edited hooks, including search-before-file and pr-kaizen-clear-fallback. | Temp telemetry run for `kaizen-search-before-file.sh` writes `{hook:"kaizen-search-before-file", exit_code:0}`. |
| Telemetry remains valid JSONL and can be disabled | Existing telemetry tests validate required fields, append behavior, disabled mode, nonnegative duration, and valid JSON lines. | Full hook suite covers shell hook contracts under isolated state/audit dirs. | Live summary/audit can now observe all registered hook files instead of only the previous 8-hook subset. |

## Validation

- [x] `bash .claude/hooks/tests/test-hook-telemetry.sh` -> 21 passed, 0 failed
- [x] `bash .claude/hooks/tests/test-run-tsx.sh` -> 7 passed, 0 failed
- [x] `npm run test:hooks` -> 447 passed, 0 failed
- [x] `npm run typecheck` -> passed
- [x] `npm run test:fast` -> no changed Vitest files, exited 0
- [x] Coverage audit -> `registered_commands=32 unique_hook_files=27 covered=27 missing=0`
- [x] Temp telemetry rows -> `kaizen-search-before-file` and `kaizen-prehook-no-verify`

## Known Limitations

- This does not add trend analysis, anomaly detection, or runtime benchmarking.
- Early exits before a hook reaches its sourced helpers remain fail-open by design when required libraries are missing.
