### PR TITLE
Wire auto-dent finalization through replay projection

### DIFF
--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -21,6 +21,7 @@ import type { ProcessVerdict } from './auto-dent-lifecycle.js';
 import type { PhaseProviderRecord } from './auto-dent-provider.js';
 import type { HookActivationVerdict } from './auto-dent-hook-activation.js';
 import type { WorkflowGateId, WorkflowGateState } from './workflow-gate-ledger.js';
+import type { PostMergeVerificationVerdict, TestHealthVerdict } from '../src/verdict-binding-policy.js';
 
 // Event type definitions
 
@@ -82,7 +83,13 @@ export interface RunCompleteEvent extends BaseEvent {
   tool_calls: number;
   prs_created: number;
   issues_filed: number;
+  /** Stable refs for filed issues; counts remain for backwards-compatible summaries. */
+  issues_filed_refs?: string[];
   issues_closed: number;
+  /** Stable refs for closed issues; counts remain for backwards-compatible summaries. */
+  issues_closed_refs?: string[];
+  /** Stable case/worktree ids observed during this run. */
+  cases?: string[];
   stop_requested: boolean;
   failure_class?: string;
   lifecycle_violations: number;
@@ -92,6 +99,8 @@ export interface RunCompleteEvent extends BaseEvent {
   lifecycle_critical?: number;
   /** Durable process-evidence verdict (#1149) */
   process_verdict?: ProcessVerdict;
+  /** Post-merge/deployment verification verdict (#1165). */
+  post_merge_verification?: PostMergeVerificationVerdict;
   /** Count of failed/warning process evidence checks (#1149) */
   process_issue_count?: number;
   /** Compact human-readable process evidence summary (#1149) */
@@ -121,8 +130,20 @@ export interface RunCompleteEvent extends BaseEvent {
   review_verdict?: 'pass' | 'fail' | 'skipped';
   /** Review battery cost (USD) */
   review_cost_usd?: number;
+  /** Run-level test-health verdict derived from observed failed test ids (#1527). */
+  test_health?: TestHealthVerdict;
   /** Hook-activation verdict from the session init event or explicit unknown fallback (#1501). */
   hook_activation?: HookActivationVerdict;
+  /** Prompt template file name used for this run. */
+  prompt_template?: string;
+  /** SHA-256 hash of the prompt template content (first 12 chars). */
+  prompt_hash?: string;
+  /** Status of the schema-constrained final run claim (#1145). */
+  final_claim_status?: 'valid' | 'invalid' | 'missing';
+  /** Sidecar path for the persisted final claim object (#1145). */
+  final_claim_path?: string;
+  /** Warnings from final-claim parsing or claim/evidence comparison (#1145). */
+  final_claim_warnings?: string[];
   /**
    * Provider + billing mode per lifecycle phase (#1143, epic #1134).
    * Absent on older events. Keyed by phase → { provider, billing }.

--- a/scripts/auto-dent-replay.test.ts
+++ b/scripts/auto-dent-replay.test.ts
@@ -230,13 +230,15 @@ describe('auto-dent replay fixtures', () => {
     );
   });
 
-  it('does not wire replay into auto-dent finalization in the schema PR', () => {
+  it('wires replay projection into auto-dent finalization after projection parity exists', () => {
     const runSource = readFileSync(
       new URL('./auto-dent-run.ts', import.meta.url),
       'utf8',
     );
 
-    expect(runSource).not.toContain('auto-dent-replay');
+    expect(runSource).toContain('projectReplayRuns');
+    expect(runSource).toContain('runMetricsFromReplayProjection');
+    expect(runSource).toContain('buildFinalizationReplayEvents');
   });
 
   it('projects replayed fixture events into current run-metrics fields', () => {

--- a/scripts/auto-dent-replay.ts
+++ b/scripts/auto-dent-replay.ts
@@ -143,6 +143,9 @@ export interface ReplayRunProjection {
   issue_title?: string;
   labels?: string[];
   prs: string[];
+  issues_filed?: string[];
+  issues_closed?: string[];
+  cases?: string[];
   duration_seconds?: number;
   exit_code?: number;
   cost_usd?: number;
@@ -157,6 +160,7 @@ export interface ReplayRunProjection {
   lifecycle_health?: RunCompleteEvent['lifecycle_health'];
   lifecycle_critical?: number;
   process_verdict?: RunCompleteEvent['process_verdict'];
+  post_merge_verification?: RunCompleteEvent['post_merge_verification'];
   process_issue_count?: number;
   process_summary?: string;
   workflow_gate_states?: RunCompleteEvent['workflow_gate_states'];
@@ -169,9 +173,13 @@ export interface ReplayRunProjection {
   context_delegation_recommended_substeps?: string[];
   review_verdict?: RunCompleteEvent['review_verdict'];
   review_cost_usd?: number;
+  test_health?: RunCompleteEvent['test_health'];
   phase_providers?: RunCompleteEvent['phase_providers'];
   hook_activation?: RunCompleteEvent['hook_activation'];
   bandit_decision?: RunCompleteEvent['bandit_decision'];
+  final_claim_status?: RunCompleteEvent['final_claim_status'];
+  final_claim_path?: string;
+  final_claim_warnings?: string[];
   outcome?: RunCompleteEvent['outcome'];
   missingFromEvents: string[];
   warnings: string[];
@@ -296,13 +304,17 @@ function applyRunComplete(projection: ReplayRunProjection, envelope: EventEnvelo
   projection.tool_calls = event.tool_calls;
   projection.prs_created = event.prs_created;
   projection.issues_filed_count = event.issues_filed;
+  projection.issues_filed = event.issues_filed_refs;
   projection.issues_closed_count = event.issues_closed;
+  projection.issues_closed = event.issues_closed_refs;
+  projection.cases = event.cases;
   projection.stop_requested = event.stop_requested;
   projection.failure_class = event.failure_class;
   projection.lifecycle_violations = event.lifecycle_violations;
   projection.lifecycle_health = event.lifecycle_health;
   projection.lifecycle_critical = event.lifecycle_critical;
   projection.process_verdict = event.process_verdict;
+  projection.post_merge_verification = event.post_merge_verification;
   projection.process_issue_count = event.process_issue_count;
   projection.process_summary = event.process_summary;
   projection.workflow_gate_states = event.workflow_gate_states;
@@ -315,11 +327,17 @@ function applyRunComplete(projection: ReplayRunProjection, envelope: EventEnvelo
   projection.context_delegation_recommended_substeps = event.context_delegation_recommended_substeps;
   projection.review_verdict = event.review_verdict;
   projection.review_cost_usd = event.review_cost_usd;
+  projection.test_health = event.test_health;
   projection.phase_providers = event.phase_providers;
   projection.hook_activation = event.hook_activation;
   projection.bandit_decision = event.bandit_decision;
+  projection.final_claim_status = event.final_claim_status;
+  projection.final_claim_path = event.final_claim_path;
+  projection.final_claim_warnings = event.final_claim_warnings;
   projection.outcome = event.outcome;
   if (event.mode && !projection.mode) projection.mode = event.mode;
+  if (event.prompt_template && !projection.prompt_template) projection.prompt_template = event.prompt_template;
+  if (event.prompt_hash && !projection.prompt_hash) projection.prompt_hash = event.prompt_hash;
 }
 
 function finalizeProjection(entry: MutableProjection): ReplayRunProjection {
@@ -327,11 +345,9 @@ function finalizeProjection(entry: MutableProjection): ReplayRunProjection {
   if (!entry.observedTypes.has('run.start')) missing.add('run.start');
   if (!entry.observedTypes.has('run.complete')) missing.add('run.complete');
 
-  // events.jsonl currently records counts for these fields, not stable identities.
-  // Keep the absence explicit so #1680 does not silently fabricate state arrays.
-  missing.add('cases');
-  missing.add('issues_filed');
-  missing.add('issues_closed');
+  if (!entry.projection.cases) missing.add('cases');
+  if (!entry.projection.issues_filed) missing.add('issues_filed');
+  if (!entry.projection.issues_closed) missing.add('issues_closed');
 
   return {
     ...entry.projection,

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -35,6 +35,8 @@ import {
   deriveRunOutcome,
   buildRunMetrics,
   buildRunCompleteEvent,
+  buildFinalizationReplayEvents,
+  runMetricsFromReplayProjection,
   mergeVerifiedClosedIssuesIntoRunResult,
   weightedModeSelect,
   computeModeDistribution,
@@ -75,6 +77,7 @@ import * as github from './auto-dent-github.js';
 import type { ProviderCapability } from './auto-dent-provider.js';
 import { makeBatchState, makeRunResult } from './auto-dent-test-utils.js';
 import { decideAutoMergeSafety } from './auto-dent-merge-policy.js';
+import { projectReplayRuns } from './auto-dent-replay.js';
 
 const AUTO_DENT_RUN_SOURCE = readFileSync(new URL('./auto-dent-run.ts', import.meta.url), 'utf8');
 
@@ -3652,6 +3655,216 @@ describe('buildRunMetrics', () => {
 
     expect(event.bandit_decision).toEqual(metrics.bandit_decision);
   });
+
+  it('emits run.complete identities and evidence needed for replay-derived run history (#1680)', () => {
+    const result = makeRunResult({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1680'],
+      issuesFiled: ['#1700'],
+      issuesClosed: ['#1680'],
+      cases: ['260629-k1680-replay-finalization'],
+      finalClaimStatus: 'valid',
+      finalClaimPath: '/tmp/final-claim.json',
+      finalClaimWarnings: ['claim warning'],
+    });
+    const metrics = buildRunMetrics({
+      runNum: 12,
+      runStartEpoch: 1742681800,
+      duration: 8,
+      exitCode: 0,
+      runMode: 'exploit',
+      result,
+      provider: 'claude',
+      metadata: {
+        prompt_template: 'deep-dive-default.md',
+        prompt_hash: 'abc123',
+        post_merge_verification: 'pass',
+        test_health: 'pass',
+        workflow_gate_states: { 'meet-reality': 'done' },
+        workflow_repair_gates: [],
+        workflow_repair_state: 'merge_ready',
+        review_verdict: 'pass',
+        review_cost_usd: 0.12,
+      },
+    });
+
+    const event = buildRunCompleteEvent({
+      runId: 'batch/run-12',
+      batchId: 'batch',
+      runNum: 12,
+      duration: 8,
+      exitCode: 0,
+      result,
+      runMode: 'exploit',
+      outcome: 'success',
+      runMetricsForOutcome: metrics,
+      lifecycleViolationCount: 0,
+      workflowGateStates: { 'meet-reality': 'done' },
+      workflowRepairGates: [],
+      workflowRepairState: 'merge_ready',
+      reviewVerdict: 'pass',
+      reviewCostUsd: 0.12,
+    });
+
+    expect(event).toMatchObject({
+      issues_filed: 1,
+      issues_filed_refs: ['#1700'],
+      issues_closed: 1,
+      issues_closed_refs: ['#1680'],
+      cases: ['260629-k1680-replay-finalization'],
+      post_merge_verification: 'pass',
+      test_health: 'pass',
+      prompt_template: 'deep-dive-default.md',
+      prompt_hash: 'abc123',
+      final_claim_status: 'valid',
+      final_claim_path: '/tmp/final-claim.json',
+      final_claim_warnings: ['claim warning'],
+      workflow_gate_states: { 'meet-reality': 'done' },
+      workflow_repair_state: 'merge_ready',
+      review_verdict: 'pass',
+      review_cost_usd: 0.12,
+    });
+  });
+
+  it('derives persisted run metrics from finalization replay projection (#1680)', () => {
+    const result = makeRunResult({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1680'],
+      issuesFiled: ['#1700'],
+      issuesClosed: ['#1680'],
+      cases: ['260629-k1680-replay-finalization'],
+      cost: 2.25,
+      toolCalls: 9,
+      finalClaimStatus: 'valid',
+      finalClaimPath: '/tmp/final-claim.json',
+      finalClaimWarnings: ['claim warning'],
+    });
+    const fallback = buildRunMetrics({
+      runNum: 13,
+      runStartEpoch: 1742681900,
+      duration: 17,
+      exitCode: 0,
+      runMode: 'exploit',
+      result,
+      provider: 'claude',
+      metadata: {
+        prompt_template: 'deep-dive-default.md',
+        prompt_hash: 'abc123',
+        lifecycle_violations: 0,
+        lifecycle_health: 'clean',
+        process_verdict: 'pass',
+        post_merge_verification: 'pass',
+        process_issue_count: 0,
+        process_summary: 'ok',
+        workflow_gate_states: { 'meet-reality': 'done' },
+        workflow_repair_state: 'merge_ready',
+        review_verdict: 'pass',
+        review_cost_usd: 0.12,
+        test_health: 'pass',
+      },
+    });
+    const completeEvent = buildRunCompleteEvent({
+      runId: 'batch/run-13',
+      batchId: 'batch',
+      runNum: 13,
+      duration: 17,
+      exitCode: 0,
+      result,
+      runMode: 'exploit',
+      outcome: 'success',
+      runMetricsForOutcome: fallback,
+      lifecycleViolationCount: 0,
+      lifecycleHealth: 'clean',
+      processVerdict: 'pass',
+      processIssueCount: 0,
+      processSummary: 'ok',
+      workflowGateStates: { 'meet-reality': 'done' },
+      workflowRepairState: 'merge_ready',
+      reviewVerdict: 'pass',
+      reviewCostUsd: 0.12,
+    });
+
+    const replayEvents = buildFinalizationReplayEvents({
+      runId: 'batch/run-13',
+      batchId: 'batch',
+      runNum: 13,
+      runStartEpoch: 1742681900,
+      runMode: 'exploit',
+      runModeReason: 'test',
+      promptMeta: { template: 'deep-dive-default.md', hash: 'abc123' },
+      pickedIssue: '#1680',
+      pickedIssueTitle: 'Provider-neutral replay integration',
+      result,
+      completeEvent,
+    });
+    const [projection] = projectReplayRuns(replayEvents);
+    const metrics = runMetricsFromReplayProjection(projection, fallback);
+
+    expect(metrics).toMatchObject({
+      run: 13,
+      start_epoch: 1742681900,
+      duration_seconds: 17,
+      cost_usd: 2.25,
+      tool_calls: 9,
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1680'],
+      issues_filed: ['#1700'],
+      issues_closed: ['#1680'],
+      cases: ['260629-k1680-replay-finalization'],
+      prompt_template: 'deep-dive-default.md',
+      prompt_hash: 'abc123',
+      lifecycle_health: 'clean',
+      process_verdict: 'pass',
+      post_merge_verification: 'pass',
+      workflow_gate_states: { 'meet-reality': 'done' },
+      workflow_repair_state: 'merge_ready',
+      review_verdict: 'pass',
+      review_cost_usd: 0.12,
+      test_health: 'pass',
+      final_claim_status: 'valid',
+      final_claim_path: '/tmp/final-claim.json',
+      final_claim_warnings: ['claim warning'],
+    });
+    expect(metrics.replay_projection_warnings).toBeUndefined();
+  });
+
+  it('keeps fallback state and records warnings for incomplete replay projections (#1680)', () => {
+    const fallback = buildRunMetrics({
+      runNum: 14,
+      runStartEpoch: 1742682000,
+      duration: 20,
+      exitCode: 0,
+      runMode: 'exploit',
+      result: makeRunResult({
+        issuesFiled: ['#1700'],
+        issuesClosed: ['#1680'],
+        cases: ['260629-k1680-replay-finalization'],
+      }),
+    });
+    const [projection] = projectReplayRuns([{
+      timestamp: '2026-03-26T00:00:00.000Z',
+      event: {
+        type: 'run.start',
+        run_id: 'batch/run-14',
+        batch_id: 'batch',
+        run_num: 14,
+        mode: 'exploit',
+        mode_reason: 'test',
+        prompt_template: 'deep-dive-default.md',
+        prompt_hash: 'abc123',
+        start_epoch: 1742682000,
+      },
+    }]);
+
+    const metrics = runMetricsFromReplayProjection(projection, fallback);
+
+    expect(metrics.issues_filed).toEqual(['#1700']);
+    expect(metrics.issues_closed).toEqual(['#1680']);
+    expect(metrics.cases).toEqual(['260629-k1680-replay-finalization']);
+    expect(metrics.replay_projection_warnings).toEqual(expect.arrayContaining([
+      'missing:run.complete',
+      'missing:cases',
+      'missing:issues_filed',
+      'missing:issues_closed',
+    ]));
+  });
 });
 
 describe('mergeVerifiedClosedIssuesIntoRunResult (#1210)', () => {
@@ -3685,7 +3898,7 @@ describe('mergeVerifiedClosedIssuesIntoRunResult (#1210)', () => {
 
   it('runs before persisted run metrics are built', () => {
     const mergeIndex = AUTO_DENT_RUN_SOURCE.indexOf('mergeVerifiedClosedIssuesIntoRunResult(result, verifyResults)');
-    const metricsIndex = AUTO_DENT_RUN_SOURCE.indexOf('const runMetrics = buildRunMetrics({');
+    const metricsIndex = AUTO_DENT_RUN_SOURCE.indexOf('const runMetrics = projectedRun');
 
     expect(mergeIndex).toBeGreaterThan(-1);
     expect(metricsIndex).toBeGreaterThan(-1);
@@ -5241,12 +5454,14 @@ describe('auto-merge verdict binding wiring (#1220)', () => {
   it('emits hook_activation on run.complete from the normalized run metrics (#1501)', () => {
     const runCompleteBlock = AUTO_DENT_RUN_SOURCE.slice(
       AUTO_DENT_RUN_SOURCE.indexOf('const runMetricsForOutcome = buildRunMetrics({'),
-      AUTO_DENT_RUN_SOURCE.indexOf('events.emit(buildRunCompleteEvent({') + 900,
+      AUTO_DENT_RUN_SOURCE.indexOf('events.emit(finalizedRunCompleteEvent);') + 900,
     );
 
     expect(runCompleteBlock).toContain("provider: state.provider ?? 'claude'");
     expect(runCompleteBlock).toContain('const outcome = deriveRunOutcome({');
-    expect(runCompleteBlock).toContain('events.emit(buildRunCompleteEvent({');
+    expect(runCompleteBlock).toContain('const runCompleteEvent = buildRunCompleteEvent({');
+    expect(runCompleteBlock).toContain('const finalizedRunCompleteEvent: RunCompleteEvent = {');
+    expect(runCompleteBlock).toContain('events.emit(finalizedRunCompleteEvent);');
     expect(runCompleteBlock).toContain('runMetricsForOutcome,');
     expect(AUTO_DENT_RUN_SOURCE).toContain('hook_activation: runMetricsForOutcome.hook_activation');
   });

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -36,7 +36,8 @@ import {
   resolvePromptsDir,
   renderTemplate,
 } from '../src/review-battery.js';
-import { EventEmitter, makeRunId, type AutoDentEvent, type BanditDecisionTelemetry, type RunCompleteEvent } from './auto-dent-events.js';
+import { EventEmitter, makeRunId, type AutoDentEvent, type BanditDecisionTelemetry, type EventEnvelope, type RunCompleteEvent } from './auto-dent-events.js';
+import { projectReplayRuns, type ReplayRunProjection } from './auto-dent-replay.js';
 import { defaultReviewFixProviders, runFixLoop } from './review-fix.js';
 import { buildRunManifest, writeRunManifest, bundleArtifacts, formatManifestSummary } from './auto-dent-artifacts.js';
 import { uploadBatchArtifacts } from './batch-artifacts-upload.js';
@@ -344,6 +345,22 @@ export interface RunMetrics {
   process_issue_count?: number;
   /** Compact process evidence summary (#1149) */
   process_summary?: string;
+  /** Canonical workflow gate states (#1533). */
+  workflow_gate_states?: Partial<Record<WorkflowGateId, WorkflowGateState>>;
+  /** Canonical workflow gates that need repair before success/merge readiness (#1533). */
+  workflow_repair_gates?: WorkflowGateId[];
+  /** Evidence repair loop state for PR-producing incomplete runs (#1533). */
+  workflow_repair_state?: RunCompleteEvent['workflow_repair_state'];
+  /** Targeted repair instruction for the next attempt against the same PR (#1533). */
+  workflow_repair_prompt?: string;
+  /** Whether this run crossed the context-delegation pressure threshold (#1629). */
+  context_delegation_required?: boolean;
+  /** Whether this run showed observed subagent/tool delegation before implementation (#1629). */
+  context_delegation_observed?: boolean;
+  /** Machine-readable context/tool-call pressure reasons (#1629). */
+  context_delegation_reasons?: string[];
+  /** Default-delegated sub-work suggested by the pressure analysis (#1629). */
+  context_delegation_recommended_substeps?: string[];
   /** Review battery verdict for PRs created in this run */
   review_verdict?: 'pass' | 'fail' | 'skipped';
   /** Review battery cost (USD) */
@@ -371,6 +388,8 @@ export interface RunMetrics {
    * kaizen plugin absent — the run was NOT gated by kaizen enforcement.
    */
   hook_activation?: HookActivationVerdict;
+  /** Warnings recorded while deriving this row from replay projection (#1680). */
+  replay_projection_warnings?: string[];
 }
 
 export interface RunResult {
@@ -501,6 +520,61 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     final_claim_warnings: result.finalClaimWarnings,
     hook_activation: hookActivation,
     ...metadata,
+  };
+}
+
+export function runMetricsFromReplayProjection(
+  projection: ReplayRunProjection,
+  fallback: RunMetrics,
+): RunMetrics {
+  const warnings = [
+    ...(fallback.replay_projection_warnings ?? []),
+    ...(projection.warnings ?? []),
+    ...projection.missingFromEvents.map((field) => `missing:${field}`),
+  ];
+  return {
+    ...fallback,
+    run: projection.run ?? fallback.run,
+    start_epoch: projection.start_epoch ?? fallback.start_epoch,
+    duration_seconds: projection.duration_seconds ?? fallback.duration_seconds,
+    exit_code: projection.exit_code ?? fallback.exit_code,
+    cost_usd: projection.cost_usd ?? fallback.cost_usd,
+    cost_integrity_warnings: projection.cost_integrity_warnings ?? fallback.cost_integrity_warnings,
+    tool_calls: projection.tool_calls ?? fallback.tool_calls,
+    prs: projection.prs.length > 0 ? projection.prs : fallback.prs,
+    issues_filed: projection.issues_filed ?? fallback.issues_filed,
+    issues_closed: projection.issues_closed ?? fallback.issues_closed,
+    cases: projection.cases ?? fallback.cases,
+    stop_requested: projection.stop_requested ?? fallback.stop_requested,
+    mode: projection.mode ?? fallback.mode,
+    prompt_template: projection.prompt_template ?? fallback.prompt_template,
+    prompt_hash: projection.prompt_hash ?? fallback.prompt_hash,
+    failure_class: projection.failure_class ?? fallback.failure_class,
+    lifecycle_violations: projection.lifecycle_violations ?? fallback.lifecycle_violations,
+    lifecycle_health: projection.lifecycle_health ?? fallback.lifecycle_health,
+    process_verdict: projection.process_verdict ?? fallback.process_verdict,
+    post_merge_verification: projection.post_merge_verification ?? fallback.post_merge_verification,
+    process_issue_count: projection.process_issue_count ?? fallback.process_issue_count,
+    process_summary: projection.process_summary ?? fallback.process_summary,
+    workflow_gate_states: projection.workflow_gate_states ?? fallback.workflow_gate_states,
+    workflow_repair_gates: projection.workflow_repair_gates ?? fallback.workflow_repair_gates,
+    workflow_repair_state: projection.workflow_repair_state ?? fallback.workflow_repair_state,
+    workflow_repair_prompt: projection.workflow_repair_prompt ?? fallback.workflow_repair_prompt,
+    context_delegation_required: projection.context_delegation_required ?? fallback.context_delegation_required,
+    context_delegation_observed: projection.context_delegation_observed ?? fallback.context_delegation_observed,
+    context_delegation_reasons: projection.context_delegation_reasons ?? fallback.context_delegation_reasons,
+    context_delegation_recommended_substeps:
+      projection.context_delegation_recommended_substeps ?? fallback.context_delegation_recommended_substeps,
+    review_verdict: projection.review_verdict ?? fallback.review_verdict,
+    review_cost_usd: projection.review_cost_usd ?? fallback.review_cost_usd,
+    test_health: projection.test_health ?? fallback.test_health,
+    phase_providers: projection.phase_providers ?? fallback.phase_providers,
+    hook_activation: projection.hook_activation ?? fallback.hook_activation,
+    bandit_decision: projection.bandit_decision ?? fallback.bandit_decision,
+    final_claim_status: projection.final_claim_status ?? fallback.final_claim_status,
+    final_claim_path: projection.final_claim_path ?? fallback.final_claim_path,
+    final_claim_warnings: projection.final_claim_warnings ?? fallback.final_claim_warnings,
+    replay_projection_warnings: warnings.length > 0 ? [...new Set(warnings)].sort() : undefined,
   };
 }
 
@@ -1431,13 +1505,17 @@ export function buildRunCompleteEvent(input: BuildRunCompleteEventInput): RunCom
     tool_calls: result.toolCalls,
     prs_created: result.prs.length,
     issues_filed: result.issuesFiled.length,
+    issues_filed_refs: result.issuesFiled,
     issues_closed: result.issuesClosed.length,
+    issues_closed_refs: result.issuesClosed,
+    cases: result.cases,
     stop_requested: result.stopRequested,
     failure_class: result.failureClass,
     lifecycle_violations: lifecycleViolationCount,
     lifecycle_health: lifecycleHealth,
     lifecycle_critical: lifecycleCriticalCount,
     process_verdict: processVerdict,
+    post_merge_verification: runMetricsForOutcome.post_merge_verification,
     process_issue_count: processIssueCount,
     process_summary: processSummary,
     workflow_gate_states: workflowGateStates,
@@ -1450,12 +1528,82 @@ export function buildRunCompleteEvent(input: BuildRunCompleteEventInput): RunCom
     context_delegation_recommended_substeps: contextDelegationAnalysis?.pressure.recommendedSubsteps,
     review_verdict: reviewVerdict,
     review_cost_usd: reviewCostUsd,
+    test_health: runMetricsForOutcome.test_health,
     phase_providers: phaseProviders,
     hook_activation: runMetricsForOutcome.hook_activation,
     bandit_decision: runMetricsForOutcome.bandit_decision,
+    prompt_template: runMetricsForOutcome.prompt_template,
+    prompt_hash: runMetricsForOutcome.prompt_hash,
+    final_claim_status: runMetricsForOutcome.final_claim_status,
+    final_claim_path: runMetricsForOutcome.final_claim_path,
+    final_claim_warnings: runMetricsForOutcome.final_claim_warnings,
     outcome,
     mode: runMode,
   };
+}
+
+export interface BuildFinalizationReplayEventsInput {
+  runId: string;
+  batchId: string;
+  runNum: number;
+  runStartEpoch: number;
+  runMode: string;
+  runModeReason: string;
+  promptMeta: { template: string; hash: string };
+  pickedIssue?: string;
+  pickedIssueTitle?: string;
+  result: RunResult;
+  completeEvent: RunCompleteEvent;
+}
+
+export function buildFinalizationReplayEvents(input: BuildFinalizationReplayEventsInput): EventEnvelope[] {
+  const startedAt = new Date(input.runStartEpoch * 1000).toISOString();
+  const completedAt = new Date((input.runStartEpoch * 1000) + input.completeEvent.duration_ms).toISOString();
+  const base = {
+    run_id: input.runId,
+    batch_id: input.batchId,
+    run_num: input.runNum,
+  };
+  const events: EventEnvelope[] = [
+    {
+      timestamp: startedAt,
+      event: {
+        type: 'run.start',
+        ...base,
+        mode: input.runMode,
+        mode_reason: input.runModeReason,
+        prompt_template: input.promptMeta.template,
+        prompt_hash: input.promptMeta.hash,
+        start_epoch: input.runStartEpoch,
+      },
+    },
+  ];
+
+  if (input.pickedIssue) {
+    events.push({
+      timestamp: startedAt,
+      event: {
+        type: 'run.issue_picked',
+        ...base,
+        issue: input.pickedIssue,
+        title: input.pickedIssueTitle ?? '',
+      },
+    });
+  }
+
+  for (const prUrl of input.result.prs) {
+    events.push({
+      timestamp: completedAt,
+      event: {
+        type: 'run.pr_created',
+        ...base,
+        pr_url: prUrl,
+      },
+    });
+  }
+
+  events.push({ timestamp: completedAt, event: input.completeEvent });
+  return events;
 }
 
 export function applyContextDelegationAnalysis(
@@ -3715,74 +3863,81 @@ async function main(): Promise<void> {
     }
   }
 
