### PR TITLE
fix(hooks): require ff-only main sync guidance

### DIFF
--- a/.agents/kaizen/docs/hook-design-principles.md
+++ b/.agents/kaizen/docs/hook-design-principles.md
@@ -36,7 +36,7 @@ Merge (gated)
   │  If branch behind → merge main, push (auto-merge retries)
   ▼
 Post-Merge
-  │  Sync main: git fetch origin main && git merge origin/main
+  │  Sync main: git fetch origin main && git merge --ff-only origin/main
   │  kaizen-reflect.sh (PostToolUse) prompts for process improvement
   │  check-cleanup-on-stop.sh verifies worktree cleanup
   ▼
@@ -65,7 +65,7 @@ Branch protection has `strict: true` status checks. Auto-merge is enabled. Moder
 3. **L3 repo backstop**: branch protection should require `Review verdict gate / Review verdict gate`, which fails when the latest stored review round derives `FAIL`.
 4. **Wait**: `gh pr checks <url> --repo Garsson-io/kaizen --watch` or `gh run watch <id>`
 5. **Verify**: `gh pr view <url> --json state --jq .state` → expect `MERGED`
-6. **Sync**: `MAIN_CHECKOUT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"; git -C "$MAIN_CHECKOUT" fetch origin main && git -C "$MAIN_CHECKOUT" merge origin/main --no-edit`
+6. **Sync**: `MAIN_CHECKOUT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"; git -C "$MAIN_CHECKOUT" fetch origin main && git -C "$MAIN_CHECKOUT" merge --ff-only origin/main`
 
 **Failure handling** (agent does this autonomously, no human needed):
 - **CI fails**: fix the issue, commit, push. Auto-merge stays queued, CI re-runs.

--- a/.agents/kaizen/prompts/post-merge-block.md
+++ b/.agents/kaizen/prompts/post-merge-block.md
@@ -6,7 +6,7 @@ You MUST complete these steps before finishing:
 1. Run `/kaizen` — reflect on impediments, what you'd do differently, process friction
    (One /kaizen invocation clears ALL pending post-merge gates)
 2. Mark the case as done (if a case exists for this work)
-3. Sync main: `git -C {{MAIN_CHECKOUT}} fetch origin main && git -C {{MAIN_CHECKOUT}} merge origin/main --no-edit`
+3. Sync main: `git -C {{MAIN_CHECKOUT}} fetch origin main && git -C {{MAIN_CHECKOUT}} merge --ff-only origin/main`
 4. Update linked kaizen issue if applicable
 
 IMPORTANT: Use the `/kaizen` skill to clear this gate. Do NOT use `KAIZEN_IMPEDIMENTS` or

--- a/.agents/skills/kaizen-update/SKILL.md
+++ b/.agents/skills/kaizen-update/SKILL.md
@@ -32,7 +32,7 @@ claude plugin update kaizen
 
 **For self-dogfood (kaizen repo itself):**
 ```bash
-git fetch origin main && git merge origin/main --no-edit
+git fetch origin main && git merge --ff-only origin/main
 ```
 
 ## Step 2: Install dependencies

--- a/src/hooks/kaizen-reflect.ts
+++ b/src/hooks/kaizen-reflect.ts
@@ -21,6 +21,7 @@ import { type HookInput, readHookInput, writeHookOutput, traceNullInput } from '
 import { currentHookBranch } from './lib/current-branch.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
