### PR TITLE
docs(hooks): document shared tsx trampoline runtime

### DIFF
--- a/.agents/kaizen/docs/hook-catalog.md
+++ b/.agents/kaizen/docs/hook-catalog.md
@@ -81,7 +81,11 @@ Computer-level installation (`kaizen@kaizen` in `~/.claude/settings.json`) is **
 
 ## TS Migration Status
 
-All enforcement hooks are now in TypeScript. Each `-ts.sh` shim is a thin bash wrapper (~5 lines) that calls `npx tsx` to invoke the TypeScript implementation.
+All enforcement hooks are now in TypeScript. Each `-ts.sh` shim is a thin bash
+wrapper that sources `.claude/hooks/lib/run-tsx.sh`; the shared resolver locates
+`tsx` from the kaizen checkout, parent worktree installs, or git common dir and
+then invokes the TypeScript implementation. Production hook shims do not call
+`npx tsx` directly.
 
 | Registered shim | TS implementation | Tests |
 |-----------------|-------------------|-------|

--- a/docs/hook-language-boundaries.md
+++ b/docs/hook-language-boundaries.md
@@ -126,7 +126,9 @@ Migration approach per script:
 - Create TypeScript module in `src/hooks/`
 - Port logic with proper types and error handling
 - Add vitest tests (replacing hand-rolled bash tests)
-- Thin bash wrapper (`-ts.sh`) calls `npx tsx` — registered in `plugin.json`
+- Thin bash wrapper (`-ts.sh`) sources `.claude/hooks/lib/run-tsx.sh` and calls
+  `run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/<hook>.ts"` — registered in
+  `plugin.json`
 - Old bash scripts deleted after migration is wired up
 
 ### Phase 4: Evaluate escalation to L2
@@ -152,8 +154,16 @@ Migration approach per script:
 
 ## Design Decisions
 
-**Q: Should TypeScript hooks use `tsx` (dev) or compiled JS (prod)?**
-A: `tsx` — hooks aren't latency-sensitive, and it avoids build step complexity. If startup becomes a problem, compile as an optimization later.
+**Q: Should TypeScript hooks use `tsx` (dev), Bun, or compiled JS (prod)?**
+A: Use the shared `run-tsx.sh` resolver for production hook shims. It resolves
+repo-local or parent-checkout `tsx` without `npx`, works in worktrees where the
+current checkout lacks `node_modules`, and fails open with an actionable
+diagnostic if dependencies are unavailable. A #454 measurement on this host put
+the real `pr-review-loop-ts.sh` resolver path at 0.54-0.90s, direct `npx tsx`
+at 0.68-0.88s, `npx -y bun` at 0.59-0.68s, and precompiled
+`node dist/hooks/pr-review-loop.js` at 0.10s. Keep the resolver as the default
+until #1662 defines a build-freshness contract for precompiled hooks or a
+standard production Bun installation path.
 
 **Q: Should we migrate `claude-wt.sh`?**
 A: Not yet. It's L2-L3 boundary — orchestration but mostly delegating. Migrate when it breaks or grows.

--- a/docs/hooks-design.md
+++ b/docs/hooks-design.md
@@ -132,17 +132,44 @@ See [`hook-language-boundaries.md`](hook-language-boundaries.md) for the full po
 
 ### Trampoline Pattern
 
-All enforcement hooks use a thin bash wrapper that delegates to TypeScript:
+All enforcement hooks use a thin bash wrapper that delegates to TypeScript
+through the shared `run-tsx.sh` resolver:
 
 ```bash
 #!/bin/bash
 # kaizen-some-hook-ts.sh — trampoline to TypeScript implementation
 source "$(dirname "$0")/lib/scope-guard.sh"
-KAIZEN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec npx --prefix "$KAIZEN_DIR" tsx "$KAIZEN_DIR/src/hooks/some-hook.ts" 2>/dev/null
+source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
+run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/some-hook.ts"
 ```
 
