### PR TITLE
test(hooks): guard allowlist bash ts parity

### DIFF
--- a/src/hooks/bash-ts-parity.test.ts
+++ b/src/hooks/bash-ts-parity.test.ts
@@ -1,23 +1,33 @@
 /**
  * bash-ts-parity.test.ts — CI sync check for bash/TS shared library parity.
  *
- * Ensures that functions in the bash shared libraries (parse-command.sh)
- * have corresponding TypeScript implementations, and vice versa.
+ * Ensures that functions in duplicated bash/TS shared libraries have
+ * corresponding sibling implementations or documented exclusions.
  * Drift between the two was undetected until manual comparison (kaizen #347).
  *
  * state-utils.sh was deleted in kaizen #790 — all state management is now
- * TypeScript-only. Only parse-command parity remains.
+ * TypeScript-only. parse-command and allowlist remain as guarded overlap.
  *
  * Naming convention: bash uses snake_case, TS uses camelCase.
  * The test normalizes both to compare.
  */
 
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import {
+  isAllowedRuntimeDir,
+  isReadonlyMonitoringCommand,
+} from './lib/allowlist.js';
 
 const HOOKS_LIB_DIR = join(__dirname, '../../.claude/hooks/lib');
 const HOOKS_TS_DIR = __dirname;
+
+const PARITY_TARGETS = [
+  { label: 'parse-command', bashFile: 'parse-command.sh', tsFile: 'parse-command.ts' },
+  { label: 'allowlist', bashFile: 'allowlist.sh', tsFile: 'lib/allowlist.ts' },
+] as const;
 
 // Functions intentionally present in only one version.
 // Each entry must have a comment explaining WHY it's excluded.
@@ -36,6 +46,26 @@ const EXCLUSIONS: Record<string, string> = {
   // corresponding body-file read path to keep in sync.
   effectiveCwdBeforeCommand:
     'ts-only: used by enforce-plan-stored Impact body-file resolution; no bash consumer',
+
+  // Bash exposes helper functions globally because shell has no module-private
+  // function scope. TS keeps these private; behavior parity below covers their
+  // exported composition through isReadonlyMonitoringCommand.
+  is_neutral_setup_segment:
+    'bash-only public helper: TS equivalent is private isNeutralSetupSegment',
+  is_readonly_monitoring_segment:
+    'bash-only public helper: TS equivalent is private isReadonlyMonitoringSegment',
+  is_readonly_or_setup_segment:
+    'bash-only public helper: TS equivalent is private isReadonlyOrSetupSegment',
+
+  // These are used by TS-only review/reflection gates. The bash gates that
+  // still source allowlist.sh only need readonly monitoring and runtime-dir
+  // checks, so adding bash equivalents would create dead surface.
+  isEscapeHatch:
+    'ts-only: used by TS review/reflection gates; no bash gate consumer remains',
+  isReviewCommand:
+    'ts-only: used by TS review gate; no bash gate consumer remains',
+  isKaizenCommand:
+    'ts-only: used by TS reflection gate; no bash gate consumer remains',
 };
 
 /** Extract function names from a bash script (matches `function_name() {`). */
@@ -101,58 +131,111 @@ function checkParity(bashFile: string, tsFile: string) {
   return { bashFns, tsFns, missingInTs, missingInBash };
 }
 
