### PR TITLE
fix(hooks): gate precompiled ts runtime on freshness

### DIFF
--- a/.agents/kaizen/docs/hook-catalog.md
+++ b/.agents/kaizen/docs/hook-catalog.md
@@ -83,9 +83,10 @@ Computer-level installation (`kaizen@kaizen` in `~/.claude/settings.json`) is **
 
 All enforcement hooks are now in TypeScript. Each `-ts.sh` shim is a thin bash
 wrapper that sources `.claude/hooks/lib/run-tsx.sh`; the shared resolver locates
-`tsx` from the kaizen checkout, parent worktree installs, or git common dir and
-then invokes the TypeScript implementation. Production hook shims do not call
-`npx tsx` directly.
+fresh precompiled `dist/*.js` output via `dist/.kaizen-hook-build`, then falls
+back to `tsx` from the kaizen checkout, parent worktree installs, or git common
+dir and invokes the TypeScript implementation source. Production hook shims do
+not call `npx tsx` directly.
 
 | Registered shim | TS implementation | Tests |
 |-----------------|-------------------|-------|

--- a/.claude/hooks/lib/run-tsx.sh
+++ b/.claude/hooks/lib/run-tsx.sh
@@ -2,10 +2,11 @@
 # Part of kAIzen Agent Control Flow
 # run-tsx.sh — Reliable tsx execution for TS hook shims
 #
-# Resolves tsx from KAIZEN_DIR/node_modules, parent/worktree installs, or the
-# git common dir, then gives up loudly but fail-open. Prevents opaque hook
-# errors when node_modules is missing (e.g., plugin installations without npm
-# install) while keeping hooks non-blocking.
+# Runs precompiled dist output when a build freshness marker proves it is
+# current, otherwise resolves tsx from KAIZEN_DIR/node_modules,
+# parent/worktree installs, or the git common dir, then gives up loudly but
+# fail-open. Prevents opaque hook errors when node_modules is missing (e.g.,
+# plugin installations without npm install) while keeping hooks non-blocking.
 #
 # Usage (in a TS shim):
 #   source "$(dirname "$0")/lib/run-tsx.sh"
@@ -24,6 +25,42 @@ if [ -n "${BASH_SOURCE[1]:-}" ]; then
   unset KAIZEN_HOOK_TELEMETRY_NAME
 fi
 
