### PR TITLE
fix(hooks): rerun review verdict gate after summary comments

### DIFF
--- a/.github/workflows/review-verdict-rerun.yml
+++ b/.github/workflows/review-verdict-rerun.yml
@@ -1,0 +1,38 @@
+name: Review verdict gate rerun
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: review-verdict-rerun-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rerun-after-review-summary:
+    if: >-
+      ${{
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, 'kaizen:review/r') &&
+        contains(github.event.comment.body, '/summary -->')
+      }}
+    name: Rerun PR Review verdict gate after stored summary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Rerun PR-attached Review verdict gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: npx tsx scripts/rerun-review-verdict-gate.ts --repo "$GITHUB_REPOSITORY" --pr "$PR_NUMBER"

--- a/scripts/rerun-review-verdict-gate.test.ts
+++ b/scripts/rerun-review-verdict-gate.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  decideRerun,
+  fetchWorkflowRuns,
+  isReviewSummaryAttachmentComment,
+  rerunReviewVerdictGate,
+  selectPrHeadPullRequestRun,
+  type GhRunner,
+  type ReviewGateWorkflowRun,
+} from './rerun-review-verdict-gate.js';
+
+const HEAD = '16588db5eeac5682111b2e5c411445c79e4e6ded';
+
+function run(overrides: Partial<ReviewGateWorkflowRun>): ReviewGateWorkflowRun {
+  return {
+    id: 100,
+    event: 'pull_request',
+    head_sha: HEAD,
+    status: 'completed',
+    conclusion: 'failure',
+    ...overrides,
+  };
+}
+
+function ok(stdout: string) {
+  return { status: 0, stdout, stderr: '' };
+}
+
+describe('isReviewSummaryAttachmentComment', () => {
+  it('matches only kaizen review summary attachment marker comments', () => {
+    expect(isReviewSummaryAttachmentComment('<!-- kaizen:review/r1/summary -->\n## Review Round 1')).toBe(true);
+    expect(isReviewSummaryAttachmentComment('<!-- kaizen:review/r12/correctness -->')).toBe(false);
+    expect(isReviewSummaryAttachmentComment('plain review summary prose')).toBe(false);
+  });
+});
+
+describe('selectPrHeadPullRequestRun', () => {
+  it('chooses the newest pull_request run for the current PR head SHA', () => {
+    const selected = selectPrHeadPullRequestRun([
+      run({ id: 1, event: 'workflow_dispatch', head_sha: HEAD, conclusion: 'success' }),
+      run({ id: 2, event: 'pull_request', head_sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }),
+      run({ id: 3, event: 'pull_request', head_sha: HEAD }),
+    ], HEAD);
+
+    expect(selected?.id).toBe(3);
+  });
+
+  it('ignores runs without a run id', () => {
+    expect(selectPrHeadPullRequestRun([run({ id: undefined, database_id: undefined })], HEAD)).toBeNull();
+  });
+});
+
+describe('decideRerun', () => {
+  it('reruns completed non-success pull_request runs', () => {
+    expect(decideRerun(run({ conclusion: 'failure' }))).toEqual({
+      action: 'rerun',
+      reason: 'matching pull_request run concluded failure',
+    });
+  });
+
+  it('skips active runs and successful runs', () => {
+    expect(decideRerun(run({ status: 'in_progress', conclusion: null })).action).toBe('skip');
+    expect(decideRerun(run({ conclusion: 'success' })).action).toBe('skip');
+  });
+});
+
+describe('fetchWorkflowRuns', () => {
+  it('lists only pull_request runs for the exact head SHA', () => {
+    const gh = vi.fn(() => ok(JSON.stringify({ workflow_runs: [] })));
+
+    fetchWorkflowRuns('Garsson-io/kaizen', 'review-verdict-gate.yml', HEAD, gh);
+
+    expect(gh).toHaveBeenCalledWith([
+      'api',
+      '--method',
+      'GET',
+      'repos/Garsson-io/kaizen/actions/workflows/review-verdict-gate.yml/runs',
+      '-F',
+      'event=pull_request',
+      '-F',
+      `head_sha=${HEAD}`,
+      '-F',
+      'per_page=50',
+    ], 30_000);
+  });
+});
+
+describe('rerunReviewVerdictGate', () => {
+  it('reruns the matching failed pull_request run for the current PR head', () => {
+    const gh: GhRunner = vi.fn((args) => {
+      if (args[0] === 'pr') return ok(`${HEAD}\n`);
+      if (args[0] === 'api' && args.includes('/rerun')) return ok('');
+      return ok(JSON.stringify({ workflow_runs: [run({ id: 28345819453 })] }));
+    });
+
+    const result = rerunReviewVerdictGate('Garsson-io/kaizen', '1658', { gh });
+
+    expect(result).toMatchObject({ action: 'rerun', runId: 28345819453 });
+    expect(gh).toHaveBeenLastCalledWith([
+      'api',
+      '--method',
+      'POST',
+      'repos/Garsson-io/kaizen/actions/runs/28345819453/rerun',
+    ], 30_000);
+  });
+
+  it('does not rerun an already successful pull_request run', () => {
+    const gh: GhRunner = vi.fn((args) => {
+      if (args[0] === 'pr') return ok(`${HEAD}\n`);
+      return ok(JSON.stringify({ workflow_runs: [run({ id: 44, conclusion: 'success' })] }));
+    });
+
+    const result = rerunReviewVerdictGate('Garsson-io/kaizen', '1658', { gh });
+
+    expect(result).toEqual({
+      action: 'skip',
+      runId: 44,
+      message: 'matching pull_request run already succeeded',
+    });
+    expect(vi.mocked(gh).mock.calls.some(([args]) => args.includes('/rerun'))).toBe(false);
+  });
+});