-  // Emit run.complete telemetry event (#647, #657)
-  // Uses mode-aware success: explore/reflect runs that file issues count as success,
-  // not just runs that produce PRs.
-  {
-    const runMetricsForOutcome = buildRunMetrics({
-      runNum,
-      runStartEpoch,
-      duration,
-      exitCode,
-      runMode,
-      result,
-      modeReason: runModeReason,
-      bandit: runBandit,
-      provider: state.provider ?? 'claude',
-    });
-    // Bind the run-success stamp to the verdicts this run already recorded
-    // (#1224, meta #1227): a review FAIL / process-incomplete / critical
-    // lifecycle gap must never roll up to `success` — red runs cannot read as
-    // green in the batch summary.
-    const outcome = deriveRunOutcome({
-      stopRequested: result.stopRequested,
-      exitCode,
-      artifactCount: modeSuccess(runMode, runMetricsForOutcome),
-      reviewVerdict,
-      processVerdict,
-      lifecycleHealth,
-      postMergeVerification,
-    });
-    events.emit(buildRunCompleteEvent({
-      runId,
-      batchId: state.batch_id,
-      runNum,
-      duration,
-      exitCode,
-      result,
-      runMode,
-      outcome,
-      runMetricsForOutcome,
-      lifecycleViolationCount,
-      lifecycleHealth,
-      lifecycleCriticalCount,
-      processVerdict,
-      processIssueCount,
-      processSummary,
-      workflowGateStates,
-      workflowRepairGates,
-      workflowRepairState,
-      workflowRepairPrompt,
-      contextDelegationAnalysis,
-      reviewVerdict,
-      reviewCostUsd,
-      phaseProviders: phaseProvidersForState(state),
-    }));
-  }
+  const runMetricsForOutcome = buildRunMetrics({
+    runNum,
+    runStartEpoch,
+    duration,
+    exitCode,
+    runMode,
+    result,
+    modeReason: runModeReason,
+    bandit: runBandit,
+    provider: state.provider ?? 'claude',
+    metadata: {
+      prompt_template: promptMeta.template,
+      prompt_hash: promptMeta.hash,
+      lifecycle_violations: lifecycleViolationCount,
+      lifecycle_health: lifecycleHealth,
+      process_verdict: processVerdict,
+      post_merge_verification: postMergeVerification,
+      process_issue_count: processIssueCount,
+      process_summary: processSummary,
+      workflow_gate_states: workflowGateStates,
+      workflow_repair_gates: workflowRepairGates,
+      workflow_repair_state: workflowRepairState,
+      workflow_repair_prompt: workflowRepairPrompt,
+      context_delegation_required: contextDelegationAnalysis.pressure.required,
+      context_delegation_observed: contextDelegationAnalysis.delegation.observed,
+      context_delegation_reasons: contextDelegationAnalysis.pressure.reasons,
+      context_delegation_recommended_substeps: contextDelegationAnalysis.pressure.recommendedSubsteps,
+      review_verdict: reviewVerdict,
+      review_cost_usd: reviewCostUsd,
+      test_health: testHealth,
+      phase_providers: phaseProvidersForState(state),
+    },
+  });
+  // Bind the run-success stamp to the verdicts this run already recorded
+  // (#1224, meta #1227): a review FAIL / process-incomplete / critical
+  // lifecycle gap must never roll up to `success` — red runs cannot read as
+  // green in the batch summary.
+  const outcome = deriveRunOutcome({
+    stopRequested: result.stopRequested,
+    exitCode,
+    artifactCount: modeSuccess(runMode, runMetricsForOutcome),
+    reviewVerdict,
+    processVerdict,
+    lifecycleHealth,
+    postMergeVerification,
+  });
+  const runCompleteEvent = buildRunCompleteEvent({
+    runId,
+    batchId: state.batch_id,
+    runNum,
+    duration,
+    exitCode,
+    result,
+    runMode,
+    outcome,
+    runMetricsForOutcome,
+    lifecycleViolationCount,
+    lifecycleHealth,
+    lifecycleCriticalCount,
+    processVerdict,
+    processIssueCount,
+    processSummary,
+    workflowGateStates,
+    workflowRepairGates,
+    workflowRepairState,
+    workflowRepairPrompt,
+    contextDelegationAnalysis,
+    reviewVerdict,
+    reviewCostUsd,
+    phaseProviders: phaseProvidersForState(state),
+  });
 
