### PR TITLE
fix(case): reject scope-conflicting plans

### DIFF
--- a/src/case-system.test.ts
+++ b/src/case-system.test.ts
@@ -125,6 +125,55 @@ describe('CaseSystem.checkPlanGate', () => {
     be.storeTestPlan(number, 'r', '');
     expect(new CaseSystem(be).checkPlanGate(number, 'r').passed).toBe(false);
   });
+
+  it('fails when the plan explicitly closes a different issue (#1161)', () => {
+    const be = new InMemoryBackend();
+    be.createIssue({ title: 'selected', body: '', repo: 'r' });
+    be.storePlan(1, 'r', '## Plan\n\nShip the batch in one PR.\n\nCloses #1, #2, and #3');
+    be.storeTestPlan(1, 'r', '## Test Plan\n\n- unit');
+
+    const r = new CaseSystem(be).checkPlanGate(1, 'r');
+
+    expect(r.passed).toBe(false);
+    expect(r.hasPlan).toBe(true);
+    expect(r.hasTestPlan).toBe(true);
+    expect(r.reason).toContain('scope-conflicting close target');
+    expect(r.reason).toContain('#2');
+    expect(r.reason).toContain('#3');
+  });
+
+  it('allows closing-keyword targets for the selected issue', () => {
+    const be = new InMemoryBackend();
+    be.createIssue({ title: 'selected', body: '', repo: 'r' });
+    be.storePlan(1, 'r', '## Plan\n\nFixes #1 with a scoped PR.');
+    be.storeTestPlan(1, 'r', '## Test Plan\n\n- unit');
+
+    const r = new CaseSystem(be).checkPlanGate(1, 'r');
+
+    expect(r.passed).toBe(true);
+  });
+
+  it('allows non-closing context references to parent or sibling issues', () => {
+    const be = new InMemoryBackend();
+    be.createIssue({ title: 'selected', body: '', repo: 'r' });
+    be.storePlan(1, 'r', 'Parent: #1134\n\nCompare behavior observed on #2, but only implement #1.');
+    be.storeTestPlan(1, 'r', '## Test Plan\n\n- unit');
+
+    const r = new CaseSystem(be).checkPlanGate(1, 'r');
+
+    expect(r.passed).toBe(true);
+  });
+
+  it('allows prose-separated context references after a selected close target', () => {
+    const be = new InMemoryBackend();
+    be.createIssue({ title: 'selected', body: '', repo: 'r' });
+    be.storePlan(1, 'r', 'Fixes #1 by comparing the incident observed on #2.');
+    be.storeTestPlan(1, 'r', '## Test Plan\n\n- unit');
+
+    const r = new CaseSystem(be).checkPlanGate(1, 'r');
+
+    expect(r.passed).toBe(true);
+  });
 });
 
 // ── Plan store / retrieve round-trip ───────────────────────────────