-The bash shim handles scope-guard and kaizen dir resolution. The TypeScript file handles all logic, reads stdin JSON, and writes stdout JSON. This makes the logic fully testable with vitest.
+The bash shim handles scope-guard and production dispatch. `run-tsx.sh`
+resolves `tsx` from the kaizen checkout, parent worktree installs, or git
+common dir through `resolve-tsx-bin.sh`; it also honors `KAIZEN_TSX_BIN` for
+deterministic test harnesses. The shim intentionally avoids `npx --prefix ...
+tsx` in production hook paths because missing dependencies produced opaque
+non-blocking hook failures (#1131) and because `npx` adds startup overhead.
+
+Current #454 measurement on this host after `npm run build`:
+
+| Launcher | Five-run wall time | Max RSS | Decision |
+|---|---:|---:|---|
+| `pr-review-loop-ts.sh` via `run-tsx.sh` shared resolver | 0.54-0.90s | 107-117 MB | Current production default |
+| Direct `npx tsx src/hooks/pr-review-loop.ts` | 0.68-0.88s | 108-114 MB | Avoid in production shims |
+| `npx --no-install tsx src/hooks/pr-review-loop.ts` | 0.62-0.65s | 112-118 MB | Similar to resolver but less worktree-aware |
+| `npx -y bun src/hooks/pr-review-loop.ts` | 0.59-0.68s | 101-103 MB | Not a production win through `npx` |
+| `node dist/hooks/pr-review-loop.js` | 0.10s | 63-65 MB | Fastest, needs build-freshness contract |
+
+Decision: keep the shared `run-tsx.sh` resolver as the production trampoline.
+It avoids `npx` overhead, works from worktrees without local `node_modules`,
+fails open with an actionable diagnostic when `tsx` is unavailable, and does
+not require Bun as an operator dependency. Precompiled Node is the measured
+fastest path, but adopting it safely requires a freshness contract so hooks do
+not silently run stale `dist` output. Track that production-runtime adoption
+decision in #1662.
+
+The TypeScript file handles all logic, reads stdin JSON, and writes stdout JSON.
+This makes the logic fully testable with vitest.
 
 ### Hook Testability (kaizen #775)
 
@@ -241,7 +268,10 @@ STATE_DIR=$(mktemp -d) CLAUDECODE=1 \
 - **Session hook registries are manifest-derived:** `SessionSimulator` loads `.claude-plugin/plugin.json` through `loadDefaultHookRegistry()`. Do not hand-maintain a parallel full hook list in E2E tests; narrow `session.hooks` only when the test intentionally exercises a focused subset.
 - **Hook subprocess tests should be deterministic in worktrees:** use `resolveTsxBin()` from `src/e2e/test-runtime.ts` for TypeScript E2E tests, pass `KAIZEN_TSX_BIN` to bash trampolines when invoking them from test harnesses, and disable advisory background noise with `HOOK_TIMING_SENTINEL_DISABLED=true` and `SEND_TELEGRAM_IPC_DISABLED=true`.
 - **Do not silently skip outcome-proof tests:** if an outcome E2E test requires `tsx`, assert that it is present and fail loudly. Skip guards are acceptable for live fixtures whose subject is explicitly optional local infrastructure.
-- **Production best-effort hooks are separate from test harness resolution:** `resolve-tsx-bin.sh` exists for harness determinism and TS hook trampolines. A few startup/advisory production hooks still use local `node_modules/.bin/tsx` plus `npx --prefix` fallback so missing dependencies cannot block a session.
+- **Production best-effort hooks use the shared resolver:** `run-tsx.sh` and
+  `resolve-tsx-bin.sh` are the TS hook trampoline contract. They resolve a
+  usable `tsx` binary without `npx`, support `KAIZEN_TSX_BIN` for tests, and
+  fail open with an actionable diagnostic when dependencies are missing.
 
 ## Anti-Patterns
 

--- a/src/policy-docs.test.ts
+++ b/src/policy-docs.test.ts
@@ -258,6 +258,35 @@ describe('hook source files — @enforces JSDoc cross-references', () => {
   });
 });
 