--- a/scripts/rerun-review-verdict-gate.ts
+++ b/scripts/rerun-review-verdict-gate.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env tsx
+/**
+ * Rerun the PR-attached Review verdict gate after a stored review summary changes.
+ *
+ * A manual workflow_dispatch run can pass after review data is stored, but it is
+ * not the pull_request check run shown in the PR status rollup. This helper
+ * finds the latest pull_request run for the PR's current head SHA and reruns it
+ * so the attached check can observe the newly stored authoritative review round.
+ */
+
+import { ghResult, type GhResult } from '../src/lib/gh-exec.js';
+
+const DEFAULT_WORKFLOW = 'review-verdict-gate.yml';
+const ACTIVE_STATUSES = new Set(['queued', 'in_progress', 'waiting', 'requested', 'pending']);
+
+export interface ReviewGateWorkflowRun {
+  id?: number;
+  database_id?: number;
+  event?: string;
+  head_sha?: string;
+  status?: string;
+  conclusion?: string | null;
+  html_url?: string;
+}
+
+export interface RerunDecision {
+  action: 'rerun' | 'skip';
+  reason: string;
+}
+
+export interface RerunResult {
+  action: 'rerun' | 'skip';
+  runId?: number;
+  message: string;
+}
+
+export type GhRunner = (args: string[], timeoutMs?: number, input?: string) => GhResult;
+
+function readArg(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  return idx >= 0 ? process.argv[idx + 1] : undefined;
+}
+
+function usage(): never {
+  console.error('Usage: npx tsx scripts/rerun-review-verdict-gate.ts --repo owner/repo --pr N [--workflow review-verdict-gate.yml]');
+  process.exit(2);
+}
+
+function runGh(gh: GhRunner, args: string[], context: string): string {
+  const result = gh(args, 30_000);
+  if (result.status !== 0) {
+    throw new Error(`${context} failed: ${result.stderr || result.stdout || `gh ${args.join(' ')}`}`);
+  }
+  return result.stdout;
+}
+
+function runId(run: ReviewGateWorkflowRun): number | null {
+  return typeof run.id === 'number' ? run.id
+    : typeof run.database_id === 'number' ? run.database_id
+      : null;
+}
+
+export function isReviewSummaryAttachmentComment(body: string): boolean {
+  return /<!--\s*kaizen:review\/r\d+\/summary\s*-->/.test(body);
+}
+
+export function selectPrHeadPullRequestRun(
+  runs: ReviewGateWorkflowRun[],
+  headSha: string,
+): ReviewGateWorkflowRun | null {
+  return runs.find((run) => run.event === 'pull_request' && run.head_sha === headSha && runId(run) !== null) ?? null;
+}
+
+export function decideRerun(run: ReviewGateWorkflowRun): RerunDecision {
+  const status = (run.status ?? '').toLowerCase();
+  const conclusion = (run.conclusion ?? '').toLowerCase();
+
+  if (ACTIVE_STATUSES.has(status)) {
+    return { action: 'skip', reason: `matching pull_request run is already ${status}` };
+  }
+  if (conclusion === 'success') {
+    return { action: 'skip', reason: 'matching pull_request run already succeeded' };
+  }
+  return { action: 'rerun', reason: `matching pull_request run concluded ${conclusion || status || 'unknown'}` };
+}
+
+export function fetchPrHeadSha(repo: string, pr: string, gh: GhRunner = ghResult): string {
+  const stdout = runGh(
+    gh,
+    ['pr', 'view', pr, '--repo', repo, '--json', 'headRefOid', '--jq', '.headRefOid'],
+    'fetch PR head SHA',
+  );
+  const headSha = stdout.trim();
+  if (!/^[0-9a-f]{40}$/i.test(headSha)) {
+    throw new Error(`fetch PR head SHA returned invalid SHA: ${JSON.stringify(headSha)}`);
+  }
+  return headSha;
+}
+
+export function fetchWorkflowRuns(
+  repo: string,
+  workflow: string,
+  headSha: string,
+  gh: GhRunner = ghResult,
+): ReviewGateWorkflowRun[] {
+  const stdout = runGh(
+    gh,
+    [
+      'api',
+      '--method',
+      'GET',
+      `repos/${repo}/actions/workflows/${workflow}/runs`,
+      '-F',
+      'event=pull_request',
+      '-F',
+      `head_sha=${headSha}`,
+      '-F',
+      'per_page=50',
+    ],
+    'list Review verdict gate workflow runs',
+  );
+  const parsed = JSON.parse(stdout) as { workflow_runs?: ReviewGateWorkflowRun[] };
+  return Array.isArray(parsed.workflow_runs) ? parsed.workflow_runs : [];
+}
+
+export function rerunReviewVerdictGate(
+  repo: string,
+  pr: string,
+  options: { workflow?: string; gh?: GhRunner } = {},
+): RerunResult {
+  const workflow = options.workflow ?? DEFAULT_WORKFLOW;
+  const gh = options.gh ?? ghResult;
+  const headSha = fetchPrHeadSha(repo, pr, gh);
+  const runs = fetchWorkflowRuns(repo, workflow, headSha, gh);
+  const run = selectPrHeadPullRequestRun(runs, headSha);
+
+  if (!run) {
+    throw new Error(`No pull_request ${workflow} run found for PR #${pr} at ${headSha}`);
+  }
+
+  const id = runId(run);
+  if (id === null) {
+    throw new Error(`Matching pull_request ${workflow} run has no run id`);
+  }
+
+  const decision = decideRerun(run);
+  if (decision.action === 'skip') {
+    return { action: 'skip', runId: id, message: decision.reason };
+  }
+
+  runGh(gh, ['api', '--method', 'POST', `repos/${repo}/actions/runs/${id}/rerun`], 'rerun Review verdict gate');
+  return {
+    action: 'rerun',
+    runId: id,
+    message: `Rerun requested for ${workflow} pull_request run ${id}: ${decision.reason}`,
+  };
+}
+
+if (process.argv[1]?.endsWith('rerun-review-verdict-gate.ts') || process.argv[1]?.endsWith('rerun-review-verdict-gate.js')) {
+  const repo = readArg('--repo') ?? process.env.GITHUB_REPOSITORY;
+  const pr = readArg('--pr') ?? process.env.PR_NUMBER;
+  const workflow = readArg('--workflow') ?? DEFAULT_WORKFLOW;
+  if (!repo || !pr || !/^\d+$/.test(pr)) usage();
+
+  try {
+    const result = rerunReviewVerdictGate(repo, pr, { workflow });
+    console.log(result.message);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/scripts/review-verdict-workflow.test.ts
+++ b/scripts/review-verdict-workflow.test.ts
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const gateWorkflow = readFileSync(join(process.cwd(), '.github/workflows/review-verdict-gate.yml'), 'utf8');
+const rerunWorkflowPath = join(process.cwd(), '.github/workflows/review-verdict-rerun.yml');
+const rerunWorkflow = readFileSync(rerunWorkflowPath, 'utf8');
+
+describe('Review verdict gate workflow', () => {
+  it('keeps the PR-attached verdict workflow free of issue_comment helper jobs', () => {
+    expect(gateWorkflow).toContain('pull_request:');
+    expect(gateWorkflow).toContain('workflow_dispatch:');
+    expect(gateWorkflow).not.toContain('issue_comment:');
+    expect(gateWorkflow).not.toContain('rerun-after-review-summary');
+  });
+
+  it('reruns the PR-attached verdict gate from a separate comment-only workflow', () => {
+    expect(existsSync(rerunWorkflowPath)).toBe(true);
+    expect(rerunWorkflow).toContain('issue_comment:');
+    expect(rerunWorkflow).toContain('types: [created, edited]');
+    expect(rerunWorkflow).toContain('actions: write');
+    expect(rerunWorkflow).toContain('github.event.issue.pull_request');
+    expect(rerunWorkflow).toContain('kaizen:review/r');
+    expect(rerunWorkflow).toContain('/summary -->');
+    expect(rerunWorkflow).toContain('scripts/rerun-review-verdict-gate.ts');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1657.

After the Review verdict gate fails closed on a new PR, storing the review summary as a kaizen PR-comment attachment now triggers an issue_comment helper job. That helper finds the latest PR-head pull_request run of the Review verdict gate workflow and reruns it, so the PR-attached check observes the newly stored authoritative review verdict without requiring an empty commit.

The storage path stays pure: store-review-summary still only stores the derived summary/sentinel and does not publish statuses or perform CI proof.

## Test Plan

- RED: npx vitest run scripts/rerun-review-verdict-gate.test.ts scripts/review-verdict-workflow.test.ts (workflow trigger tests failed before wiring)
- npx vitest run scripts/rerun-review-verdict-gate.test.ts scripts/review-verdict-workflow.test.ts scripts/review-verdict-status.test.ts
- npm run typecheck
- npm run test:fast
- npm run test:hooks
- Live API shape check: gh api --method GET repos/Garsson-io/kaizen/actions/workflows/review-verdict-gate.yml/runs -F event=pull_request -F head_sha=16588db5eeac5682111b2e5c411445c79e4e6ded -F per_page=5

## Notes

The PR itself should prove the fixed path: its initial Review verdict gate is expected to fail until the review summary is stored, then the issue_comment helper should rerun the PR-attached pull_request run for this head SHA.

## Impact

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Review-summary comments should refresh the PR-attached Review verdict gate without empty commits | PR #1656: workflow_dispatch passed after summary storage, but gh pr checks still showed the stale failed pull_request Review verdict gate until an empty commit retriggered checks | PR #1659 adds .github/workflows/review-verdict-rerun.yml plus scripts/rerun-review-verdict-gate.ts to rerun the pull_request Review verdict gate for the current head SHA when a <!-- kaizen:review/rN/summary --> comment is created/edited | Summary-comment event now targets the existing PR-head pull_request run instead of creating an unattached manual run | yes |
| store-review-summary remains deterministic storage | Existing cli-structured-data test guards storeReviewSummary(target, round, note) with no CI/status options | This PR does not modify src/cli-structured-data.ts or src/structured-data.ts and keeps the guard test unchanged | CI/status proof stays in the workflow layer | yes |
| Helper does not add a skipped PR-rollup context | Initial PR #1659 attempt with a same-workflow helper showed a skipped helper job in gh pr checks | The final diff moves the listener into separate Review verdict gate rerun workflow and restores review-verdict-gate.yml to pull_request/workflow_dispatch only | PR-attached verdict workflow remains the single Review verdict gate check context | yes |
| Rerun API path works against a real PR-head verdict run | Before the round 1/2 summaries, PR #1659 showed a stale failed PR-attached Review verdict gate | `npx tsx scripts/rerun-review-verdict-gate.ts --repo Garsson-io/kaizen --pr 1659` requested a rerun of run 28346153456; current head cdc0e2a has Review Round 2 PASS and Review verdict gate pass | Existing pull_request run can be refreshed without pushing an empty commit | yes |

Residual scan: GitHub only starts `issue_comment` workflows from workflow files present on the default branch, so the automatic comment-trigger path is structurally tested in this PR and becomes live for subsequent PRs after merge. The critical rerun API path was live-proved on PR #1659. If GitHub later refuses Actions rerun from GITHUB_TOKEN despite actions:write, that will be visible in the comment-triggered helper run and should be filed as a follow-up with the run URL.

## Validation

- [x] RED: `npx vitest run scripts/rerun-review-verdict-gate.test.ts scripts/review-verdict-workflow.test.ts` failed before workflow wiring because no comment trigger existed.
- [x] `npx vitest run scripts/rerun-review-verdict-gate.test.ts scripts/review-verdict-workflow.test.ts scripts/review-verdict-status.test.ts` -> 19 passed.
- [x] `npx vitest run scripts/rerun-review-verdict-gate.test.ts scripts/review-verdict-workflow.test.ts src/verdict-binding-inventory.test.ts` -> 18 passed after the DTO rename.
- [x] `npm run typecheck` -> passed.
- [x] `npm run test:fast` -> 10 changed tests passed.
- [x] `npm run test:hooks` -> 468/468 passed after rebasing onto #1658.
- [x] `npm run test:ci:shard -- --shard=2/2` -> passed locally after renaming the workflow-run DTO that the verdict inventory scanner had flagged.
- [x] Live API shape check: `gh api --method GET repos/Garsson-io/kaizen/actions/workflows/review-verdict-gate.yml/runs -F event=pull_request -F head_sha=16588db5eeac5682111b2e5c411445c79e4e6ded -F per_page=5` returned the PR-head pull_request run expected by the helper.
- [x] Live helper proof: `npx tsx scripts/rerun-review-verdict-gate.ts --repo Garsson-io/kaizen --pr 1659` requested a rerun of PR-attached Review verdict gate run 28346153456 without an empty commit.
- [x] Current PR head `cdc0e2a` has Review Round 2 PASS and the PR-attached Review verdict gate is passing.