### PR TITLE
Store auto-dent progress updates as structured attachments

### DIFF
--- a/scripts/auto-dent-review-wiring.test.ts
+++ b/scripts/auto-dent-review-wiring.test.ts
@@ -182,6 +182,28 @@ describe('runReviewWiring', () => {
     expect(result.reviewVerdict).toBe('fail');
   });
 
+  it('stores an exhausted fix loop notice as a named PR attachment', async () => {
+    const deps = makeDeps({
+      reviewBattery: vi.fn().mockResolvedValue(makeFailingBatteryResult()),
+      runFixLoop: vi.fn().mockResolvedValue(makeReviewFixState({
+        currentRound: 2,
+        totalCostUsd: 0.30,
+        outcome: 'max_rounds',
+      })),
+      writeAttachment: vi.fn().mockReturnValue('https://github.com/test/repo/pull/1#issuecomment-10'),
+    });
+    const result = await runReviewWiring(makeInput(), deps);
+
+    expect(result.reviewVerdict).toBe('fail');
+    expect(result.reviewUrls).toEqual(['https://github.com/test/repo/pull/1#issuecomment-10']);
+    expect(deps.writeAttachment).toHaveBeenCalledWith(
+      { kind: 'pr', number: '1', repo: 'test/repo' },
+      'review-fix-loop',
+      expect.stringContaining('## Review Fix Loop: Exhausted'),
+    );
+    expect(deps.ghExec).not.toHaveBeenCalled();
+  });
+
   it('INVARIANT: no PRs → verdict is skipped', async () => {
     const deps = makeDeps();
     const result = await runReviewWiring(makeInput({ prs: [] }), deps);

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -226,9 +226,19 @@ describe('closeBatchProgressIssue maintenance wiring', () => {
       AUTO_DENT_RUN_SOURCE.indexOf('// Execute Claude'),
     );
 
-    expect(closeSection).toContain('uploadBatchArtifacts(m[1], kaizenRepo, batchDir');
+    expect(closeSection).toContain('uploadBatchArtifacts(issueNum, kaizenRepo, batchDir');
     expect(closeSection).toContain('[intelligence] uploaded raw batch artifacts');
     expect(closeSection).toContain('[intelligence] no raw artifacts on disk to upload');
+  });
+
+  it('stores the batch completion summary as a named progress attachment', () => {
+    const closeSection = AUTO_DENT_RUN_SOURCE.slice(
+      AUTO_DENT_RUN_SOURCE.indexOf('export function closeBatchProgressIssue'),
+      AUTO_DENT_RUN_SOURCE.indexOf('// Execute Claude'),
+    );
+
+    expect(closeSection).toContain("'progress/batch-complete'");
+    expect(closeSection).toContain('writeProgressAttachment');
   });
 });
 
@@ -4859,36 +4869,45 @@ describe('findExistingProgressIssue', () => {
   });
 
   it('returns URL when GitHub search finds a matching issue', () => {
-    vi.spyOn(github, 'ghExec').mockReturnValue(JSON.stringify([{ url: 'https://github.com/Garsson-io/kaizen/issues/707' }]));
-    const result = findExistingProgressIssue('batch-260323-1405-5400', 'Garsson-io/kaizen');
+    const gh = vi.fn(() => JSON.stringify([{ url: 'https://github.com/Garsson-io/kaizen/issues/707' }]));
+    const result = findExistingProgressIssue('batch-260323-1405-5400', 'Garsson-io/kaizen', gh);
     expect(result).toBe('https://github.com/Garsson-io/kaizen/issues/707');
   });
 
   it('returns empty string when no matching issue found', () => {
-    vi.spyOn(github, 'ghExec').mockReturnValue('[]');
-    const result = findExistingProgressIssue('batch-nonexistent', 'Garsson-io/kaizen');
+    const result = findExistingProgressIssue('batch-nonexistent', 'Garsson-io/kaizen', () => '[]');
     expect(result).toBe('');
   });
 
