### PR TITLE
fix(hooks): require stored review verdict before merge

### DIFF
--- a/scripts/review-verdict-status.test.ts
+++ b/scripts/review-verdict-status.test.ts
@@ -18,8 +18,11 @@ describe('decideReviewVerdictStatus', () => {
     expect(decideReviewVerdictStatus(1, 'PASS_WITH_PARTIALS').outcome).toBe('pass');
   });
 
-  it('does not fail when no stored review data exists', () => {
-    expect(decideReviewVerdictStatus(0, null).outcome).toBe('no_data');
+  it('fails when no stored review data exists', () => {
+    const status = decideReviewVerdictStatus(0, null);
+    expect(status.outcome).toBe('fail');
+    expect(status.message).toContain('No stored review rounds found');
+    expect(status.message).toContain('merge is blocked');
   });
 });
 
@@ -84,7 +87,7 @@ describe('getReviewVerdictStatus', () => {
     expect(derive).toHaveBeenCalledWith({ kind: 'pr', number: '1498', repo: 'Garsson-io/kaizen' }, 2);
   });
 
-  it('does not read a round verdict when no review rounds exist', () => {
+  it('fails closed and does not read a round verdict when no review rounds exist', () => {
     const authoritative = vi.fn(() => 0);
     const derive = vi.fn(() => 'FAIL' as const);
 
@@ -93,7 +96,7 @@ describe('getReviewVerdictStatus', () => {
       deriveStoredRoundVerdict: derive,
     });
 
-    expect(status.outcome).toBe('no_data');
+    expect(status.outcome).toBe('fail');
     expect(derive).not.toHaveBeenCalled();
   });
 });

