### PR TITLE
test(hooks): isolate symlinked dist during hook tests

### DIFF
--- a/.claude/hooks/tests/run-all-tests.sh
+++ b/.claude/hooks/tests/run-all-tests.sh
@@ -20,8 +20,11 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUNNER_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 MODE="all"
 REQUESTED_JOBS="${KAIZEN_HOOK_TEST_JOBS:-}"
+
+source "$SCRIPT_DIR/runner-dist-isolation.sh"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -101,7 +104,11 @@ export AUDIT_DIR="$GLOBAL_TEST_AUDIT_DIR"
 export AUDIT_LOG="$GLOBAL_TEST_AUDIT_DIR/no-action.log"
 export DEBUG_LOG="/dev/null"
 export KAIZEN_TEST_RUNNER=1
+
+setup_private_dist_if_symlink "$RUNNER_ROOT"
+
 cleanup_global_isolation() {
+  restore_private_dist
   rm -rf "$GLOBAL_TEST_STATE_DIR" "$GLOBAL_TEST_AUDIT_DIR"
 }
 trap cleanup_global_isolation EXIT

--- a/.claude/hooks/tests/runner-dist-isolation.sh
+++ b/.claude/hooks/tests/runner-dist-isolation.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# runner-dist-isolation.sh — private dist handling for hook test runs.
+#
+# Worktree setup intentionally symlinks dist from the main checkout for speed.
+# Hook tests that execute real entrypoints should not measure shared dist
+# contention, so the test runner swaps only symlinked dist directories to a
+# private per-run copy and restores the original symlink on exit.
+
+KAIZEN_HOOK_TEST_DIST_ROOT=""
+KAIZEN_HOOK_TEST_DIST_CHECKOUT=""
+KAIZEN_HOOK_TEST_ORIGINAL_DIST_TARGET=""
+KAIZEN_HOOK_TEST_DIST_ISOLATED=0
+
+setup_private_dist_if_symlink() {
+  local checkout_root="$1"
+  local dist_path="$checkout_root/dist"
+  local original_target target_abs private_dist
+
+  [ "${KAIZEN_HOOK_TEST_ISOLATE_DIST:-1}" != "0" ] || return 0
+  [ -L "$dist_path" ] || return 0
+
+  original_target=$(readlink "$dist_path" 2>/dev/null || true)
+  [ -n "$original_target" ] || return 0
+
+  case "$original_target" in
+    /*) target_abs="$original_target" ;;
+    *) target_abs=$(cd "$checkout_root" 2>/dev/null && realpath -m "$original_target" 2>/dev/null) || return 0 ;;
+  esac
+
+  [ -d "$target_abs" ] || return 0
+
+  KAIZEN_HOOK_TEST_DIST_ROOT=$(mktemp -d "/tmp/.kaizen-hook-test-dist-XXXXXX")
+  private_dist="$KAIZEN_HOOK_TEST_DIST_ROOT/dist"
+  mkdir -p "$private_dist" || return 1
+  cp -a "$target_abs/." "$private_dist/" || {
+    rm -rf "$KAIZEN_HOOK_TEST_DIST_ROOT"
+    KAIZEN_HOOK_TEST_DIST_ROOT=""
+    return 1
+  }
+
+  rm "$dist_path" || {
+    rm -rf "$KAIZEN_HOOK_TEST_DIST_ROOT"
+    KAIZEN_HOOK_TEST_DIST_ROOT=""
+    return 1
+  }
+  ln -s "$private_dist" "$dist_path" || {
+    ln -s "$original_target" "$dist_path" 2>/dev/null || true
+    rm -rf "$KAIZEN_HOOK_TEST_DIST_ROOT"
+    KAIZEN_HOOK_TEST_DIST_ROOT=""
+    return 1
+  }
+
+  KAIZEN_HOOK_TEST_DIST_CHECKOUT="$checkout_root"
+  KAIZEN_HOOK_TEST_ORIGINAL_DIST_TARGET="$original_target"
+  KAIZEN_HOOK_TEST_DIST_ISOLATED=1
+}
+
+restore_private_dist() {
+  local dist_path
+
+  if [ "$KAIZEN_HOOK_TEST_DIST_ISOLATED" = "1" ] && [ -n "$KAIZEN_HOOK_TEST_DIST_CHECKOUT" ]; then
+    dist_path="$KAIZEN_HOOK_TEST_DIST_CHECKOUT/dist"
+    if [ -L "$dist_path" ]; then
+      rm "$dist_path" 2>/dev/null || true
+      ln -s "$KAIZEN_HOOK_TEST_ORIGINAL_DIST_TARGET" "$dist_path" 2>/dev/null || true
+    fi
+  fi
+
+  [ -n "$KAIZEN_HOOK_TEST_DIST_ROOT" ] && rm -rf "$KAIZEN_HOOK_TEST_DIST_ROOT"
+
+  KAIZEN_HOOK_TEST_DIST_ROOT=""
+  KAIZEN_HOOK_TEST_DIST_CHECKOUT=""
+  KAIZEN_HOOK_TEST_ORIGINAL_DIST_TARGET=""
+  KAIZEN_HOOK_TEST_DIST_ISOLATED=0
+}

--- a/.claude/hooks/tests/test-runner-dist-isolation.sh
+++ b/.claude/hooks/tests/test-runner-dist-isolation.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Tests for hook test runner dist isolation.
+# SUT: .claude/hooks/tests/runner-dist-isolation.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+source "$SCRIPT_DIR/runner-dist-isolation.sh"
+
+TMP_ROOT=$(mktemp -d)
+trap 'restore_private_dist 2>/dev/null || true; rm -rf "$TMP_ROOT"' EXIT
+
+echo "=== symlinked dist gets private per-run copy ==="
+
+SHARED_DIST="$TMP_ROOT/shared-dist"
+WORKTREE="$TMP_ROOT/worktree"
+mkdir -p "$SHARED_DIST/hooks" "$WORKTREE"
+printf 'shared\n' > "$SHARED_DIST/hooks/tool.js"
+ln -s "$SHARED_DIST" "$WORKTREE/dist"
+
+setup_private_dist_if_symlink "$WORKTREE"
+
+PRIVATE_TARGET=$(readlink "$WORKTREE/dist")
+assert_not_contains "private dist no longer points at shared target" "$SHARED_DIST" "$PRIVATE_TARGET"
+assert_contains "private dist path names hook test isolation" ".kaizen-hook-test-dist-" "$PRIVATE_TARGET"
+assert_eq "private dist copied existing artifact" "shared" "$(cat "$WORKTREE/dist/hooks/tool.js")"
+
+printf 'private\n' > "$WORKTREE/dist/hooks/private-only.js"
+if [ -f "$SHARED_DIST/hooks/private-only.js" ]; then
+  SHARED_MUTATED="yes"
+else
+  SHARED_MUTATED="no"
+fi
+assert_eq "writes through isolated dist do not mutate shared dist" "no" "$SHARED_MUTATED"
+
+restore_private_dist
+
+assert_eq "restore returns dist symlink to shared target" "$SHARED_DIST" "$(readlink "$WORKTREE/dist")"
+
+echo ""
+echo "=== run-all-tests wires private dist during test execution ==="
+
+RUNNER_ROOT="$TMP_ROOT/runner-root"
+RUNNER_TESTS="$RUNNER_ROOT/.claude/hooks/tests"
+mkdir -p "$RUNNER_TESTS" "$RUNNER_ROOT/shared-dist/hooks"
+printf 'shared\n' > "$RUNNER_ROOT/shared-dist/hooks/tool.js"
+ln -s "$RUNNER_ROOT/shared-dist" "$RUNNER_ROOT/dist"
+cp "$SCRIPT_DIR/run-all-tests.sh" "$RUNNER_TESTS/run-all-tests.sh"
+cp "$SCRIPT_DIR/runner-dist-isolation.sh" "$RUNNER_TESTS/runner-dist-isolation.sh"
+cat > "$RUNNER_TESTS/test-dist-visible.sh" <<'TEST'
+#!/bin/bash
+target=$(readlink dist 2>/dev/null || true)
+if echo "$target" | grep -q ".kaizen-hook-test-dist-" && [ -f dist/hooks/tool.js ]; then
+  printf 'private\n' > dist/hooks/private-only.js
+  echo "  PASS: runner isolated dist during test"
+  echo "Results: 1 passed, 0 failed"
+  exit 0
+fi
+echo "  FAIL: runner did not isolate dist during test"
+echo "Results: 0 passed, 1 failed"
+exit 1
+TEST
+chmod +x "$RUNNER_TESTS/test-dist-visible.sh"
+
+RUNNER_OUTPUT=$(cd "$RUNNER_ROOT" && bash .claude/hooks/tests/run-all-tests.sh --unit)
+
+assert_contains "runner reports synthetic test pass" "TOTAL: 1 tests, 1 passed, 0 failed" "$RUNNER_OUTPUT"
+assert_eq "runner restores original dist symlink" "$RUNNER_ROOT/shared-dist" "$(readlink "$RUNNER_ROOT/dist")"
+if [ -f "$RUNNER_ROOT/shared-dist/hooks/private-only.js" ]; then
+  RUNNER_SHARED_MUTATED="yes"
+else
+  RUNNER_SHARED_MUTATED="no"
+fi
+assert_eq "runner private write does not mutate shared dist" "no" "$RUNNER_SHARED_MUTATED"
+
+echo ""
+echo "=== real dist directory keeps fast path ==="
+
+REAL_ROOT="$TMP_ROOT/real-root"
+mkdir -p "$REAL_ROOT/dist/hooks"
+
+setup_private_dist_if_symlink "$REAL_ROOT"
+
+if [ -L "$REAL_ROOT/dist" ]; then
+  REAL_WAS_SYMLINK="yes"
+else
+  REAL_WAS_SYMLINK="no"
+fi
+assert_eq "real dist not replaced" "no" "$REAL_WAS_SYMLINK"
+restore_private_dist
+
+echo ""
+echo "=== missing dist keeps fast path ==="
+
+NO_DIST_ROOT="$TMP_ROOT/no-dist-root"
+mkdir -p "$NO_DIST_ROOT"
+
+setup_private_dist_if_symlink "$NO_DIST_ROOT"
+
+if [ -e "$NO_DIST_ROOT/dist" ] || [ -L "$NO_DIST_ROOT/dist" ]; then
+  MISSING_CREATED="yes"
+else
+  MISSING_CREATED="no"
+fi
+assert_eq "missing dist not created" "no" "$MISSING_CREATED"
+restore_private_dist
+
+print_results


### PR DESCRIPTION
Once upon a time, `test:hooks` ran inside case worktrees that are optimized for startup by reusing a shared `dist` symlink from the main checkout.

Every day, that was fast enough for ordinary local work, but it meant hook tests that execute real built entrypoints could still read and write through the same shared artifact tree as other concurrent worktrees.

One day, while completing #1120 under fleet load, the hook suite exposed a trust gap: a failing hook test could be measuring shared `dist` contention instead of the hook behavior under review.

Because of that, this PR moves the isolation to the hook test runner itself. When the runner sees a symlinked checkout-level `dist`, it copies the target into a private temp directory, swaps the checkout symlink for the duration of the run, and restores the original symlink through the existing cleanup trap.

Because of that, normal setup remains fast: real `dist` directories and missing `dist` paths stay untouched, and no worktree startup behavior changes.

Until finally, the new regression proves both the direct helper contract and the `run-all-tests.sh` wiring: private writes do not mutate shared artifacts, and the original symlink is restored after the run.

And ever since, hook test results are less likely to be polluted by concurrent shared artifact writes while preserving the fast symlinked-worktree path outside test execution.

Closes #1654
Parent: #1532

## Architecture

```text
.claude/hooks/tests/run-all-tests.sh
  -> source runner-dist-isolation.sh
  -> setup_private_dist_if_symlink(repo_root)
       symlinked dist -> /tmp/.kaizen-hook-test-dist-*/dist copy
       real dist      -> no-op
       missing dist   -> no-op
  -> run discovered hook tests
  -> cleanup trap restores original dist symlink and removes temp copy
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Isolate inside `run-all-tests.sh` | The problem is test measurement contamination, not ordinary worktree startup. | Full hook runs pay one copy of `dist` only when `dist` is symlinked. |
| Only handle symlinked `dist` | Shared symlinked artifacts are the contention vector from #1654. | Real local `dist` directories keep their existing behavior. |
| Restore the original symlink text | Relative and absolute symlinks go back to the same checkout-level contract. | The helper intentionally avoids normalizing the restored link. |
| Keep helper shell-native | The runner is a shell harness and needs to work before TypeScript test infrastructure is involved. | More explicit cleanup code than a higher-level abstraction. |

## What's In This PR

| File | Purpose |
|---|---|
| `.claude/hooks/tests/run-all-tests.sh` | Wires per-run `dist` isolation before tests and restores it in the existing cleanup trap. |
| `.claude/hooks/tests/runner-dist-isolation.sh` | Adds the symlink-only setup/restore helper. |
| `.claude/hooks/tests/test-runner-dist-isolation.sh` | Covers symlink isolation, runner wiring, restoration, real `dist`, and missing `dist` fast paths. |

## Test Plan (Behaviors x Levels)

| Behavior | Unit / focused | Runner integration | Suite / repo checks | Status |
|---|---:|---:|---:|---|
| Symlinked `dist` is replaced with a private per-run copy | `.claude/hooks/tests/test-runner-dist-isolation.sh` | `npm run test:hooks -- --unit` includes `test-runner-dist-isolation` | `npm run test:hooks` | tested |
| Private writes do not mutate shared `dist` | `.claude/hooks/tests/test-runner-dist-isolation.sh` | Synthetic `run-all-tests.sh` fixture writes through private copy | `npm run test:hooks` | tested |
| Original symlink is restored on cleanup | `.claude/hooks/tests/test-runner-dist-isolation.sh` | Synthetic runner fixture asserts restoration | `npm run test:hooks` | tested |
| Real `dist` directories stay untouched | `.claude/hooks/tests/test-runner-dist-isolation.sh` | Covered by unit-discovered shell test | `npm run test:hooks` | tested |
| Missing `dist` path stays untouched | `.claude/hooks/tests/test-runner-dist-isolation.sh` | Covered by unit-discovered shell test | `npm run test:hooks` | tested |
| Existing repo checks remain green | N/A | N/A | `npm run typecheck`, `npm run check:fast`, `npm test`, `git diff --check` | tested |

## Impact (goal -> before/after -> match)

- Goal (#1654): keep normal worktree setup fast while preventing hook tests from sharing a contended symlinked `dist` tree under fleet load.
- Acceptance signal: when checkout `dist` is a symlink, the hook test runner uses a private copy during the run, restores the original symlink afterward, and leaves real/missing `dist` fast paths unchanged.
- BEFORE: `run-all-tests.sh` had no `dist` isolation; hook tests in symlinked worktrees executed against the shared checkout artifact tree observed during the #1120 fleet-load incident.
- AFTER: `run-all-tests.sh` calls `setup_private_dist_if_symlink`, and the focused regression verifies private copy, shared-artifact non-mutation, restoration, real-dir no-op, and missing-dir no-op.
- Delta: 0 runner-level protections -> 1 symlink-only per-run isolation contract with 10 focused assertions; full hook suite remains green at 468/468.
- Goal met?: yes.
- Residual scan: no additional follow-up filed from this slice; the separate `kaizen-check-wip` timing concern remains tracked on #451.

## Validation

- [x] `bash .claude/hooks/tests/test-runner-dist-isolation.sh` — 10 passed, 0 failed.
- [x] `npm run test:hooks -- --unit` — 385 passed, 0 failed.
- [x] `npm run test:hooks` — 468 passed, 0 failed.
- [x] `npm run typecheck` — passed.
- [x] `npm run check:fast` — passed; changed Vitest shard found no applicable files relative to `origin/main`.
- [x] `npm test` — 177 files passed, 2 skipped; 4,231 tests passed, 14 skipped.
- [x] `git diff --check` — passed.

## Known Limitations

- This isolates only the hook test runner path. It does not change general worktree startup or prevent other non-test commands from intentionally using the shared symlinked `dist` optimization.
- The private copy is per full hook-runner invocation, not per individual test file. That keeps the copy cost bounded while removing cross-worktree shared artifact contention.