-describe('bash/TS shared library parity', () => {
-  describe('parse-command', () => {
-    it('all bash functions have TS equivalents (or are excluded)', () => {
-      const { missingInTs } = checkParity(
-        'parse-command.sh',
-        'parse-command.ts',
-      );
-      expect(
-        missingInTs,
-        `Bash functions missing TS equivalent: ${missingInTs.join(', ')}. Either port them or add to EXCLUSIONS with a reason.`,
-      ).toEqual([]);
-    });
+function allKnownFunctions(): Set<string> {
+  const functions = new Set<string>();
+  for (const target of PARITY_TARGETS) {
+    for (const fn of extractBashFunctions(join(HOOKS_LIB_DIR, target.bashFile))) {
+      functions.add(fn);
+    }
+    for (const fn of extractTsFunctions(join(HOOKS_TS_DIR, target.tsFile))) {
+      functions.add(fn);
+    }
+  }
+  return functions;
+}
 
-    it('all TS functions have bash equivalents (or are excluded)', () => {
-      const { missingInBash } = checkParity(
-        'parse-command.sh',
-        'parse-command.ts',
-      );
-      expect(
-        missingInBash,
-        `TS functions missing bash equivalent: ${missingInBash.join(', ')}. Either port them or add to EXCLUSIONS with a reason.`,
-      ).toEqual([]);
-    });
-
-    it('extracts functions from both files', () => {
-      const { bashFns, tsFns } = checkParity(
-        'parse-command.sh',
-        'parse-command.ts',
-      );
-      expect(bashFns.length).toBeGreaterThan(3);
-      expect(tsFns.length).toBeGreaterThan(3);
-    });
+function bashBoolean(functionName: string, value: string): boolean {
+  const script = `
+    source "$HOOKS_LIB_DIR/parse-command.sh"
+    source "$HOOKS_LIB_DIR/allowlist.sh"
+    if "$FUNCTION_NAME" "$1"; then
+      printf true
+    else
+      printf false
+    fi
+  `;
+  const result = spawnSync('bash', ['-c', script, 'bash-parity', value], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOOKS_LIB_DIR,
+      FUNCTION_NAME: functionName,
+    },
   });
+
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout.trim() === 'true';
+}
+
+describe('bash/TS shared library parity', () => {
+  for (const target of PARITY_TARGETS) {
+    describe(target.label, () => {
+      it('all bash functions have TS equivalents (or are excluded)', () => {
+        const { missingInTs } = checkParity(target.bashFile, target.tsFile);
+        expect(
+          missingInTs,
+          `Bash functions missing TS equivalent: ${missingInTs.join(', ')}. Either port them or add to EXCLUSIONS with a reason.`,
+        ).toEqual([]);
+      });
+
+      it('all TS functions have bash equivalents (or are excluded)', () => {
+        const { missingInBash } = checkParity(target.bashFile, target.tsFile);
+        expect(
+          missingInBash,
+          `TS functions missing bash equivalent: ${missingInBash.join(', ')}. Either port them or add to EXCLUSIONS with a reason.`,
+        ).toEqual([]);
+      });
+
+      it('extracts functions from both files', () => {
+        const { bashFns, tsFns } = checkParity(target.bashFile, target.tsFile);
+        expect(bashFns.length).toBeGreaterThan(3);
+        expect(tsFns.length).toBeGreaterThan(3);
+      });
+    });
+  }
 
   describe('exclusions are valid', () => {
     it('all excluded functions actually exist in their source', () => {
-      const parseCommandBash = extractBashFunctions(
-        join(HOOKS_LIB_DIR, 'parse-command.sh'),
-      );
-
-      const parseCommandTs = extractTsFunctions(
-        join(HOOKS_TS_DIR, 'parse-command.ts'),
-      );
+      const knownFunctions = allKnownFunctions();
 
       for (const excluded of Object.keys(EXCLUSIONS)) {
-        const existsInBash = parseCommandBash.includes(excluded);
-        const existsInTs = parseCommandTs.includes(excluded);
         expect(
-          existsInBash || existsInTs,
+          knownFunctions.has(excluded),
           `Exclusion '${excluded}' doesn't exist in either bash or TS — remove stale exclusion`,
         ).toBe(true);
       }
+    });
+  });
+
+  describe('allowlist behavior parity', () => {
+    const readonlyCases: Array<[string, boolean]> = [
+      ['gh api repos/Garsson-io/kaizen/pulls/42', true],
+      ['gh run list --limit 5', true],
+      ['gh run rerun 12345', false],
+      ['git status && gh run list --limit 5', true],
+      ['git status && git push', false],
+      ['echo foo | gh api repos/bar', false],
+      ['cd .\ngit status', true],
+      ['npm run build', false],
+      ['npx vitest run src/hooks/lib/allowlist.test.ts', true],
+    ];
+
+    it.each(readonlyCases)('isReadonlyMonitoringCommand matches bash for %s', (cmd, expected) => {
+      expect(isReadonlyMonitoringCommand(cmd)).toBe(expected);
+      expect(bashBoolean('is_readonly_monitoring_command', cmd)).toBe(expected);
+    });
+
+    const runtimeDirCases: Array<[string, boolean]> = [
+      ['.claude/settings.json', true],
+      ['logs/app.log', true],
+      ['strategy/memory.json', true],
+      ['src/index.ts', false],
+      ['package.json', false],
+    ];
+
+    it.each(runtimeDirCases)('isAllowedRuntimeDir matches bash for %s', (path, expected) => {
+      expect(isAllowedRuntimeDir(path)).toBe(expected);
+      expect(bashBoolean('is_allowed_runtime_dir', path)).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
## Story

Once upon a time, #333 tracked the risk that bash hook shared libraries and their TypeScript ports could drift. That was real: early migration left `state-utils.sh`, `parse-command.sh`, and TypeScript siblings describing the same concepts in different runtimes.

Every day, the repo got better. `state-utils.sh` was deleted, `state-utils.ts` became canonical, and `bash-ts-parity.test.ts` guarded `parse-command.sh` against its TypeScript port.

One day, re-reading #333 against current main showed one remaining duplicated shared-library pair: `.claude/hooks/lib/allowlist.sh` and `src/hooks/lib/allowlist.ts`. Their standalone tests both passed, but nothing made the two implementations answer the same shared classification questions.

Because of that, this PR expands the existing parity test from a parse-command-only check into a small registry of guarded bash/TS pairs. It adds `allowlist.sh` / `src/hooks/lib/allowlist.ts`, documents the intentionally one-sided functions, and validates exclusions against the actual source files so stale exemptions fail.

Because of that, the test now also compares behavior, not just names: representative readonly command classifications and runtime-directory classifications run through both the TypeScript functions and the sourced bash functions.

Until finally, adding the allowlist target first failed with the exact missing-function mismatch #333 wanted exposed, and the final focused suites pass with the mismatch documented and shared behavior locked.

And ever since, the remaining allowlist overlap has an executable sync contract instead of relying on separate tests staying coincidentally aligned.

Fixes #333
Related: #790

## Impact (goal -> before/after -> match)

- Goal (#333): eliminate silent sync risk between bash and TS shared hook libraries.
- Acceptance signal: adding or changing duplicated allowlist behavior without updating the sibling implementation causes a focused parity test failure.
- BEFORE: `bash-ts-parity.test.ts` guarded only `parse-command`; `allowlist.sh` and `allowlist.ts` could drift while their separate suites passed.
- AFTER: parity targets include `allowlist`, documented exclusions are validated, and shared readonly/runtime-dir behavior is compared across bash and TS.
- Delta: focused parity coverage rose from parse-command-only to parse-command plus allowlist, with 14 cross-runtime behavior cases.
- Goal met?: yes for the current remaining duplicated shared-lib overlap; broad full bash retirement remains tracked by the hook modernization work (#1601/#762).
- Residual scan: `state-utils.sh` remains deleted; `parse-command` already covered; `allowlist` is now covered. Other bash helpers are shell-only runtime/shim helpers rather than duplicated TS shared-library implementations.

## Architecture

```text
src/hooks/bash-ts-parity.test.ts
  PARITY_TARGETS
    parse-command.sh <-> parse-command.ts
    allowlist.sh     <-> src/hooks/lib/allowlist.ts
  EXCLUSIONS
    documented one-sided functions, checked against source
  behavior parity
    TS function result == sourced bash function result
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Extend the existing parity test | Reuses the current sync-test mechanism instead of creating another framework | The test file grows, but stays the single place for bash/TS parity |
| Document one-sided allowlist functions | Some TS helpers serve TS-only gates and some bash helpers are public only because shell lacks module privacy | Exclusions must be maintained, so the test validates stale exclusions |
| Add behavior parity cases | Name parity alone would not catch classification drift | Representative cases are not exhaustive, but they cover allowed/blocked command and path classes |
| Do not port remaining bash hooks here | #333 is a sync-risk issue; broad hook migration belongs to #1601/#762 | Full retirement remains out of scope |

## What's In This PR

| File | Purpose |
|---|---|
| `src/hooks/bash-ts-parity.test.ts` | Adds allowlist parity target, validated exclusions, and bash-vs-TS behavior comparisons |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status | Evidence |
|---|---|---|---|
| 1 | Adding a function to `allowlist.sh` or `allowlist.ts` requires a sibling implementation or documented exclusion | Unit | tested | `src/hooks/bash-ts-parity.test.ts` target inventory |
| 2 | Bash and TS readonly command classification agree for representative allowed and blocked commands | Unit | tested | parity cases call TS and sourced bash functions |
| 3 | Bash and TS allowed-runtime-directory classification agree for representative paths | Unit | tested | parity cases call TS and sourced bash functions |
| 4 | Existing standalone allowlist suites remain green | Unit/System shell | tested | TS allowlist vitest + shell allowlist test both pass |

## Validation

- [x] Red first: adding `allowlist` to `PARITY_TARGETS` failed with missing bash/TS function mismatches.
- [x] `npx vitest run src/hooks/bash-ts-parity.test.ts src/hooks/lib/allowlist.test.ts` -> 56 passed.
- [x] `bash .claude/hooks/tests/test-allowlist.sh` -> 59 passed.
- [x] `npm run typecheck` passed.
- [x] `npm run test:fast` passed: 1 changed file, 21 tests.
- [x] Rebased onto current `origin/main` (`34dc6c6`) and reran focused checks.
- [x] `git diff --check` clean.

## Known Limitations

- This does not retire all bash hooks. It closes the current silent sync-risk gap for duplicated shared libraries; broader bash-to-TS migration remains a separate modernization effort.
