### PR TITLE
feat(hooks): inventory provider enforcement coverage

### DIFF
--- a/docs/kaizen-invariants.md
+++ b/docs/kaizen-invariants.md
@@ -48,6 +48,48 @@ Which artifacts uphold each invariant. Use this to answer "who cares about I7?"
 | **I27** test plan fully implemented | — | `kaizen-implement`, `kaizen-review-pr` | `plan-coverage`, `test-plan`, `scope-fidelity` | [#1038](https://github.com/Garsson-io/kaizen/issues/1038) |
 | **I28** review covers all dimensions | `pr-review-loop` (sentinel, partial) | `kaizen-review-pr` | all | [#1038](https://github.com/Garsson-io/kaizen/issues/1038) |
 
+## Provider Coverage Matrix
+
+Machine source: `src/enforcement-coverage.ts`. The self-invariant test compares this table to `.claude-plugin/plugin.json` so new hook commands cannot be added without declaring whether they work for Codex/external auto-dent runs.
+
+Status meanings:
+- `provider-agnostic`: works outside Claude Code hooks.
+- `partial`: Claude hook remains useful, but a CI/git/inside-harness fallback covers a terminal or reduced version of the invariant.
+- `claude-only-gap`: no provider-agnostic fallback is implemented yet.
+- `advisory`: non-blocking guidance; no terminal provider-agnostic block is claimed.
+- `infrastructure`: setup/observability plumbing, not a workflow safety gate.
+
+| Hook ID | Command | Surface | Status | Fallback |
+|---------|---------|---------|--------|----------|
+| `git-pre-push` | `.githooks/pre-push` | GitPrePush | `provider-agnostic` | `git-hook`: `src/hooks/pre-push.ts` |
+| `bump-plugin-version` | `kaizen-bump-plugin-version-ts.sh` | PreToolUse | `infrastructure` | `infrastructure-only`: manual version bump / release review |
+| `enforce-pr-review` | `kaizen-enforce-pr-review-ts.sh` | PreToolUse | `partial` | `ci-check`: Review verdict gate workflow + `/kaizen-autodent` inside-harness review step |
+| `enforce-merge-verdict` | `kaizen-enforce-merge-verdict-ts.sh` | PreToolUse | `partial` | `ci-check`: Review verdict gate workflow / branch protection |
+| `enforce-case-worktree` | `kaizen-enforce-case-worktree.sh` | PreToolUse | `claude-only-gap` | `external-validator-needed`: #1166 follow-up provider-agnostic case/worktree validator |
+| `pr-quality-checks` | `kaizen-pr-quality-checks-ts.sh` | PreToolUse | `advisory` | `advisory-only`: review dimensions |
+| `check-dirty-files` | `kaizen-check-dirty-files-ts.sh` | PreToolUse | `claude-only-gap` | `external-validator-needed`: #1166 follow-up dirty-worktree validator |
+| `enforce-plan-stored` | `kaizen-enforce-plan-stored-ts.sh` | PreToolUse | `partial` | `inside-harness-step`: `/kaizen-autodent` and `/kaizen-do` plan/test-plan evidence contract |
+| `enforce-pr-reflect` | `kaizen-enforce-pr-reflect-ts.sh` | PreToolUse | `claude-only-gap` | `external-validator-needed`: #1166 follow-up reflection/completion validator |
+| `block-git-rebase` | `kaizen-block-git-rebase.sh` | PreToolUse | `claude-only-gap` | `external-validator-needed`: #1166 follow-up git-history policy check |
+| `prehook-no-verify` | `kaizen-prehook-no-verify.sh` | PreToolUse | `partial` | `ci-check`: branch protection / required checks |
+| `block-self-plugin-enable` | `kaizen-block-self-plugin-enable.sh` | PreToolUse | `infrastructure` | `infrastructure-only`: `scripts/kaizen-self-invariants.test.ts` |
+| `search-before-file` | `kaizen-search-before-file.sh` | PreToolUse | `advisory` | `advisory-only`: `/kaizen-file-issue` duplicate-search discipline |
+| `enforce-worktree-writes` | `kaizen-enforce-worktree-writes.sh` | PreToolUse | `claude-only-gap` | `external-validator-needed`: #1166 follow-up write-location validator |
+| `enforce-case-exists` | `kaizen-enforce-case-exists.sh` | PreToolUse | `claude-only-gap` | `external-validator-needed`: #1166 follow-up case binding validator |
+| `check-wip` | `kaizen-check-wip.sh` | SessionStart | `infrastructure` | `infrastructure-only`: `/kaizen-wip` |
+| `session-cleanup` | `kaizen-session-cleanup-ts.sh` | SessionStart | `infrastructure` | `infrastructure-only`: manual cleanup / `kaizen-cleanup` |
+| `worktree-setup` | `kaizen-worktree-setup.sh` | SessionStart | `partial` | `inside-harness-step`: `/kaizen-autodent` worktree binding contract |
+| `session-snapshot` | `kaizen-session-snapshot.sh` | SessionStart | `infrastructure` | `infrastructure-only`: transcript/session artifacts |
+| `pr-review-loop` | `pr-review-loop-ts.sh` | PostToolUse | `partial` | `ci-check`: Review verdict gate workflow |
+| `kaizen-reflect` | `kaizen-reflect-ts.sh` | PostToolUse | `claude-only-gap` | `external-validator-needed`: #1166 follow-up post-run reflection validator |
+| `post-merge-clear` | `kaizen-post-merge-clear-ts.sh` | PostToolUse | `partial` | `inside-harness-step`: `/kaizen-autodent` cleanup/status evidence |
+| `pr-kaizen-clear` | `pr-kaizen-clear-ts.sh` | PostToolUse | `partial` | `inside-harness-step`: `/kaizen-autodent` workflow status ledger |
+| `pr-kaizen-clear-fallback` | `kaizen-pr-kaizen-clear-fallback.sh` | PostToolUse | `partial` | `inside-harness-step`: `/kaizen-autodent` workflow status ledger |
+| `capture-worktree-context` | `kaizen-capture-worktree-context.sh` | PostToolUse | `infrastructure` | `infrastructure-only`: `/kaizen-cleanup` and `worktree-du` |
+| `stop-gate` | `kaizen-stop-gate.sh` | Stop | `partial` | `inside-harness-step`: `/kaizen-autodent` workflow status CLI |
+| `verify-before-stop` | `kaizen-verify-before-stop.sh` | Stop | `advisory` | `advisory-only`: CI checks / PR verification section |
+| `check-cleanup-on-stop` | `kaizen-check-cleanup-on-stop.sh` | Stop | `advisory` | `advisory-only`: `/kaizen-cleanup` |
+
 ## Enforcement matrix — Artifact → Invariants (reverse index)
 
 ### Hooks

--- a/scripts/kaizen-self-invariants.test.ts
+++ b/scripts/kaizen-self-invariants.test.ts
@@ -9,8 +9,31 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { ENFORCEMENT_COVERAGE, coverageByCommandBasename } from '../src/enforcement-coverage.js';
 
 const REPO_ROOT = join(__dirname, '..');
+
+function commandBasename(command: string): string {
+  return command.replace(/^.*\//, '');
+}
+
+function registeredHookCommandBasenames(): string[] {
+  const raw = readFileSync(join(REPO_ROOT, '.claude-plugin/plugin.json'), 'utf-8');
+  const data = JSON.parse(raw) as { hooks?: unknown };
+  const commands: string[] = [];
+  const walk = (x: unknown): void => {
+    if (Array.isArray(x)) x.forEach(walk);
+    else if (x && typeof x === 'object') {
+      const obj = x as Record<string, unknown>;
+      if (obj.type === 'command' && typeof obj.command === 'string') {
+        commands.push(commandBasename(obj.command));
+      }
+      for (const v of Object.values(obj)) walk(v);
+    }
+  };
+  walk(data.hooks ?? {});
+  return [...new Set(commands)].sort();
+}
 
 describe('kaizen self-invariants (#1063)', () => {
   it('.claude/settings.json has NO `hooks` block (single source of truth is plugin.json)', () => {
@@ -45,5 +68,41 @@ describe('kaizen self-invariants (#1063)', () => {
     };
     walk(data.hooks ?? {});
     expect(n).toBeGreaterThan(0);
+  });
+
+  it('provider enforcement coverage has one row per hook command (#1166)', () => {
+    const coverage = coverageByCommandBasename();
+    const missing = registeredHookCommandBasenames().filter(command => !coverage.has(command));
+    expect(
+      missing,
+      `Every registered hook command needs an explicit provider coverage row in src/enforcement-coverage.ts (#1166). Missing: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('provider enforcement coverage rows are complete and uniquely keyed (#1166)', () => {
+    const seen = new Set<string>();
+    for (const row of ENFORCEMENT_COVERAGE) {
+      expect(row.hookId, 'hookId must be present').not.toBe('');
+      expect(row.commandBasename, `${row.hookId} commandBasename`).not.toBe('');
+      expect(seen.has(row.commandBasename), `${row.commandBasename} appears more than once`).toBe(false);
+      seen.add(row.commandBasename);
+      expect(row.status, `${row.hookId} status`).not.toBe('');
+      expect(row.fallbackClass, `${row.hookId} fallbackClass`).not.toBe('');
+      expect(row.fallbackArtifact, `${row.hookId} fallbackArtifact`).not.toBe('');
+      expect(row.notes, `${row.hookId} notes`).not.toBe('');
+      if (row.status === 'provider-agnostic') {
+        expect(row.claudeHookDependent, `${row.hookId} provider-agnostic row must not depend on Claude hooks`).toBe(false);
+      }
+    }
+  });
+
+  it('provider coverage doc projection lists every inventory row (#1166)', () => {
+    const doc = readFileSync(join(REPO_ROOT, 'docs/kaizen-invariants.md'), 'utf-8');
+    expect(doc).toContain('Provider Coverage Matrix');
+    for (const row of ENFORCEMENT_COVERAGE) {
+      expect(doc, `docs/kaizen-invariants.md must list ${row.hookId}`).toContain(`\`${row.hookId}\``);
+      expect(doc, `docs/kaizen-invariants.md must mention ${row.commandBasename}`).toContain(`\`${row.commandBasename}\``);
+      expect(doc, `docs/kaizen-invariants.md must include status ${row.status}`).toContain(`\`${row.status}\``);
+    }
   });
 });

--- a/src/enforcement-coverage.ts
+++ b/src/enforcement-coverage.ts
@@ -1,0 +1,357 @@
+/**
+ * enforcement-coverage.ts — provider coverage inventory for kaizen gates.
+ *
+ * This is the machine-readable source for #1166: every registered hook command
+ * must have an explicit provider story, even when that story is "Claude-only
+ * gap". Human docs render the same matrix in docs/kaizen-invariants.md.
+ */
+
+export type HookSurface =
+  | 'SessionStart'
+  | 'PreToolUse'
+  | 'PostToolUse'
+  | 'Stop'
+  | 'GitPrePush';
+
+export type ProviderCoverageStatus =
+  | 'provider-agnostic'
+  | 'partial'
+  | 'claude-only-gap'
+  | 'advisory'
+  | 'infrastructure';
+
+export type ProviderFallbackClass =
+  | 'git-hook'
+  | 'ci-check'
+  | 'inside-harness-step'
+  | 'external-validator-needed'
+  | 'advisory-only'
+  | 'infrastructure-only'
+  | 'not-needed';
+
+export interface EnforcementCoverageRow {
+  hookId: string;
+  commandBasename: string;
+  surface: HookSurface;
+  invariants: string[];
+  claudeHookDependent: boolean;
+  status: ProviderCoverageStatus;
+  fallbackClass: ProviderFallbackClass;
+  fallbackArtifact: string;
+  notes: string;
+}
+
+export const ENFORCEMENT_COVERAGE: readonly EnforcementCoverageRow[] = [
+  {
+    hookId: 'git-pre-push',
+    commandBasename: '.githooks/pre-push',
+    surface: 'GitPrePush',
+    invariants: ['I7', 'I15'],
+    claudeHookDependent: false,
+    status: 'provider-agnostic',
+    fallbackClass: 'git-hook',
+    fallbackArtifact: 'src/hooks/pre-push.ts',
+    notes: 'Native git hook; fires for Claude, Codex, humans, and any external agent that runs git push without --no-verify.',
+  },
+  {
+    hookId: 'bump-plugin-version',
+    commandBasename: 'kaizen-bump-plugin-version-ts.sh',
+    surface: 'PreToolUse',
+    invariants: [],
+    claudeHookDependent: true,
+    status: 'infrastructure',
+    fallbackClass: 'infrastructure-only',
+    fallbackArtifact: 'manual version bump / release review',
+    notes: 'Repository release hygiene, not a kaizen workflow safety gate.',
+  },
+  {
+    hookId: 'enforce-pr-review',
+    commandBasename: 'kaizen-enforce-pr-review-ts.sh',
+    surface: 'PreToolUse',
+    invariants: ['I13', 'I15', 'I28'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'ci-check',
+    fallbackArtifact: 'Review verdict gate workflow + /kaizen-autodent inside-harness review step',
+    notes: 'Claude hook limits tools during review; provider-agnostic terminal binding is the stored review verdict check.',
+  },
+  {
+    hookId: 'enforce-merge-verdict',
+    commandBasename: 'kaizen-enforce-merge-verdict-ts.sh',
+    surface: 'PreToolUse',
+    invariants: ['I5', 'I13', 'I28'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'ci-check',
+    fallbackArtifact: 'Review verdict gate workflow / branch protection',
+    notes: 'Direct local gh merge is Claude-hook guarded; GitHub-side merge readiness still depends on the CI verdict check.',
+  },
+  {
+    hookId: 'enforce-case-worktree',
+    commandBasename: 'kaizen-enforce-case-worktree.sh',
+    surface: 'PreToolUse',
+    invariants: ['I9', 'I10', 'I26'],
+    claudeHookDependent: true,
+    status: 'claude-only-gap',
+    fallbackClass: 'external-validator-needed',
+    fallbackArtifact: '#1166 follow-up: provider-agnostic case/worktree validator',
+    notes: 'Blocks main-checkout or wrong-worktree actions only when Claude Code invokes hooks.',
+  },
+  {
+    hookId: 'pr-quality-checks',
+    commandBasename: 'kaizen-pr-quality-checks-ts.sh',
+    surface: 'PreToolUse',
+    invariants: ['I17', 'I18', 'I19'],
+    claudeHookDependent: true,
+    status: 'advisory',
+    fallbackClass: 'advisory-only',
+    fallbackArtifact: 'review dimensions: test-quality, test-plan, security, pr-description',
+    notes: 'Advisory quality checks are intentionally not terminal provider-agnostic gates.',
+  },
+  {
+    hookId: 'check-dirty-files',
+    commandBasename: 'kaizen-check-dirty-files-ts.sh',
+    surface: 'PreToolUse',
+    invariants: ['I11', 'I25'],
+    claudeHookDependent: true,
+    status: 'claude-only-gap',
+    fallbackClass: 'external-validator-needed',
+    fallbackArtifact: '#1166 follow-up: git/CI dirty-worktree validator for external runs',
+    notes: 'Blocks dirty PR creation only under Claude Code; external agents need an explicit status/PR-body validator.',
+  },
+  {
+    hookId: 'enforce-plan-stored',
+    commandBasename: 'kaizen-enforce-plan-stored-ts.sh',
+    surface: 'PreToolUse',
+    invariants: ['I3', 'I8'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'inside-harness-step',
+    fallbackArtifact: '/kaizen-autodent and /kaizen-do plan/test-plan evidence contract',
+    notes: 'Claude hook blocks first edit; inside-harness auto-dent can require stored plan evidence for Codex/external runs.',
+  },
+  {
+    hookId: 'enforce-pr-reflect',
+    commandBasename: 'kaizen-enforce-pr-reflect-ts.sh',
+    surface: 'PreToolUse',
+    invariants: ['I14', 'I16'],
+    claudeHookDependent: true,
+    status: 'claude-only-gap',
+    fallbackClass: 'external-validator-needed',
+    fallbackArtifact: '#1166 follow-up: provider-agnostic reflection/completion validator',
+    notes: 'Reflection gate is local-session enforcement; external runs can currently merge/stop without this hook firing.',
+  },
+  {
+    hookId: 'block-git-rebase',
+    commandBasename: 'kaizen-block-git-rebase.sh',
+    surface: 'PreToolUse',
+    invariants: ['I12'],
+    claudeHookDependent: true,
+    status: 'claude-only-gap',
+    fallbackClass: 'external-validator-needed',
+    fallbackArtifact: '#1166 follow-up: git-history policy check',
+    notes: 'Rebase command blocking is Claude-only; provider-agnostic detection would need git-history inspection.',
+  },
+  {
+    hookId: 'prehook-no-verify',
+    commandBasename: 'kaizen-prehook-no-verify.sh',
+    surface: 'PreToolUse',
+    invariants: ['I7', 'I15'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'ci-check',
+    fallbackArtifact: 'branch protection / required checks',
+    notes: 'Claude blocks --no-verify; non-Claude pushes can bypass local git hooks, so server-side checks remain the fallback.',
+  },
+  {
+    hookId: 'block-self-plugin-enable',
+    commandBasename: 'kaizen-block-self-plugin-enable.sh',
+    surface: 'PreToolUse',
+    invariants: [],
+    claudeHookDependent: true,
+    status: 'infrastructure',
+    fallbackClass: 'infrastructure-only',
+    fallbackArtifact: 'scripts/kaizen-self-invariants.test.ts',
+    notes: 'Self-plugin activation guard; CI invariants protect the durable source state.',
+  },
+  {
+    hookId: 'search-before-file',
+    commandBasename: 'kaizen-search-before-file.sh',
+    surface: 'PreToolUse',
+    invariants: ['I20'],
+    claudeHookDependent: true,
+    status: 'advisory',
+    fallbackClass: 'advisory-only',
+    fallbackArtifact: '/kaizen-file-issue duplicate-search discipline',
+    notes: 'Advisory duplicate-prevention prompt; no provider-agnostic block is claimed.',
+  },
+  {
+    hookId: 'enforce-worktree-writes',
+    commandBasename: 'kaizen-enforce-worktree-writes.sh',
+    surface: 'PreToolUse',
+    invariants: ['I9'],
+    claudeHookDependent: true,
+    status: 'claude-only-gap',
+    fallbackClass: 'external-validator-needed',
+    fallbackArtifact: '#1166 follow-up: provider-agnostic write-location validator',
+    notes: 'Edit/Write location blocking depends on Claude tool events.',
+  },
+  {
+    hookId: 'enforce-case-exists',
+    commandBasename: 'kaizen-enforce-case-exists.sh',
+    surface: 'PreToolUse',
+    invariants: ['I10'],
+    claudeHookDependent: true,
+    status: 'claude-only-gap',
+    fallbackClass: 'external-validator-needed',
+    fallbackArtifact: '#1166 follow-up: provider-agnostic case binding validator',
+    notes: 'Edit/Write case binding is unavailable outside Claude hook invocation.',
+  },
+  {
+    hookId: 'check-wip',
+    commandBasename: 'kaizen-check-wip.sh',
+    surface: 'SessionStart',
+    invariants: [],
+    claudeHookDependent: true,
+    status: 'infrastructure',
+    fallbackClass: 'infrastructure-only',
+    fallbackArtifact: '/kaizen-wip',
+    notes: 'Session awareness helper, not a blocking provider-agnostic safety gate.',
+  },
+  {
+    hookId: 'session-cleanup',
+    commandBasename: 'kaizen-session-cleanup-ts.sh',
+    surface: 'SessionStart',
+    invariants: [],
+    claudeHookDependent: true,
+    status: 'infrastructure',
+    fallbackClass: 'infrastructure-only',
+    fallbackArtifact: 'manual cleanup / kaizen-cleanup',
+    notes: 'Session hygiene helper.',
+  },
+  {
+    hookId: 'worktree-setup',
+    commandBasename: 'kaizen-worktree-setup.sh',
+    surface: 'SessionStart',
+    invariants: ['I9', 'I10'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'inside-harness-step',
+    fallbackArtifact: '/kaizen-autodent worktree binding contract',
+    notes: 'Claude session setup warns/normalizes; inside-harness workflows must bind worktrees explicitly.',
+  },
+  {
+    hookId: 'session-snapshot',
+    commandBasename: 'kaizen-session-snapshot.sh',
+    surface: 'SessionStart',
+    invariants: [],
+    claudeHookDependent: true,
+    status: 'infrastructure',
+    fallbackClass: 'infrastructure-only',
+    fallbackArtifact: 'transcript/session artifacts',
+    notes: 'Observability helper.',
+  },
+  {
+    hookId: 'pr-review-loop',
+    commandBasename: 'pr-review-loop-ts.sh',
+    surface: 'PostToolUse',
+    invariants: ['I5', 'I15', 'I16', 'I28'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'ci-check',
+    fallbackArtifact: 'Review verdict gate workflow',
+    notes: 'Claude hook manages round state after gh/pr operations; CI verdict check is the provider-agnostic terminal reader.',
+  },
+  {
+    hookId: 'kaizen-reflect',
+    commandBasename: 'kaizen-reflect-ts.sh',
+    surface: 'PostToolUse',
+    invariants: ['I16'],
+    claudeHookDependent: true,
+    status: 'claude-only-gap',
+    fallbackClass: 'external-validator-needed',
+    fallbackArtifact: '#1166 follow-up: post-run reflection validator',
+    notes: 'Reflection prompt automation is Claude-hook only.',
+  },
+  {
+    hookId: 'post-merge-clear',
+    commandBasename: 'kaizen-post-merge-clear-ts.sh',
+    surface: 'PostToolUse',
+    invariants: ['I6', 'I24'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'inside-harness-step',
+    fallbackArtifact: '/kaizen-autodent cleanup/status evidence',
+    notes: 'Claude clears local gates after merge; external runs need explicit cleanup evidence.',
+  },
+  {
+    hookId: 'pr-kaizen-clear',
+    commandBasename: 'pr-kaizen-clear-ts.sh',
+    surface: 'PostToolUse',
+    invariants: ['I6', 'I16'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'inside-harness-step',
+    fallbackArtifact: '/kaizen-autodent workflow status ledger',
+    notes: 'Claude hook clears PR/kaizen gates; inside-harness status ledger is the external fallback contract.',
+  },
+  {
+    hookId: 'pr-kaizen-clear-fallback',
+    commandBasename: 'kaizen-pr-kaizen-clear-fallback.sh',
+    surface: 'PostToolUse',
+    invariants: ['I6', 'I16'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'inside-harness-step',
+    fallbackArtifact: '/kaizen-autodent workflow status ledger',
+    notes: 'Fallback wrapper for Claude-hook clear path.',
+  },
+  {
+    hookId: 'capture-worktree-context',
+    commandBasename: 'kaizen-capture-worktree-context.sh',
+    surface: 'PostToolUse',
+    invariants: ['I24'],
+    claudeHookDependent: true,
+    status: 'infrastructure',
+    fallbackClass: 'infrastructure-only',
+    fallbackArtifact: '/kaizen-cleanup and worktree-du',
+    notes: 'Context capture helper for cleanup visibility.',
+  },
+  {
+    hookId: 'stop-gate',
+    commandBasename: 'kaizen-stop-gate.sh',
+    surface: 'Stop',
+    invariants: ['I6', 'I13', 'I14', 'I16', 'I24'],
+    claudeHookDependent: true,
+    status: 'partial',
+    fallbackClass: 'inside-harness-step',
+    fallbackArtifact: '/kaizen-autodent workflow status CLI',
+    notes: 'Claude Stop gate blocks incomplete sessions; external runs need durable workflow-status evidence.',
+  },
+  {
+    hookId: 'verify-before-stop',
+    commandBasename: 'kaizen-verify-before-stop.sh',
+    surface: 'Stop',
+    invariants: ['I18'],
+    claudeHookDependent: true,
+    status: 'advisory',
+    fallbackClass: 'advisory-only',
+    fallbackArtifact: 'CI checks / PR verification section',
+    notes: 'Advisory stop-time reminder; CI is the terminal verification mechanism.',
+  },
+  {
+    hookId: 'check-cleanup-on-stop',
+    commandBasename: 'kaizen-check-cleanup-on-stop.sh',
+    surface: 'Stop',
+    invariants: ['I21', 'I24'],
+    claudeHookDependent: true,
+    status: 'advisory',
+    fallbackClass: 'advisory-only',
+    fallbackArtifact: '/kaizen-cleanup',
+    notes: 'Advisory cleanup reminder.',
+  },
+] as const;
+
+export function coverageByCommandBasename(): Map<string, EnforcementCoverageRow> {
+  return new Map(ENFORCEMENT_COVERAGE.map(row => [row.commandBasename, row]));
+}


### PR DESCRIPTION
## Summary

Adds a tested provider-coverage inventory for kaizen hook enforcement so Claude-only gates and Codex/external fallbacks are explicit instead of tribal knowledge.

Fixes #1166

## Impact (goal -> before/after -> match)

- Goal (#1166): make the provider-agnostic enforcement gap visible and prevent new hook gates from being added without a fallback story.
- Acceptance signal: `.claude-plugin/plugin.json` hook commands are checked against `src/enforcement-coverage.ts`, and `docs/kaizen-invariants.md` must project every row.
- BEFORE: PreToolUse/Stop/PostToolUse hooks were documented in scattered places, but no CI invariant classified Claude-only gates versus provider-agnostic fallbacks.
- AFTER: every registered hook command has a typed row with surface, invariant IDs, Claude dependency, coverage status, fallback class, fallback artifact, and notes; docs list the same matrix.
- Delta: unclassified hook commands now fail `scripts/kaizen-self-invariants.test.ts`.
- Goal met?: yes for the inventory/invariant deliverable; implementing every missing fallback is intentionally left as future scoped work.
- Residual scan: existing `claude-only-gap` rows are named explicitly instead of silently claimed complete.

## Behaviors x Levels

| Behavior | L1 | L2 | L3 | L4 | L5 |
|---|---:|---:|---:|---:|---:|
| Registered hook commands require coverage rows | ✅ | ✅ | — | — | — |
| Coverage rows require fallback/status fields | ✅ | ✅ | — | — | — |
| Provider-agnostic pre-push is distinguished from Claude-only hooks | ✅ | ✅ | — | — | — |
| Human docs stay in sync with machine inventory | ✅ | ✅ | — | — | — |

## Plan / Test Plan

- Stored plan: https://github.com/Garsson-io/kaizen/issues/1166#issuecomment-4828815667
- Retrieved test plan: `npx tsx src/cli-structured-data.ts retrieve-testplan --issue 1166 --repo Garsson-io/kaizen`

## Verification

- RED: `npx vitest run scripts/kaizen-self-invariants.test.ts` failed before the docs projection with missing `Provider Coverage Matrix`.
- GREEN: `npx vitest run scripts/kaizen-self-invariants.test.ts`
- `npm run typecheck`
- `npm run test:fast`
- `npm test` (180 files passed, 2 skipped; 4260 tests passed, 14 skipped)
- `git diff --check`
