### PR TITLE
fix(worktree): clean squash-merged worktrees

### DIFF
--- a/src/worktree-du.test.ts
+++ b/src/worktree-du.test.ts
@@ -426,6 +426,42 @@ describe("cleanupWorktrees", () => {
     expect(result.skipped).toBe(0);
   });
 
+  it("removes clean squash-merged worktrees even when local commits are not on the deleted remote branch", () => {
+    const calls: string[][] = [];
+    const writes: string[] = [];
+    const deps = makeDeps({
+      readdir: () => ["wt-squashed"],
+      isDir: () => true,
+      exists: () => false,
+      writeFile: (p) => { writes.push(p); },
+      git: (args) => {
+        calls.push([...args]);
+        const cmd = args.join(" ");
+        if (cmd.includes("branch --merged main")) return "* main";
+        if (cmd.includes("rev-parse --abbrev-ref HEAD")) return "feat-squashed";
+        if (cmd.includes("diff --stat main..feat-squashed")) return "";
+        if (cmd.includes("status --porcelain")) return "";
+        if (cmd.includes("log --oneline @{u}..HEAD")) return "a111 first\nb222 second";
+        if (cmd.includes("worktree remove")) return "";
+        if (cmd.includes("worktree list")) return "";
+        if (cmd.endsWith("branch")) return "* main\n  feat-squashed";
+        return "";
+      },
+    });
+
+    const result = cleanupWorktrees(makePaths(), deps, false);
+
+    expect(result.removedWorktrees).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.actions).toContainEqual({
+      type: "remove",
+      target: "wt-squashed",
+      reason: "squash-merged",
+    });
+    expect(writes.some((p) => p.endsWith(".worktree-will-delete"))).toBe(true);
+    expect(calls.some((args) => args.includes("worktree") && args.includes("remove"))).toBe(true);
+  });
+
   it("dry-run does not call unlink or exec remove", () => {
     let execCmds: string[] = [];
     const deps = makeDeps({

--- a/src/worktree-du.ts
+++ b/src/worktree-du.ts
@@ -413,7 +413,7 @@ export function cleanupWorktrees(
       continue;
     }
 
-    if (ms !== "at-main") {
+    if (ms !== "at-main" && ms !== "squash-merged") {
       const unpushed = getUnpushedCount(wtPath, deps);
       if (unpushed > 0) {
         result.actions.push({


### PR DESCRIPTION
## Summary

Closes #972.

worktree-du cleanup already detected content-equivalent squash-merged branches, but the cleanup path still applied the unpushed-commit safety gate to them. That made a clean squash-merged worktree look risky when its local branch commits were not ancestors of main.

This narrows the unpushed-commit gate so squash-merged worktrees are treated like content-shipped work while dirty files, locks, and genuinely unmerged branches remain protected.

## Changes

- Allow cleanup of clean squash-merged worktrees even when upstream comparison reports local commits.
- Add regression coverage for the false-positive: squash-merged branch, clean worktree, local commits reported as unpushed, expected removal.
- Preserve existing unmerged-worktree protection.

## Verification

RED before implementation:
- npx vitest run src/worktree-du.test.ts failed the new regression: expected 1 removed worktree, got 0.

GREEN after implementation:
- npx vitest run src/worktree-du.test.ts -> 38 passed
- npm run typecheck -> pass
- npm run test:fast -> 2 files, 48 tests passed
- npm test -> 4,232 passed, 14 skipped
- git diff --check -> pass

Reality smoke check:
- Created a temp Git repo with a real linked worktree branch.
- Committed branch changes, squash-merged the content into main, then ran the real worktree-du cleanup CLI.
- CLI removed wt-squashed and feature/squashed as squash-merged with 0 skipped.