### PR TITLE
fix(hooks): catch root checkout drift from worktrees

### DIFF
--- a/.claude/hooks/kaizen-enforce-case-worktree.sh
+++ b/.claude/hooks/kaizen-enforce-case-worktree.sh
@@ -1,29 +1,126 @@
 #!/bin/bash
 # Part of kAIzen Agent Control Flow — see .agents/kaizen/README.md
-# enforce-case-worktree.sh — Advisory early warning
+# enforce-case-worktree.sh — Worktree boundary guard
 # Warns when git commit/push is attempted outside a worktree.
+# Denies Bash commands from a linked worktree when the main checkout has dirty
+# source files, catching patch-style edits that landed in the wrong checkout.
 # Real enforcement is in git hooks (.husky/pre-commit, .husky/pre-push).
 #
 # Runs as PreToolUse hook on Bash tool calls.
-# Always exits 0 (advisory only — never blocks).
 
-source "$(dirname "$0")/lib/input-utils.sh" 2>/dev/null || { exit 0; }
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+source "$HOOK_DIR/lib/input-utils.sh" 2>/dev/null || { exit 0; }
 
 read_hook_input
 get_command
 
-# Only check git commit and git push commands
-if ! echo "$COMMAND" | grep -qE '^\s*git\s+(commit|push)'; then
+source "$HOOK_DIR/lib/scope-guard.sh"
+source "$HOOK_DIR/lib/hook-telemetry.sh" 2>/dev/null || true
+source "$HOOK_DIR/lib/hook-output.sh" 2>/dev/null || { exit 0; }
+source "$HOOK_DIR/lib/allowlist.sh" 2>/dev/null || { exit 0; }
+
+is_linked_git_worktree() {
+  GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || true)
+  GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || true)
+  [ -n "$GIT_DIR" ] && [ -n "$GIT_COMMON" ] && [ "$GIT_DIR" != "$GIT_COMMON" ]
+}
+
+resolve_main_checkout_root() {
+  local worktree_root common_dir common_abs
+  worktree_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+
+  [ -n "$worktree_root" ] || return 1
+  [ -n "$common_dir" ] || return 1
+
+  if echo "$common_dir" | grep -qE '^/'; then
+    common_abs=$(realpath -m "$common_dir" 2>/dev/null || echo "$common_dir")
+  else
+    common_abs=$(cd "$worktree_root" 2>/dev/null && realpath -m "$common_dir" 2>/dev/null) || return 1
+  fi
+
+  if [ "$(basename "$common_abs")" = ".git" ]; then
+    dirname "$common_abs"
+    return 0
+  fi
+
+  return 1
+}
+
+dirty_root_source_files() {
+  local main_root="$1"
+  local line rel_path
+  ROOT_SOURCE_DIRTY_FILES=()
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+
+    rel_path="${line:3}"
+    if echo "$rel_path" | grep -q ' -> '; then
+      rel_path="${rel_path##* -> }"
+    fi
+
+    [ -n "$rel_path" ] || continue
+    if is_allowed_runtime_dir "$rel_path"; then
+      continue
+    fi
+
+    ROOT_SOURCE_DIRTY_FILES+=("$rel_path")
+  done < <(git -C "$main_root" status --porcelain --untracked-files=all 2>/dev/null)
+
+  [ "${#ROOT_SOURCE_DIRTY_FILES[@]}" -gt 0 ]
+}
+
+deny_root_source_drift_if_needed() {
+  local main_root worktree_root file_count file_list limit idx reason
+
+  main_root=$(resolve_main_checkout_root) || return 0
+  worktree_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  [ -n "$worktree_root" ] || return 0
+  [ "$main_root" != "$worktree_root" ] || return 0
+
+  if ! dirty_root_source_files "$main_root"; then
+    return 0
+  fi
+
+  file_count="${#ROOT_SOURCE_DIRTY_FILES[@]}"
+  limit="$file_count"
+  [ "$limit" -gt 8 ] && limit=8
+
+  file_list=""
+  for ((idx = 0; idx < limit; idx++)); do
+    file_list="${file_list}
+  - ${ROOT_SOURCE_DIRTY_FILES[$idx]}"
+  done
+  if [ "$file_count" -gt "$limit" ]; then
+    file_list="${file_list}
+  - ... $((file_count - limit)) more"
+  fi
+
+  reason="BLOCKED: root checkout has dirty source files while this session is running from a case worktree.
+
+Current worktree:
+  $worktree_root
+
+Root checkout:
+  $main_root
+
+Dirty root source files:${file_list}
+
+Patch-style tools can target the root checkout when the path is not anchored to the case worktree. Move or reapply these changes into the current worktree, or clean the root checkout, before continuing."
+
+  emit_deny "$reason"
+}
+
+if is_linked_git_worktree; then
+  deny_root_source_drift_if_needed
+  # Worktree command context is valid once the root checkout is clean.
   exit 0
 fi
 
