### PR TITLE
Emit auto-dent OTel GenAI traces

### DIFF
--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -334,6 +334,14 @@ After a batch completes:
        --repo Garsson-io/kaizen --name batch-artifacts
      ```
 
+4. **OpenTelemetry GenAI traces** — JSONL remains the durable source of truth.
+   To mirror completed runs to an OTLP/GenAI-compatible HTTP collector, set:
+   ```bash
+   KAIZEN_OTEL_ENDPOINT=https://otel.example/v1/traces
+   ```
+   Export is best-effort and fail-open: a collector outage must not block the
+   auto-dent run or prevent `events.jsonl` from being written.
+
 ## Scoring
 
 The `auto-dent-score.ts` module scores run quality. Per-run scores consider:

--- a/scripts/auto-dent-events.test.ts
+++ b/scripts/auto-dent-events.test.ts
@@ -8,6 +8,7 @@ import {
   type AutoDentEvent,
   type EventEnvelope,
 } from './auto-dent-events.js';
+import { AutoDentOtelSink, MemoryOtelTransport, type AutoDentOtelTransport } from './auto-dent-otel.js';
 
 const AUTO_DENT_EVENTS_SOURCE = readFileSync(new URL('./auto-dent-events.ts', import.meta.url), 'utf8');
 
@@ -408,5 +409,115 @@ describe('EventEmitter', () => {
         prompt_hash: 'abc',
       }),
     ).not.toThrow();
+  });
+
+  it('exports OTel traces through a configured sink while preserving JSONL output', () => {
+    const transport = new MemoryOtelTransport();
+    emitter = new EventEmitter(tmpDir, { otelSink: new AutoDentOtelSink(transport) });
+
+    emitter.emitAt(new Date('2026-06-29T10:00:00.000Z'), {
+      type: 'run.start',
+      run_id: 'batch-test/run-1',
+      batch_id: 'batch-test',
+      run_num: 1,
+      mode: 'exploit',
+      mode_reason: 'schedule',
+      prompt_template: 'deep-dive-default.md',
+      prompt_hash: 'abc123',
+    });
+    emitter.emitAt(new Date('2026-06-29T10:01:00.000Z'), {
+      type: 'run.complete',
+      run_id: 'batch-test/run-1',
+      batch_id: 'batch-test',
+      run_num: 1,
+      duration_ms: 60_000,
+      exit_code: 0,
+      cost_usd: 1.25,
+      tool_calls: 5,
+      prs_created: 1,
+      issues_filed: 0,
+      issues_closed: 1,
+      issues_closed_refs: ['#1188'],
+      stop_requested: false,
+      lifecycle_violations: 0,
+      outcome: 'success',
+      mode: 'exploit',
+    });
+
+    expect(readEvents(emitter.getFilePath())).toHaveLength(2);
+    expect(transport.traces).toHaveLength(1);
+    expect(transport.traces[0].spans[0].attributes).toMatchObject({
+      'gen_ai.operation.name': 'invoke_agent',
+      'gen_ai.agent.name': 'kaizen-auto-dent',
+      'kaizen.run.issues_closed_refs': ['#1188'],
+    });
+  });
+
+  it('keeps OTel export failures fail-open and still writes JSONL', () => {
+    const failingTransport: AutoDentOtelTransport = {
+      exportTrace: () => {
+        throw new Error('network down');
+      },
+    };
+    const sink = new AutoDentOtelSink(failingTransport);
+    emitter = new EventEmitter(tmpDir, { otelSink: sink });
+
+    emitter.emit({
+      type: 'run.complete',
+      run_id: 'batch-test/run-2',
+      batch_id: 'batch-test',
+      run_num: 2,
+      duration_ms: 1,
+      exit_code: 0,
+      cost_usd: 0,
+      tool_calls: 0,
+      prs_created: 0,
+      issues_filed: 0,
+      issues_closed: 0,
+      stop_requested: false,
+      lifecycle_violations: 0,
+      outcome: 'empty_success',
+    });
+
+    expect(readEvents(emitter.getFilePath())).toHaveLength(1);
+    expect(sink.warnings).toContain('missing:run.start');
+    expect(sink.warnings.some((warning) => warning.includes('otel_export_failed:network down'))).toBe(true);
+  });
+
+  it('uses emitAt timestamps in exported OTel spans', () => {
+    const transport = new MemoryOtelTransport();
+    emitter = new EventEmitter(tmpDir, { otelSink: new AutoDentOtelSink(transport) });
+
+    emitter.emitAt(new Date('2026-06-29T10:00:00.000Z'), {
+      type: 'run.start',
+      run_id: 'batch-test/run-3',
+      batch_id: 'batch-test',
+      run_num: 3,
+      mode: 'exploit',
+      mode_reason: 'schedule',
+      prompt_template: 'test.md',
+      prompt_hash: 'def456',
+    });
+    emitter.emitAt(new Date('2026-06-29T10:00:05.000Z'), {
+      type: 'run.complete',
+      run_id: 'batch-test/run-3',
+      batch_id: 'batch-test',
+      run_num: 3,
+      duration_ms: 5_000,
+      exit_code: 0,
+      cost_usd: 0.5,
+      tool_calls: 1,
+      prs_created: 0,
+      issues_filed: 0,
+      issues_closed: 0,
+      stop_requested: false,
+      lifecycle_violations: 0,
+      outcome: 'empty_success',
+    });
+
+    expect(transport.traces[0].spans[0]).toMatchObject({
+      startTimeUnixNano: '1782727200000000000',
+      endTimeUnixNano: '1782727205000000000',
+    });
   });
 });

--- a/scripts/auto-dent-events.ts
+++ b/scripts/auto-dent-events.ts
@@ -22,6 +22,7 @@ import type { PhaseProviderRecord } from './auto-dent-provider.js';
 import type { HookActivationVerdict } from './auto-dent-hook-activation.js';
 import type { WorkflowGateId, WorkflowGateState } from './workflow-gate-ledger.js';
 import type { PostMergeVerificationVerdict, TestHealthVerdict } from '../src/verdict-binding-policy.js';
+import { createOtelSinkFromEnv, type AutoDentOtelSink } from './auto-dent-otel.js';
 
 // Event type definitions
 
@@ -207,6 +208,10 @@ export interface EventEnvelope {
   event: AutoDentEvent;
 }
 
+export interface EventEmitterOptions {
+  otelSink?: AutoDentOtelSink;
+}
+
 /**
  * EventEmitter writes structured JSONL events to a file.
  *
@@ -218,9 +223,11 @@ export interface EventEnvelope {
  */
 export class EventEmitter {
   private readonly filePath: string;
+  private readonly otelSink?: AutoDentOtelSink;
 
-  constructor(logDir: string) {
+  constructor(logDir: string, options: EventEmitterOptions = {}) {
     this.filePath = resolve(logDir, 'events.jsonl');
+    this.otelSink = options.otelSink ?? createOtelSinkFromEnv();
   }
 
   emit(event: AutoDentEvent): void {
@@ -237,6 +244,11 @@ export class EventEmitter {
       appendJsonLine(this.filePath, envelope);
     } catch {
       // Telemetry is best-effort — never break the run
+    }
+    try {
+      this.otelSink?.emit(envelope);
+    } catch {
+      // OTel export is best-effort — never break the run
     }
   }
 

--- a/scripts/auto-dent-otel.test.ts
+++ b/scripts/auto-dent-otel.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAutoDentOtelTrace,
+  createOtelSinkFromEnv,
+  HttpOtelTransport,
+  MemoryOtelTransport,
+  toOtlpJson,
+} from './auto-dent-otel.js';
+import type { EventEnvelope } from './auto-dent-events.js';
+
+const runStart: EventEnvelope = {
+  timestamp: '2026-06-29T10:00:00.000Z',
+  event: {
+    type: 'run.start',
+    run_id: 'batch/run-1',
+    batch_id: 'batch',
+    run_num: 1,
+    mode: 'exploit',
+    mode_reason: 'schedule',
+    prompt_template: 'deep-dive-default.md',
+    prompt_hash: 'abc123',
+  },
+};
+
+const reviewStart: EventEnvelope = {
+  timestamp: '2026-06-29T10:00:10.000Z',
+  event: {
+    type: 'review.round_start',
+    run_id: 'batch/run-1',
+    batch_id: 'batch',
+    run_num: 1,
+    pr_url: 'https://github.com/Garsson-io/kaizen/pull/1188',
+    round: 1,
+    dimensions: ['correctness', 'security'],
+  },
+};
+
+const reviewComplete: EventEnvelope = {
+  timestamp: '2026-06-29T10:00:20.000Z',
+  event: {
+    type: 'review.round_complete',
+    run_id: 'batch/run-1',
+    batch_id: 'batch',
+    run_num: 1,
+    pr_url: 'https://github.com/Garsson-io/kaizen/pull/1188',
+    round: 1,
+    verdict: 'pass',
+    missing_count: 0,
+    partial_count: 0,
+    cost_usd: 0.15,
+    duration_ms: 10_000,
+  },
+};
+
+const fixStart: EventEnvelope = {
+  timestamp: '2026-06-29T10:00:30.000Z',
+  event: {
+    type: 'review.fix_spawned',
+    run_id: 'batch/run-1',
+    batch_id: 'batch',
+    run_num: 1,
+    pr_url: 'https://github.com/Garsson-io/kaizen/pull/1188',
+    round: 1,
+    gaps_count: 2,
+  },
+};
+
+const fixComplete: EventEnvelope = {
+  timestamp: '2026-06-29T10:00:45.000Z',
+  event: {
+    type: 'review.fix_complete',
+    run_id: 'batch/run-1',
+    batch_id: 'batch',
+    run_num: 1,
+    pr_url: 'https://github.com/Garsson-io/kaizen/pull/1188',
+    round: 1,
+    success: true,
+    cost_usd: 0.25,
+  },
+};
+
+const runComplete: EventEnvelope = {
+  timestamp: '2026-06-29T10:01:00.000Z',
+  event: {
+    type: 'run.complete',
+    run_id: 'batch/run-1',
+    batch_id: 'batch',
+    run_num: 1,
+    duration_ms: 60_000,
+    exit_code: 0,
+    cost_usd: 2.5,
+    tool_calls: 42,
+    prs_created: 1,
+    issues_filed: 0,
+    issues_filed_refs: [],
+    issues_closed: 1,
+    issues_closed_refs: ['#1188'],
+    cases: ['260629-k1188-otel-genai-traces'],
+    stop_requested: false,
+    lifecycle_violations: 0,
+    lifecycle_health: 'clean',
+    process_verdict: 'pass',
+    post_merge_verification: 'pass',
+    process_issue_count: 0,
+    process_summary: 'ok',
+    review_verdict: 'pass',
+    review_cost_usd: 0.15,
+    test_health: 'pass',
+    workflow_repair_state: 'merge_ready',
+    phase_providers: {
+      implementation: { provider: 'codex', billing: 'subscription-cli' },
+    },
+    prompt_template: 'deep-dive-default.md',
+    prompt_hash: 'abc123',
+    final_claim_status: 'valid',
+    outcome: 'success',
+    mode: 'exploit',
+  },
+};
+
+describe('auto-dent OTel GenAI projection (#1188)', () => {
+  it('maps run events to a GenAI-semconv root span with kaizen correlation attributes', () => {
+    const result = buildAutoDentOtelTrace([runStart, runComplete]);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.trace?.spans).toHaveLength(1);
+    const root = result.trace?.spans[0];
+    expect(root).toMatchObject({
+      name: 'auto-dent run 1',
+      kind: 'INTERNAL',
+      status: { code: 'OK' },
+    });
+    expect(root?.attributes).toMatchObject({
+      'gen_ai.operation.name': 'invoke_agent',
+      'gen_ai.provider.name': 'codex',
+      'gen_ai.agent.name': 'kaizen-auto-dent',
+      'gen_ai.prompt.name': 'deep-dive-default.md',
+      'kaizen.prompt.hash': 'abc123',
+      'kaizen.run.id': 'batch/run-1',
+      'kaizen.run.mode': 'exploit',
+      'kaizen.run.outcome': 'success',
+      'kaizen.run.cost_usd': 2.5,
+      'kaizen.run.issues_closed_refs': ['#1188'],
+      'kaizen.run.cases': ['260629-k1188-otel-genai-traces'],
+      'kaizen.run.process_verdict': 'pass',
+      'kaizen.run.test_health': 'pass',
+    });
+  });
+
+  it('maps review and fix-loop events as child spans under the run span', () => {
+    const result = buildAutoDentOtelTrace([
+      runStart,
+      reviewStart,
+      reviewComplete,
+      fixStart,
+      fixComplete,
+      runComplete,
+    ]);
+
+    const spans = result.trace?.spans ?? [];
+    expect(spans).toHaveLength(3);
+    const root = spans.find((span) => span.name === 'auto-dent run 1');
+    const review = spans.find((span) => span.name === 'review round 1');
+    const fix = spans.find((span) => span.name === 'review fix round 1');
+    expect(review?.parentSpanId).toBe(root?.spanId);
+    expect(fix?.parentSpanId).toBe(root?.spanId);
+    expect(review?.attributes).toMatchObject({
+      'gen_ai.operation.name': 'invoke_agent',
+      'gen_ai.agent.name': 'kaizen-review-battery',
+      'kaizen.review.dimensions': ['correctness', 'security'],
+      'kaizen.review.verdict': 'pass',
+    });
+    expect(fix?.attributes).toMatchObject({
+      'gen_ai.agent.name': 'kaizen-review-fix',
+      'kaizen.review.gaps_count': 2,
+      'kaizen.review.fix_success': true,
+    });
+  });
+
+  it('does not emit sensitive GenAI content attributes by default', () => {
+    const result = buildAutoDentOtelTrace([runStart, runComplete]);
+    const attrs = result.trace?.spans.flatMap((span) => Object.keys(span.attributes)) ?? [];
+
+    expect(attrs).not.toContain('gen_ai.input.messages');
+    expect(attrs).not.toContain('gen_ai.output.messages');
+    expect(attrs).not.toContain('gen_ai.system_instructions');
+    expect(attrs).not.toContain('gen_ai.tool.call.arguments');
+    expect(attrs).not.toContain('gen_ai.tool.call.result');
+    expect(attrs).not.toContain('gen_ai.usage.input_tokens');
+    expect(attrs).not.toContain('gen_ai.usage.output_tokens');
+  });
+
+  it('does not fabricate a completed span when run.complete is missing', () => {
+    const result = buildAutoDentOtelTrace([runStart]);
+
+    expect(result.trace).toBeUndefined();
+    expect(result.warnings).toEqual(['missing:run.complete']);
+  });
+
+  it('converts spans to an OTLP JSON trace payload shape', () => {
+    const result = buildAutoDentOtelTrace([runStart, runComplete]);
+    const payload = toOtlpJson(result.trace!);
+
+    expect(payload).toMatchObject({
+      resourceSpans: [{
+        scopeSpans: [{
+          scope: { name: 'kaizen.auto-dent-otel' },
+        }],
+      }],
+    });
+    expect(JSON.stringify(payload)).toContain('gen_ai.operation.name');
+    expect(JSON.stringify(payload)).toContain('kaizen.run.id');
+  });
+
+  it('provides an in-memory transport for deterministic sink tests', () => {
+    const transport = new MemoryOtelTransport();
+    const trace = buildAutoDentOtelTrace([runStart, runComplete]).trace!;
+
+    transport.exportTrace(trace);
+
+    expect(transport.traces).toEqual([trace]);
+  });
+
+  it('constructs an env-gated sink only when KAIZEN_OTEL_ENDPOINT is set', () => {
+    expect(createOtelSinkFromEnv({ KAIZEN_OTEL_ENDPOINT: '' })).toBeUndefined();
+    expect(createOtelSinkFromEnv({ KAIZEN_OTEL_ENDPOINT: 'https://otel.example/v1/traces' })).toBeDefined();
+  });
+
+  it('posts OTLP JSON to the configured HTTP endpoint', async () => {
+    const calls: Array<{ url: string; init: { method: string; headers: Record<string, string>; body: string } }> = [];
+    const transport = new HttpOtelTransport('https://otel.example/v1/traces', async (url, init) => {
+      calls.push({ url, init });
+      return { ok: true, status: 200, statusText: 'OK' };
+    });
+    const trace = buildAutoDentOtelTrace([runStart, runComplete]).trace!;
+
+    await transport.exportTrace(trace);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      url: 'https://otel.example/v1/traces',
+      init: {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+      },
+    });
+    expect(JSON.parse(calls[0].init.body)).toMatchObject({
+      resourceSpans: expect.any(Array),
+    });
+  });
+});

--- a/scripts/auto-dent-otel.ts
+++ b/scripts/auto-dent-otel.ts
@@ -1,0 +1,354 @@
+import { createHash } from 'crypto';
+import type {
+  EventEnvelope,
+  ReviewFixCompleteEvent,
+  ReviewFixSpawnedEvent,
+  ReviewRoundCompleteEvent,
+  ReviewRoundStartEvent,
+  RunCompleteEvent,
+  RunStartEvent,
+} from './auto-dent-events.js';
+
+export type OtelAttributeValue = string | number | boolean | string[] | number[] | boolean[];
+
+export interface AutoDentOtelSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind: 'INTERNAL';
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes: Record<string, OtelAttributeValue>;
+  status: {
+    code: 'OK' | 'ERROR';
+    message?: string;
+  };
+}
+
+export interface AutoDentOtelTrace {
+  traceId: string;
+  runId: string;
+  spans: AutoDentOtelSpan[];
+  warnings: string[];
+}
+
+export interface BuildAutoDentOtelTraceResult {
+  trace?: AutoDentOtelTrace;
+  warnings: string[];
+}
+
+export interface AutoDentOtelTransport {
+  exportTrace(trace: AutoDentOtelTrace): void | Promise<void>;
+}
+
+export class MemoryOtelTransport implements AutoDentOtelTransport {
+  readonly traces: AutoDentOtelTrace[] = [];
+
+  exportTrace(trace: AutoDentOtelTrace): void {
+    this.traces.push(trace);
+  }
+}
+
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number; statusText: string }>;
+
+export class HttpOtelTransport implements AutoDentOtelTransport {
+  constructor(
+    private readonly endpoint: string,
+    private readonly fetchImpl: FetchLike = globalThis.fetch as FetchLike,
+  ) {}
+
+  async exportTrace(trace: AutoDentOtelTrace): Promise<void> {
+    const response = await this.fetchImpl(this.endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(toOtlpJson(trace)),
+    });
+    if (!response.ok) {
+      throw new Error(`OTel export failed: ${response.status} ${response.statusText}`);
+    }
+  }
+}
+
+export class AutoDentOtelSink {
+  private readonly eventsByRun = new Map<string, EventEnvelope[]>();
+  readonly warnings: string[] = [];
+
+  constructor(private readonly transport: AutoDentOtelTransport) {}
+
+  emit(envelope: EventEnvelope): void {
+    const runId = envelope.event.run_id;
+    const events = this.eventsByRun.get(runId) ?? [];
+    events.push(envelope);
+    this.eventsByRun.set(runId, events);
+
+    if (envelope.event.type !== 'run.complete') return;
+    const result = buildAutoDentOtelTrace(events);
+    this.eventsByRun.delete(runId);
+    this.warnings.push(...result.warnings);
+    if (!result.trace) return;
+
+    try {
+      const exportResult = this.transport.exportTrace(result.trace);
+      if (exportResult && typeof (exportResult as Promise<void>).catch === 'function') {
+        void (exportResult as Promise<void>).catch((err) => {
+          this.warnings.push(formatExportWarning(err));
+        });
+      }
+    } catch (err) {
+      this.warnings.push(formatExportWarning(err));
+    }
+  }
+}
+
+export function createOtelSinkFromEnv(
+  env: Pick<NodeJS.ProcessEnv, 'KAIZEN_OTEL_ENDPOINT'> = process.env,
+): AutoDentOtelSink | undefined {
+  const endpoint = env.KAIZEN_OTEL_ENDPOINT?.trim();
+  if (!endpoint) return undefined;
+  return new AutoDentOtelSink(new HttpOtelTransport(endpoint));
+}
+
+export function buildAutoDentOtelTrace(events: EventEnvelope[]): BuildAutoDentOtelTraceResult {
+  const warnings: string[] = [];
+  const start = findEvent<RunStartEvent>(events, 'run.start');
+  const complete = findEvent<RunCompleteEvent>(events, 'run.complete');
+  if (!complete) {
+    return { warnings: ['missing:run.complete'] };
+  }
+  if (!start) warnings.push('missing:run.start');
+
+  const runId = complete.event.run_id;
+  const traceId = stableHex(`trace:${runId}`, 32);
+  const rootSpanId = stableHex(`span:${runId}:run`, 16);
+  const rootStart = start?.timestamp ?? complete.timestamp;
+  const rootSpan: AutoDentOtelSpan = {
+    traceId,
+    spanId: rootSpanId,
+    name: `auto-dent run ${complete.event.run_num}`,
+    kind: 'INTERNAL',
+    startTimeUnixNano: isoToUnixNano(rootStart),
+    endTimeUnixNano: isoToUnixNano(complete.timestamp),
+    attributes: buildRunAttributes(start?.event, complete.event),
+    status: buildStatus(complete.event),
+  };
+
+  const spans = [
+    rootSpan,
+    ...buildReviewRoundSpans(events, traceId, rootSpanId),
+    ...buildReviewFixSpans(events, traceId, rootSpanId),
+  ];
+  return {
+    trace: { traceId, runId, spans, warnings },
+    warnings,
+  };
+}
+
+function buildRunAttributes(
+  start: RunStartEvent | undefined,
+  complete: RunCompleteEvent,
+): Record<string, OtelAttributeValue> {
+  return compactAttributes({
+    'gen_ai.operation.name': 'invoke_agent',
+    'gen_ai.provider.name': providerName(complete),
+    'gen_ai.agent.name': 'kaizen-auto-dent',
+    'gen_ai.prompt.name': complete.prompt_template ?? start?.prompt_template,
+    'kaizen.prompt.hash': complete.prompt_hash ?? start?.prompt_hash,
+    'kaizen.run.id': complete.run_id,
+    'kaizen.batch.id': complete.batch_id,
+    'kaizen.run.number': complete.run_num,
+    'kaizen.run.mode': complete.mode ?? start?.mode,
+    'kaizen.run.mode_reason': start?.mode_reason,
+    'kaizen.run.outcome': complete.outcome,
+    'kaizen.run.exit_code': complete.exit_code,
+    'kaizen.run.cost_usd': complete.cost_usd,
+    'kaizen.run.tool_calls': complete.tool_calls,
+    'kaizen.run.prs_created': complete.prs_created,
+    'kaizen.run.issues_filed': complete.issues_filed,
+    'kaizen.run.issues_closed': complete.issues_closed,
+    'kaizen.run.issues_filed_refs': complete.issues_filed_refs,
+    'kaizen.run.issues_closed_refs': complete.issues_closed_refs,
+    'kaizen.run.cases': complete.cases,
+    'kaizen.run.lifecycle_health': complete.lifecycle_health,
+    'kaizen.run.process_verdict': complete.process_verdict,
+    'kaizen.run.post_merge_verification': complete.post_merge_verification,
+    'kaizen.run.test_health': complete.test_health,
+    'kaizen.run.hook_activation_status': complete.hook_activation?.status,
+    'kaizen.run.review_verdict': complete.review_verdict,
+    'kaizen.run.review_cost_usd': complete.review_cost_usd,
+    'kaizen.run.workflow_repair_state': complete.workflow_repair_state,
+    'kaizen.run.final_claim_status': complete.final_claim_status,
+  });
+}
+
+function buildReviewRoundSpans(
+  events: EventEnvelope[],
+  traceId: string,
+  parentSpanId: string,
+): AutoDentOtelSpan[] {
+  const starts = events.filter(isEventType<ReviewRoundStartEvent>('review.round_start'));
+  const completes = events.filter(isEventType<ReviewRoundCompleteEvent>('review.round_complete'));
+  return completes.map((complete) => {
+    const start = starts.find((candidate) =>
+      candidate.event.pr_url === complete.event.pr_url &&
+      candidate.event.round === complete.event.round,
+    );
+    const spanId = stableHex(`span:${complete.event.run_id}:review:${complete.event.pr_url}:${complete.event.round}`, 16);
+    return {
+      traceId,
+      spanId,
+      parentSpanId,
+      name: `review round ${complete.event.round}`,
+      kind: 'INTERNAL',
+      startTimeUnixNano: isoToUnixNano(start?.timestamp ?? complete.timestamp),
+      endTimeUnixNano: isoToUnixNano(complete.timestamp),
+      attributes: compactAttributes({
+        'gen_ai.operation.name': 'invoke_agent',
+        'gen_ai.provider.name': 'kaizen',
+        'gen_ai.agent.name': 'kaizen-review-battery',
+        'kaizen.review.pr_url': complete.event.pr_url,
+        'kaizen.review.round': complete.event.round,
+        'kaizen.review.dimensions': start?.event.dimensions,
+        'kaizen.review.verdict': complete.event.verdict,
+        'kaizen.review.missing_count': complete.event.missing_count,
+        'kaizen.review.partial_count': complete.event.partial_count,
+        'kaizen.review.cost_usd': complete.event.cost_usd,
+      }),
+      status: complete.event.verdict === 'pass' ? { code: 'OK' } : { code: 'ERROR', message: 'review failed' },
+    };
+  });
+}
+
+function buildReviewFixSpans(
+  events: EventEnvelope[],
+  traceId: string,
+  parentSpanId: string,
+): AutoDentOtelSpan[] {
+  const starts = events.filter(isEventType<ReviewFixSpawnedEvent>('review.fix_spawned'));
+  const completes = events.filter(isEventType<ReviewFixCompleteEvent>('review.fix_complete'));
+  return completes.map((complete) => {
+    const start = starts.find((candidate) =>
+      candidate.event.pr_url === complete.event.pr_url &&
+      candidate.event.round === complete.event.round,
+    );
+    const spanId = stableHex(`span:${complete.event.run_id}:fix:${complete.event.pr_url}:${complete.event.round}`, 16);
+    return {
+      traceId,
+      spanId,
+      parentSpanId,
+      name: `review fix round ${complete.event.round}`,
+      kind: 'INTERNAL',
+      startTimeUnixNano: isoToUnixNano(start?.timestamp ?? complete.timestamp),
+      endTimeUnixNano: isoToUnixNano(complete.timestamp),
+      attributes: compactAttributes({
+        'gen_ai.operation.name': 'invoke_agent',
+        'gen_ai.provider.name': 'kaizen',
+        'gen_ai.agent.name': 'kaizen-review-fix',
+        'kaizen.review.pr_url': complete.event.pr_url,
+        'kaizen.review.round': complete.event.round,
+        'kaizen.review.gaps_count': start?.event.gaps_count,
+        'kaizen.review.fix_success': complete.event.success,
+        'kaizen.review.fix_cost_usd': complete.event.cost_usd,
+      }),
+      status: complete.event.success ? { code: 'OK' } : { code: 'ERROR', message: 'review fix failed' },
+    };
+  });
+}
+
+export function toOtlpJson(trace: AutoDentOtelTrace): unknown {
+  return {
+    resourceSpans: [{
+      resource: {
+        attributes: [
+          keyValue('service.name', 'kaizen-auto-dent'),
+          keyValue('kaizen.run.id', trace.runId),
+        ],
+      },
+      scopeSpans: [{
+        scope: { name: 'kaizen.auto-dent-otel' },
+        spans: trace.spans.map((span) => ({
+          traceId: span.traceId,
+          spanId: span.spanId,
+          parentSpanId: span.parentSpanId,
+          name: span.name,
+          kind: 1,
+          startTimeUnixNano: span.startTimeUnixNano,
+          endTimeUnixNano: span.endTimeUnixNano,
+          attributes: Object.entries(span.attributes).map(([key, value]) => keyValue(key, value)),
+          status: {
+            code: span.status.code === 'OK' ? 1 : 2,
+            message: span.status.message,
+          },
+        })),
+      }],
+    }],
+  };
+}
+
+function providerName(complete: RunCompleteEvent): string {
+  const firstProvider = Object.values(complete.phase_providers ?? {})[0]?.provider;
+  return firstProvider ?? 'kaizen';
+}
+
+function buildStatus(event: RunCompleteEvent): AutoDentOtelSpan['status'] {
+  if (event.exit_code === 0 && event.outcome !== 'failure') return { code: 'OK' };
+  return { code: 'ERROR', message: event.failure_class ?? `exit_code_${event.exit_code}` };
+}
+
+function findEvent<T extends EventEnvelope['event']>(
+  events: EventEnvelope[],
+  type: T['type'],
+): (EventEnvelope & { event: T }) | undefined {
+  return events.find((event): event is EventEnvelope & { event: T } => event.event.type === type);
+}
+
+function isEventType<T extends EventEnvelope['event']>(
+  type: T['type'],
+): (event: EventEnvelope) => event is EventEnvelope & { event: T } {
+  return (event): event is EventEnvelope & { event: T } => event.event.type === type;
+}
+
+function stableHex(input: string, length: number): string {
+  return createHash('sha256').update(input).digest('hex').slice(0, length);
+}
+
+function isoToUnixNano(iso: string): string {
+  return String(BigInt(new Date(iso).getTime()) * 1_000_000n);
+}
+
+function compactAttributes(input: Record<string, OtelAttributeValue | undefined>): Record<string, OtelAttributeValue> {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, value]) =>
+      value !== undefined &&
+      (!Array.isArray(value) || value.length > 0),
+    ),
+  ) as Record<string, OtelAttributeValue>;
+}
+
+function keyValue(key: string, value: OtelAttributeValue): unknown {
+  if (Array.isArray(value)) {
+    return {
+      key,
+      value: {
+        arrayValue: {
+          values: value.map((item) => primitiveValue(item)),
+        },
+      },
+    };
+  }
+  return { key, value: primitiveValue(value) };
+}
+
+function primitiveValue(value: string | number | boolean): unknown {
+  if (typeof value === 'string') return { stringValue: value };
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (Number.isInteger(value)) return { intValue: value };
+  return { doubleValue: value };
+}
+
+function formatExportWarning(err: unknown): string {
+  return `otel_export_failed:${err instanceof Error ? err.message : String(err)}`;
+}


### PR DESCRIPTION
Once upon a time, auto-dent had a rich event stream in `events.jsonl`. It recorded run starts and completions, review rounds, fix attempts, costs, verdicts, lifecycle health, issues, PRs, and cases.

Every day, that stream was useful only to kaizen-specific readers. Batch summaries, replay, and finalization could mine it, but standard observability tools needed a custom converter because the event names and attributes were private to this repo.

One day, #1188 made that a concrete blocker for the self-improving core epic. The current OpenTelemetry GenAI conventions now define `gen_ai.*` attributes for agent/model/tool telemetry, so kaizen no longer needs a platform-specific Langfuse/LangSmith/Phoenix adapter per backend. It needs one standard trace boundary beside the existing JSONL.

Because of that, this PR adds `scripts/auto-dent-otel.ts`: a typed mapper from `EventEnvelope[]` into a GenAI-style trace with a root auto-dent run span and child review/fix spans. The root span carries required GenAI attributes plus kaizen correlation fields for run id, batch id, mode, prompt template/hash, outcome, cost, lifecycle/process/test/hook/workflow verdicts, and produced PR/issue/case refs.

Because of that, `EventEmitter` now accepts an optional OTel sink and also creates one from `KAIZEN_OTEL_ENDPOINT` when configured. JSONL remains unconditional and primary. OTel export is best-effort and fail-open, so a collector outage cannot break a run or prevent `events.jsonl` from being written.

Until finally, the implementation deliberately avoids sensitive GenAI content capture. It does not emit `gen_ai.input.messages`, `gen_ai.output.messages`, system instructions, tool arguments/results, or token counts when the current event stream cannot provide safe values.

And ever since, auto-dent has a standard trace emission boundary for later consumers (#545/#556, #912, #1358) without replacing the canonical event stream established by #1678, #1679, and #1680.

Closes #1188
Parent: #1677
Refs: #545, #556, #912, #940, #1167, #1678, #1679, #1680, #1643, #1682

## Architecture

```text
EventEmitter.emit()/emitAt()
        |
        +--> appendJsonLine(<batch>/events.jsonl)   [unchanged durable source]
        |
        +--> AutoDentOtelSink.emit(envelope)        [optional]
                  |
                  v
          buildAutoDentOtelTrace(events)
                  |
                  v
          AutoDentOtelTransport.exportTrace(trace)
                  |
                  v
          OTLP JSON HTTP POST when KAIZEN_OTEL_ENDPOINT is set
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep `events.jsonl` as the unconditional source | Replay, finalization, batch summaries, and artifact upload already depend on it | OTel is a mirror, not the source of truth |
| Use one dedicated mapper module | Prevents trace mapping from drifting across run/replay/summary code | Adds one small surface area to own semconv mapping |
| Make export optional and fail-open | Observability outages must not break autonomous runs | Export failures are warnings, not gates |
| Omit sensitive content attributes by default | Upstream GenAI content fields are opt-in and may contain secrets/PII | Full prompt/tool content tracing remains a future privacy/redaction issue |
| Avoid adding OTel SDK dependencies for the first slice | The issue needs semconv-compatible trace emission and an HTTP sink; a small OTLP JSON transport is enough for this boundary | Future backend-specific requirements may justify official SDK wiring later |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-otel.ts` | GenAI trace/span model, event-to-span mapper, in-memory transport, env-gated HTTP transport, OTLP JSON conversion |
| `scripts/auto-dent-otel.test.ts` | Unit tests for root spans, review/fix child spans, sensitive attribute omission, incomplete events, env gating, HTTP payloads |
| `scripts/auto-dent-events.ts` | Optional OTel sink wiring in `EventEmitter`, preserving existing constructor behavior |
| `scripts/auto-dent-events.test.ts` | Integration tests proving JSONL preservation, configured sink export, fail-open export errors, and `emitAt()` timestamps |
| `docs/auto-dent-operations.md` | Operator note for `KAIZEN_OTEL_ENDPOINT` and fail-open behavior |

## Test Plan (Behaviors x Levels)

| # | Behavior | Unit | Integration | System | Agentic | Workflow | Status |
|---|---|---|---|---|---|---|---|
| 1 | Auto-dent events map to a GenAI-semconv root run span | `scripts/auto-dent-otel.test.ts` | Not required | Not required | Not required | Not required | Tested |
| 2 | Review round and fix-loop events map to child spans | `scripts/auto-dent-otel.test.ts` | Not required | Not required | Not required | Not required | Tested |
| 3 | Sensitive content/token attributes are omitted when unavailable or unsafe | `scripts/auto-dent-otel.test.ts` | Not required | Not required | Not required | Not required | Tested |
| 4 | Missing `run.complete` does not fabricate a completed trace | `scripts/auto-dent-otel.test.ts` | Not required | Not required | Not required | Not required | Tested |
| 5 | `EventEmitter` still writes JSONL when OTel is unconfigured | Existing event tests | `scripts/auto-dent-events.test.ts` | Not required | Not required | Not required | Tested |
| 6 | Configured OTel sink receives span payloads with `emitAt()` timestamps | Not required | `scripts/auto-dent-events.test.ts` | Not required | Not required | Not required | Tested |
| 7 | OTel sink/export failure is fail-open | Not required | `scripts/auto-dent-events.test.ts` | Not required | Not required | Not required | Tested |
| 8 | Existing replay/finalization/harness consumers remain compatible | Not required | `scripts/auto-dent-replay.test.ts`, `scripts/auto-dent-run.test.ts`, `scripts/batch-summary.test.ts`, harness bridge slice | Not required | Not required | Focused workflow slice | Tested |
| 9 | One mapping boundary, no competing converter | `rg` source scan | Not required | Not required | Not required | Not required | Tested |

## Impact (goal -> before/after -> match)

- Goal (#1188): make auto-dent event telemetry portable to OpenTelemetry GenAI-compatible tooling without replacing the canonical JSONL event stream.
- Acceptance signal: synthetic auto-dent events produce a trace/span payload with required `gen_ai.*` attributes, optional configured export works through an injected/HTTP transport, JSONL still writes, and export failures remain fail-open.
- BEFORE: `rg "opentelemetry|otel|gen_ai" package.json package-lock.json scripts src docs .github` found no implementation references outside lockfile transitive metadata; auto-dent emitted only kaizen-private JSONL.
- AFTER: `EventEmitter` can mirror completed runs to an OTel sink through `KAIZEN_OTEL_ENDPOINT`; `scripts/auto-dent-otel.ts` maps run/review/fix events to spans; tests assert semconv attributes, parent/child relationships, safe omission of content attributes, OTLP JSON shape, and fail-open behavior.
- Delta: one standard trace boundary added beside the existing durable source; zero behavior change required for existing JSONL consumers; no prompt/content leakage by default.
- Goal met?: yes.
- Residual scan: related code scan found the new OTel surface only in `auto-dent-otel`, `auto-dent-events`, tests, and operator docs. Downstream dashboard/structured memory/cloud log consumers remain tracked by #545/#556, #912, and #1643.

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run scripts/auto-dent-otel.test.ts scripts/auto-dent-events.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-run.test.ts scripts/batch-summary.test.ts --reporter=default` - 492 tests passed
- [x] `npx vitest run scripts/auto-dent-harness.test.ts -t "bridge:|end-to-end: harness" --reporter=default` - 13 passed, 216 skipped
- [x] `git diff --check`
- [x] Related-area scan: `rg "opentelemetry|otel|gen_ai|AutoDentOtel|createOtelSinkFromEnv|KAIZEN_OTEL_ENDPOINT|toOtlpJson" scripts src package.json docs .github --glob '!node_modules'`

## Known Limitations

- Full prompt/input/output/tool content capture is intentionally deferred because those upstream GenAI fields are sensitive and opt-in.
- The full captured-log harness suite still has the pre-existing shorthand issue-ref failures tracked by #1682; the relevant harness bridge/end-to-end slice passed.
- UI/dashboard consumption, structured PR/issue memory, and compressed cloud-backed raw logs remain #545/#556, #912, and #1643.

## Kaizen

- **Root cause:** Auto-dent had a rich typed event stream, but no standard GenAI trace projection/export boundary, so every external observability backend would need kaizen-specific parsing.
- **Fix level:** L3 — `EventEmitter` now structurally mirrors completed runs to a typed OTel/GenAI sink when configured, while JSONL remains the durable source.
- **Repeat failure?** No for this concrete exporter slice; it is the planned #1188 follow-on after #1680 made replay/finalization canonical.
- **Escalation needed?** No separate escalation. Sensitive content capture and UI/cloud consumers remain explicit downstream issues, not hidden deferrals.
- **Backlog issue:** N/A — implemented in this PR. Related downstream work remains #545/#556, #912, and #1643.