+import { safeMainSyncCommand } from './lib/post-merge-workflows.js';
 import {
   extractRepoFlag,
   isGhPrCommand,
@@ -285,7 +286,7 @@ Valid categories: docs-only, formatting, typo, config-only, test-only, trivial-r
 
 **Also complete post-merge steps** (while the subagent runs reflection):
 - Follow Post-Merge deployment procedure in CLAUDE.md
-- Sync main: \`git -C ${mainCheckout} fetch origin main && git -C ${mainCheckout} merge --ff-only origin/main\`
+- Sync main: \`${safeMainSyncCommand(mainCheckout)}\`
 - Close resolved kaizen issues
 - Delete merged branch and worktree
 ${auditIssuesAdvisory}

--- a/src/hooks/lib/gate-manager.test.ts
+++ b/src/hooks/lib/gate-manager.test.ts
@@ -96,6 +96,9 @@ describe('readAllPendingGates', () => {
     expect(report.gates[0].type).toBe('post_merge');
     expect(report.gates[0].detail).toContain('gh run list --repo org/repo --branch main --commit <merge-sha>');
     expect(report.gates[0].detail).toContain('git fetch origin main');
+    expect(report.gates[0].detail).toContain('git merge --ff-only origin/main');
+    expect(report.gates[0].action).toBe('git fetch origin main && git merge --ff-only origin/main');
+    expect(report.gates[0].detail).not.toContain('git merge origin/main');
   });
 
   it('post-merge gate detail mentions /kaizen reflection as first step (#936)', () => {

--- a/src/hooks/lib/gate-manager.ts
+++ b/src/hooks/lib/gate-manager.ts
@@ -28,7 +28,7 @@ import {
   readStateFile,
 } from '../state-utils.js';
 import { readJsonValueFile, writeJsonValueFile } from '../../lib/json-file.js';
-import { postMergeWorkflowVerificationLines } from './post-merge-workflows.js';
+import { postMergeWorkflowVerificationLines, safeMainSyncCommand } from './post-merge-workflows.js';
 
 export interface PendingGate {
   type: 'review' | 'reflection' | 'post_merge';
@@ -103,9 +103,9 @@ export function readAllPendingGates(
       detail: [
         '1. Run /kaizen to reflect on this PR',
         `   2. ${postMergeWorkflowVerificationLines(r.prUrl)}`,
-        '   3. Then: git fetch origin main && git merge origin/main',
+        `   3. Then: ${safeMainSyncCommand()}`,
       ].join('\n'),
-      action: 'git fetch origin main && git merge origin/main',
+      action: safeMainSyncCommand(),
       filepath: r.filepath,
     });
   }

--- a/src/hooks/lib/post-merge-workflows.test.ts
+++ b/src/hooks/lib/post-merge-workflows.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { postMergeWorkflowVerificationLines } from './post-merge-workflows.js';
+import { postMergeWorkflowVerificationLines, safeMainSyncCommand } from './post-merge-workflows.js';
 
 describe('postMergeWorkflowVerificationLines', () => {
   it('builds a concrete main workflow verification command from a PR URL', () => {
@@ -16,5 +16,21 @@ describe('postMergeWorkflowVerificationLines', () => {
 
     expect(lines).toContain('gh run list --branch main --commit <merge-sha>');
     expect(lines).not.toContain('--repo');
+  });
+});
+
+describe('safeMainSyncCommand', () => {
+  it('uses ff-only sync without creating a local main merge commit', () => {
+    expect(safeMainSyncCommand()).toBe('git fetch origin main && git merge --ff-only origin/main');
+  });
+
+  it('quotes main checkout paths used with git -C', () => {
+    expect(safeMainSyncCommand('/tmp/main checkout')).toBe(
+      "git -C '/tmp/main checkout' fetch origin main && git -C '/tmp/main checkout' merge --ff-only origin/main",
+    );
+  });
+
+  it('quotes single quotes in main checkout paths', () => {
+    expect(safeMainSyncCommand("/tmp/main's checkout")).toContain("'/tmp/main'\\''s checkout'");
   });
 });

--- a/src/hooks/lib/post-merge-workflows.ts
+++ b/src/hooks/lib/post-merge-workflows.ts
@@ -19,3 +19,12 @@ export function postMergeWorkflowVerificationLines(prUrl: string): string {
     '   - If any run failed, investigate and report or fix it before declaring the work done.',
   ].join('\n');
 }
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function safeMainSyncCommand(mainCheckout?: string): string {
+  const prefix = mainCheckout ? `git -C ${shellQuote(mainCheckout)}` : 'git';
+  return `${prefix} fetch origin main && ${prefix} merge --ff-only origin/main`;
+}

--- a/src/hooks/main-sync-guidance.test.ts
+++ b/src/hooks/main-sync-guidance.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '../..');
+
+function read(path: string): string {
+  return readFileSync(resolve(ROOT, path), 'utf8');
+}
+
+describe('local main sync guidance', () => {
+  it('uses ff-only sync in the kaizen-update self-dogfood path', () => {
+    const skill = read('.agents/skills/kaizen-update/SKILL.md');
+    expect(skill).toContain('git fetch origin main && git merge --ff-only origin/main');
+    expect(skill).not.toContain('git fetch origin main && git merge origin/main --no-edit');
+  });
+
+  it('uses ff-only sync in post-merge prompt templates', () => {
+    const prompt = read('.agents/kaizen/prompts/post-merge-block.md');
+    expect(prompt).toContain('git -C {{MAIN_CHECKOUT}} fetch origin main && git -C {{MAIN_CHECKOUT}} merge --ff-only origin/main');
+    expect(prompt).not.toContain('git -C {{MAIN_CHECKOUT}} fetch origin main && git -C {{MAIN_CHECKOUT}} merge origin/main --no-edit');
+  });
+
+  it('uses ff-only sync in hook design docs for local main checkout', () => {
+    const docs = read('.agents/kaizen/docs/hook-design-principles.md');
+    expect(docs).toContain('git -C "$MAIN_CHECKOUT" fetch origin main && git -C "$MAIN_CHECKOUT" merge --ff-only origin/main');
+    expect(docs).not.toContain('git -C "$MAIN_CHECKOUT" fetch origin main && git -C "$MAIN_CHECKOUT" merge origin/main --no-edit');
+  });
+});

--- a/src/hooks/post-merge-clear.test.ts
+++ b/src/hooks/post-merge-clear.test.ts
@@ -38,6 +38,8 @@ describe('processPostMergeClear — Skill trigger', () => {
 
     expect(output).toContain('Post-merge gate cleared');
     expect(output).toContain('1 PR');
+    expect(output).toContain('merge --ff-only origin/main');
+    expect(output).not.toContain('merge origin/main --no-edit');
     // State file should be gone
     expect(existsSync(join(TEST_STATE_DIR, 'post-merge-org_repo_42'))).toBe(false);
   });
@@ -142,6 +144,8 @@ describe('processPostMergeClear — Bash trigger (MERGED detection)', () => {
     expect(output).toContain('pull/50');
     expect(output).toContain('gh run list --repo org/repo --branch main --commit <merge-sha>');
     expect(output).toContain('If any run failed');
+    expect(output).toContain('merge --ff-only origin/main');
+    expect(output).not.toContain('merge origin/main --no-edit');
 
     // awaiting_merge should be cleared, needs_post_merge should be written
     const stateFile = join(TEST_STATE_DIR, 'post-merge-org_repo_50');

--- a/src/hooks/post-merge-clear.ts
+++ b/src/hooks/post-merge-clear.ts
@@ -18,7 +18,7 @@
 import { getCurrentBranch, readHookInput, writeHookOutput, traceNullInput } from './hook-io.js';
 import { formatGateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
-import { postMergeWorkflowVerificationLines } from './lib/post-merge-workflows.js';
+import { postMergeWorkflowVerificationLines, safeMainSyncCommand } from './lib/post-merge-workflows.js';
 import { isGhPrCommand, stripHeredocBody } from './parse-command.js';
 import {
   DEFAULT_STATE_DIR,
@@ -50,7 +50,7 @@ export function processPostMergeClear(
       if (cleared > 0) {
         const mc = resolveMainCheckout();
         return formatGateSignal({ hook: 'post-merge-clear', type: 'gate-clear', gate: 'needs_post_merge', reason: 'Kaizen reflection completed' }) +
-          `\nPost-merge gate cleared (${cleared} PR${cleared !== 1 ? 's' : ''}). The /kaizen reflection satisfies the post-merge workflow requirement.\n\nRemember to also:\n- Mark the case as done (if applicable)\n- Sync main: \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n- Update linked kaizen issue`;
+          `\nPost-merge gate cleared (${cleared} PR${cleared !== 1 ? 's' : ''}). The /kaizen reflection satisfies the post-merge workflow requirement.\n\nRemember to also:\n- Mark the case as done (if applicable)\n- Sync main: \`${safeMainSyncCommand(mc)}\`\n- Update linked kaizen issue`;
       }
     }
     return '';