+hook_dist_file_for_source() {
+  local kaizen_dir="$1"
+  local ts_file="$2"
+
+  case "$ts_file" in
+    "$kaizen_dir"/src/*.ts)
+      local rel_path="${ts_file#"$kaizen_dir"/src/}"
+      printf '%s\n' "$kaizen_dir/dist/${rel_path%.ts}.js"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+hook_build_is_fresh() {
+  local kaizen_dir="$1"
+  local marker="$kaizen_dir/dist/.kaizen-hook-build"
+
+  [ -f "$marker" ] || return 1
+  [ -d "$kaizen_dir/src" ] || return 1
+
+  local newer_source
+  newer_source="$(
+    find "$kaizen_dir/src" \
+      -type f \
+      -name '*.ts' \
+      ! -name '*.test.ts' \
+      -newer "$marker" \
+      -print \
+      -quit 2>/dev/null
+  )" || return 1
+
+  [ -z "$newer_source" ]
+}
+
 run_tsx() {
   local kaizen_dir="$1"
   local ts_file="$2"
@@ -40,7 +77,21 @@ run_tsx() {
     exit $?
   fi
 
-  # 1. Shared resolver — local node_modules, parent worktree installs, git common dir
+  # 1. Fast path — use precompiled dist only when npm run build wrote a fresh
+  # marker after all production TypeScript sources.
+  local dist_file
+  if dist_file="$(hook_dist_file_for_source "$kaizen_dir" "$ts_file")"; then
+    if [ -f "$dist_file" ] && hook_build_is_fresh "$kaizen_dir"; then
+      local node_bin
+      node_bin="$(command -v node || true)"
+      if [ -n "$node_bin" ]; then
+        "$node_bin" "$dist_file"
+        exit $?
+      fi
+    fi
+  fi
+
+  # 2. Shared resolver — local node_modules, parent worktree installs, git common dir
   local resolved_tsx
   resolved_tsx="$(resolve_tsx_bin "$kaizen_dir" || true)"
   if [ -n "$resolved_tsx" ]; then
@@ -48,7 +99,7 @@ run_tsx() {
     exit $?
   fi
 
-  # 2. tsx not available — exit gracefully instead of crashing. Do not shell
+  # 3. tsx not available — exit gracefully instead of crashing. Do not shell
   # through `npx --prefix ... 2>/dev/null`: when the bound plugin/worktree root
   # lacks node_modules, npx exits non-zero with empty stderr and Claude reports
   # only "Failed with non-blocking status code: No stderr output" (#1131).

--- a/.claude/hooks/pr-review-loop-ts.sh
+++ b/.claude/hooks/pr-review-loop-ts.sh
@@ -3,4 +3,4 @@
 
 source "$(dirname "$0")/lib/scope-guard.sh"
 source "$(dirname "$0")/lib/run-tsx.sh" 2>/dev/null || { exit 0; }
-run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/$(basename "${BASH_SOURCE[0]}" .sh | sed 's/-ts$//' ).ts"
+run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/$(basename "${BASH_SOURCE[0]}" .sh | sed 's/-ts$//').ts"

--- a/.claude/hooks/tests/test-run-tsx.sh
+++ b/.claude/hooks/tests/test-run-tsx.sh
@@ -26,6 +26,90 @@ cat > "$TMP_DIR/hook.ts" <<'EOF'
 console.log("hook");
 EOF
 
+mkdir -p "$TMP_DIR/bin"
+cat > "$TMP_DIR/bin/node" <<'EOF'
+#!/bin/bash
+echo "node-dist:$1"
+EOF
+chmod +x "$TMP_DIR/bin/node"
+
+echo ""
+echo "=== precompiled dist runtime ==="
+
+FRESH_ROOT="$TMP_DIR/fresh-root"
+mkdir -p "$FRESH_ROOT/src/hooks" "$FRESH_ROOT/dist/hooks" "$FRESH_ROOT/node_modules/.bin"
+printf 'source\n' > "$FRESH_ROOT/src/hooks/fresh-hook.ts"
+printf 'compiled\n' > "$FRESH_ROOT/dist/hooks/fresh-hook.js"
+cat > "$FRESH_ROOT/node_modules/.bin/tsx" <<'EOF'
+#!/bin/bash
+echo "fallback-tsx:$1"
+EOF
+chmod +x "$FRESH_ROOT/node_modules/.bin/tsx"
+touch "$FRESH_ROOT/src/hooks/fresh-hook.ts"
+sleep 1
+touch "$FRESH_ROOT/dist/.kaizen-hook-build"
+
+result=$(
+  PATH="$TMP_DIR/bin:$PATH" bash -c "
+    source '$RUN_TSX'
+    run_tsx '$FRESH_ROOT' '$FRESH_ROOT/src/hooks/fresh-hook.ts'
+  " 2>&1
+)
+exit_code=$?
+
+assert_eq "fresh dist exits 0" "0" "$exit_code"
+assert_contains "fresh dist runs compiled hook through node" "node-dist:$FRESH_ROOT/dist/hooks/fresh-hook.js" "$result"
+assert_not_contains "fresh dist does not fall back to tsx" "fallback-tsx:" "$result"
+
+STALE_ROOT="$TMP_DIR/stale-root"
+mkdir -p "$STALE_ROOT/src/hooks" "$STALE_ROOT/dist/hooks" "$STALE_ROOT/node_modules/.bin"
+printf 'compiled\n' > "$STALE_ROOT/dist/hooks/stale-hook.js"
+touch "$STALE_ROOT/dist/.kaizen-hook-build"
+sleep 1
+printf 'new source\n' > "$STALE_ROOT/src/hooks/stale-hook.ts"
+cat > "$STALE_ROOT/node_modules/.bin/tsx" <<'EOF'
+#!/bin/bash
+echo "fallback-tsx:$1"
+EOF
+chmod +x "$STALE_ROOT/node_modules/.bin/tsx"
+
+result=$(
+  PATH="$TMP_DIR/bin:$PATH" bash -c "
+    source '$RUN_TSX'
+    run_tsx '$STALE_ROOT' '$STALE_ROOT/src/hooks/stale-hook.ts'
+  " 2>&1
+)
+exit_code=$?
+
+assert_eq "stale dist exits 0 through fallback" "0" "$exit_code"
+assert_contains "stale source falls back to tsx" "fallback-tsx:$STALE_ROOT/src/hooks/stale-hook.ts" "$result"
+assert_not_contains "stale dist is not executed" "node-dist:" "$result"
+
+MISSING_MARKER_ROOT="$TMP_DIR/missing-marker-root"
+mkdir -p "$MISSING_MARKER_ROOT/src/hooks" "$MISSING_MARKER_ROOT/dist/hooks" "$MISSING_MARKER_ROOT/node_modules/.bin"
+printf 'source\n' > "$MISSING_MARKER_ROOT/src/hooks/no-marker-hook.ts"
+printf 'compiled\n' > "$MISSING_MARKER_ROOT/dist/hooks/no-marker-hook.js"
+cat > "$MISSING_MARKER_ROOT/node_modules/.bin/tsx" <<'EOF'
+#!/bin/bash
+echo "fallback-tsx:$1"
+EOF
+chmod +x "$MISSING_MARKER_ROOT/node_modules/.bin/tsx"
+
+result=$(
+  PATH="$TMP_DIR/bin:$PATH" bash -c "
+    source '$RUN_TSX'
+    run_tsx '$MISSING_MARKER_ROOT' '$MISSING_MARKER_ROOT/src/hooks/no-marker-hook.ts'
+  " 2>&1
+)
+exit_code=$?
+
+assert_eq "missing build marker exits 0 through fallback" "0" "$exit_code"
+assert_contains "missing build marker falls back to tsx" "fallback-tsx:$MISSING_MARKER_ROOT/src/hooks/no-marker-hook.ts" "$result"
+assert_not_contains "missing build marker does not run dist" "node-dist:" "$result"
+
+echo ""
+echo "=== test harness override ==="
+
 result=$(
   KAIZEN_TSX_BIN="$TMP_DIR/mock-tsx" bash -c "
     source '$RUN_TSX'

--- a/.claude/hooks/tests/validate-hook-integrity.sh
+++ b/.claude/hooks/tests/validate-hook-integrity.sh
@@ -144,6 +144,18 @@ if [ -d "$HOOKS_DIR" ]; then
 fi
 
 echo ""
+echo "--- Lint: TS shim dynamic source targets have no literal-space suffix ---"
+if [ -d "$HOOKS_DIR" ]; then
+  BAD_TS_TARGETS=$(grep -R -nE 'run_tsx .*\$\([^)]*\)[[:space:]]+\.ts' "$HOOKS_DIR"/*.sh 2>/dev/null || true)
+  if [ -n "$BAD_TS_TARGETS" ]; then
+    echo "::error::[tsx-target] Dynamic TS hook target contains whitespace before .ts:"
+    echo "$BAD_TS_TARGETS"
+    ((ERRORS++))
+  fi
+  echo "  Checked dynamic TS shim source targets"
+fi
+
+echo ""
 echo "--- Single source of truth: settings.json AND plugin.json must not BOTH have hooks (kaizen #1063) ---"
 # Previous rule (kaizen #793) required settings.json and plugin.json to declare
 # the SAME hooks. That was the dual-load state #1063 identified as the root

--- a/docs/hook-language-boundaries.md
+++ b/docs/hook-language-boundaries.md
@@ -155,15 +155,19 @@ Migration approach per script:
 ## Design Decisions
 
 **Q: Should TypeScript hooks use `tsx` (dev), Bun, or compiled JS (prod)?**
-A: Use the shared `run-tsx.sh` resolver for production hook shims. It resolves
+A: Use the shared `run-tsx.sh` trampoline for production hook shims. It honors
+`KAIZEN_TSX_BIN` first for deterministic tests, then prefers precompiled
+`node dist/...` output when `npm run build` has written
+`dist/.kaizen-hook-build` after all non-test `src/**/*.ts` files and the
+matching compiled file exists. If the marker is missing or stale, it resolves
 repo-local or parent-checkout `tsx` without `npx`, works in worktrees where the
 current checkout lacks `node_modules`, and fails open with an actionable
 diagnostic if dependencies are unavailable. A #454 measurement on this host put
 the real `pr-review-loop-ts.sh` resolver path at 0.54-0.90s, direct `npx tsx`
 at 0.68-0.88s, `npx -y bun` at 0.59-0.68s, and precompiled
-`node dist/hooks/pr-review-loop.js` at 0.10s. Keep the resolver as the default
-until #1662 defines a build-freshness contract for precompiled hooks or a
-standard production Bun installation path.
+`node dist/hooks/pr-review-loop.js` at 0.10s. Bun remains out of the production
+hot path unless it becomes a standard installed dependency instead of
+`npx -y bun`.
 
 **Q: Should we migrate `claude-wt.sh`?**
 A: Not yet. It's L2-L3 boundary — orchestration but mostly delegating. Migrate when it breaks or grows.

--- a/docs/hooks-design.md
+++ b/docs/hooks-design.md
@@ -144,29 +144,33 @@ run_tsx "$KAIZEN_DIR" "$KAIZEN_DIR/src/hooks/some-hook.ts"
 ```
 
 The bash shim handles scope-guard and production dispatch. `run-tsx.sh`
-resolves `tsx` from the kaizen checkout, parent worktree installs, or git
-common dir through `resolve-tsx-bin.sh`; it also honors `KAIZEN_TSX_BIN` for
-deterministic test harnesses. The shim intentionally avoids `npx --prefix ...
-tsx` in production hook paths because missing dependencies produced opaque
-non-blocking hook failures (#1131) and because `npx` adds startup overhead.
+honors `KAIZEN_TSX_BIN` first for deterministic test harnesses. In production
+it prefers precompiled `node dist/...` output only when `npm run build` has
+written `dist/.kaizen-hook-build` after all non-test `src/**/*.ts` files and
+the matching compiled file exists. If the marker is missing or stale, it falls
+back to resolving `tsx` from the kaizen checkout, parent worktree installs, or
+git common dir through `resolve-tsx-bin.sh`. The shim intentionally avoids
+`npx --prefix ... tsx` in production hook paths because missing dependencies
+produced opaque non-blocking hook failures (#1131) and because `npx` adds
+startup overhead.
 
 Current #454 measurement on this host after `npm run build`:
 
 | Launcher | Five-run wall time | Max RSS | Decision |
 |---|---:|---:|---|
-| `pr-review-loop-ts.sh` via `run-tsx.sh` shared resolver | 0.54-0.90s | 107-117 MB | Current production default |
+| `pr-review-loop-ts.sh` via `run-tsx.sh` shared resolver | 0.54-0.90s | 107-117 MB | Source fallback when dist is stale or unavailable |
 | Direct `npx tsx src/hooks/pr-review-loop.ts` | 0.68-0.88s | 108-114 MB | Avoid in production shims |
 | `npx --no-install tsx src/hooks/pr-review-loop.ts` | 0.62-0.65s | 112-118 MB | Similar to resolver but less worktree-aware |
 | `npx -y bun src/hooks/pr-review-loop.ts` | 0.59-0.68s | 101-103 MB | Not a production win through `npx` |
-| `node dist/hooks/pr-review-loop.js` | 0.10s | 63-65 MB | Fastest, needs build-freshness contract |
+| `node dist/hooks/pr-review-loop.js` | 0.10s | 63-65 MB | Fastest path when build marker is fresh |
 
-Decision: keep the shared `run-tsx.sh` resolver as the production trampoline.
-It avoids `npx` overhead, works from worktrees without local `node_modules`,
-fails open with an actionable diagnostic when `tsx` is unavailable, and does
-not require Bun as an operator dependency. Precompiled Node is the measured
-fastest path, but adopting it safely requires a freshness contract so hooks do
-not silently run stale `dist` output. Track that production-runtime adoption
-decision in #1662.
+Decision matrix:
+
+| Runtime | Production decision | Contract |
+|---|---|---|
+| Precompiled Node | Prefer first when fresh | `npm run build` writes `dist/.kaizen-hook-build`; `run-tsx.sh` requires marker newer than non-test `src/**/*.ts` and a matching `dist/*.js` file |
+| Source `tsx` | Required fallback | Shared resolver stays worktree-aware and fail-open when dependencies are missing |
+| Bun | Do not use by default | `npx -y bun` is not a measured production win; adopting Bun would require a standard installed dependency instead of hot-path `npx` |
 
 The TypeScript file handles all logic, reads stdin JSON, and writes stdout JSON.
 This makes the logic fully testable with vitest.
@@ -268,10 +272,12 @@ STATE_DIR=$(mktemp -d) CLAUDECODE=1 \
 - **Session hook registries are manifest-derived:** `SessionSimulator` loads `.claude-plugin/plugin.json` through `loadDefaultHookRegistry()`. Do not hand-maintain a parallel full hook list in E2E tests; narrow `session.hooks` only when the test intentionally exercises a focused subset.
 - **Hook subprocess tests should be deterministic in worktrees:** use `resolveTsxBin()` from `src/e2e/test-runtime.ts` for TypeScript E2E tests, pass `KAIZEN_TSX_BIN` to bash trampolines when invoking them from test harnesses, and disable advisory background noise with `HOOK_TIMING_SENTINEL_DISABLED=true` and `SEND_TELEGRAM_IPC_DISABLED=true`.
 - **Do not silently skip outcome-proof tests:** if an outcome E2E test requires `tsx`, assert that it is present and fail loudly. Skip guards are acceptable for live fixtures whose subject is explicitly optional local infrastructure.
-- **Production best-effort hooks use the shared resolver:** `run-tsx.sh` and
-  `resolve-tsx-bin.sh` are the TS hook trampoline contract. They resolve a
-  usable `tsx` binary without `npx`, support `KAIZEN_TSX_BIN` for tests, and
-  fail open with an actionable diagnostic when dependencies are missing.
+- **Production best-effort hooks use the shared trampoline:** `run-tsx.sh`
+  first supports `KAIZEN_TSX_BIN` for tests, then uses precompiled `node
+  dist/...` only when `dist/.kaizen-hook-build` proves the build is fresh, then
+  falls back through `resolve-tsx-bin.sh` to a usable `tsx` binary without
+  `npx`, and finally fails open with an actionable diagnostic when
+  dependencies are missing.
 
 ## Anti-Patterns
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "postinstall": "git config core.hooksPath .githooks 2>/dev/null || true",
-    "build": "tsc",
+    "build": "tsc && bash scripts/write-hook-build-marker.sh",
     "check:fast": "npm run typecheck && npm run test:fast",
     "test": "timeout --kill-after=10 120 vitest run",
     "test:fast": "timeout --kill-after=10 60 vitest run --changed origin/main --passWithNoTests --exclude 'src/e2e/**' --exclude '**/*.e2e.test.ts'",

--- a/scripts/write-hook-build-marker.sh
+++ b/scripts/write-hook-build-marker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Writes the freshness marker that allows TS hook shims to use dist/.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MARKER="$REPO_ROOT/dist/.kaizen-hook-build"
+
+mkdir -p "$(dirname "$MARKER")"
+
+{
+  echo "# kaizen hook build freshness marker"
+  echo "built_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  echo "source_root=$REPO_ROOT/src"
+} > "$MARKER"

--- a/src/policy-docs.test.ts
+++ b/src/policy-docs.test.ts
@@ -271,6 +271,16 @@ describe('hook runtime docs — TypeScript shim contract', () => {
     expect(hooksDesign).toMatch(/KAIZEN_TSX_BIN/);
   });
 
+  it('documents the precompiled Node freshness contract and fallback matrix', () => {
+    for (const doc of [hooksDesign, hookCatalog, languageBoundaries]) {
+      expect(doc).toMatch(/dist\/\.kaizen-hook-build/);
+    }
+    expect(hooksDesign).toMatch(/Precompiled Node/);
+    expect(hooksDesign).toMatch(/Source `tsx`/);
+    expect(hooksDesign).toMatch(/Bun/);
+    expect(hooksDesign).toMatch(/non-test `src\/\*\*\/\*\.ts`/);
+  });
+
   it('does not claim TS hook shims call npx tsx directly', () => {
     const staleDirectShimClaims = [
       /shim[^.\n]*calls `npx tsx`/i,


### PR DESCRIPTION
## Story

Once upon a time, every TypeScript Claude hook shim delegated through `.claude/hooks/lib/run-tsx.sh` and always ran source through `tsx`. That was worktree-safe and fail-open, but #454 measured a faster path: `node dist/hooks/pr-review-loop.js` ran at about 0.10s locally while the shared source resolver path took 0.54-0.90s.

Every day, we left precompiled Node documented as “fastest, but unsafe” because there was no contract proving `dist/` was current. One source edit after a build could silently make production hooks run old code.

One day, #1662 asked for the runtime decision instead of another measurement pass: decide between source `tsx`, Bun, and precompiled Node, and if Node wins, prevent stale compiled hooks.

Because of that, this PR keeps the single shared trampoline but adds a build freshness marker. `npm run build` now writes `dist/.kaizen-hook-build` after `tsc` succeeds. `run-tsx.sh` honors `KAIZEN_TSX_BIN` first for tests, then uses `node dist/...` only when the matching compiled file exists and the marker is newer than non-test `src/**/*.ts`; otherwise it falls back to the existing `resolve-tsx-bin.sh` source path.

Because of that, the symlinked dynamic shims now resolve `src/hooks/<shim>.ts` without the literal-space typo that previously produced `<shim> .ts`. That makes the precompiled path reachable for the shared `pr-review-loop-ts.sh`/`pr-kaizen-clear-ts.sh`/`kaizen-reflect-ts.sh` symlink target.

Until finally, the focused shell test proves all three runtime cases: fresh dist runs through `node`, stale source falls back to `tsx`, and missing marker falls back to `tsx`. The hook-integrity validator also guards the dynamic shim typo.

And ever since, production hook shims have one runtime contract instead of an unresolved fork between speed and correctness.

Closes #1662

Refs: #454
Parent: #451
Parent: #1532

## Impact (goal -> before/after -> match)

- Goal (#1662): production TS hook runtime can safely use faster precompiled Node without stale `dist` risk.
- Acceptance signal: stale source after build refuses precompiled `dist` and uses source `tsx`; fresh build uses `node dist/...`; docs/tests define source `tsx`, Bun, and precompiled Node decisions.
- BEFORE: `run-tsx.sh` never attempted `dist`, and docs said precompiled Node was fastest but still needed a freshness contract. The symlinked dynamic shim target also contained a literal space before `.ts`, preventing those shims from reaching a matching source/dist path.
- AFTER: `run-tsx.sh` dispatches fresh compiled hooks through `node dist/...`, rejects stale or missing-marker builds, falls back to the existing resolver, and the dynamic shim target resolves without whitespace.
- Delta: focused runtime shell coverage increased from 7 to 16 assertions; hook integrity now lints dynamic TS shim targets; `npm run build` now produces `dist/.kaizen-hook-build`; docs include the runtime decision matrix.
- Goal met?: yes.
- Residual scan: no per-shim divergence found; production direct `npx --prefix ... tsx` fallback remains guarded by the existing shell assertion.

## Architecture

```text
TS hook shim
  -> scope-guard.sh
  -> run-tsx.sh
      1. KAIZEN_TSX_BIN override for deterministic tests
      2. node dist/<same path>.js if dist/.kaizen-hook-build is fresh
      3. resolve-tsx-bin.sh source fallback
      4. fail-open diagnostic if no runtime is available

npm run build
  -> tsc
  -> scripts/write-hook-build-marker.sh
  -> dist/.kaizen-hook-build
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Prefer precompiled Node only with a fresh marker | Gets the measured fastest path without stale `dist` execution | Adds one marker script and an mtime check in the trampoline |
| Keep `KAIZEN_TSX_BIN` before dist | Existing tests and harnesses need deterministic source execution | Test override can bypass the production fast path intentionally |
| Check marker against non-test `src/**/*.ts` | Hook imports can come from shared source, not only `src/hooks/*.ts` | Slightly broader freshness check than the single hook file |
| Keep source `tsx` fallback | Worktrees without fresh builds still work and fail open as before | Fresh builds are needed to get the faster path |
| Keep symlinked shims dynamic but lint the target suffix | One file backs three registered hook names, and each must map to its own TS source | Static validation catches the whitespace typo rather than expanding symlinks into duplicate files |
| Do not adopt Bun | `npx -y bun` is not a clear production win and Bun is not a standard dependency here | Bun can be reconsidered if installed and supported as a real runtime |

## What's In This PR

| File | Purpose |
|---|---|
| `.claude/hooks/lib/run-tsx.sh` | Adds fresh `node dist/...` dispatch before the existing source resolver fallback |
| `.claude/hooks/pr-review-loop-ts.sh` | Fixes the symlink-safe dynamic source target so it resolves `<shim>.ts`, not `<shim> .ts` |
| `scripts/write-hook-build-marker.sh` | Writes `dist/.kaizen-hook-build` after successful builds |
| `package.json` | Runs the marker script after `tsc` in `npm run build` |
| `.claude/hooks/tests/test-run-tsx.sh` | Covers fresh dist, stale source fallback, missing-marker fallback, and existing fallback invariants |
| `.claude/hooks/tests/validate-hook-integrity.sh` | Lints dynamic TS shim targets for the literal-space suffix failure |
| `docs/hooks-design.md` | Documents the production runtime matrix and build-freshness contract |
| `docs/hook-language-boundaries.md` | Updates the TypeScript runtime decision answer |
| `.agents/kaizen/docs/hook-catalog.md` | Keeps the hook catalog aligned with the trampoline contract |
| `src/policy-docs.test.ts` | Locks the docs against losing the marker/matrix language |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status | Evidence |
|---|---|---|---|---|
| 1 | Fresh compiled hook dispatches through `node dist/...` before `tsx` fallback | Unit/System shell | tested | `bash .claude/hooks/tests/test-run-tsx.sh` -> 16 passed |
| 2 | Source newer than the build marker refuses dist and falls back to `tsx` | Unit/System shell | tested | `bash .claude/hooks/tests/test-run-tsx.sh` -> stale source uses `fallback-tsx` and not `node-dist` |
| 3 | Missing dist or marker preserves existing source fallback and fail-open diagnostic | Unit/System shell | tested | `bash .claude/hooks/tests/test-run-tsx.sh` -> missing marker uses fallback; no silent `npx` fallback remains |
| 4 | `npm run build` writes the build freshness marker after `tsc` succeeds | System | tested | `npm run build`; observed `dist/.kaizen-hook-build` with build timestamp |
| 5 | Docs describe the chosen source/Bun/precompiled decision matrix | Unit | tested | `npx vitest run src/policy-docs.test.ts` -> 54 passed |
| 6 | Symlinked dynamic TS shims do not reintroduce the whitespace target typo | Unit/System shell | tested | `bash .claude/hooks/tests/test-validate-hook-integrity.sh`; `bash .claude/hooks/tests/validate-hook-integrity.sh` -> 0 errors |

No Agentic/Workflow test is included because this is deterministic shell/runtime dispatch with no LLM-dependent decision.

## Validation

- [x] Red first: `bash .claude/hooks/tests/test-run-tsx.sh` failed before implementation because fresh dist fell back to `tsx`.
- [x] `bash .claude/hooks/tests/test-run-tsx.sh` -> 16 passed, 0 failed.
- [x] `bash .claude/hooks/tests/test-validate-hook-integrity.sh` -> 12 passed, 0 failed.
- [x] `bash .claude/hooks/tests/validate-hook-integrity.sh` -> 27 hook commands checked, 0 errors.
- [x] `npx vitest run src/policy-docs.test.ts` -> 54 passed.
- [x] `npm run build` -> `tsc` succeeded and wrote `dist/.kaizen-hook-build`.
- [x] Real shim smoke: `printf '{"tool_input":{"command":"npm run build"}}' | .claude/hooks/pr-review-loop-ts.sh` -> exit 0 after build marker existed.
- [x] `npm run test:hooks` -> 477 passed, 0 failed.
- [x] `npm run check:fast` -> typecheck plus changed tests passed.
- [x] `npm test` -> 4,251 passed, 14 skipped. Existing fixture prints `Unknown option: --bogus` while the suite exits 0.
- [x] `git diff --check HEAD~1..HEAD` -> clean.

## Known Limitations

- The freshness contract is mtime-based. That matches the local build artifact contract, but it is not a content hash.
- Generated `dist/` remains ignored; operators must run `npm run build` to refresh the precompiled path after source edits. Stale or missing builds intentionally use the source fallback.