--- a/scripts/review-verdict-status.ts
+++ b/scripts/review-verdict-status.ts
@@ -16,7 +16,7 @@ import {
 import type { RoundVerdict } from '../src/review-finding-contract.js';
 
 export interface ReviewVerdictStatus {
-  outcome: 'pass' | 'fail' | 'no_data';
+  outcome: 'pass' | 'fail';
   message: string;
   round: number;
   verdict: RoundVerdict | null;
@@ -25,8 +25,8 @@ export interface ReviewVerdictStatus {
 export function decideReviewVerdictStatus(round: number, verdict: RoundVerdict | null): ReviewVerdictStatus {
   if (round === 0 || verdict === null) {
     return {
-      outcome: 'no_data',
-      message: 'No stored review rounds found; review verdict gate has no failing verdict to block.',
+      outcome: 'fail',
+      message: 'No stored review rounds found; merge is blocked until /kaizen-review-pr stores an authoritative PASS review round.',
       round,
       verdict: null,
     };

--- a/src/hooks/enforce-merge-verdict.test.ts
+++ b/src/hooks/enforce-merge-verdict.test.ts
@@ -93,8 +93,11 @@ describe('decideMergeGate', () => {
     expect(decideMergeGate('PASS_WITH_PARTIALS', { override: false, target }).action).toBe('allow');
   });
 
-  it('warns without blocking when no review data exists', () => {
-    expect(decideMergeGate(null, { override: false, target }).action).toBe('warn');
+  it('denies without stored review data', () => {
+    const result = decideMergeGate(null, { override: false, target });
+    expect(result.action).toBe('deny');
+    expect(result.message).toContain('No stored review rounds found');
+    expect(result.message).toContain('MERGE BLOCKED');
   });
 
   it('allows FAIL under an explicit override and marks it bypassed', () => {
@@ -140,11 +143,11 @@ describe('checkMergeVerdict', () => {
     }).action).toBe('allow');
   });
 
-  it('warns when there are no review rounds', () => {
+  it('blocks when there are no review rounds', () => {
     expect(checkMergeVerdict('gh pr merge 999 --repo Garsson-io/kaizen', {
       readVerdict: noDataReader,
       env: {},
-    }).action).toBe('warn');
+    }).action).toBe('deny');
   });
 
   it('honours the explicit override env on FAIL', () => {

--- a/src/hooks/enforce-merge-verdict.ts
+++ b/src/hooks/enforce-merge-verdict.ts
@@ -122,10 +122,13 @@ This gate binds the stored review verdict to the irreversible merge step.`,
 
   if (verdict === null) {
     return {
-      action: 'warn',
-      message:
-        `[enforce-merge-verdict] No stored review rounds found for ${prRef}; ` +
-        `merge-verdict gate is advisory for this invocation.`,
+      action: 'deny',
+      message: `MERGE BLOCKED: No stored review rounds found for ${prRef}.
+
+Run /kaizen-review-pr for this PR, store findings for every applicable
+dimension, and store the derived review summary before merging.
+
+This gate requires a durable authoritative review verdict on the PR itself.`,
     };
   }
 
@@ -182,13 +185,18 @@ async function main(): Promise<void> {
   }
 
   const result = checkMergeVerdict(input.tool_input?.command ?? '');
+  const reason = result.bypassed
+    ? 'override'
+    : result.action === 'deny'
+      ? result.verdict === null ? 'missing_review_verdict' : 'fail_verdict'
+      : result.action;
   traceHookEvent('enforce-merge-verdict', {
     action: result.action,
     bypassed: result.bypassed ?? false,
     pr: result.target?.pr,
     repo: result.target?.repo,
     verdict: result.verdict,
-    reason: result.bypassed ? 'override' : result.action === 'deny' ? 'fail_verdict' : result.action,
+    reason,
   });
   if (result.action === 'deny') {
     process.stdout.write(JSON.stringify({


### PR DESCRIPTION
Closes #462

## Story

PR review artifacts are supposed to be durable records on the PR itself. One day, while closing #1651 through PR #1653, the PR merged before any structured review findings or summary existed. Immediately after merge, `list-review-dims --pr 1653 --round 1` returned `No dimensions found`, while the Review verdict gate had already passed.

Because of that, this PR makes absence of review data a blocking state, not an advisory state. The GitHub Actions review verdict status and the direct `gh pr merge` PreToolUse hook now both fail closed for resolvable PRs with no authoritative stored review round.

Because of that, a clean review must be posted and summarized before merge. PASS and PASS_WITH_PARTIALS continue to allow, FAIL continues to block, and ambiguous read/target failures remain advisory so network or parsing ambiguity does not strand users.

## Impact (goal -> before/after -> match)

- Goal (#462): require a durable clean review artifact on the PR before merge.
- Acceptance signal: no stored review round blocks both the CI review verdict gate and direct `gh pr merge` hook decision.
- BEFORE: `decideReviewVerdictStatus(0, null)` returned `outcome: no_data` and exited 0; `decideMergeGate(null)` returned `action: warn`.
- AFTER: `decideReviewVerdictStatus(0, null)` returns `outcome: fail`; `decideMergeGate(null)` returns `action: deny` with `MERGE BLOCKED` guidance.
- Delta: missing review data moved from safe/advisory to terminal blocking for resolvable PRs.
- Goal met?: yes.
- Residual scan: branch protection configuration and full review-loop UX are broader than this PR; the code-level merge/status gates now enforce the #462 invariant.

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Block merge with no stored review round | #1653 merged with no review dims/summary; unit tests expected `no_data`/`warn` | Direct proof: CI decision `outcome: fail`; hook decision `action: deny` | No-review state is no longer merge-safe | yes |
| Preserve clean review behavior | Existing PASS/PASS_WITH_PARTIALS tests | Same tests still pass | Clean stored review still allows | yes |
| Preserve failed review blocking | Existing FAIL tests | Same tests still pass | Failed stored review still blocks | yes |

## Architecture

```text
GitHub Actions: Review verdict gate
  -> scripts/review-verdict-status.ts
      -> authoritativeReviewRound(pr)
      -> deriveStoredRoundVerdict(pr, round)
      -> fail when round=0 or verdict=null

Claude PreToolUse: gh pr merge
  -> .claude/hooks/kaizen-enforce-merge-verdict-ts.sh
      -> src/hooks/enforce-merge-verdict.ts
      -> deny when resolvable PR has verdict=null
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Fail closed on `round=0` / `verdict=null` | #462 is specifically about PRs merging without a durable clean review artifact. | A new PR will show a failing review verdict check until review findings and summary are stored. |
| Keep read errors advisory | A network/API/cache failure is different from a confirmed no-review state. | A rare transient read failure can still warn instead of block; this PR fixes confirmed absence, not all infrastructure ambiguity. |
| Keep explicit FAIL override behavior | Existing emergency override path remains intentional and logged. | No override was added for missing review data; that can be designed separately if needed. |
| Do not add a new policy module | Existing status/action contracts are enough for this small slice. | Messages are aligned by intent rather than a shared formatter. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/review-verdict-status.ts` | Makes no stored review round a failing CI status outcome. |
| `scripts/review-verdict-status.test.ts` | Pins fail-closed no-review behavior and no verdict derivation when no round exists. |
| `src/hooks/enforce-merge-verdict.ts` | Denies direct `gh pr merge` when a resolvable PR has no stored review verdict. |
| `src/hooks/enforce-merge-verdict.test.ts` | Pins no-review denial while preserving PASS/FAIL/override behavior. |

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration/System | Reality Proof |
|---|---|---|---|
| CI review verdict gate blocks PRs with no stored review round | `scripts/review-verdict-status.test.ts` asserts `decideReviewVerdictStatus(0, null)` returns `fail` and no-round readers do not derive verdicts. | Existing workflow calls `npx tsx scripts/review-verdict-status.ts`; CLI exit mapping remains `outcome === fail ? 1 : 0`, so no-data fail exits non-zero. | Direct proof shows no authoritative round now produces `outcome: fail` instead of `no_data` success. |
| Direct `gh pr merge` hook blocks resolvable PRs with no stored review round | `src/hooks/enforce-merge-verdict.test.ts` asserts `decideMergeGate(null)` and `checkMergeVerdict(...readVerdict: null...)` deny. | Hook wrapper remains registered through `kaizen-enforce-merge-verdict-ts.sh`; full hook suite passed. | Direct proof for PR #999 returns `action: deny` and `MERGE BLOCKED`. |
| Clean review still allows merge | Existing PASS and PASS_WITH_PARTIALS tests stay green for both CI status and merge hook. | Typecheck and changed Vitest validate public contracts. | PASS fixture remains allowed after the fail-closed change. |
| Failed review still blocks, override remains explicit | Existing FAIL tests stay green; explicit override on FAIL remains allowed and marked bypassed. | Focused hook tests prove override behavior remains limited to the existing FAIL path. | FAIL fixture remains blocked; override message still names `KAIZEN_ALLOW_MERGE_ON_FAIL`. |

## Validation

- [x] RED: focused tests initially failed on old `no_data`/`warn` behavior.
- [x] `npx vitest run scripts/review-verdict-status.test.ts src/hooks/enforce-merge-verdict.test.ts` -> 26 passed, 0 failed
- [x] `npm run typecheck` -> passed
- [x] `npm run test:fast` -> 2 files, 26 passed
- [x] `npm run test:hooks` -> 447 passed, 0 failed
- [x] Direct proof: `decideReviewVerdictStatus(0, null)` -> `outcome: fail`; `decideMergeGate(null)` -> `action: deny`
- [x] `git diff --check` -> passed
- [x] Review Round 1 stored -> PASS across 15 dimensions
- [x] PR CI after review-summary retrigger -> all checks passed, including Review verdict gate

## Known Limitations

- This does not change branch protection configuration outside the repo code.
- Review summary comments do not automatically retrigger `pull_request` checks; the existing `workflow_dispatch` path can rerun the Review verdict gate for the head branch after review is stored, and #119 tracks making this smoother.
- Unresolvable PR targets and review-read exceptions still warn rather than deny; this preserves fail-open behavior for infrastructure ambiguity, not confirmed missing review data.