--- a/src/case-system.ts
+++ b/src/case-system.ts
@@ -39,6 +39,7 @@ export interface PlanGateResult {
   passed: boolean;
   hasPlan: boolean;
   hasTestPlan: boolean;
+  problems: Array<'plan' | 'testplan' | 'scope-conflict'>;
   issueNumber: number;
   repo: string;
   /** The actual plan text (if present), for substance checks without refetch. */
@@ -47,6 +48,32 @@ export interface PlanGateResult {
   testPlanText?: string | null;
   /** Why the gate failed, if it did. */
   reason?: string;
+}
+
+const CLOSING_KEYWORD_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#(\d+)\b/i;
+const ISSUE_REF_RE = /(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#(\d+)\b/g;
+const CLOSE_TARGET_LIST_SEPARATOR_RE = /^[\s,]*(?:and|or)?[\s,]*$/i;
+
+function extractClosingIssueTargets(text: string): number[] {
+  const targets = new Set<number>();
+  for (const line of text.split(/\r?\n/)) {
+    const closingMatch = line.match(CLOSING_KEYWORD_RE);
+    if (!closingMatch || closingMatch.index === undefined) continue;
+    const firstIssue = Number.parseInt(closingMatch[1], 10);
+    if (Number.isInteger(firstIssue)) targets.add(firstIssue);
+
+    let cursor = closingMatch.index + closingMatch[0].length;
+    ISSUE_REF_RE.lastIndex = cursor;
+    let match: RegExpExecArray | null;
+    while ((match = ISSUE_REF_RE.exec(line)) !== null) {
+      const separator = line.slice(cursor, match.index);
+      if (!CLOSE_TARGET_LIST_SEPARATOR_RE.test(separator)) break;
+      const issueNumber = Number.parseInt(match[1], 10);
+      if (Number.isInteger(issueNumber)) targets.add(issueNumber);
+      cursor = match.index + match[0].length;
+    }
+  }
+  return [...targets].sort((a, b) => a - b);
 }
 
 export interface CreateIssueOpts {
@@ -194,23 +221,36 @@ export class CaseSystem {
 
     const hasPlan = !!planText && planText.length > 0;
     const hasTestPlan = !!testPlanText && testPlanText.length > 0;
-    const passed = hasPlan && hasTestPlan;
+    const scopeConflicts = hasPlan
+      ? extractClosingIssueTargets(planText).filter(target => target !== issueNumber)
+      : [];
+    const passed = hasPlan && hasTestPlan && scopeConflicts.length === 0;
 
     const missing: string[] = [];
     if (!hasPlan) missing.push('implementation plan');
     if (!hasTestPlan) missing.push('test plan');
+    if (scopeConflicts.length > 0) missing.push('scope-conflicting close target');
+    const problems: PlanGateResult['problems'] = [];
+    if (!hasPlan) problems.push('plan');
+    if (!hasTestPlan) problems.push('testplan');
+    if (scopeConflicts.length > 0) problems.push('scope-conflict');
+
+    const conflictReason = scopeConflicts.length > 0
+      ? `Issue #${issueNumber} plan has scope-conflicting close target(s): ${scopeConflicts.map(n => `#${n}`).join(', ')}. Store a corrected one-issue plan before implementation.`
+      : undefined;
 
     return {
       passed,
       hasPlan,
       hasTestPlan,
+      problems,
       issueNumber,
       repo,
       planText: planText ?? null,
       testPlanText: testPlanText ?? null,
       reason: passed
         ? undefined
-        : `Issue #${issueNumber} is missing: ${missing.join(', ')}. Run /kaizen-write-plan first.`,
+        : conflictReason ?? `Issue #${issueNumber} is missing: ${missing.join(', ')}. Run /kaizen-write-plan first.`,
     };
   }
 

--- a/src/hooks/enforce-plan-stored.test.ts
+++ b/src/hooks/enforce-plan-stored.test.ts
@@ -217,6 +217,18 @@ describe('checkPlanBeforeEdit', () => {
       expect(result.allowed).toBe(false);
       expect(result.reason).toMatch(/No plan or test plan stored/);
     });
+
+    it('scope conflict → message says the stored plan conflicts with the issue scope (#1161)', () => {
+      const result = checkPlanBeforeEdit(
+        'src/thing.ts',
+        makeDeps({ retrievePlan: () => `${GOOD_PLAN}\n\nCloses #1056` }),
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.missing).toEqual(['scope-conflict']);
+      expect(result.reason).toContain('conflicts with this issue scope');
+      expect(result.reason).toContain('#1056');
+      expect(result.reason).not.toMatch(/test plan is missing/);
+    });
   });
 
   it('allows non-source files even without plan', () => {
@@ -377,6 +389,18 @@ describe('checkPlanBeforePr', () => {
 
   it('allows when plan + testplan exist and PR body contains populated Impact proof', () => {
     expect(checkPlanBeforePr(ghPrCreate(`${GOOD_IMPACT_SECTION}\n\nCloses #1055`), makeDeps()).allowed).toBe(true);
+  });
+
+  it('DENIES PR creation when the stored plan closes a different issue (#1161)', () => {
+    const result = checkPlanBeforePr(
+      ghPrCreate(`${GOOD_IMPACT_SECTION}\n\nCloses #1055`),
+      makeDeps({ retrievePlan: () => `${GOOD_PLAN}\n\nCloses #1056` }),
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toEqual(['scope-conflict']);
+    expect(result.reason).toContain('scope-conflicting close target');
+    expect(result.reason).toContain('#1056');
   });
 
   it('allows populated Impact proof supplied through --body-file', () => {

--- a/src/hooks/enforce-plan-stored.ts
+++ b/src/hooks/enforce-plan-stored.ts
@@ -450,9 +450,12 @@ This hook enforces I8: implementation must be tied to a planned issue.`,
     // Name the ACTUAL missing artifact so the author doesn't burn a diagnostic
     // round (#1069). "No plan stored" was misleading when the plan existed and
     // only the test plan was missing.
-    const missing = !gate.hasPlan ? 'plan' : 'testplan';
+    const scopeConflict = gate.problems.includes('scope-conflict');
+    const missing = scopeConflict ? 'scope-conflict' : !gate.hasPlan ? 'plan' : 'testplan';
     let headline: string;
-    if (!gate.hasPlan && !gate.hasTestPlan) {
+    if (scopeConflict) {
+      headline = `BLOCKED: Stored plan for issue #${issueNum} conflicts with this issue scope.`;
+    } else if (!gate.hasPlan && !gate.hasTestPlan) {
       headline = `BLOCKED: No plan or test plan stored for issue #${issueNum}.`;
     } else if (!gate.hasPlan) {
       headline = `BLOCKED: No implementation plan stored for issue #${issueNum} (a test plan exists, the plan does not).`;
@@ -464,6 +467,8 @@ This hook enforces I8: implementation must be tied to a planned issue.`,
       allowed: false,
       missing: [missing],
       reason: `${headline} You MUST run /kaizen-write-plan before writing any code.
+
+${scopeConflict && gate.reason ? `${gate.reason}\n` : ''}
 
 DO THIS NOW:
   Skill({ skill: "kaizen-write-plan", args: "#${issueNum}" })
@@ -592,10 +597,14 @@ This hook enforces I3 (stored test plan) and I8 (plan before implementation).`,
   // Use Case FE for existence check
   const gate = deps.caseSystem.checkPlanGate(parseInt(issueNum, 10), repo);
   if (!gate.passed) {
+    const scopeConflict = gate.problems.includes('scope-conflict');
+    const headline = scopeConflict
+      ? `BLOCKED: Stored plan for issue #${issueNum} conflicts with this PR scope.`
+      : `BLOCKED: PR requires a stored plan and test plan on issue #${issueNum} (I3, I8).`;
     return {
       allowed: false,
-      missing: [!gate.hasPlan ? 'plan' : 'testplan'],
-      reason: `BLOCKED: PR requires a stored plan and test plan on issue #${issueNum} (I3, I8).
+      missing: [scopeConflict ? 'scope-conflict' : !gate.hasPlan ? 'plan' : 'testplan'],
+      reason: `${headline}
 
 ${gate.reason}
 


### PR DESCRIPTION
## Summary

The shared Case FE plan gate now rejects stored implementation plans that explicitly claim they will close/fix/resolve issues other than the selected issue. This catches stale or over-broad retrieved plans before first source edit and before PR creation, without blocking ordinary parent/sibling context references.

Fixes #1161

## Impact (goal -> before/after -> match)

- Goal (#1161): Retrieved implementation plans must not silently authorize a broader closure scope than the selected sub-issue.
- Acceptance signal: `CaseSystem.checkPlanGate(issue, repo)` fails when stored plan text includes closing-keyword targets for other issues, and hook callers surface `scope-conflict` instead of a missing-plan/testplan error.
- BEFORE: A stored plan for #1 containing `Closes #1, #2, and #3` passed the shared plan gate as long as a test plan existed.
- AFTER: The same plan fails with a scope-conflicting close target reason naming #2 and #3; `Closes`/`Fixes` for the selected issue still pass.
- Delta: Scope conflict changes from accepted to blocked at the shared readiness gate.
- Goal met?: yes.
- Residual scan: plain references like `Parent: #1134` and `Compare #2` remain allowed because they are not close/fix/resolve claims.

## Behaviors x Levels

| Behavior | L1 | L2 | L3 | L4 | L5 |
|---|---:|---:|---:|---:|---:|
| Reject sibling close targets in stored plan | ✅ | ✅ | — | — | — |
| Allow selected issue close target | ✅ | ✅ | — | — | — |
| Allow non-closing parent/sibling references | ✅ | ✅ | — | — | — |
| Surface hook scope-conflict instead of missing artifact | ✅ | ✅ | — | — | — |

## Plan / Test Plan

- Stored plan: https://github.com/Garsson-io/kaizen/issues/1161#issuecomment-4828751345
- Retrieved test plan: `npx tsx src/cli-structured-data.ts retrieve-testplan --issue 1161 --repo Garsson-io/kaizen`

## Verification

- RED: `npx vitest run src/case-system.test.ts` failed because a plan with sibling close targets still passed the gate.
- GREEN: `npx vitest run src/case-system.test.ts src/hooks/enforce-plan-stored.test.ts` (101 tests passed)
- `npm run typecheck`
- `npm run test:fast`
- `npm test` (180 files passed, 2 skipped; 4256 tests passed, 14 skipped)
- `git diff --check`