### PR TITLE
Track auto-dent timeout cost integrity

### DIFF
--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -61,6 +61,7 @@ All cross-run state lives in `logs/auto-dent/<batch-id>/state.json`. Key fields:
 | `stop_reason` | string | Why the batch stopped (empty while running) |
 | `progress_issue` | string | GitHub issue URL for batch progress tracking |
 | `run_history` | RunMetrics[] | Per-run duration, cost, tool calls, exit code |
+| `cost_integrity_warnings` | string[] per run | Data-integrity warnings for cost attribution, such as timeout kills that leave a tool-using run at `$0.00` |
 | `review_verdict` | `"pass"\|"fail"\|"error"\|"skipped"` per run | Requirements review verdict for the PR produced by this run; `"fail"` blocks auto-merge |
 | `review_cost_usd` | number per run | Cost of the requirements review for this run (typically $0.10–0.20) |
 

--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -77,6 +77,8 @@ export interface RunCompleteEvent extends BaseEvent {
   duration_ms: number;
   exit_code: number;
   cost_usd: number;
+  /** Cost data-integrity warnings detected from incomplete/ambiguous provider streams. */
+  cost_integrity_warnings?: string[];
   tool_calls: number;
   prs_created: number;
   issues_filed: number;

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -1688,6 +1688,52 @@ describe('processStreamMessage', () => {
     expect(result.cost).toBe(2.5);
   });
 
+  it('records best-known cost from non-result stream messages', () => {
+    const result = makeRunResult();
+    processStreamMessage(
+      {
+        type: 'assistant',
+        message: {
+          usage: {
+            total_cost_usd: 1.25,
+          },
+          content: [],
+        },
+      },
+      result,
+      Date.now(),
+    );
+    expect(result.cost).toBe(1.25);
+  });
+
+  it('lets terminal result cost override earlier stream cost', () => {
+    const result = makeRunResult();
+    processStreamMessage(
+      {
+        type: 'assistant',
+        message: {
+          usage: {
+            total_cost_usd: 1.25,
+          },
+          content: [],
+        },
+      },
+      result,
+      Date.now(),
+    );
+    processStreamMessage(
+      {
+        type: 'result',
+        subtype: 'success',
+        total_cost_usd: 2.5,
+        result: 'All done',
+      },
+      result,
+      Date.now(),
+    );
+    expect(result.cost).toBe(2.5);
+  });
+
   it('extracts artifacts from result text', () => {
     const result = makeRunResult();
     processStreamMessage(
@@ -3138,6 +3184,40 @@ describe('buildRunMetrics', () => {
     });
   });
 
+  it('flags timed-out zero-cost runs that used tools', () => {
+    const metrics = buildRunMetrics({
+      runNum: 6,
+      runStartEpoch: 1742681000,
+      duration: 600,
+      exitCode: 124,
+      runMode: 'exploit',
+      result: makeRunResult({
+        cost: 0,
+        toolCalls: 3,
+        timedOut: true,
+      }),
+    });
+
+    expect(metrics.cost_integrity_warnings).toEqual(['timeout_zero_cost_with_tool_calls']);
+  });
+
+  it('does not flag zero-cost runs without tool usage evidence', () => {
+    const metrics = buildRunMetrics({
+      runNum: 7,
+      runStartEpoch: 1742681000,
+      duration: 30,
+      exitCode: 0,
+      runMode: 'exploit',
+      result: makeRunResult({
+        cost: 0,
+        toolCalls: 0,
+        timedOut: true,
+      }),
+    });
+
+    expect(metrics.cost_integrity_warnings).toBeUndefined();
+  });
+
   it('adds persisted metadata without duplicating the base mapping', () => {
     const metrics = buildRunMetrics({
       runNum: 4,
@@ -3327,6 +3407,33 @@ describe('buildRunMetrics', () => {
       status: 'unknown',
       degraded: true,
     });
+  });
+
+  it('emits cost integrity warnings on run.complete from normalized run metrics', () => {
+    const result = makeRunResult({ cost: 0, toolCalls: 2, timedOut: true });
+    const metrics = buildRunMetrics({
+      runNum: 9,
+      runStartEpoch: 1742681400,
+      duration: 600,
+      exitCode: 124,
+      runMode: 'exploit',
+      result,
+    });
+
+    const event = buildRunCompleteEvent({
+      runId: 'batch/run-9',
+      batchId: 'batch',
+      runNum: 9,
+      duration: 600,
+      exitCode: 124,
+      result,
+      runMode: 'exploit',
+      outcome: 'failure',
+      runMetricsForOutcome: metrics,
+      lifecycleViolationCount: 0,
+    });
+
+    expect(event.cost_integrity_warnings).toEqual(['timeout_zero_cost_with_tool_calls']);
   });
 
   it('emits context-delegation pressure diagnostics on run.complete telemetry', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -288,6 +288,8 @@ export interface RunMetrics {
   duration_seconds: number;
   exit_code: number;
   cost_usd: number;
+  /** Cost data-integrity warnings detected from incomplete/ambiguous provider streams. */
+  cost_integrity_warnings?: string[];
   tool_calls: number;
   prs: string[];
   issues_filed: string[];
@@ -422,6 +424,7 @@ type RunMetricsBaseField =
   | 'duration_seconds'
   | 'exit_code'
   | 'cost_usd'
+  | 'cost_integrity_warnings'
   | 'tool_calls'
   | 'prs'
   | 'issues_filed'
@@ -459,12 +462,14 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
   const { runNum, runStartEpoch, duration, exitCode, runMode, result, modeReason, bandit, provider, metadata = {} } = input;
   const hookActivation = result.hookActivation
     ?? (provider ? unknownHookActivationVerdict(provider, 'no system.init observed') : undefined);
+  const costIntegrityWarnings = buildCostIntegrityWarnings(result);
   return {
     run: runNum,
     start_epoch: runStartEpoch,
     duration_seconds: duration,
     exit_code: exitCode,
     cost_usd: result.cost,
+    cost_integrity_warnings: costIntegrityWarnings.length > 0 ? costIntegrityWarnings : undefined,
     tool_calls: result.toolCalls,
     prs: result.prs,
     issues_filed: result.issuesFiled,
@@ -487,6 +492,13 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     hook_activation: hookActivation,
     ...metadata,
   };
+}
+
+function buildCostIntegrityWarnings(result: RunResult): string[] {
+  if (result.timedOut && result.cost === 0 && result.toolCalls > 0) {
+    return ['timeout_zero_cost_with_tool_calls'];
+  }
+  return [];
 }
 
 export interface CandidateTaskManifestParseResult {
@@ -1405,6 +1417,7 @@ export function buildRunCompleteEvent(input: BuildRunCompleteEventInput): RunCom
     duration_ms: duration * 1000,
     exit_code: exitCode,
     cost_usd: result.cost,
+    cost_integrity_warnings: runMetricsForOutcome.cost_integrity_warnings,
     tool_calls: result.toolCalls,
     prs_created: result.prs.length,
     issues_filed: result.issuesFiled.length,

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -596,6 +596,33 @@ export function ingestRunText(
   if (insights.length > 0) (result.reflectionInsights ??= []).push(...insights);
 }
 
+function streamCostCandidate(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function extractStreamCostUsd(msg: Record<string, any>): number | undefined {
+  const candidates = [
+    msg.total_cost_usd,
+    msg.cost_usd,
+    msg.usage?.total_cost_usd,
+    msg.usage?.cost_usd,
+    msg.message?.usage?.total_cost_usd,
+    msg.message?.usage?.cost_usd,
+    msg.message?.cost_usd,
+  ];
+
+  return candidates.map(streamCostCandidate).find((cost) => cost !== undefined);
+}
+
+function updateStreamCost(msg: Record<string, any>, result: RunResult, opts: { terminal: boolean }): void {
+  const cost = extractStreamCostUsd(msg);
+  if (cost === undefined) return;
+
+  if (opts.terminal || cost > result.cost) {
+    result.cost = cost;
+  }
+}
+
 // Main stream message processor
 
 export function processStreamMessage(
@@ -605,6 +632,7 @@ export function processStreamMessage(
   ctx?: StreamContext,
 ): void {
   const elapsed = formatElapsed(runStart);
+  if (msg.type !== 'result') updateStreamCost(msg, result, { terminal: false });
 
   switch (msg.type) {
     case 'system':
@@ -680,9 +708,7 @@ export function processStreamMessage(
       if (ctx) {
         ctx.resultReceivedAt = Date.now();
       }
-      if (msg.total_cost_usd) {
-        result.cost = msg.total_cost_usd;
-      }
+      updateStreamCost(msg, result, { terminal: true });
       if (msg.result) {
         // Final result is agent-authoritative → control signals honoured.
         ingestRunText(msg.result, result, elapsed, ctx, { control: true });


### PR DESCRIPTION
## Summary

Closes #1357.

This fixes the auto-dent timeout cost attribution gap where a provider process killed before its terminal `result` event could leave a tool-using run recorded as a true `$0.00` run.

## Changes

- Record best-known cumulative stream cost from non-terminal stream messages when numeric cost metadata is present.
- Keep terminal `result.total_cost_usd` authoritative when the terminal result event arrives.
- Add `cost_integrity_warnings` to `RunMetrics` and `run.complete` telemetry for timed-out, zero-cost runs that used tools.
- Document the new run-history warning field in the auto-dent operations guide.

## Verification

- RED: `npx vitest run scripts/auto-dent-run.test.ts` failed on missing intermediate stream cost capture and missing timeout warning.
- GREEN: `npx vitest run scripts/auto-dent-run.test.ts` — 396 passed.
- GREEN: `npm run typecheck`.
- GREEN: `npm run test:fast` — 13 files passed, 854 passed, 2 skipped.
- GREEN: `npm test` — 180 files passed, 2 skipped; 4266 passed, 14 skipped.
- GREEN: `git diff --check`.