-source "$(dirname "$0")/lib/scope-guard.sh"
-source "$(dirname "$0")/lib/hook-telemetry.sh" 2>/dev/null || true
-
-# Allow if running inside a git worktree
-GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
-GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
-if [ -n "$GIT_DIR" ] && [ -n "$GIT_COMMON" ] && [ "$GIT_DIR" != "$GIT_COMMON" ]; then
+# Only warn for git commit and git push commands in the main checkout.
+if ! echo "$COMMAND" | grep -qE '^\s*git\s+(commit|push)'; then
   exit 0
 fi
 

--- a/.claude/hooks/tests/test-enforce-case-worktree.sh
+++ b/.claude/hooks/tests/test-enforce-case-worktree.sh
@@ -4,7 +4,8 @@
 #
 # INVARIANT: git commit/push inside a git worktree are ALLOWED.
 # INVARIANT: git commit/push outside a worktree (main checkout) produce a warning on stderr.
-# INVARIANT: Non-git-commit/push commands are always ALLOWED regardless of location.
+# INVARIANT: Non-git-commit/push commands are ALLOWED unless a case worktree
+#            detects dirty source files in the root checkout.
 # SUT: kaizen-enforce-case-worktree.sh
 
 set -u
@@ -20,21 +21,30 @@ trap 'rm -rf "$MOCK_DIR"' EXIT
 # Helper: mock git to simulate being inside a worktree
 # In a worktree, --git-dir and --git-common-dir return different paths
 setup_worktree_mock() {
-  cat > "$MOCK_DIR/git" << 'MOCK'
+  local root_status="${1:-}"
+  cat > "$MOCK_DIR/git" << MOCK
 #!/bin/bash
-if echo "$@" | grep -q "rev-parse --git-dir"; then
+if echo "\$@" | grep -q "rev-parse --git-dir"; then
   echo "/repo/.git/worktrees/my-worktree"
   exit 0
 fi
-if echo "$@" | grep -q "rev-parse --git-common-dir"; then
+if echo "\$@" | grep -q "rev-parse --git-common-dir"; then
   echo "/repo/.git"
   exit 0
 fi
-if echo "$@" | grep -q "rev-parse --abbrev-ref HEAD"; then
-  echo "some-branch"
+if echo "\$@" | grep -q "rev-parse --show-toplevel"; then
+  echo "/repo/.claude/worktrees/my-worktree"
   exit 0
 fi
-/usr/bin/git "$@"
+if echo "\$@" | grep -q "rev-parse --abbrev-ref HEAD"; then
+  echo "case/260629-k1631-root-patch-drift"
+  exit 0
+fi
+if [ "\$1" = "-C" ] && [ "\$2" = "/repo" ] && echo "\$@" | grep -q "status --porcelain"; then
+  printf '%b' "$root_status"
+  exit 0
+fi
+/usr/bin/git "\$@"
 MOCK
   chmod +x "$MOCK_DIR/git"
 }
@@ -93,6 +103,33 @@ assert_eq "push allowed in worktree" "" "$OUTPUT"
 
 OUTPUT=$(run_hook "$HOOK" "git push -u origin my-branch")
 assert_eq "push -u allowed in worktree" "" "$OUTPUT"
