### PR TITLE
fix(actions): isolate review verdict rerun concurrency

### DIFF
--- a/.github/workflows/review-verdict-rerun.yml
+++ b/.github/workflows/review-verdict-rerun.yml
@@ -11,7 +11,14 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: review-verdict-rerun-${{ github.event.issue.number || github.ref }}
+  group: >-
+    review-verdict-rerun-${{ github.event.issue.number || github.ref }}-${{
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, 'kaizen:review/r') &&
+      contains(github.event.comment.body, '/summary -->') &&
+      'summary' ||
+      github.event.comment.id
+    }}
   cancel-in-progress: true
 
 jobs:

--- a/scripts/review-verdict-workflow.test.ts
+++ b/scripts/review-verdict-workflow.test.ts
@@ -1,10 +1,18 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
 
 const gateWorkflow = readFileSync(join(process.cwd(), '.github/workflows/review-verdict-gate.yml'), 'utf8');
 const rerunWorkflowPath = join(process.cwd(), '.github/workflows/review-verdict-rerun.yml');
 const rerunWorkflow = readFileSync(rerunWorkflowPath, 'utf8');
+const rerunWorkflowConfig = YAML.parse(rerunWorkflow) as {
+  concurrency?: { group?: unknown; 'cancel-in-progress'?: unknown };
+};
+
+function compactExpression(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ');
+}
 
 describe('Review verdict gate workflow', () => {
   it('keeps the PR-attached verdict workflow free of issue_comment helper jobs', () => {
@@ -23,5 +31,17 @@ describe('Review verdict gate workflow', () => {
     expect(rerunWorkflow).toContain('kaizen:review/r');
     expect(rerunWorkflow).toContain('/summary -->');
     expect(rerunWorkflow).toContain('scripts/rerun-review-verdict-gate.ts');
+  });
+
+  it('keeps non-summary comments out of the cancellable summary rerun lane', () => {
+    const concurrency = rerunWorkflowConfig.concurrency;
+    expect(concurrency?.['cancel-in-progress']).toBe(true);
+
+    const group = compactExpression(concurrency?.group);
+    expect(group).toContain('github.event.issue.number');
+    expect(group).toContain("contains(github.event.comment.body, 'kaizen:review/r')");
+    expect(group).toContain("contains(github.event.comment.body, '/summary -->')");
+    expect(group).toContain("'summary'");
+    expect(group).toContain('github.event.comment.id');
   });
 });


### PR DESCRIPTION
## Story

Once upon a time, #1657 gave review summaries a way to refresh the PR-attached Review verdict gate without pushing an empty commit. The fix lived in a separate `issue_comment` workflow that watches for stored review summary comments and reruns the pull-request workflow run for the current PR head.

Every day, that looked sufficient: summary comments matched the job `if:` condition, non-summary review comments skipped the job, and the helper itself was idempotent around active or successful gate runs.

One day, PR #1664 showed the scheduler-level gap. The summary-triggered issue_comment workflow run `28347111863` started, then a later non-summary review bookkeeping comment created a skipped workflow run for the same PR. Because the workflow used one PR-wide concurrency group with `cancel-in-progress: true`, the skipped run cancelled the useful summary rerun before it reached the helper.

Because of that, this PR keeps the same workflow and helper, but changes the concurrency group. Summary comments still share a per-PR `summary` lane, so newer summaries can supersede older summary reruns. Non-summary comments use their own `github.event.comment.id` suffix, so they cannot collide with or cancel an in-progress summary rerun.

Because of that, the regression test now parses `.github/workflows/review-verdict-rerun.yml` as YAML and asserts the concurrency contract structurally: the group must include the summary marker predicate, the shared `summary` suffix, and the non-summary `comment.id` fallback.

Until finally, the old workflow shape fails that test for the exact reason observed in #1664, and the updated workflow passes alongside the existing helper tests.

And ever since, review summary reruns are protected at the Actions scheduling layer instead of relying on helper code that may never run.

Fixes #1666
Related: #1657

## Impact (goal -> before/after -> match)

- Goal (#1666): summary-triggered Review verdict reruns should not be cancelled by non-summary review comments.
- Acceptance signal: workflow concurrency distinguishes summary comments from non-summary comments, and tests fail on the old PR-wide unconditional cancellation shape.
- BEFORE: all issue_comment runs for the same PR used `review-verdict-rerun-${{ github.event.issue.number || github.ref }}` with unconditional `cancel-in-progress: true`; #1664 summary run `28347111863` was cancelled by a later skipped issue_comment run.
- AFTER: summary comments use the shared per-PR `summary` suffix, while non-summary comments use `github.event.comment.id`, preventing non-summary cancellation of summary reruns.
- Delta: one workflow expression now encodes the scheduling contract; one YAML-structure test locks it.
- Goal met?: yes.
- Residual scan: no duplicate rerun workflow or direct `gh run rerun` path found; the only ad-hoc `gh run rerun` reference is an allowlist test that blocks it.

## Architecture

```text
issue_comment event
  -> workflow concurrency group
      summary PR comment      -> review-verdict-rerun-<pr>-summary
      non-summary PR comment  -> review-verdict-rerun-<pr>-<comment-id>
  -> job if still admits only review summary comments
  -> scripts/rerun-review-verdict-gate.ts
  -> rerun PR-attached Review verdict gate when needed
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep one workflow/helper | The bug is scheduling scope, not helper logic | The workflow still starts skipped runs for non-summary comments |
| Keep `cancel-in-progress: true` | Newer summary comments should still supersede older summary reruns for the same PR | Requires a more precise group expression |
| Use `github.event.comment.id` for non-summary events | Gives non-summary comments unique lanes, so they cannot cancel summary work | Non-summary skipped runs are not deduped, but they do no npm install work because the job is skipped |
| Parse YAML in the regression test | Protects the workflow contract structurally instead of relying only on broad string checks | Adds a small test import of the existing `yaml` dependency |

## What's In This PR

| File | Purpose |
|---|---|
| `.github/workflows/review-verdict-rerun.yml` | Separates summary and non-summary issue_comment concurrency lanes |
| `scripts/review-verdict-workflow.test.ts` | Adds a regression test for the non-summary cancellation invariant |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status | Evidence |
|---|---|---|---|
| 1 | Non-summary issue_comment events cannot cancel an in-progress summary-triggered rerun | Unit | tested | `scripts/review-verdict-workflow.test.ts` parses workflow concurrency |
| 2 | Summary comments still target a shared per-PR rerun lane | Unit | tested | same structural workflow test checks the `summary` suffix |
| 3 | Workflow still only runs the helper for PR review summary comments | Unit | tested | existing workflow test still checks issue_comment trigger, summary markers, and helper invocation |
| 4 | Helper stays idempotent for active/successful PR-attached gate runs | Unit | tested | `scripts/rerun-review-verdict-gate.test.ts` remains green |
| 5 | GitHub observes the updated issue_comment workflow from default branch | System | deferred by platform | GitHub issue_comment workflows run from default branch, so PR-local static tests are the merge-time proof; live observation happens on the next review-summary incident after merge |

## Validation

- [x] Red first: `npx vitest run scripts/review-verdict-workflow.test.ts` failed because the old group lacked the summary predicate and `comment.id` fallback.
- [x] `npx vitest run scripts/review-verdict-workflow.test.ts scripts/rerun-review-verdict-gate.test.ts` -> 11 passed.
- [x] Parsed workflow YAML after the change and confirmed the concurrency group contains the summary predicate, `summary`, and `github.event.comment.id`.
- [x] DRY sweep: `rg` found one rerun workflow and one helper; no duplicate direct rerun path.
- [x] `npm run typecheck` passed.
- [x] `npm run test:fast` passed: 1 changed file, 3 tests.
- [x] `git diff --check` clean.

## Known Limitations

- The automatic issue_comment path cannot be fully live-proved from this PR before merge because GitHub runs issue_comment workflows from the default branch workflow definition. The static workflow test is the merge-time guard; the next review-summary comment after merge can provide live confirmation.