@@ -88,7 +88,7 @@ export function processPostMergeClear(
 
     const mc = resolveMainCheckout();
     return formatGateSignal({ hook: 'post-merge-clear', type: 'gate-set', gate: 'needs_post_merge', pr: prUrl, reason: 'Merge confirmed — run /kaizen to reflect' }) +
-      `\n🎉 PR merge confirmed: ${prUrl}\n\nNow complete the post-merge workflow:\n1. **Kaizen reflection (REQUIRED)** — Run \`/kaizen\` NOW to reflect on impediments and process friction\n2. ${postMergeWorkflowVerificationLines(prUrl)}\n3. **Mark case done** — if a case exists for this work\n4. **Sync main** — \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n5. **Update linked issue** — close the kaizen/tracking issue with lessons learned\n\n⛔ You will NOT be able to finish until /kaizen is run.`;
+      `\n🎉 PR merge confirmed: ${prUrl}\n\nNow complete the post-merge workflow:\n1. **Kaizen reflection (REQUIRED)** — Run \`/kaizen\` NOW to reflect on impediments and process friction\n2. ${postMergeWorkflowVerificationLines(prUrl)}\n3. **Mark case done** — if a case exists for this work\n4. **Sync main** — \`${safeMainSyncCommand(mc)}\`\n5. **Update linked issue** — close the kaizen/tracking issue with lessons learned\n\n⛔ You will NOT be able to finish until /kaizen is run.`;
   }
 
   return '';

