### PR TITLE
Project auto-dent replay runs

### DIFF
--- a/scripts/auto-dent-replay.test.ts
+++ b/scripts/auto-dent-replay.test.ts
@@ -4,9 +4,16 @@ import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 import {
   parseReplayEventsJsonl,
+  projectReplayRuns,
   readReplayEventsFile,
   replayCapturedRun,
 } from './auto-dent-replay.js';
+import {
+  captureToEvents,
+  captureToRunMetrics,
+  runStream,
+  scenarios,
+} from './auto-dent-harness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -230,5 +237,204 @@ describe('auto-dent replay fixtures', () => {
     );
 
     expect(runSource).not.toContain('auto-dent-replay');
+  });
+
+  it('projects replayed fixture events into current run-metrics fields', () => {
+    const result = replayCapturedRun(join(fixtureRoot, 'basic-run'));
+
+    const projections = projectReplayRuns(result.events);
+
+    expect(projections).toHaveLength(1);
+    expect(projections[0]).toMatchObject({
+      batch_id: 'fixture-batch',
+      run_id: 'fixture-batch/run-1',
+      run: 1,
+      run_num: 1,
+      mode: 'exploit',
+      mode_reason: 'fixture',
+      prompt_template: 'deep-dive-default.md',
+      prompt_hash: 'abc123',
+      issue: '#1678',
+      issue_title: 'Event replay schema and captured-run fixtures',
+      labels: ['kaizen', 'auto-dent', 'area/auto-dent'],
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1678'],
+      duration_seconds: 180,
+      exit_code: 0,
+      cost_usd: 1.25,
+      tool_calls: 42,
+      prs_created: 1,
+      issues_filed_count: 0,
+      issues_closed_count: 1,
+      stop_requested: false,
+      lifecycle_violations: 0,
+      outcome: 'success',
+      workflow_gate_states: {
+        'ticket-identity': 'done',
+        'plan-testplan': 'done',
+      },
+    });
+    expect(projections[0].missingFromEvents).toEqual(
+      expect.arrayContaining(['cases', 'issues_filed', 'issues_closed']),
+    );
+  });
+
+  it('preserves workflow gate repair fields from run.complete events', () => {
+    const content = JSON.stringify({
+      timestamp: '2026-03-26T00:03:00.000Z',
+      event: {
+        type: 'run.complete',
+        run_id: 'fixture-batch/run-4',
+        batch_id: 'fixture-batch',
+        run_num: 4,
+        duration_ms: 1000,
+        exit_code: 1,
+        cost_usd: 0.5,
+        tool_calls: 7,
+        prs_created: 1,
+        issues_filed: 0,
+        issues_closed: 0,
+        stop_requested: false,
+        lifecycle_violations: 2,
+        outcome: 'failure',
+        workflow_gate_states: {
+          'dry-refactor': 'pending',
+          'meet-reality': 'invalid',
+        },
+        workflow_repair_gates: ['dry-refactor', 'meet-reality'],
+        workflow_repair_state: 'repair_scheduled',
+        workflow_repair_prompt: 'Record dry/refactor and meet-reality evidence.',
+      },
+    });
+
+    const [projection] = projectReplayRuns(parseReplayEventsJsonl(content).events);
+
+    expect(projection).toMatchObject({
+      workflow_gate_states: {
+        'dry-refactor': 'pending',
+        'meet-reality': 'invalid',
+      },
+      workflow_repair_gates: ['dry-refactor', 'meet-reality'],
+      workflow_repair_state: 'repair_scheduled',
+      workflow_repair_prompt: 'Record dry/refactor and meet-reality evidence.',
+    });
+  });
+
+  it('matches synthetic harness RunMetrics for event-representable fields', () => {
+    const capture = runStream(scenarios.successfulRun({
+      issue: '#1679',
+      title: 'State projection parity from events.jsonl',
+      prUrl: 'https://github.com/Garsson-io/kaizen/pull/1679',
+      cost: 2.25,
+    }));
+    const metrics = captureToRunMetrics(capture, {
+      runNum: 7,
+      mode: 'exploit',
+    });
+    const events = captureToEvents(capture, {
+      batchId: 'synthetic-batch',
+      runNum: 7,
+      mode: 'exploit',
+    });
+
+    const [projection] = projectReplayRuns(events);
+
+    expect(projection).toMatchObject({
+      run: metrics.run,
+      run_num: metrics.run,
+      exit_code: metrics.exit_code,
+      cost_usd: metrics.cost_usd,
+      tool_calls: metrics.tool_calls,
+      prs: metrics.prs,
+      stop_requested: metrics.stop_requested,
+      mode: metrics.mode,
+      lifecycle_violations: metrics.lifecycle_violations,
+    });
+    expect(projection.issue).toBe('#1679');
+    expect(projection.issue_title).toBe('State projection parity from events.jsonl');
+  });
+
+  it('reports missing source events without fabricating unavailable state', () => {
+    const startOnly = parseReplayEventsJsonl(JSON.stringify({
+      timestamp: '2026-03-26T00:00:00.000Z',
+      event: {
+        type: 'run.start',
+        run_id: 'fixture-batch/run-5',
+        batch_id: 'fixture-batch',
+        run_num: 5,
+        mode: 'exploit',
+        mode_reason: 'partial fixture',
+        prompt_template: 'deep-dive-default.md',
+        prompt_hash: 'partial',
+      },
+    }));
+
+    const [projection] = projectReplayRuns(startOnly.events);
+
+    expect(projection).toMatchObject({
+      run_id: 'fixture-batch/run-5',
+      run: 5,
+      mode: 'exploit',
+      prs: [],
+    });
+    expect(projection.duration_seconds).toBeUndefined();
+    expect(projection.exit_code).toBeUndefined();
+    expect(projection.missingFromEvents).toEqual(
+      expect.arrayContaining(['run.complete', 'cases', 'issues_filed', 'issues_closed']),
+    );
+  });
+
+  it('projects multiple PR events for the same run', () => {
+    const base = {
+      timestamp: '2026-03-26T00:00:00.000Z',
+      event: {
+        run_id: 'fixture-batch/run-6',
+        batch_id: 'fixture-batch',
+        run_num: 6,
+      },
+    };
+    const content = [
+      {
+        ...base,
+        event: {
+          ...base.event,
+          type: 'run.pr_created',
+          pr_url: 'https://github.com/Garsson-io/kaizen/pull/1701',
+        },
+      },
+      {
+        ...base,
+        event: {
+          ...base.event,
+          type: 'run.pr_created',
+          pr_url: 'https://github.com/Garsson-io/kaizen/pull/1702',
+        },
+      },
+      {
+        ...base,
+        event: {
+          ...base.event,
+          type: 'run.complete',
+          duration_ms: 2000,
+          exit_code: 0,
+          cost_usd: 1,
+          tool_calls: 3,
+          prs_created: 2,
+          issues_filed: 0,
+          issues_closed: 2,
+          stop_requested: false,
+          lifecycle_violations: 0,
+          outcome: 'success',
+        },
+      },
+    ].map((event) => JSON.stringify(event)).join('\n');
+
+    const [projection] = projectReplayRuns(parseReplayEventsJsonl(content).events);
+
+    expect(projection.prs).toEqual([
+      'https://github.com/Garsson-io/kaizen/pull/1701',
+      'https://github.com/Garsson-io/kaizen/pull/1702',
+    ]);
+    expect(projection.prs_created).toBe(2);
+    expect(projection.issues_closed_count).toBe(2);
   });
 });