+
+echo ""
+echo "=== Inside a worktree: root checkout source drift is denied ==="
+
+setup_worktree_mock " M src/root-drift.ts\n?? package-lock.json\n"
+
+OUTPUT=$(run_hook "$HOOK" "npm test")
+assert_contains "root drift emits deny JSON" "permissionDecision" "$OUTPUT"
+assert_contains "root drift denial mentions root checkout" "root checkout has dirty source files" "$OUTPUT"
+assert_contains "root drift denial lists source file" "src/root-drift.ts" "$OUTPUT"
+assert_contains "root drift denial mentions active worktree" "/repo/.claude/worktrees/my-worktree" "$OUTPUT"
+
+echo ""
+echo "=== Inside a worktree: runtime-only root dirt is allowed ==="
+
+setup_worktree_mock " M .claude/settings.json\n?? logs/run.log\n"
+
+OUTPUT=$(run_hook "$HOOK" "npm test")
+assert_eq "runtime-only root dirt allowed" "" "$OUTPUT"
+
+echo ""
+echo "=== Inside a worktree: clean root allows normal commands ==="
+
+setup_worktree_mock
+
+OUTPUT=$(run_hook "$HOOK" "npm test")
+assert_eq "clean root normal command allowed" "" "$OUTPUT"
 
 echo ""
 echo "=== Outside a worktree (main checkout): commit and push produce warnings ==="


### PR DESCRIPTION
## Summary

Closes #1631.

This adds a worktree-boundary guard to the Bash PreToolUse hook. When a session is running from a linked worktree, the hook now resolves the shared main checkout from Git's common dir, checks the root checkout status, filters allowed runtime paths through the existing allowlist, and denies the next Bash command if root source files are dirty.

The denial message names the current worktree, the root checkout, and the dirty root source files so a patch that landed in the wrong checkout is visible immediately after the edit.

## Changes

- Extend  beyond commit/push advisory behavior for linked worktrees.
- Add root-checkout dirty source detection with runtime directory filtering.
- Preserve existing main-checkout commit/push warnings and normal clean-worktree behavior.
- Add regression coverage for source drift denial, runtime-only root dirt allowance, and clean-root worktree commands.

## Verification

RED before implementation:
- === Non-git-commit/push commands are always allowed ===
  PASS: npm command allowed in main checkout
  PASS: git status allowed in main checkout
  PASS: git add allowed in main checkout
  PASS: git diff allowed in main checkout
  PASS: git log allowed in main checkout

=== Inside a worktree: commit and push are ALLOWED ===
  PASS: commit allowed in worktree
  PASS: push allowed in worktree
  PASS: push -u allowed in worktree

=== Inside a worktree: root checkout source drift is denied ===
  PASS: root drift emits deny JSON
  PASS: root drift denial mentions root checkout
  PASS: root drift denial lists source file
  PASS: root drift denial mentions active worktree

=== Inside a worktree: runtime-only root dirt is allowed ===
  PASS: runtime-only root dirt allowed

=== Inside a worktree: clean root allows normal commands ===
  PASS: clean root normal command allowed

=== Outside a worktree (main checkout): commit and push produce warnings ===
  PASS: commit warned in main checkout
  PASS: commit warning mentions main checkout
  PASS: push warned in main checkout
  PASS: push -u warned in main checkout

=== Branch name doesn't matter — only worktree context ===
  PASS: main checkout warned regardless of branch name
  PASS: worktree allowed regardless of branch name

================================
Results: 20 passed, 0 failed
All tests passed. failed 4 assertions because root checkout source drift produced no deny output.

GREEN after implementation:
- === Non-git-commit/push commands are always allowed ===
  PASS: npm command allowed in main checkout
  PASS: git status allowed in main checkout
  PASS: git add allowed in main checkout
  PASS: git diff allowed in main checkout
  PASS: git log allowed in main checkout

=== Inside a worktree: commit and push are ALLOWED ===
  PASS: commit allowed in worktree
  PASS: push allowed in worktree
  PASS: push -u allowed in worktree

=== Inside a worktree: root checkout source drift is denied ===
  PASS: root drift emits deny JSON
  PASS: root drift denial mentions root checkout
  PASS: root drift denial lists source file
  PASS: root drift denial mentions active worktree

=== Inside a worktree: runtime-only root dirt is allowed ===
  PASS: runtime-only root dirt allowed

=== Inside a worktree: clean root allows normal commands ===
  PASS: clean root normal command allowed

=== Outside a worktree (main checkout): commit and push produce warnings ===
  PASS: commit warned in main checkout
  PASS: commit warning mentions main checkout
  PASS: push warned in main checkout
  PASS: push -u warned in main checkout

=== Branch name doesn't matter — only worktree context ===
  PASS: main checkout warned regardless of branch name
  PASS: worktree allowed regardless of branch name