-  it('returns empty string when ghExec returns empty string', () => {
-    vi.spyOn(github, 'ghExec').mockReturnValue('');
-    const result = findExistingProgressIssue('batch-123', 'Garsson-io/kaizen');
+  it('returns empty string when gh returns empty string', () => {
+    const result = findExistingProgressIssue('batch-123', 'Garsson-io/kaizen', () => '');
     expect(result).toBe('');
   });
 
-  it('returns empty string when ghExec returns invalid JSON', () => {
-    vi.spyOn(github, 'ghExec').mockReturnValue('not-json');
-    const result = findExistingProgressIssue('batch-123', 'Garsson-io/kaizen');
+  it('returns empty string when gh returns invalid JSON', () => {
+    const result = findExistingProgressIssue('batch-123', 'Garsson-io/kaizen', () => 'not-json');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when gh throws', () => {
+    const result = findExistingProgressIssue('batch-123', 'Garsson-io/kaizen', () => {
+      throw new Error('permission denied');
+    });
     expect(result).toBe('');
   });
 
   it('passes batch ID in search query', () => {
-    const spy = vi.spyOn(github, 'ghExec').mockReturnValue('[]');
-    findExistingProgressIssue('batch-260323-1405-5400', 'Garsson-io/kaizen');
-    expect(spy).toHaveBeenCalledOnce();
-    expect(spy.mock.calls[0][0]).toContain('batch-260323-1405-5400');
-    expect(spy.mock.calls[0][0]).toContain('--repo Garsson-io/kaizen');
-    expect(spy.mock.calls[0][0]).toContain('--label auto-dent');
+    const gh = vi.fn(() => '[]');
+    findExistingProgressIssue('batch-260323-1405-5400', 'Garsson-io/kaizen', gh);
+    expect(gh).toHaveBeenCalledOnce();
+    expect(gh.mock.calls[0][0]).toEqual([
+      'issue', 'list',
+      '--repo', 'Garsson-io/kaizen',
+      '--label', 'auto-dent',
+      '--search', 'batch-260323-1405-5400',
+      '--json', 'url',
+      '--limit', '1',
+    ]);
   });
 });
 
@@ -4907,53 +4926,53 @@ describe('ensureBatchProgressIssue', () => {
   });
 
   it('returns cached progress_issue without calling GitHub', () => {
-    const spy = vi.spyOn(github, 'ghExec');
+    const gh = vi.fn();
     const state = makeBatchState({ progress_issue: 'https://github.com/o/r/issues/42' });
     writeState(stateFile, state);
-    const result = ensureBatchProgressIssue(state, stateFile);
+    const result = ensureBatchProgressIssue(state, stateFile, { gh });
     expect(result).toBe('https://github.com/o/r/issues/42');
-    expect(spy).not.toHaveBeenCalled();
+    expect(gh).not.toHaveBeenCalled();
   });
 
   it('returns empty string when kaizen_repo is empty', () => {
-    const spy = vi.spyOn(github, 'ghExec');
+    const gh = vi.fn();
     const state = makeBatchState({ kaizen_repo: '' });
     writeState(stateFile, state);
-    const result = ensureBatchProgressIssue(state, stateFile);
+    const result = ensureBatchProgressIssue(state, stateFile, { gh });
     expect(result).toBe('');
-    expect(spy).not.toHaveBeenCalled();
+    expect(gh).not.toHaveBeenCalled();
   });
 
   it('reuses existing issue found via search instead of creating duplicate', () => {
     const existingUrl = 'https://github.com/Garsson-io/kaizen/issues/707';
-    const spy = vi.spyOn(github, 'ghExec')
-      .mockReturnValueOnce(JSON.stringify([{ url: existingUrl }]));
+    const gh = vi.fn(() => JSON.stringify([{ url: existingUrl }]));
     const state = makeBatchState({ progress_issue: undefined });
     writeState(stateFile, state);
 
-    const result = ensureBatchProgressIssue(state, stateFile);
+    const result = ensureBatchProgressIssue(state, stateFile, { gh });
 
     expect(result).toBe(existingUrl);
-    expect(spy).toHaveBeenCalledOnce(); // only search, no create
-    expect(spy.mock.calls[0][0]).toContain('issue list');
+    expect(gh).toHaveBeenCalledOnce(); // only search, no create
+    expect(gh.mock.calls[0][0].slice(0, 2)).toEqual(['issue', 'list']);
     const saved = readState(stateFile);
     expect(saved.progress_issue).toBe(existingUrl);
   });
 
   it('creates new issue when search finds nothing', () => {
     const newUrl = 'https://github.com/Garsson-io/kaizen/issues/800';
-    const spy = vi.spyOn(github, 'ghExec')
+    const gh = vi.fn()
       .mockReturnValueOnce('[]')       // search returns empty
       .mockReturnValueOnce(newUrl);     // create returns new URL
     const state = makeBatchState({ progress_issue: undefined });
     writeState(stateFile, state);
 
-    const result = ensureBatchProgressIssue(state, stateFile);
+    const result = ensureBatchProgressIssue(state, stateFile, { gh });
 
     expect(result).toBe(newUrl);
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy.mock.calls[0][0]).toContain('issue list');   // search
-    expect(spy.mock.calls[1][0]).toContain('issue create'); // create
+    expect(gh).toHaveBeenCalledTimes(2);
+    expect(gh.mock.calls[0][0].slice(0, 2)).toEqual(['issue', 'list']);
+    expect(gh.mock.calls[1][0].slice(0, 2)).toEqual(['issue', 'create']);
+    expect(gh.mock.calls[1][0]).toContain('--body');
     const saved = readState(stateFile);
     expect(saved.progress_issue).toBe(newUrl);
   });
@@ -4964,8 +4983,8 @@ describe('updateBatchProgressIssue', () => {
     vi.restoreAllMocks();
   });
 
-  it('posts issue, PR, review, and structured work-cycle artifacts', () => {
-    const spy = vi.spyOn(github, 'ghExec').mockReturnValue('https://github.com/Garsson-io/kaizen/issues/1226#issuecomment-1');
+  it('stores issue, PR, review, and structured work-cycle artifacts in a named attachment', () => {
+    const writeAttachment = vi.fn(() => 'https://github.com/Garsson-io/kaizen/issues/1226#issuecomment-1');
     const result = makeRunResult({
       pickedIssue: '#1225',
       pickedIssueTitle: 'redo CI proof gate',
@@ -5000,12 +5019,13 @@ describe('updateBatchProgressIssue', () => {
       1,
       1205,
       result,
+      { writeAttachment },
     );
 
-    expect(spy).toHaveBeenCalledOnce();
-    const cmd = spy.mock.calls[0][0];
-    expect(cmd).toContain('gh issue comment 1226');
-    const body = JSON.parse(cmd.match(/--body (.+)$/)![1]);
+    expect(writeAttachment).toHaveBeenCalledOnce();
+    expect(writeAttachment.mock.calls[0][0]).toEqual({ kind: 'issue', number: '1226', repo: 'Garsson-io/kaizen' });
+    expect(writeAttachment.mock.calls[0][1]).toBe('progress/run-1');
+    const body = writeAttachment.mock.calls[0][2];
     expect(body).toContain('| **Issue worked** | https://github.com/Garsson-io/kaizen/issues/1225 — redo CI proof gate |');
     expect(body).toContain('| **PR generated** | https://github.com/Garsson-io/kaizen/pull/1227 |');
     expect(body).toContain('| **Review state** | fail (https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2) |');
@@ -5019,6 +5039,22 @@ describe('updateBatchProgressIssue', () => {
     expect(body).toContain('| CLEANUP | not observed | - | - |');
     expect(body.indexOf('| PICK |')).toBeLessThan(body.indexOf('| REVIEW |'));
     expect(body.indexOf('| REVIEW |')).toBeLessThan(body.indexOf('| STOP |'));
+  });
+
+  it('keeps progress writes fail-open when the attachment write fails', () => {
+    const writeAttachment = vi.fn(() => {
+      throw new Error('network failed');
+    });
+
+    expect(() => updateBatchProgressIssue(
+      'https://github.com/Garsson-io/kaizen/issues/1226',
+      'Garsson-io/kaizen',
+      2,
+      0,
+      60,
+      makeRunResult(),
+      { writeAttachment },
+    )).not.toThrow();
   });
 });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2210,14 +2210,57 @@ export function cleanGuidanceForTitle(guidance: string): string {
 
 // Batch progress issue management
 
+type ProgressAttachmentWriter = typeof writeAttachment;
+
+function parseProgressIssueNumber(progressIssue: string): string {
+  return progressIssue.match(/issues\/(\d+)/)?.[1] ?? '';
+}
+
+function progressIssueTarget(progressIssue: string, repo: string): { kind: 'issue'; number: string; repo: string } | null {
+  const number = parseProgressIssueNumber(progressIssue);
+  if (!number || !repo) return null;
+  return { kind: 'issue', number, repo };
+}
+
+function writeProgressAttachment(
+  progressIssue: string,
+  repo: string,
+  name: string,
+  markdown: string,
+  write: ProgressAttachmentWriter = writeAttachment,
+): string {
+  const target = progressIssueTarget(progressIssue, repo);
+  if (!target) return '';
+  try {
+    return write(target, name, markdown);
+  } catch (err) {
+    console.log(`  [hygiene] progress attachment ${name} skipped: ${(err as Error).message}`);
+    return '';
+  }
+}
+
 /**
  * Search GitHub for an existing batch progress issue by batch ID.
  * Returns the issue URL if found, empty string otherwise.
  */
-export function findExistingProgressIssue(batchId: string, kaizenRepo: string): string {
-  const result = ghExec(
-    `gh issue list --repo ${kaizenRepo} --label auto-dent --search ${JSON.stringify(batchId)} --json url --limit 1`,
-  );
+export function findExistingProgressIssue(
+  batchId: string,
+  kaizenRepo: string,
+  runGh: (args: string[]) => string = gh,
+): string {
+  let result = '';
+  try {
+    result = runGh([
+      'issue', 'list',
+      '--repo', kaizenRepo,
+      '--label', 'auto-dent',
+      '--search', batchId,
+      '--json', 'url',
+      '--limit', '1',
+    ]);
+  } catch {
+    return '';
+  }
   if (!result) return '';
   try {
     const issues = JSON.parse(result) as Array<{ url: string }>;
@@ -2231,14 +2274,16 @@ export function findExistingProgressIssue(batchId: string, kaizenRepo: string): 
 export function ensureBatchProgressIssue(
   state: BatchState,
   stateFile: string,
+  deps: { gh?: (args: string[]) => string } = {},
 ): string {
   if (state.progress_issue) return state.progress_issue;
 
   const kaizenRepo = state.kaizen_repo;
   if (!kaizenRepo) return '';
+  const runGh = deps.gh ?? gh;
 
   // Search for an existing progress issue to avoid duplicates (#726)
-  const existing = findExistingProgressIssue(state.batch_id, kaizenRepo);
+  const existing = findExistingProgressIssue(state.batch_id, kaizenRepo, runGh);
   if (existing) {
     console.log(`  [hygiene] found existing batch progress issue: ${existing}`);
     const freshState = readState(stateFile);
@@ -2270,12 +2315,22 @@ export function ensureBatchProgressIssue(
     '',
     '</details>',
     '',
-    '_Run-by-run updates posted as comments. Auto-managed by auto-dent._',
+    '_Run-by-run updates are stored as named kaizen attachments. Auto-managed by auto-dent._',
   ].join('\n');
 
-  const url = ghExec(
-    `gh issue create --repo ${kaizenRepo} --title ${JSON.stringify(title)} --label auto-dent,kaizen --body ${JSON.stringify(body)}`,
-  );
+  let url = '';
+  try {
+    url = runGh([
+      'issue', 'create',
+      '--repo', kaizenRepo,
+      '--title', title,
+      '--label', 'auto-dent,kaizen',
+      '--body', body,
+    ]);
+  } catch (err) {
+    console.log(`  [hygiene] progress issue create skipped: ${(err as Error).message}`);
+    return '';
+  }
 
   if (url) {
     console.log(`  [hygiene] created batch progress issue: ${url}`);
@@ -2294,12 +2349,12 @@ export function updateBatchProgressIssue(
   exitCode: number,
   duration: number,
   result: RunResult,
+  deps: { writeAttachment?: ProgressAttachmentWriter } = {},
 ): void {
   if (!progressIssue || !kaizenRepo) return;
 
-  const m = progressIssue.match(/issues\/(\d+)/);
-  if (!m) return;
-  const issueNum = m[1];
+  const issueNum = parseProgressIssueNumber(progressIssue);
+  if (!issueNum) return;
 
   const score = scoreRunResult(result, exitCode, duration);
   const status = score.success ? 'pass' : exitCode === 0 ? 'no-pr' : `fail (exit ${exitCode})`;
@@ -2341,10 +2396,15 @@ export function updateBatchProgressIssue(
   }
 
   const comment = lines.join('\n');
-  ghExec(
-    `gh issue comment ${issueNum} --repo ${kaizenRepo} --body ${JSON.stringify(comment)}`,
+  const url = writeProgressAttachment(
+    progressIssue,
+    kaizenRepo,
+    `progress/run-${runNum}`,
+    comment,
+    deps.writeAttachment ?? writeAttachment,
   );
-  console.log(`  [hygiene] updated progress issue with run #${runNum}`);
+  if (url) console.log(`  [hygiene] updated progress issue with run #${runNum}: ${url}`);
+  else console.log(`  [hygiene] updated progress issue with run #${runNum}`);
 }
 
 /**
@@ -2367,10 +2427,11 @@ export function closeBatchProgressIssue(
   kaizenRepo: string,
   state: BatchState,
   batchDir?: string,
+  deps: { writeAttachment?: ProgressAttachmentWriter } = {},
 ): void {
   if (!progressIssue || !kaizenRepo) return;
-  const m = progressIssue.match(/issues\/(\d+)/);
-  if (!m) return;
+  const issueNum = parseProgressIssueNumber(progressIssue);
+  if (!issueNum) return;
 
   const elapsed = Math.floor(Date.now() / 1000) - state.batch_start;
   const hours = Math.floor(elapsed / 3600);
@@ -2415,8 +2476,12 @@ export function closeBatchProgressIssue(
     `**Issues closed:** ${formatIssuesClosedLine(reconciledClosed, state.issues_closed)}`,
   ].join('\n');
 
-  ghExec(
-    `gh issue comment ${m[1]} --repo ${kaizenRepo} --body ${JSON.stringify(summary)}`,
+  writeProgressAttachment(
+    progressIssue,
+    kaizenRepo,
+    'progress/batch-complete',
+    summary,
+    deps.writeAttachment ?? writeAttachment,
   );
 
   // Durable cross-batch learning (#1108, #940 Phase 1): write a machine-readable
@@ -2425,8 +2490,8 @@ export function closeBatchProgressIssue(
   // must never block batch close (this runs on abnormal exits too).
   try {
     const outcome = buildBatchOutcome(state, batchScore, Math.floor(Date.now() / 1000));
-    writeBatchOutcomeAttachment(m[1], kaizenRepo, outcome);
-    console.log(`  [intelligence] stored batch-outcome attachment on #${m[1]}`);
+    writeBatchOutcomeAttachment(issueNum, kaizenRepo, outcome);
+    console.log(`  [intelligence] stored batch-outcome attachment on #${issueNum}`);
   } catch (err) {
     console.log(`  [intelligence] batch-outcome write skipped: ${(err as Error).message}`);
   }
@@ -2436,8 +2501,8 @@ export function closeBatchProgressIssue(
   // not just the summary. Best-effort — must never block close (abnormal exits too).
   if (batchDir) {
     try {
-      const url = uploadBatchArtifacts(m[1], kaizenRepo, batchDir, new Date().toISOString());
-      if (url) console.log(`  [intelligence] uploaded raw batch artifacts to #${m[1]}`);
+      const url = uploadBatchArtifacts(issueNum, kaizenRepo, batchDir, new Date().toISOString());
+      if (url) console.log(`  [intelligence] uploaded raw batch artifacts to #${issueNum}`);
       else console.log(`  [intelligence] no raw artifacts on disk to upload`);
     } catch (err) {
       console.log(`  [intelligence] batch-artifacts upload skipped: ${(err as Error).message}`);
@@ -2454,7 +2519,7 @@ export function closeBatchProgressIssue(
     const result = runBacklogHealthMaintenance({
       gh: ghArgs,
       repo: kaizenRepo,
-      progressIssue: m[1],
+      progressIssue: issueNum,
       windowDays,
       log: (msg) => console.log(`  [backlog-health] ${msg}`),
       err: (msg) => console.log(`  [backlog-health] ${msg}`),
@@ -2486,7 +2551,7 @@ export function closeBatchProgressIssue(
       staleDays,
       limit: 100,
       apply,
-      progressIssue: m[1],
+      progressIssue: issueNum,
       log: (msg) => console.log(`  [stale-pr] ${msg}`),
       err: (msg) => console.log(`  [stale-pr] ${msg}`),
     });
@@ -2499,7 +2564,7 @@ export function closeBatchProgressIssue(
     console.log(`  [stale-pr] triage maintenance skipped: ${(err as Error).message}`);
   }
 
-  ghExec(`gh issue close ${m[1]} --repo ${kaizenRepo} --reason completed`);
+  ghExec(`gh issue close ${issueNum} --repo ${kaizenRepo} --reason completed`);
   console.log(`  [hygiene] closed batch progress issue`);
 }
 
@@ -3385,13 +3450,18 @@ export async function runReviewWiring(
               reviewVerdict = 'fail';
               deps.appendLog(`\nreview_fix=fail rounds=${fixState.currentRound} cost=$${fixCost.toFixed(2)} pr=${prUrl}\n`);
               try {
-                const url = deps.ghExec(`gh pr comment ${prUrl} --body ${JSON.stringify(
-                  `## Review Fix Loop: Exhausted\n\n` +
-                  `Ran ${fixState.currentRound} fix round(s) but gaps remain. ` +
-                  `Total review+fix cost: $${reviewCostUsd.toFixed(2)}.\n\n` +
-                  `@aviadr1 needs human review.`
-                )}`);
-                if (url && !reviewUrls.includes(url)) reviewUrls.push(url);
+                const prNum = prUrl.match(/\/pull\/(\d+)/)?.[1] ?? '';
+                if (prNum && input.repo) {
+                  const url = deps.writeAttachment(
+                    { kind: 'pr', number: prNum, repo: input.repo },
+                    'review-fix-loop',
+                    `## Review Fix Loop: Exhausted\n\n` +
+                      `Ran ${fixState.currentRound} fix round(s) but gaps remain. ` +
+                      `Total review+fix cost: $${reviewCostUsd.toFixed(2)}.\n\n` +
+                    `@aviadr1 needs human review.`,
+                  );
+                  if (url && !reviewUrls.includes(url)) reviewUrls.push(url);
+                }
               } catch { /* best effort */ }
             }
           } catch (e: any) {
@@ -4382,9 +4452,7 @@ function postPlan(): void {
   const kaizenRepo = state.kaizen_repo;
   if (!kaizenRepo) return;
 
-  ghExec(
-    `gh issue comment ${progressIssue} --repo ${kaizenRepo} --body ${JSON.stringify(markdown)}`,
-  );
+  writeProgressAttachment(progressIssue, kaizenRepo, 'progress/plan', markdown);
   console.log(`  [plan] Posted plan summary to ${progressIssue}`);
 }
 

--- a/scripts/auto-dent-stream.test.ts
+++ b/scripts/auto-dent-stream.test.ts
@@ -13,7 +13,6 @@ import {
   collapseWhitespace,
   type StreamContext,
 } from './auto-dent-stream.js';
-import * as github from './auto-dent-github.js';
 import { makeRunResult } from './auto-dent-test-helpers.js';
 import { buildKaizenCycleSteps } from './auto-dent-progress.js';
 import { parsePhaseMarkers } from './auto-dent-stream.js';
@@ -44,8 +43,8 @@ describe('postInFlightUpdate', () => {
     expect(postInFlightUpdate('not-a-url', 'owner/repo', 1, Date.now(), result, ctx)).toBe(false);
   });
 
-  it('posts a comment and returns true on success', () => {
-    const ghExecSpy = vi.spyOn(github, 'ghExec').mockReturnValue('ok');
+  it('stores a named in-flight attachment and returns true on success', () => {
+    const writeAttachment = vi.fn(() => 'https://github.com/o/r/issues/42#issuecomment-1');
     const result = makeRunResult({ toolCalls: 5, cost: 1.23 });
     const ctx: StreamContext = {};
 
@@ -56,17 +55,18 @@ describe('postInFlightUpdate', () => {
       Date.now() - 60_000,
       result,
       ctx,
+      writeAttachment,
     );
 
     expect(posted).toBe(true);
-    expect(ghExecSpy).toHaveBeenCalledOnce();
-    const cmd = ghExecSpy.mock.calls[0][0];
-    expect(cmd).toContain('gh issue comment 42');
-    expect(cmd).toContain('--repo owner/repo');
+    expect(writeAttachment).toHaveBeenCalledOnce();
+    expect(writeAttachment.mock.calls[0][0]).toEqual({ kind: 'issue', number: '42', repo: 'owner/repo' });
+    expect(writeAttachment.mock.calls[0][1]).toBe('progress/run-3/in-flight');
+    expect(writeAttachment.mock.calls[0][2]).toContain('Run #3');
   });
 
-  it('returns false when ghExec returns empty string', () => {
-    vi.spyOn(github, 'ghExec').mockReturnValue('');
+  it('returns false when writeAttachment returns empty string', () => {
+    const writeAttachment = vi.fn(() => '');
     const result = makeRunResult();
     const ctx: StreamContext = {};
 
@@ -77,9 +77,30 @@ describe('postInFlightUpdate', () => {
       Date.now(),
       result,
       ctx,
+      writeAttachment,
     );
 
     expect(posted).toBe(false);
+  });
+
+  it('returns false when writeAttachment throws', () => {
+    const writeAttachment = vi.fn(() => {
+      throw new Error('network failed');
+    });
+    const result = makeRunResult();
+    const ctx: StreamContext = {};
+
+    expect(
+      postInFlightUpdate(
+        'https://github.com/o/r/issues/42',
+        'owner/repo',
+        1,
+        Date.now(),
+        result,
+        ctx,
+        writeAttachment,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/scripts/auto-dent-stream.ts
+++ b/scripts/auto-dent-stream.ts
@@ -10,7 +10,6 @@
 
 import type { RunResult } from './auto-dent-run.js';
 import { parseFinalRunClaim } from './auto-dent-final-claim.js';
-import { ghExec } from './auto-dent-github.js';
 import {
   buildKaizenCycleSteps,
   formatIssueForDisplay,
@@ -24,6 +23,7 @@ import {
 } from './auto-dent-display.js';
 import { parseHookOutputs, type HookOutput } from '../src/hooks/lib/gate-signal.js';
 import { parsePhaseMarkers, type PhaseMarker } from '../src/phase-marker.js';
+import { writeAttachment, type AttachmentTarget } from '../src/section-editor.js';
 import type { Provider } from './auto-dent-provider.js';
 import {
   evaluateHookActivation,
@@ -486,17 +486,25 @@ export function postInFlightUpdate(
   runStart: number,
   result: RunResult,
   ctx: StreamContext,
+  write: (target: AttachmentTarget, name: string, content: string) => string = writeAttachment,
 ): boolean {
   if (!progressIssue || !kaizenRepo) return false;
   const m = progressIssue.match(/issues\/(\d+)/);
   if (!m) return false;
 
   const comment = buildInFlightComment(runNum, runStart, result, ctx, kaizenRepo);
-  const out = ghExec(
-    `gh issue comment ${m[1]} --repo ${kaizenRepo} --body ${JSON.stringify(comment)}`,
-  );
-  if (out) {
-    console.log(`  [in-flight] posted progress update for run #${runNum}`);
+  let url = '';
+  try {
+    url = write(
+      { kind: 'issue', number: m[1], repo: kaizenRepo },
+      `progress/run-${runNum}/in-flight`,
+      comment,
+    );
+  } catch {
+    return false;
+  }
+  if (url) {
+    console.log(`  [in-flight] posted progress update for run #${runNum}: ${url}`);
     return true;
   }
   return false;


### PR DESCRIPTION
## Story Spine

Once, auto-dent progress issues mixed durable structured attachments with one-off progress comments. Run summaries, in-flight updates, batch completion summaries, and review-fix exhaustion notices were useful to humans but awkward for machines to query or update.

Every day, the structured-data system already gave us marker-comment attachments for plans, review findings, batch artifacts, transcripts, and batch outcomes.

But one day, #912 called out that auto-dent still had local raw GitHub comment paths in the run/progress loop, so progress issue state could drift into unstructured append-only comments.

Because of that, this PR routes the touched progress issue paths through stable kaizen attachments and moves the touched progress issue search/create calls to argv-based `gh(args)` calls.

Because of that, repeated updates now replace stable marker comments instead of accumulating fresh free-form comments.

Until finally, progress issue consumers have named attachment slots for the current run, in-flight state, batch plan, batch completion, and review-fix exhaustion notices.

## Scope

Closes #912
Parent: #1677
Follow-up: #1689 owns residual non-progress structured observability gaps from the older broad #912 body.
Related: #1643 remains blocked on the compressed run-log transport contract; this PR does not claim to solve durable multi-MB transcript upload.

Attachment contract introduced or completed here:

| Attachment | Target | Producer |
|---|---|---|
| `progress/run-<n>` | progress issue | final per-run summary |
| `progress/run-<n>/in-flight` | progress issue | live in-flight update |
| `progress/plan` | progress issue | `--post-plan` summary |
| `progress/batch-complete` | progress issue | batch finalization summary |
| `review-fix-loop` | PR | exhausted review-fix notice |

## Impact (goal -> before/after -> match)

Goal: make auto-dent progress observability structured enough for future sessions and tools to read without scraping append-only comments.

Before: progress issue updates were posted as `gh issue comment` blobs, and the review-fix exhausted path posted a raw PR comment.

After: the touched paths upsert named marker-comment attachments through `writeAttachment`; the progress issue search/create path uses argv-based `gh(args)` calls; progress writes remain best-effort/fail-open.

Match: focused tests assert the stable attachment names and fail-open behavior, while existing artifact/outcome/replay tests continue to pass. The residual broader work is explicitly split to #1689 instead of being silently claimed here.

## Validation Matrix

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Final run progress is a named attachment | `auto-dent-run.test.ts` asserts `progress/run-1` | `auto-dent-run.test.ts` checks rendered issue/PR/review/work-cycle content | `npm run typecheck` | Review requested | PR body documents contract |
| In-flight progress is idempotent | `auto-dent-stream.test.ts` asserts `progress/run-3/in-flight` | Existing stream rendering tests pass | Focused stream suite passed | Review requested | Future updates replace same marker |
| Batch completion is structured | Structural finalize test asserts `progress/batch-complete` | Batch outcome/artifact tests passed | `git diff --check` passed | Review requested | Existing outcome/artifact attachments unchanged |
| Review-fix exhaustion is structured | `auto-dent-review-wiring.test.ts` asserts `review-fix-loop` | Review wiring suite passed | `npm run typecheck` | Review requested | No raw PR comment needed for this path |

## Verification

- `npm run typecheck`
- `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-stream.test.ts scripts/auto-dent-review-wiring.test.ts --reporter=default`
- `npx vitest run scripts/batch-artifacts-upload.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-events.test.ts --reporter=default`
- `npx vitest run scripts/auto-dent-harness.test.ts -t "bridge:|end-to-end: harness" --reporter=default`
- `git diff --check`

## Kaizen

- Impediment: #912's historical body mixed a PR-sized progress-comment migration with broader non-progress observability work, creating a false-close risk during review.
- Response: kept #1688 scoped to the stored progress/review attachment plan and filed #1689 for the residual non-progress gaps.
- Process learning: broad legacy issues in parent epics should be split before PR creation when the implementation plan narrows them to a slice.
- No additional source follow-up from this PR beyond #1689 and the already-blocked #1643 transport work.