-  // Write run artifact manifest and bundle (#916)
-  {
-    const manifest = buildRunManifest(logDir, state.batch_id, runNum);
-    const manifestPath = writeRunManifest(logDir, manifest);
-    console.log(`  [artifacts] ${formatManifestSummary(manifest)}`);
-    console.log(`  [artifacts] manifest: ${manifestPath}`);
-    try {
-      const archivePath = bundleArtifacts(logDir, manifest);
-      console.log(`  [artifacts] bundle: ${archivePath}`);
-    } catch (err) {
-      console.warn(`  [artifacts] bundle skipped: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
+  // Build the base completion event now for the quality/outcome fields. It is
+  // emitted after verify-close refreshes the result identities, so events.jsonl
+  // and the persisted replay projection consume the same finalized event.
 
   // Batch scoreboard (cumulative stats across all runs)
   {
@@ -3955,35 +4110,63 @@ async function main(): Promise<void> {
   freshState.run = runNum;
 
   // Append per-run metrics for batch observability
-  const runMetrics = buildRunMetrics({
+  const finalizedRunCompleteEvent: RunCompleteEvent = {
+    ...runCompleteEvent,
+    prs_created: result.prs.length,
+    issues_filed: result.issuesFiled.length,
+    issues_filed_refs: result.issuesFiled,
+    issues_closed: result.issuesClosed.length,
+    issues_closed_refs: result.issuesClosed,
+    cases: result.cases,
+  };
+  const finalizedFallbackMetrics: RunMetrics = {
+    ...runMetricsForOutcome,
+    prs: result.prs,
+    issues_filed: result.issuesFiled,
+    issues_closed: result.issuesClosed,
+    cases: result.cases,
+  };
+  const replayEventsForRun = buildFinalizationReplayEvents({
+    runId,
+    batchId: state.batch_id,
     runNum,
     runStartEpoch,
-    duration,
-    exitCode,
     runMode,
+    runModeReason,
+    promptMeta,
+    pickedIssue,
+    pickedIssueTitle: result.pickedIssueTitle,
     result,
-    modeReason: runModeReason,
-    bandit: runBandit,
-    provider: state.provider ?? 'claude',
-    metadata: {
-      prompt_template: promptMeta.template,
-      prompt_hash: promptMeta.hash,
-      lifecycle_violations: lifecycleViolationCount,
-      lifecycle_health: lifecycleHealth,
-      process_verdict: processVerdict,
-      post_merge_verification: postMergeVerification,
-      process_issue_count: processIssueCount,
-      process_summary: processSummary,
-      workflow_gate_states: workflowGateStates,
-      workflow_repair_gates: workflowRepairGates,
-      workflow_repair_state: workflowRepairState,
-      workflow_repair_prompt: workflowRepairPrompt,
-      review_verdict: reviewVerdict,
-      review_cost_usd: reviewCostUsd,
-      test_health: testHealth,
-      phase_providers: phaseProvidersForState(state),
-    },
+    completeEvent: finalizedRunCompleteEvent,
   });
+  const projectedRun = projectReplayRuns(replayEventsForRun).find((projection) => projection.run_id === runId);
+  const runMetrics = projectedRun
+    ? runMetricsFromReplayProjection(projectedRun, finalizedFallbackMetrics)
+    : {
+      ...finalizedFallbackMetrics,
+      replay_projection_warnings: [
+        ...(finalizedFallbackMetrics.replay_projection_warnings ?? []),
+        'missing:projection',
+      ],
+    };
+  // Emit run.complete telemetry event (#647, #657) from the same finalized event
+  // shape used to derive the persisted run-history row (#1680).
+  events.emit(finalizedRunCompleteEvent);
+
+  // Write run artifact manifest and bundle (#916) after run.complete is durable,
+  // so the bundle captures the canonical completion event.
+  {
+    const manifest = buildRunManifest(logDir, state.batch_id, runNum);
+    const manifestPath = writeRunManifest(logDir, manifest);
+    console.log(`  [artifacts] ${formatManifestSummary(manifest)}`);
+    console.log(`  [artifacts] manifest: ${manifestPath}`);
+    try {
+      const archivePath = bundleArtifacts(logDir, manifest);
+      console.log(`  [artifacts] bundle: ${archivePath}`);
+    } catch (err) {
+      console.warn(`  [artifacts] bundle skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
   // Classify failure: wall-clock timeout is authoritative (#686), then heuristics.
   // Feed the run log so the log-based branch (hook_rejection, infrastructure,
   // etc.) actually runs — without this argument it was dead code (#1102).


### PR DESCRIPTION
Once upon a time, auto-dent had the pieces for a provider-neutral observation contract: #1678 added typed event replay fixtures and #1679 projected those events into current run metrics. Every day, finalization still bypassed that contract by emitting `run.complete` and then separately constructing `state.json.run_history` from `RunResult` plus metadata.

One day, #1680 made that split the next blocker for the self-improving core epic. If lifecycle and evidence consumers keep reading a provider/result-specific state row, later trace, cloud artifact, and structured-memory work can drift from the canonical event stream.

Because of that, this PR enriches `run.complete` with the stable identities and evidence fields needed to reconstruct the run-history row: filed/closed issue refs, case ids, post-merge verification, test health, prompt metadata, and final-claim metadata. `projectReplayRuns()` now projects those fields instead of reporting identity arrays as inherently missing.

Because of that, finalization now builds replay events for the just-finished run, projects them through `projectReplayRuns()`, converts the projection into `RunMetrics`, and appends that projected row to `state.json.run_history`. The fallback is explicit: incomplete projection input preserves the previous state row and records `replay_projection_warnings` such as `missing:run.complete`.

Until finally, the durable event stream and persisted state row now use the same finalized completion event. `run.complete` is emitted after verify-close refreshes closed issue refs, and the artifact bundle is written after that event is durable.

And ever since, downstream consumers have one canonical finalization boundary to build on. OpenTelemetry traces (#1188), compressed cloud logs (#1643), and structured PR/issue surfaces (#912) can consume replay projection without reimplementing provider-specific finalization state.

Closes #1680
Parent: #1677
Refs: #1167, #1678, #1679, #1188, #1643, #912

## Architecture

```text
RunResult + verdict metadata
        |
        v
buildRunCompleteEvent()
        |
        v
finalized run.complete event after verify-close
        |
        +--> events.jsonl / artifact bundle
        |
        v
buildFinalizationReplayEvents()
        |
        v
projectReplayRuns()
        |
        v
runMetricsFromReplayProjection()
        |
        v
state.json.run_history[]
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep existing count fields and add optional identity arrays | Preserves existing summary consumers while making replay lossless for current state identities | Event schema grows, but backward compatibility is maintained |
| Convert `ReplayRunProjection` to `RunMetrics` through a pure adapter | Makes the finalization boundary testable without replaying a whole live batch | Some fallback merging remains necessary for incomplete legacy projections |
| Emit `run.complete` after verify-close | Ensures durable events and projected state see the same closed-issue refs | Artifact manifest/bundle moves later in finalization |
| Preserve fallback state with warnings | Avoids silently dropping run history when event input is incomplete | Consumers must inspect `replay_projection_warnings` for degraded rows |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-events.ts` | Extends `RunCompleteEvent` with replayable identity and evidence fields |
| `scripts/auto-dent-replay.ts` | Projects the enriched completion fields and only marks identities missing when absent |
| `scripts/auto-dent-run.ts` | Adds projection-to-`RunMetrics` conversion and wires finalization run history through replay projection |
| `scripts/auto-dent-run.test.ts` | Covers event enrichment, projection-derived metrics, fallback warnings, and source-order integration |
| `scripts/auto-dent-replay.test.ts` | Replaces the old no-wiring assertion with the intended finalization wiring assertion |

## Test Plan (Behaviors x Levels)

| # | Behavior | Unit | Integration | System | Agentic | Workflow | Status |
|---|---|---|---|---|---|---|---|
| 1 | `RunCompleteEvent` carries identities/evidence needed for run-history reconstruction | `scripts/auto-dent-run.test.ts` | `scripts/auto-dent-events.test.ts` in focused suite | Not required | Not required | Event schema remains backward compatible | Tested |
| 2 | `projectReplayRuns()` projects enriched fields | `scripts/auto-dent-replay.test.ts` | Replay/finalization focused suite | Not required | Not required | Missing fields remain explicit | Tested |
| 3 | Projection-to-`RunMetrics` adapter preserves state semantics and warnings | `scripts/auto-dent-run.test.ts` | Focused replay/finalization suite | Not required | Not required | Fallback warnings are durable | Tested |
| 4 | Live finalization appends replay-derived run metrics | Source-order and helper tests in `scripts/auto-dent-run.test.ts` | Focused finalization suite | Not required | Not required | `projectReplayRuns()` is in the finalization path | Tested |
| 5 | Replay/projection failure is fail-open but visible | `scripts/auto-dent-run.test.ts` incomplete projection case | Focused suite | Not required | Not required | `replay_projection_warnings` records missing fields | Tested |
| 6 | Existing batch summaries/scoring still consume valid metrics | `scripts/batch-summary.test.ts`, `scripts/auto-dent-score.test.ts` | Focused consumer suite | Not required | Not required | Existing summaries remain green | Tested |
| 7 | #1679 no-wiring assertion is replaced | `scripts/auto-dent-replay.test.ts` | Focused suite | Not required | Not required | Finalization wiring is now asserted | Tested |
| 8 | Related parser/projection drift is reduced or bounded | Source scan plus targeted tests | Focused suite | Not required | Not required | Single projection path for persisted run row | Tested |

## Impact (goal -> before/after -> match)

- Goal (#1680): auto-dent run finalization persists per-run history from the provider-neutral replay/event projection instead of a second provider/result-specific metrics path.
- Acceptance signal: finalization imports/uses `projectReplayRuns()`, converts a `ReplayRunProjection` into `RunMetrics`, and tests prove identities/evidence/fallback warnings survive.
- BEFORE: finalization emitted `run.complete` from one local metrics object, then later appended `state.json.run_history` from a second direct `buildRunMetrics()` call. `projectReplayRuns()` was intentionally absent from `auto-dent-run.ts`, and replay always marked `cases`, `issues_filed`, and `issues_closed` missing.
- AFTER: finalization builds a finalized `run.complete`, projects it through `projectReplayRuns()`, derives the persisted row through `runMetricsFromReplayProjection()`, and emits/bundles the same finalized event after verify-close refreshes identities.
- Delta: one live finalization projection path replaces the second direct persisted `buildRunMetrics()` path; replay identity gaps are conditional instead of permanent; incomplete projections produce visible `replay_projection_warnings`.
- Goal met?: yes.
- Residual scan: searched `buildRunMetrics(`, `run.complete`, `projectReplayRuns`, `RunCompleteEvent`, `missingFromEvents`, identity refs, and finalized event emission across auto-dent run/replay/events/batch-summary/harness/score tests. Downstream trace/cloud/structured surfaces remain deferred to #1188, #1643, and #912.

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-events.test.ts scripts/batch-summary.test.ts scripts/auto-dent-score.test.ts --reporter=default` — 601 tests passed
- [x] `npx vitest run scripts/auto-dent-harness.test.ts -t "bridge:|end-to-end: harness" --reporter=default` — 13 passed, 216 skipped
- [x] `git diff --check`
- [x] Related-area scan: `rg "buildRunMetrics\(|projectReplayRuns|runMetricsFromReplayProjection|run\.complete|missingFromEvents|issues_filed_refs|issues_closed_refs|finalizedRunCompleteEvent" ...`

## Known Limitations

- This does not emit OpenTelemetry/GenAI traces; #1188 owns that downstream consumer.
- This does not upload compressed run logs/cloud artifacts; #1643 owns that storage contract.
- This does not add structured PR/issue attachment surfaces; #912 owns that layer.

## Kaizen

- **Root cause:** Auto-dent finalization still had two state construction paths after #1679: canonical replay projection existed, but persisted run history was still built directly from provider/result state.
- **Fix level:** L3 — finalization now structurally derives persisted run history from the replay projection and emits the same finalized completion event to durable artifacts.
- **Repeat failure?** No for this specific integration slice; it is the planned #1680 follow-on after #1678/#1679.
- **Escalation needed?** No separate escalation; the near-miss around event ordering was fixed in this PR with source-order tests.
- **Backlog issue:** N/A — implemented in this PR. Downstream consumers remain tracked by #1188, #1643, and #912.