--- a/src/hooks/pr-review-loop.test.ts
+++ b/src/hooks/pr-review-loop.test.ts
@@ -674,6 +674,8 @@ describe('pr-review-loop: gh pr merge', () => {
     expect(output).toContain('gh run list --repo Garsson-io/kaizen --branch main --commit <merge-sha>');
     expect(output).toContain('If any run failed');
     expect(output).toContain('Sync main');
+    expect(output).toContain('merge --ff-only origin/main');
+    expect(output).not.toContain('merge origin/main --no-edit');
   });
 
   it('creates post-merge state file', () => {

--- a/src/hooks/pr-review-loop.ts
+++ b/src/hooks/pr-review-loop.ts
@@ -34,7 +34,7 @@ import { type HookInput, readHookInput, traceHookEvent, writeHookOutput } from '
 import { currentHookBranch } from './lib/current-branch.js';
 import { formatGateSignal, type GateSignal } from './lib/gate-signal.js';
 import { gitStdout } from './lib/git-state.js';
-import { postMergeWorkflowVerificationLines } from './lib/post-merge-workflows.js';
+import { postMergeWorkflowVerificationLines, safeMainSyncCommand } from './lib/post-merge-workflows.js';
 import {
   isGhPrCommand,
   isGitCommand,
@@ -385,7 +385,7 @@ export function processHookInput(
       STATUS: 'needs_post_merge',
       BRANCH: branch,
     });
-    const mergeMsg = `\n\ud83c\udf89 PR merged: ${mergeUrl}\n\nNow complete the post-merge workflow:\n1. **Kaizen reflection (REQUIRED)** \u2014 Run \`/kaizen\` NOW.\n2. **Post-merge action needed** \u2014 classify per CLAUDE.md deploy policy.\n3. ${postMergeWorkflowVerificationLines(mergeUrl)}\n4. **Sync main** \u2014 \`git -C ${mc} fetch origin main && git -C ${mc} merge origin/main --no-edit\`\n5. **Update linked issue** \u2014 Close with lessons learned.\n6. **Spec update** \u2014 Move completed work to "Already Solved".\n\n\u26d4 You will NOT be able to finish until /kaizen is run.\n`;
+    const mergeMsg = `\n\ud83c\udf89 PR merged: ${mergeUrl}\n\nNow complete the post-merge workflow:\n1. **Kaizen reflection (REQUIRED)** \u2014 Run \`/kaizen\` NOW.\n2. **Post-merge action needed** \u2014 classify per CLAUDE.md deploy policy.\n3. ${postMergeWorkflowVerificationLines(mergeUrl)}\n4. **Sync main** \u2014 \`${safeMainSyncCommand(mc)}\`\n5. **Update linked issue** \u2014 Close with lessons learned.\n6. **Spec update** \u2014 Move completed work to "Already Solved".\n\n\u26d4 You will NOT be able to finish until /kaizen is run.\n`;
     return decide('post_merge', 'merge_completed', mergeMsg, { mergeUrl });
   }
 


### PR DESCRIPTION
## Summary

Kaizen post-merge guidance still had paths that told agents to sync local main with merge origin/main or merge origin/main --no-edit. That can create local-only merge commits on main after PRs are squash-merged on GitHub.

This PR moves post-merge sync guidance to a shared safeMainSyncCommand helper that always uses merge --ff-only origin/main, then updates the hook outputs, stop-gate action, post-merge prompt, hook design docs, and kaizen-update self-dogfood command to use ff-only main sync.

Fixes Garsson-io/kaizen#893

## Changes

- Add safeMainSyncCommand() in src/hooks/lib/post-merge-workflows.ts, with quoting for git -C paths.
- Use the helper in pr-review-loop, post-merge-clear, gate-manager, and kaizen-reflect.
- Update post-merge prompt/docs and kaizen-update self-dogfood instructions to use ff-only main sync.
- Add regression coverage for hook outputs, stop-gate action, helper quoting, and local-main guidance artifacts.

## Verification

- RED: npx vitest run src/hooks/pr-review-loop.test.ts src/hooks/post-merge-clear.test.ts src/hooks/lib/gate-manager.test.ts failed on missing merge --ff-only origin/main.
- RED: npx vitest run src/hooks/main-sync-guidance.test.ts failed on stale kaizen-update, post-merge prompt, and hook design docs.
- GREEN: npx vitest run src/hooks/main-sync-guidance.test.ts src/hooks/pr-review-loop.test.ts src/hooks/post-merge-clear.test.ts src/hooks/lib/gate-manager.test.ts src/hooks/kaizen-reflect.test.ts src/hooks/lib/post-merge-workflows.test.ts -> 123 passed.
- npm run typecheck -> pass.
- npm run test:fast -> 13 files, 284 tests passed.
- npm test -> 178 files passed, 2 skipped; 4240 tests passed, 14 skipped.
- git diff --check -> pass.
- Residual scan: no unsafe local-main sync guidance remains; remaining git merge origin/main references are feature-branch/rebase-alternative guidance or negative test assertions.
- Real Git smoke: in a synthetic divergent local main, git fetch origin main && git merge --ff-only origin/main exited nonzero and left HEAD unchanged, proving it refuses to create a local merge commit.
