### PR TITLE
Make auto-dent cost-per-PR insight guidance-aware

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -591,6 +591,47 @@ describe('buildBatchReflection', () => {
     expect(reflection.avgCostPerPr).toBeCloseTo(3.25);
   });
 
+  it('keeps the expensive cost-per-PR recommendation for ordinary guidance', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        guidance: 'pick small isolated issues and ship them independently',
+        run: 2,
+        run_history: [
+          makeRunMetrics({ run: 1, cost_usd: 4.0, prs: ['https://github.com/Garsson-io/kaizen/pull/100'] }),
+          makeRunMetrics({ run: 2, cost_usd: 4.0, prs: ['https://github.com/Garsson-io/kaizen/pull/101'] }),
+        ],
+      }),
+    });
+
+    const reflection = buildBatchReflection(batch);
+    const costInsight = reflection.insights.find((i) => i.message.includes('$4.00/PR'));
+
+    expect(costInsight).toBeDefined();
+    expect(costInsight?.message).toContain('consider simpler issues');
+  });
+
+  it('reframes expensive cost-per-PR when guidance asks for bundled complete work', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        guidance: 'find meaningful tasks, bunch them together into one bigger useful task, finish it to completion perfectly',
+        run: 2,
+        run_history: [
+          makeRunMetrics({ run: 1, cost_usd: 4.0, prs: ['https://github.com/Garsson-io/kaizen/pull/100'], issues_closed: ['#10', '#11'] }),
+          makeRunMetrics({ run: 2, cost_usd: 4.0, prs: ['https://github.com/Garsson-io/kaizen/pull/101'], issues_closed: ['#12', '#13'] }),
+        ],
+      }),
+    });
+
+    const reflection = buildBatchReflection(batch);
+    const simplerIssuesAdvice = reflection.insights.find((i) => i.message.includes('consider simpler issues'));
+    const bundledCostInsight = reflection.insights.find((i) => i.message.includes('bundling guidance'));
+
+    expect(simplerIssuesAdvice).toBeUndefined();
+    expect(bundledCostInsight).toBeDefined();
+    expect(bundledCostInsight?.message).toContain('$4.00/PR');
+    expect(bundledCostInsight?.message).toContain('issues closed');
+  });
+
   it('surfaces explore to exploit conversion in reflection comments', () => {
     const batch = makeBatchInfo({
       state: makeBatchState({

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -407,6 +407,19 @@ export interface BuildBatchReflectionOptions {
   drySweepReport?: DrySweepReport | null;
 }
 
+function guidanceSignalsBundledWork(guidance: string): boolean {
+  const text = guidance.toLowerCase();
+  return [
+    /\bbunch(?:ed|ing)?\b/,
+    /\bbundl(?:e|ed|es|ing)\b/,
+    /\bone\s+(?:big|bigger|large|larger)\s+(?:task|pr|change)\b/,
+    /\blarger\s+(?:complete\s+)?(?:task|pr|change)\b/,
+    /\bfinish(?:ed|ing)?\s+(?:it\s+)?to\s+completion\b/,
+    /\bcompleteness\s+beats\b/,
+    /\bcomplete\s+pr\b/,
+  ].some((pattern) => pattern.test(text));
+}
+
 /**
  * Build a batch reflection from state data.
  * Analyzes run history to find patterns, efficiency anomalies, and recommendations.
@@ -525,10 +538,17 @@ export function buildBatchReflection(
         message: `Efficient: $${avgCostPerPr.toFixed(2)}/PR is below the $1.50 target`,
       });
     } else if (avgCostPerPr > 3.0) {
-      insights.push({
-        type: 'recommendation',
-        message: `Expensive: $${avgCostPerPr.toFixed(2)}/PR is above the $3.00 threshold — consider simpler issues`,
-      });
+      if (guidanceSignalsBundledWork(s.guidance)) {
+        insights.push({
+          type: 'recommendation',
+          message: `High cost/PR: $${avgCostPerPr.toFixed(2)}/PR is above the $3.00 threshold, but aligned with bundling guidance — evaluate issues closed and completeness before simplifying scope`,
+        });
+      } else {
+        insights.push({
+          type: 'recommendation',
+          message: `Expensive: $${avgCostPerPr.toFixed(2)}/PR is above the $3.00 threshold — consider simpler issues`,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #1206.

The reflection insight for high average cost per PR used to always say `consider simpler issues` above `$3.00/PR`, even when the batch guidance explicitly asked the agent to bunch work into larger complete PRs. This PR keeps the existing recommendation for ordinary guidance, but reframes it when the guidance signals bundling/completion.

## Changes

- Add a conservative guidance classifier for bundled work signals (`bunch`, `bundle`, `one bigger task`, `finish to completion`, etc.).
- Preserve the existing `$3.00/PR` expensive recommendation for ordinary guidance.
- For bundled-work guidance, emit a visible high-cost context insight that points operators toward issues closed/completeness instead of simpler issues.
- Add focused tests for both normal and bundled guidance.

## Verification

- RED: `npx vitest run scripts/auto-dent-ctl.test.ts` failed on bundled guidance still producing `consider simpler issues`.
- GREEN: `npx vitest run scripts/auto-dent-ctl.test.ts` — 77 passed.
- GREEN: `npm run typecheck`.
- GREEN: `npm run test:fast` — 1 file passed, 77 passed.
- GREEN: `npm test` — 180 files passed, 2 skipped; 4288 passed, 14 skipped.
- GREEN: `git diff --check`.