+describe('hook runtime docs — TypeScript shim contract', () => {
+  const hooksDesign = read('docs/hooks-design.md');
+  const hookCatalog = read('.agents/kaizen/docs/hook-catalog.md');
+  const languageBoundaries = read('docs/hook-language-boundaries.md');
+
+  it('documents run-tsx.sh as the production TypeScript hook trampoline', () => {
+    for (const doc of [hooksDesign, hookCatalog, languageBoundaries]) {
+      expect(doc).toMatch(/run-tsx\.sh/);
+    }
+    expect(hooksDesign).toMatch(/resolve-tsx-bin\.sh/);
+    expect(hooksDesign).toMatch(/KAIZEN_TSX_BIN/);
+  });
+
+  it('does not claim TS hook shims call npx tsx directly', () => {
+    const staleDirectShimClaims = [
+      /shim[^.\n]*calls `npx tsx`/i,
+      /wrapper[^.\n]*calls `npx tsx`/i,
+      /calls `npx tsx` to invoke/i,
+      /exec npx --prefix "\$KAIZEN_DIR" tsx/,
+    ];
+
+    for (const doc of [hooksDesign, hookCatalog, languageBoundaries]) {
+      for (const pattern of staleDirectShimClaims) {
+        expect(doc).not.toMatch(pattern);
+      }
+    }
+  });
+});
+
 describe('skill files — Upholds invariants section', () => {
   it('kaizen-write-pr names I1-I4', () => {
     const s = read('.agents/skills/kaizen-write-pr/SKILL.md');


### PR DESCRIPTION
Once upon a time, #454 asked us to evaluate the TypeScript hook runtime because the old trampoline story was `npx tsx`, with measured startup overhead high enough to matter as more hooks moved to TypeScript.

Every day, the code evolved: production TS shims now source `.claude/hooks/lib/run-tsx.sh`, and that shared resolver finds `tsx` from the kaizen checkout, parent worktree installs, or git common dir. But the docs still told future hook authors to write direct `npx --prefix "$KAIZEN_DIR" tsx` wrappers.

One day, while continuing the #451/#1532 runtime path, that mismatch became the remaining #454 risk: the implementation had already moved to the safer resolver, but the documented template could steer future hooks back to the slower and more fragile `npx` path.

Because of that, this PR updates the hook runtime docs to make `run-tsx.sh` the explicit production trampoline contract, records the measured launcher comparison, and states why Bun/precompiled Node are not production defaults yet.

Because of that, the policy test now pins the docs to the shared resolver contract and fails if they again claim TypeScript shims directly call `npx tsx`.

Until finally, the actual shell shim regression still proves the implementation side: `KAIZEN_TSX_BIN` override, parent-checkout resolver, missing-dependency fail-open diagnostic, and no silent `npx --prefix ... tsx` fallback.

And ever since, #454 has a durable runtime decision: use the shared resolver now; move to precompiled Node or standard Bun only after the build-freshness/runtime contract in #1662 exists.

Closes #454
Parent: #451
Refs: #1532
Follow-up: #1662

## Architecture

```text
-ts.sh hook shim
  -> source lib/scope-guard.sh
  -> source lib/run-tsx.sh
       -> resolve-tsx-bin.sh
            kaizen checkout node_modules/.bin/tsx
            parent/worktree install
            git common dir install
       -> KAIZEN_TSX_BIN override for tests
       -> fail-open diagnostic when unavailable
  -> run_tsx KAIZEN_DIR src/hooks/<hook>.ts
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Document `run-tsx.sh` as the production trampoline | It is what current shims use and it avoids the stale direct `npx` template. | This PR updates docs/tests, not runtime code. |
| Keep resolver as current default | It works in worktrees without local `node_modules` and fails open with an actionable diagnostic. | It is slower than precompiled Node. |
| Defer precompiled Node adoption to #1662 | `node dist/hooks/pr-review-loop.js` measured fastest, but production hooks need a build-freshness contract before using `dist`. | Leaves a performance opportunity open but avoids stale-hook risk. |
| Keep Bun optional | `npx -y bun` works here but is not a standard production runtime and was not faster than precompiled Node. | Bun can still be reconsidered once installed/supported without `npx` hot-path dispatch. |
| Add a policy-doc regression | Prevents the stale `npx tsx` shim claim from returning silently. | The test verifies docs contract, not microbenchmark values. |

## Runtime Measurements

Measured on this host after `npm run build`, five runs each against `pr-review-loop` with `{}` stdin:

| Launcher | Five-run wall time | Max RSS | Result |
|---|---:|---:|---|
| `pr-review-loop-ts.sh` via `run-tsx.sh` shared resolver | 0.54-0.90s | 107-117 MB | Current production default |
| Direct `npx tsx src/hooks/pr-review-loop.ts` | 0.68-0.88s | 108-114 MB | Avoid in production shims |
| `npx --no-install tsx src/hooks/pr-review-loop.ts` | 0.62-0.65s | 112-118 MB | Similar speed, weaker worktree contract |
| `npx -y bun src/hooks/pr-review-loop.ts` | 0.59-0.68s | 101-103 MB | Not a production win through `npx` |
| `node dist/hooks/pr-review-loop.js` | 0.10s | 63-65 MB | Fastest, tracked by #1662 before adoption |

## What's In This PR

| File | Purpose |
|---|---|
| `docs/hooks-design.md` | Replaces the direct `npx --prefix ... tsx` trampoline template with `run-tsx.sh`, records #454 measurements, and states the runtime decision. |
| `docs/hook-language-boundaries.md` | Updates migration guidance and runtime Q&A to the shared resolver contract. |
| `.agents/kaizen/docs/hook-catalog.md` | Fixes the TS migration summary so it no longer claims shims call `npx tsx` directly. |
| `src/policy-docs.test.ts` | Adds regression coverage for the documented TypeScript shim contract. |

## Test Plan (Behaviors x Levels)

| Behavior | Unit / focused | Hook runner | Repo suite | Status |
|---|---:|---:|---:|---|
| Docs describe `run-tsx.sh` as the TS hook trampoline | `npx vitest run src/policy-docs.test.ts` | N/A | `npm run check:fast`, `npm test` | tested |
| Docs do not claim TS shims call `npx tsx` directly | `npx vitest run src/policy-docs.test.ts` | N/A | `npm run check:fast`, `npm test` | tested |
| Actual shim contract still works | `bash .claude/hooks/tests/test-run-tsx.sh` | `npm run test:hooks -- --unit` | N/A | tested |
| Repo contracts remain green | N/A | N/A | `npm run typecheck`, `npm run check:fast`, `npm test`, `git diff --check` | tested |

## Impact (goal -> before/after -> match)

- Goal (#454): evaluate the TypeScript hook runtime and update the trampoline pattern/documentation so future hooks avoid the old high-overhead `npx tsx` path.
- Acceptance signal: docs name the shared `run-tsx.sh` resolver as the production shim contract, include measured launcher evidence, and tests catch regression to the old direct `npx tsx` claim.
- BEFORE: docs still said each `-ts.sh` shim calls `npx tsx` directly and showed `exec npx --prefix "$KAIZEN_DIR" tsx ...` as the template, despite current shims using `run-tsx.sh`.
- AFTER: docs show `source .../run-tsx.sh` plus `run_tsx ...`, record the five-way launcher measurement table, and point production adoption of precompiled Node/Bun to #1662.
- Delta: stale direct-`npx` hook template -> shared resolver contract with policy regression coverage and measured runtime decision.
- Goal met?: yes for evaluation and current trampoline template; production adoption of faster precompiled Node/Bun is deferred to #1662 because it needs a separate build-freshness/runtime contract.
- Residual scan: #1662 filed for production runtime adoption after build-freshness or standard Bun support; broader hook performance loop remains tracked by #451 and #1532.

## Validation

- [x] `npm run build` — passed; produced `dist/` for the precompiled Node benchmark.
- [x] Runtime measurement table above — collected with `/usr/bin/time -f "%e %M"`, five runs per launcher.
- [x] `bash .claude/hooks/tests/test-run-tsx.sh` — 7 passed, 0 failed.
- [x] `npx vitest run src/policy-docs.test.ts` — 53 passed, 0 failed.
- [x] `npm run test:hooks -- --unit` — 385 passed, 0 failed.
- [x] `npm run typecheck` — passed.
- [x] `npm run check:fast` — 1 changed Vitest file passed, 53 tests.
- [x] `npm test` — first run hit a transient shared `/tmp/.test-review-loop-scenarios` collision in an unrelated file; focused rerun of `src/hooks/pr-review-loop-scenarios.test.ts` passed 13/13, then full suite passed: 177 files passed, 2 skipped; 4,233 tests passed, 14 skipped.
- [x] `git diff --check` — passed.

## Known Limitations

- This PR does not switch production hooks to precompiled Node despite the speed result. That requires #1662 to define how hooks prove `dist` freshness before execution.
- This PR does not install Bun as a standard production runtime. The measured `npx -y bun` path is not the desired hot-path deployment model.
- This PR does not change runtime code; it aligns the durable contract and docs with the already-shared resolver behavior.
