### PR TITLE
Harden auto-dent PR artifact provenance

### DIFF
--- a/scripts/auto-dent-codex.test.ts
+++ b/scripts/auto-dent-codex.test.ts
@@ -165,6 +165,33 @@ describe('normalizeCodexEventToStreamMessages (#1488)', () => {
     expect(ctx).toMatchObject({ lastActivity: expect.stringContaining('gh pr create') });
   });
 
+  it('does not treat PR URLs from non-create command output as created PRs', () => {
+    const messages = normalizeCodexEventToStreamMessages({
+      type: 'item.completed',
+      item: {
+        type: 'command_execution',
+        command: 'gh pr list --repo Garsson-io/kaizen --state open',
+        aggregated_output: [
+          'https://github.com/Garsson-io/kaizen/pull/1026 fix: rename stale refs',
+          'https://github.com/Garsson-io/kaizen/pull/10 old referenced PR',
+          'https://github.com/test/test/pull/1 external fixture',
+        ].join('\n'),
+        exit_code: 0,
+        status: 'completed',
+      },
+    });
+
+    const result = makeRunResult();
+    const ctx = {};
+    for (const message of messages) {
+      processStreamMessage(message, result, Date.now(), ctx);
+    }
+
+    expect(result.toolCalls).toBe(1);
+    expect(result.prs).toEqual([]);
+    expect(ctx).toMatchObject({ lastActivity: expect.stringContaining('gh pr list') });
+  });
+
   it('turns Codex final messages into canonical result messages for final claim parsing', () => {
     const claim = {
       schema_version: 1,

--- a/scripts/auto-dent-codex.ts
+++ b/scripts/auto-dent-codex.ts
@@ -85,6 +85,10 @@ function extractPullRequestUrl(text: string): string | undefined {
   return text.match(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/)?.[0];
 }
 
+function isPrCreateCommand(command: string): boolean {
+  return /\bgh\s+pr\s+create\b/.test(command);
+}
+
 /**
  * Normalize provider-specific Codex JSONL rows into the same stream-json shape
  * that `processStreamMessage()` already consumes for Claude.
@@ -125,7 +129,7 @@ export function normalizeCodexEventToStreamMessages(event: unknown): AutoDentStr
             content: [{ type: 'tool_result', content: output }],
           },
         };
-        const prUrl = extractPullRequestUrl(output);
+        const prUrl = isPrCreateCommand(command) ? extractPullRequestUrl(output) : undefined;
         if (prUrl) {
           toolResult.tool_use_result = {
             gitOperation: {

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -1040,6 +1040,7 @@ describe('extractArtifacts', () => {
     extractArtifacts(
       '**PRs created:** https://github.com/Garsson-io/kaizen/pull/1236 (auto-merge queued)',
       result,
+      { allowPrSummary: true },
     );
 
     expect(result.prs).toEqual(['https://github.com/Garsson-io/kaizen/pull/1236']);
@@ -1754,6 +1755,46 @@ describe('processStreamMessage', () => {
       'https://github.com/Garsson-io/kaizen/pull/500',
     );
     expect(result.issuesClosed).toContain('#451');
+  });
+
+  it('extracts final PR summary artifacts only from trusted result text', () => {
+    const result = makeRunResult();
+    processStreamMessage(
+      {
+        type: 'result',
+        subtype: 'success',
+        result: '**PRs created:** https://github.com/Garsson-io/kaizen/pull/1589',
+      },
+      result,
+      Date.now(),
+    );
+
+    expect(result.prs).toEqual(['https://github.com/Garsson-io/kaizen/pull/1589']);
+  });
+
+  it('does not extract PR summary artifacts from untrusted tool output', () => {
+    const result = makeRunResult();
+    processStreamMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{
+            type: 'tool_result',
+            content: [
+              '**PRs created:** https://github.com/Garsson-io/kaizen/pull/1026',
+              '**PRs created:** https://github.com/Garsson-io/kaizen/pull/10',
+              '**PRs created:** https://github.com/Garsson-io/kaizen/pull/100',
+              '**PRs created:** https://github.com/test/test/pull/1',
+              '**PRs created:** https://github.com/Garsson-io/kaizen/pull/1589',
+            ].join('\n'),
+          }],
+        },
+      },
+      result,
+      Date.now(),
+    );
+
+    expect(result.prs).toEqual([]);
   });
 
   it('extracts PR artifacts from Claude Code tool result metadata', () => {

--- a/scripts/auto-dent-stream.test.ts
+++ b/scripts/auto-dent-stream.test.ts
@@ -748,7 +748,7 @@ describe('branch-push helper URLs vs real PRs (#1492)', () => {
     extractArtifacts('https://github.com/o/r/pull/new/case-x', result);
     expect(result.progressSteps?.find((s) => s.phase === 'PR')?.state).toBe('branch-pushed');
 
-    extractArtifacts('PRs created: https://github.com/o/r/pull/123', result);
+    extractArtifacts('PRs created: https://github.com/o/r/pull/123', result, { allowPrSummary: true });
     expect(result.prs).toContain('https://github.com/o/r/pull/123');
     const prStep = result.progressSteps?.find((s) => s.phase === 'PR');
     expect(prStep?.state).toBe('created');

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -167,7 +167,15 @@ export function extractBranchPushUrl(text: string): string | null {
   return m ? m[0] : null;
 }
 
-export function extractArtifacts(text: string, result: RunResult): void {
+export interface ExtractArtifactOptions {
+  allowPrSummary?: boolean;
+}
+
+export function extractArtifacts(
+  text: string,
+  result: RunResult,
+  options: ExtractArtifactOptions = {},
+): void {
   for (const output of parseHookOutputs(text)) {
     updateProgressFromHookOutput(output, result);
   }
@@ -196,8 +204,10 @@ export function extractArtifacts(text: string, result: RunResult): void {
       }
     }
   }
-  for (const m of text.matchAll(/^\s*(?:\*\*)?PRs created:\s*(?:\*\*)?\s*(https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+)/gmi)) {
-    pushPr(result, m[1]);
+  if (options.allowPrSummary) {
+    for (const m of text.matchAll(/^\s*(?:\*\*)?PRs created:\s*(?:\*\*)?\s*(https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+)/gmi)) {
+      pushPr(result, m[1]);
+    }
   }
   // A GitHub branch-push helper URL is NOT a PR (#1492). Surface it as a
   // distinct "branch pushed — PR pending" signal so a pushed branch is not
@@ -575,9 +585,9 @@ export function ingestRunText(
   result: RunResult,
   elapsed: string,
   ctx?: StreamContext,
-  opts: { control?: boolean } = {},
+  opts: { control?: boolean; allowPrSummary?: boolean } = {},
 ): void {
-  extractArtifacts(text, result);
+  extractArtifacts(text, result, { allowPrSummary: opts.allowPrSummary });
   emitPhaseMarkers(text, elapsed, ctx);
   const pushUrl = extractBranchPushUrl(text);
   if (pushUrl) {
@@ -711,7 +721,7 @@ export function processStreamMessage(
       updateStreamCost(msg, result, { terminal: true });
       if (msg.result) {
         // Final result is agent-authoritative → control signals honoured.
-        ingestRunText(msg.result, result, elapsed, ctx, { control: true });
+        ingestRunText(msg.result, result, elapsed, ctx, { control: true, allowPrSummary: true });
         const claimResult = parseFinalRunClaim(msg.result);
         result.finalClaimStatus = claimResult.status;
         result.finalClaim = claimResult.claim;


### PR DESCRIPTION
## Summary

Fixes #1203.

Auto-dent had two remaining ways to mistake referenced PRs for current-run artifacts after the earlier broad-regex fix:

1. Codex command output synthesized `tool_use_result.gitOperation.pr.created` from the first PR URL in any command output.
2. `extractArtifacts()` trusted free-form `PRs created:` lines from any text source, including tool output and copied transcripts.

This PR makes both paths provenance-aware.

## Changes

- Only synthesize Codex PR-created metadata for command executions that are actually `gh pr create` commands.
- Gate the free-form `PRs created:` fallback behind `allowPrSummary`, enabled only for trusted terminal result text.
- Preserve structured `AUTO_DENT_PHASE: PR | url=...` and Claude Code native `tool_use_result.gitOperation.pr.created` handling.
- Add regression coverage for `immense-cow`-style unrelated PR URLs in `gh pr list` output and untrusted `PRs created:` tool output.

## Verification

- RED: `npx vitest run scripts/auto-dent-codex.test.ts scripts/auto-dent-run.test.ts` failed on Codex `gh pr list` output and untrusted `PRs created:` tool output.
- GREEN: `npx vitest run scripts/auto-dent-codex.test.ts scripts/auto-dent-run.test.ts` — 409 passed.
- GREEN: `npm run typecheck`.
- GREEN: `npm run test:fast` — 13 files passed, 922 passed, 2 skipped.
- GREEN: `npm test` — 180 files passed, 2 skipped; 4286 passed, 14 skipped.
- GREEN: `git diff --check`.