================================
Results: 20 passed, 0 failed
All tests passed. -> 20 passed
- Hook Test Suite
===============
Discovered 24 unit tests, 4 integration tests
Running all tests...
Running shell test files with 8 parallel jobs...

━━━ test-allowlist ━━━
  RESULT: 59 passed, 0 failed

━━━ test-block-git-rebase ━━━
  RESULT: 18 passed, 0 failed

━━━ test-block-self-plugin-enable ━━━
  RESULT: 7 passed, 0 failed

━━━ test-capture-worktree-context ━━━
  RESULT: 18 passed, 0 failed

━━━ test-capture-worktree-runtag ━━━
  RESULT: 4 passed, 0 failed

━━━ test-check-cleanup-on-stop ━━━
  RESULT: 19 passed, 0 failed

━━━ test-check-wip ━━━
  RESULT: 18 passed, 0 failed

━━━ test-enforce-case-exists ━━━
  RESULT: 17 passed, 0 failed

━━━ test-enforce-case-worktree ━━━
  RESULT: 20 passed, 0 failed

━━━ test-enforce-worktree-writes ━━━
  RESULT: 13 passed, 0 failed

━━━ test-hook-telemetry ━━━
  RESULT: 21 passed, 0 failed

━━━ test-issue-repo-routing ━━━
  RESULT: 12 passed, 0 failed

━━━ test-parse-command ━━━
  RESULT: 46 passed, 0 failed

━━━ test-pr-kaizen-clear-fallback ━━━
  RESULT: 9 passed, 0 failed

━━━ test-pre-push-wrapper ━━━
  RESULT: 0 passed, 0 failed

━━━ test-prehook-no-verify ━━━
  RESULT: 0 passed, 0 failed

━━━ test-resilient-source ━━━
  RESULT: 5 passed, 0 failed

━━━ test-resolve-cli-kaizen ━━━
  RESULT: 15 passed, 0 failed

━━━ test-run-tsx ━━━
  RESULT: 7 passed, 0 failed

━━━ test-search-before-file ━━━
  RESULT: 19 passed, 0 failed

━━━ test-tsx-exec ━━━
  RESULT: 9 passed, 0 failed

━━━ test-validate-hook-integrity ━━━
  RESULT: 12 passed, 0 failed

━━━ test-verify-before-stop ━━━
  RESULT: 11 passed, 0 failed

━━━ test-worktree-setup-leak ━━━
  RESULT: 16 passed, 0 failed

━━━ test-integration-parallel-hooks ━━━
  RESULT: 4 passed, 0 failed

━━━ test-integration-test-isolation ━━━
  RESULT: 9 passed, 0 failed

━━━ test-schema-validation ━━━
  RESULT: 12 passed, 0 failed

━━━ test-worktree-context-integration ━━━
  RESULT: 15 passed, 0 failed

━━━ test_hooks.py (pytest) ━━━
  RESULT: 38 passed, 0 failed

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
TOTAL: 453 tests, 453 passed, 0 failed
All tests passed. -> 453 passed
- 
> @garsson-io/kaizen@0.1.0 typecheck
> tsc --noEmit -> pass
- 
> @garsson-io/kaizen@0.1.0 test:fast
> timeout --kill-after=10 60 vitest run --changed origin/main --passWithNoTests --exclude 'src/e2e/**' --exclude '**/*.e2e.test.ts'


 RUN  v4.1.9 /home/aviad/projects/kaizen/.claude/worktrees/260629-k1631-root-patch-drift

No test files found, exiting with code 0 -> no changed Vitest files, exit 0
- 
> @garsson-io/kaizen@0.1.0 test
> timeout --kill-after=10 120 vitest run


 RUN  v4.1.9 /home/aviad/projects/kaizen/.claude/worktrees/260629-k1631-root-patch-drift


 Test Files  177 passed | 2 skipped (179)
      Tests  4231 passed | 14 skipped (4245)
   Start at  05:48:35
   Duration  15.53s (transform 158.96s, setup 0ms, import 230.14s, tests 140.66s, environment 26ms) -> 4,231 passed, 14 skipped
-  -> pass

Reality smoke check:
- Created a temporary source file in the root checkout while invoking the hook from this case worktree.
- Hook emitted PreToolUse deny listing the real case worktree path, root checkout path, and dirty root source file.
- Temporary file was removed and root checkout returned clean.