### PR TITLE
test(hooks): add vitest coverage for rebase block

### DIFF
--- a/.claude/hooks/tests/test-block-git-rebase.sh
+++ b/.claude/hooks/tests/test-block-git-rebase.sh
@@ -5,6 +5,10 @@
 # `git rebase --abort` is always allowed (recovery path).
 # `git merge origin/main` is always allowed (safe alternative).
 # Non-rebase git commands are not affected.
+#
+# Paired TS coverage: src/e2e/block-git-rebase-live.test.ts (#1675).
+# Keep this shell test as the temporary #761 cross-check until the broader bash
+# hook-test migration has enough burn-in.
 source "$(dirname "$0")/test-helpers.sh"
 
 HOOK="$(dirname "$0")/../kaizen-block-git-rebase.sh"

--- a/src/e2e/block-git-rebase-live.test.ts
+++ b/src/e2e/block-git-rebase-live.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { allows, bashPre, denies, denyReason, runHook } from "./hook-runner.js";
+
+const HOOK = ".claude/hooks/kaizen-block-git-rebase.sh";
+
+function runCommand(command: string) {
+  return runHook(HOOK, bashPre(command), {
+    env: {
+      ...process.env,
+      DEBUG_LOG: "/dev/null",
+      HOOK_TIMING_SENTINEL_DISABLED: "true",
+      SEND_TELEGRAM_IPC_DISABLED: "true",
+      KAIZEN_TEST_RUNNER: "1",
+    },
+  });
+}
+
+describe("kaizen-block-git-rebase live wrapper", () => {
+  it.each([
+    "git rebase origin/main",
+    "git rebase main",
+    "git rebase -i HEAD~3",
+    "git rebase --onto main feature",
+    "git -C /some/path rebase origin/main",
+    "echo 'hello' && git rebase origin/main",
+  ])("blocks dangerous rebase command: %s", (command) => {
+    const result = runCommand(command);
+
+    expect(denies(result), `${command}: ${result.stdout}`).toBe(true);
+  });
+
+  it("suggests the merge alternative for a blocked rebase", () => {
+    const result = runCommand("git rebase origin/main");
+
+    expect(denies(result), result.stdout).toBe(true);
+    expect(denyReason(result)).toContain("git merge origin/main");
+  });
+
+  it.each([
+    "git rebase --abort",
+    "git rebase --continue",
+    "git rebase --skip",
+    "git merge origin/main",
+    "git push origin feature",
+    "git log --oneline -5",
+    "npm run build",
+  ])("allows recovery or non-rebase command: %s", (command) => {
+    const result = runCommand(command);
+
+    expect(allows(result), `${command}: ${result.stdout}`).toBe(true);
+  });
+
+  it("explains force-push risk in the blocking message", () => {
+    const result = runCommand("git rebase origin/main");
+
+    expect(denyReason(result)).toContain("force-push");
+  });
+
+  it.each([
+    "echo 'use git rebase to fix it'",
+    "# git rebase origin/main",
+  ])("does not block textual mention: %s", (command) => {
+    const result = runCommand(command);
+
+    expect(allows(result), `${command}: ${result.stdout}`).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #1675
Related: #761
Related: #1601

## Story

#1076 moved the hook lifecycle harness into Vitest. The next #761 step is to start moving bash-only hook test matrices into the same TypeScript test stack without deleting their shell cross-checks too early.

This PR takes the smallest Phase 1 slice: `test-block-git-rebase.sh`. The hook was already lightly covered by broader plugin-lifecycle smoke tests, but the full bash matrix was still the only place that checked rebase variants, recovery commands, guidance text, and textual false positives together.

## What Changed

- Added `src/e2e/block-git-rebase-live.test.ts`, using `src/e2e/hook-runner.ts` against the real `kaizen-block-git-rebase.sh` wrapper.
- Covered blocked rebase variants, `git -C` rebase, chained command segments, recovery commands, safe alternatives, guidance text, and echo/comment false positives.
- Marked `.claude/hooks/tests/test-block-git-rebase.sh` as paired TS coverage while keeping it as the temporary #761 cross-check.

## Impact Proof

Before:
- The full block-git-rebase command matrix lived only in `.claude/hooks/tests/test-block-git-rebase.sh`.
- Existing TS coverage was smoke-level and did not mirror the shell matrix.

After:
- Focused Vitest coverage: `src/e2e/block-git-rebase-live.test.ts` → 17 passed.
- Shell cross-check remains green: `test-block-git-rebase.sh` → 18 passed, 0 failed.
- Full hook suite remains green: 479 passed, 0 failed.

## Validation

- `npx vitest run src/e2e/block-git-rebase-live.test.ts` → 17 passed
- `bash .claude/hooks/tests/test-block-git-rebase.sh` → 18 passed, 0 failed
- `npm run typecheck`
- `npm run test:fast` → no non-E2E changed tests found, pass
- `npm run test:hooks` → 479 passed, 0 failed
- `git diff --check HEAD~1 HEAD`