--- a/scripts/auto-dent-replay.ts
+++ b/scripts/auto-dent-replay.ts
@@ -2,7 +2,13 @@ import { existsSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { z } from 'zod';
 import { parseJsonLinesWithMalformedRows } from '../src/lib/json-lines.js';
-import type { EventEnvelope } from './auto-dent-events.js';
+import type {
+  EventEnvelope,
+  RunCompleteEvent,
+  RunIssuePickedEvent,
+  RunPrCreatedEvent,
+  RunStartEvent,
+} from './auto-dent-events.js';
 
 const baseEventSchema = z.object({
   run_id: z.string(),
@@ -121,6 +127,61 @@ export interface ReplayEventsResult {
   summary: ReplaySummary;
 }
 
+export interface ReplayRunProjection {
+  batch_id: string;
+  run_id: string;
+  run: number;
+  run_num: number;
+  start_timestamp?: string;
+  complete_timestamp?: string;
+  start_epoch?: number;
+  mode?: string;
+  mode_reason?: string;
+  prompt_template?: string;
+  prompt_hash?: string;
+  issue?: string;
+  issue_title?: string;
+  labels?: string[];
+  prs: string[];
+  duration_seconds?: number;
+  exit_code?: number;
+  cost_usd?: number;
+  cost_integrity_warnings?: string[];
+  tool_calls?: number;
+  prs_created?: number;
+  issues_filed_count?: number;
+  issues_closed_count?: number;
+  stop_requested?: boolean;
+  failure_class?: string;
+  lifecycle_violations?: number;
+  lifecycle_health?: RunCompleteEvent['lifecycle_health'];
+  lifecycle_critical?: number;
+  process_verdict?: RunCompleteEvent['process_verdict'];
+  process_issue_count?: number;
+  process_summary?: string;
+  workflow_gate_states?: RunCompleteEvent['workflow_gate_states'];
+  workflow_repair_gates?: RunCompleteEvent['workflow_repair_gates'];
+  workflow_repair_state?: RunCompleteEvent['workflow_repair_state'];
+  workflow_repair_prompt?: string;
+  context_delegation_required?: boolean;
+  context_delegation_observed?: boolean;
+  context_delegation_reasons?: string[];
+  context_delegation_recommended_substeps?: string[];
+  review_verdict?: RunCompleteEvent['review_verdict'];
+  review_cost_usd?: number;
+  phase_providers?: RunCompleteEvent['phase_providers'];
+  hook_activation?: RunCompleteEvent['hook_activation'];
+  bandit_decision?: RunCompleteEvent['bandit_decision'];
+  outcome?: RunCompleteEvent['outcome'];
+  missingFromEvents: string[];
+  warnings: string[];
+}
+
+interface MutableProjection {
+  projection: ReplayRunProjection;
+  observedTypes: Set<EventEnvelope['event']['type']>;
+}
+
 function summarizeReplay(events: EventEnvelope[]): ReplaySummary {
   const batchIds = new Set<string>();
   const runIds = new Set<string>();
@@ -180,4 +241,131 @@ export function readReplayEventsFile(eventsPath: string): ReplayEventsResult {
 
 export function replayCapturedRun(runDir: string): ReplayEventsResult {
   return readReplayEventsFile(join(runDir, 'events.jsonl'));
+}
+
+function getOrCreateProjection(
+  projections: Map<string, MutableProjection>,
+  envelope: EventEnvelope,
+): MutableProjection {
+  const { event } = envelope;
+  const existing = projections.get(event.run_id);
+  if (existing) return existing;
+
+  const created: MutableProjection = {
+    projection: {
+      batch_id: event.batch_id,
+      run_id: event.run_id,
+      run: event.run_num,
+      run_num: event.run_num,
+      prs: [],
+      missingFromEvents: [],
+      warnings: [],
+    },
+    observedTypes: new Set(),
+  };
+  projections.set(event.run_id, created);
+  return created;
+}
+
+function applyRunStart(projection: ReplayRunProjection, envelope: EventEnvelope & { event: RunStartEvent }): void {
+  projection.start_timestamp = envelope.timestamp;
+  projection.start_epoch = envelope.event.start_epoch;
+  projection.mode = envelope.event.mode;
+  projection.mode_reason = envelope.event.mode_reason;
+  projection.prompt_template = envelope.event.prompt_template;
+  projection.prompt_hash = envelope.event.prompt_hash;
+}
+
+function applyIssuePicked(projection: ReplayRunProjection, event: RunIssuePickedEvent): void {
+  projection.issue = event.issue;
+  projection.issue_title = event.title;
+  projection.labels = event.labels;
+}
+
+function applyPrCreated(projection: ReplayRunProjection, event: RunPrCreatedEvent): void {
+  if (!projection.prs.includes(event.pr_url)) projection.prs.push(event.pr_url);
+}
+
+function applyRunComplete(projection: ReplayRunProjection, envelope: EventEnvelope & { event: RunCompleteEvent }): void {
+  const event = envelope.event;
+  projection.complete_timestamp = envelope.timestamp;
+  projection.duration_seconds = Math.round(event.duration_ms / 1000);
+  projection.exit_code = event.exit_code;
+  projection.cost_usd = event.cost_usd;
+  projection.cost_integrity_warnings = event.cost_integrity_warnings;
+  projection.tool_calls = event.tool_calls;
+  projection.prs_created = event.prs_created;
+  projection.issues_filed_count = event.issues_filed;
+  projection.issues_closed_count = event.issues_closed;
+  projection.stop_requested = event.stop_requested;
+  projection.failure_class = event.failure_class;
+  projection.lifecycle_violations = event.lifecycle_violations;
+  projection.lifecycle_health = event.lifecycle_health;
+  projection.lifecycle_critical = event.lifecycle_critical;
+  projection.process_verdict = event.process_verdict;
+  projection.process_issue_count = event.process_issue_count;
+  projection.process_summary = event.process_summary;
+  projection.workflow_gate_states = event.workflow_gate_states;
+  projection.workflow_repair_gates = event.workflow_repair_gates;
+  projection.workflow_repair_state = event.workflow_repair_state;
+  projection.workflow_repair_prompt = event.workflow_repair_prompt;
+  projection.context_delegation_required = event.context_delegation_required;
+  projection.context_delegation_observed = event.context_delegation_observed;
+  projection.context_delegation_reasons = event.context_delegation_reasons;
+  projection.context_delegation_recommended_substeps = event.context_delegation_recommended_substeps;
+  projection.review_verdict = event.review_verdict;
+  projection.review_cost_usd = event.review_cost_usd;
+  projection.phase_providers = event.phase_providers;
+  projection.hook_activation = event.hook_activation;
+  projection.bandit_decision = event.bandit_decision;
+  projection.outcome = event.outcome;
+  if (event.mode && !projection.mode) projection.mode = event.mode;
+}
+
+function finalizeProjection(entry: MutableProjection): ReplayRunProjection {
+  const missing = new Set(entry.projection.missingFromEvents);
+  if (!entry.observedTypes.has('run.start')) missing.add('run.start');
+  if (!entry.observedTypes.has('run.complete')) missing.add('run.complete');
+
+  // events.jsonl currently records counts for these fields, not stable identities.
+  // Keep the absence explicit so #1680 does not silently fabricate state arrays.
+  missing.add('cases');
+  missing.add('issues_filed');
+  missing.add('issues_closed');
+
+  return {
+    ...entry.projection,
+    missingFromEvents: [...missing].sort(),
+  };
+}
+
+export function projectReplayRuns(input: EventEnvelope[] | ReplayEventsResult): ReplayRunProjection[] {
+  const events = Array.isArray(input) ? input : input.events;
+  const projections = new Map<string, MutableProjection>();
+
+  for (const envelope of events) {
+    const entry = getOrCreateProjection(projections, envelope);
+    entry.observedTypes.add(envelope.event.type);
+
+    switch (envelope.event.type) {
+      case 'run.start':
+        applyRunStart(entry.projection, envelope as EventEnvelope & { event: RunStartEvent });
+        break;
+      case 'run.issue_picked':
+        applyIssuePicked(entry.projection, envelope.event);
+        break;
+      case 'run.pr_created':
+        applyPrCreated(entry.projection, envelope.event);
+        break;
+      case 'run.complete':
+        applyRunComplete(entry.projection, envelope as EventEnvelope & { event: RunCompleteEvent });
+        break;
+      default:
+        break;
+    }
+  }
+
+  return [...projections.values()]
+    .map(finalizeProjection)
+    .sort((a, b) => a.run_num - b.run_num || a.run_id.localeCompare(b.run_id));
 }

--- a/scripts/batch-summary.ts
+++ b/scripts/batch-summary.ts
@@ -15,9 +15,9 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
-import { parseJsonLines } from '../src/lib/json-lines.js';
 import type { EventEnvelope, RunCompleteEvent, RunIssuePickedEvent, RunPrCreatedEvent } from './auto-dent-events.js';
 import type { ProcessVerdict } from './auto-dent-lifecycle.js';
+import { parseReplayEventsJsonl } from './auto-dent-replay.js';
 import { parseBatchArtifactCliArgs } from './batch-artifacts-cli.js';
 import { readArtifactPartsFromProgressIssue } from './batch-artifacts-upload.js';
 import {
@@ -109,7 +109,7 @@ export function parseEventsFile(eventsPath: string): EventEnvelope[] {
 export function parseEventsJsonl(content: string): EventEnvelope[] {
   const trimmed = content.trim();
   if (!trimmed) return [];
-  return parseJsonLines<EventEnvelope>(trimmed);
+  return parseReplayEventsJsonl(trimmed).events;
 }
 
 export function parseEventsFromProgressIssue(issueNumber: string, repo: string): EventEnvelope[] {

--- a/src/verdict-binding-inventory.ts
+++ b/src/verdict-binding-inventory.ts
@@ -234,6 +234,16 @@ export const VERDICT_BINDING_INVENTORY: VerdictBindingInventory = {
       rationale: 'Analytics copy of the review verdict; terminal binding is represented by review-battery-verdict.',
     },
     {
+      signature: 'scripts/auto-dent-replay.ts:field:process_verdict',
+      label: 'Auto-dent replay process verdict projection',
+      rationale: 'Replay-state reporting copy of the process verdict from events.jsonl; terminal binding is represented by process-evidence-verdict.',
+    },
+    {
+      signature: 'scripts/auto-dent-replay.ts:field:review_verdict',
+      label: 'Auto-dent replay review verdict projection',
+      rationale: 'Replay-state reporting copy of the review verdict from events.jsonl; terminal binding is represented by review-battery-verdict.',
+    },
+    {
       signature: 'scripts/batch-summary.ts:field:process_verdict_distribution',
       label: 'Batch summary process verdict distribution',
       rationale: 'Aggregated reporting over process verdicts; terminal binding is represented by process-evidence-verdict.',


### PR DESCRIPTION
Once upon a time, auto-dent wrote two parallel sources of truth: mutable `state.json` / `RunMetrics` for run history, and `events.jsonl` for durable telemetry. Every day, downstream consumers could summarize some `run.complete` fields from events, but there was no per-run replay projection that matched the current metrics path.

One day, #1677 split the event-sourced run-state work into ordered child issues. #1678 gave us a typed replay parser and committed fixtures; #1679 is the next slice: prove replay output can reconstruct the current run-level fields before #1680 changes live finalization.

Because of that, this PR adds `projectReplayRuns()`, a pure projection boundary over typed replay events. It groups replayed events by run, maps `run.start`, `run.issue_picked`, `run.pr_created`, and `run.complete` into current `RunMetrics`-relevant fields, and carries workflow-gate repair data forward unchanged.

Because of that, `batch-summary` now reuses the replay parser instead of maintaining a second JSONL-to-event parser. The public `parseEventsJsonl()` API stays intact, but the validation boundary is shared.

Until finally, the proof is executable: committed replay fixtures project to expected run metrics, synthetic harness events match `captureToRunMetrics()` for event-representable fields, partial logs report missing source events instead of fabricating state, and the live auto-dent finalization path is still untouched.

Closes #1679
Parent: #1677
Refs: #1167
Refs: #1680
Refs: #1682

## Architecture

```text
events.jsonl
  -> parseReplayEventsJsonl()
      -> EventEnvelope[] + malformed/invalid diagnostics
          -> projectReplayRuns()
              -> ReplayRunProjection[]
                  -> #1680 can compare/consume before finalization rewiring

batch-summary.parseEventsJsonl()
  -> parseReplayEventsJsonl().events
```

`projectReplayRuns()` is intentionally pure. It does not write `state.json`, mutate auto-dent finalization, or queue merge decisions.

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add projection beside replay parser | Keeps #1679 focused on parity before #1680 finalization integration | Adds an intermediate projection type |
| Preserve event-derived counts separately from identity arrays | `events.jsonl` currently records issue counts, not stable issue/case identity arrays | Projection exposes `missingFromEvents` so missing state is explicit |
| Reuse replay parser from `batch-summary` | Reduces parser drift in the touched area | Batch summary now validates event shapes rather than only JSON shape |
| Keep finalization unwired | #1680 owns the behavior-changing integration | This PR is proof infrastructure, not the final event-sourced state switch |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-replay.ts` | Adds `ReplayRunProjection` and `projectReplayRuns()` over typed replay events |
| `scripts/auto-dent-replay.test.ts` | Adds fixture, workflow-gate, synthetic parity, partial-log, multi-PR, and no-finalization-wiring tests |
| `scripts/batch-summary.ts` | Reuses `parseReplayEventsJsonl()` for its existing `parseEventsJsonl()` API |
| `src/verdict-binding-inventory.ts` | Classifies replay verdict projection fields as non-terminal reporting copies so the verdict inventory invariant stays explicit |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Coverage |
|---|---|---|---|
| 1 | Valid replay events project into one run-level object with run ids, mode, issue, PRs, counts, cost, duration, exit code, stop flag, lifecycle count, and outcome. | Unit | [x] `scripts/auto-dent-replay.test.ts` fixture projection test |
| 2 | Workflow gate repair fields from `run.complete` survive projection unchanged. | Unit | [x] `scripts/auto-dent-replay.test.ts` workflow repair projection test |
| 3 | Synthetic harness events project to the same current metrics values as `captureToRunMetrics` for event-representable fields. | Integration | [x] `scripts/auto-dent-replay.test.ts` synthetic harness parity test |
| 4 | Partial event logs expose missing-data diagnostics instead of fabricated state. | Unit | [x] `scripts/auto-dent-replay.test.ts` partial log test |
| 5 | Existing batch-summary workflow-gate aggregation remains compatible. | Integration | [x] `scripts/batch-summary.test.ts` targeted suite |
| 6 | Replay projection is not wired into live finalization/state writing in this PR. | Unit | [x] `scripts/auto-dent-replay.test.ts` source boundary assertion |
| 7 | Related parsing/projection drift is reduced or bounded. | Unit | [x] `batch-summary.parseEventsJsonl()` now uses `parseReplayEventsJsonl()`; #1680 remains the finalization boundary |

## Impact (goal -> before/after -> match)

| Goal | BEFORE artifact | AFTER artifact | Observable delta | Goal met? |
|---|---|---|---|---|
| Project replay output into current run metrics / workflow-gate fields | `events.jsonl` parsed into typed events, but no per-run projection API reconstructed metrics fields | `projectReplayRuns()` returns one projection per run with event-derived metrics, PRs, issue selection, outcome, and workflow repair fields | Fixture run projects to `duration_seconds=180`, `cost_usd=1.25`, `prs_created=1`, `workflow_gate_states.ticket-identity=done`; synthetic harness projection matches `captureToRunMetrics()` for representable fields | yes |
| Keep #1680 behavior change out of scope | `auto-dent-run.ts` was the live finalization/state writer | Source assertion verifies `auto-dent-run.ts` does not import `auto-dent-replay` | Projection exists for parity proof without changing live finalization | yes |
| Reduce parser drift in touched area | `batch-summary.ts` had its own `parseEventsJsonl()` implementation over raw JSON lines | `batch-summary.ts` delegates to `parseReplayEventsJsonl().events` | Existing batch-summary tests still pass while sharing the replay validation boundary | yes |

Residual scan: searched `RunMetrics`, `run.complete`, `workflow_repair_state`, `parseEventsJsonl`, and `captureToRunMetrics`. Low-risk parser drift in `batch-summary` is consolidated here; live finalization integration remains explicitly deferred to #1680.

## Validation

- [x] `npx vitest run scripts/auto-dent-replay.test.ts --reporter=default` - 14 tests passed.
- [x] `npx vitest run scripts/auto-dent-replay.test.ts scripts/batch-summary.test.ts scripts/auto-dent-score.test.ts --reporter=default` - 175 tests passed.
- [x] `npx vitest run scripts/auto-dent-harness.test.ts -t "bridge:|end-to-end: harness" --reporter=default` - 13 relevant harness bridge tests passed.
- [x] `npx vitest run src/verdict-binding-inventory.test.ts --reporter=default` - 8 tests passed.
- [x] `npm run typecheck` - passed.
- [x] Broader harness captured-log run still has 5 known-owned failures, all classified under #1682.

## Known Limitations

- `projectReplayRuns()` exposes `missingFromEvents` for fields that current events do not carry as stable identities (`cases`, `issues_filed`, `issues_closed`). It does not fabricate those arrays from counts.
- #1680 still owns wiring this projection into run finalization and state writes.
- #1188, #1643, and later structured-memory issues still own trace/cloud surfaces.