### PR TITLE
Store mode-output fallbacks as structured attachments

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -240,6 +240,16 @@ describe('closeBatchProgressIssue maintenance wiring', () => {
     expect(closeSection).toContain("'progress/batch-complete'");
     expect(closeSection).toContain('writeProgressAttachment');
   });
+
+  it('closes the progress issue with argv-based gh execution', () => {
+    const closeSection = AUTO_DENT_RUN_SOURCE.slice(
+      AUTO_DENT_RUN_SOURCE.indexOf('export function closeBatchProgressIssue'),
+      AUTO_DENT_RUN_SOURCE.indexOf('// Execute Claude'),
+    );
+
+    expect(closeSection).toContain("(deps.gh ?? gh)(['issue', 'close', issueNum");
+    expect(closeSection).toContain('progress issue close skipped');
+  });
 });
 
 describe('buildTemplateVars', () => {
@@ -5074,8 +5084,8 @@ describe('mode-output progress fallback (#702)', () => {
     expect(output).not.toContain('auto-dent metadata');
   });
 
-  it('posts harness-owned explore output to the progress issue', () => {
-    const commands: string[][] = [];
+  it('stores harness-owned explore output as a named attachment', () => {
+    const writeAttachment = vi.fn(() => 'https://github.com/Garsson-io/kaizen/issues/7020#issuecomment-1');
 
     postModeOutputToProgressIssue({
       progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
@@ -5084,23 +5094,21 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 3,
       logFile: '/logs/run-3.log',
       readLog: () => exploreLog,
-      gh: (args) => {
-        commands.push(args);
-        return 'https://github.com/Garsson-io/kaizen/issues/7020#issuecomment-1';
-      },
+      writeAttachment,
       log: () => {},
     });
 
-    expect(commands).toHaveLength(1);
-    expect(commands[0].slice(0, 5)).toEqual(['issue', 'comment', '7020', '--repo', 'Garsson-io/kaizen']);
-    const body = commands[0][commands[0].indexOf('--body') + 1];
+    expect(writeAttachment).toHaveBeenCalledOnce();
+    expect(writeAttachment.mock.calls[0][0]).toEqual({ kind: 'issue', number: '7020', repo: 'Garsson-io/kaizen' });
+    expect(writeAttachment.mock.calls[0][1]).toBe('mode-output/explore/run-3');
+    const body = writeAttachment.mock.calls[0][2];
     expect(body).toContain('### explore run #3 — analysis fallback');
     expect(body).toContain('Candidate analysis');
     expect(body).toContain('File #11 for missing fallback');
   });
 
-  it('posts reflect output from codex final text blocks', () => {
-    const commands: string[][] = [];
+  it('stores reflect output from codex final text blocks', () => {
+    const writeAttachment = vi.fn(() => '');
     const reflectLog = [
       '[provider] codex subscription-cli',
       '--- codex final text ---',
@@ -5118,14 +5126,13 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 4,
       logFile: '/logs/run-4.log',
       readLog: () => reflectLog,
-      gh: (args) => {
-        commands.push(args);
-        return '';
-      },
+      writeAttachment,
       log: () => {},
     });
 
-    const body = commands[0][commands[0].indexOf('--body') + 1];
+    expect(writeAttachment).toHaveBeenCalledOnce();
+    expect(writeAttachment.mock.calls[0][1]).toBe('mode-output/reflect/run-4');
+    const body = writeAttachment.mock.calls[0][2];
     expect(body).toContain('### reflect run #4 — analysis fallback');
     expect(body).toContain('REFLECTION_INSIGHT: progress issue fallback is missing');
     expect(body).toContain('Detailed reflection body.');
@@ -5133,7 +5140,7 @@ describe('mode-output progress fallback (#702)', () => {
   });
 
   it('does not post for exploit mode', () => {
-    const commands: string[][] = [];
+    const writeAttachment = vi.fn();
 
     postModeOutputToProgressIssue({
       progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
@@ -5142,18 +5149,15 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 5,
       logFile: '/logs/run-5.log',
       readLog: () => exploreLog,
-      gh: (args) => {
-        commands.push(args);
-        return '';
-      },
+      writeAttachment,
       log: () => {},
     });
 
-    expect(commands).toHaveLength(0);
+    expect(writeAttachment).not.toHaveBeenCalled();
   });
 
   it('deduplicates contemplate when the agent already posted to the progress issue', () => {
-    const commands: string[][] = [];
+    const writeAttachment = vi.fn();
     const logs: string[] = [];
 
     postModeOutputToProgressIssue({
@@ -5163,19 +5167,16 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 6,
       logFile: '/logs/run-6.log',
       readLog: () => 'Strategic output\nReflection complete (posted to progress issue).',
-      gh: (args) => {
-        commands.push(args);
-        return '';
-      },
+      writeAttachment,
       log: (msg) => logs.push(msg),
     });
 
-    expect(commands).toHaveLength(0);
+    expect(writeAttachment).not.toHaveBeenCalled();
     expect(logs.some((msg) => msg.includes('already posted'))).toBe(true);
   });
 
   it('fails open when the log cannot be read', () => {
-    const commands: string[][] = [];
+    const writeAttachment = vi.fn();
     const logs: string[] = [];
 
     expect(() => postModeOutputToProgressIssue({
@@ -5185,19 +5186,16 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 7,
       logFile: '/logs/missing.log',
       readLog: () => { throw new Error('ENOENT'); },
-      gh: (args) => {
-        commands.push(args);
-        return '';
-      },
+      writeAttachment,
       log: (msg) => logs.push(msg),
     })).not.toThrow();
 
-    expect(commands).toHaveLength(0);
+    expect(writeAttachment).not.toHaveBeenCalled();
     expect(logs.some((msg) => msg.includes('skipped'))).toBe(true);
   });
 
   it('fails open without a progress issue or repository', () => {
-    const commands: string[][] = [];
+    const writeAttachment = vi.fn();
     const logs: string[] = [];
 
     postModeOutputToProgressIssue({
@@ -5207,15 +5205,29 @@ describe('mode-output progress fallback (#702)', () => {
       runNum: 8,
       logFile: '/logs/run-8.log',
       readLog: () => exploreLog,
-      gh: (args) => {
-        commands.push(args);
-        return '';
-      },
+      writeAttachment,
       log: (msg) => logs.push(msg),
     });
 
-    expect(commands).toHaveLength(0);
+    expect(writeAttachment).not.toHaveBeenCalled();
     expect(logs.some((msg) => msg.includes('no progress issue'))).toBe(true);
+  });
+
+  it('fails open when the mode-output attachment write fails', () => {
+    const logs: string[] = [];
+
+    expect(() => postModeOutputToProgressIssue({
+      progressIssue: 'https://github.com/Garsson-io/kaizen/issues/7020',
+      repo: 'Garsson-io/kaizen',
+      mode: 'explore',
+      runNum: 9,
+      logFile: '/logs/run-9.log',
+      readLog: () => exploreLog,
+      writeAttachment: () => { throw new Error('write failed'); },
+      log: (msg) => logs.push(msg),
+    })).not.toThrow();
+
+    expect(logs.some((msg) => msg.includes('write failed'))).toBe(true);
   });
 
   it('wires the fallback immediately after run metadata and before review/metrics updates', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2427,7 +2427,7 @@ export function closeBatchProgressIssue(
   kaizenRepo: string,
   state: BatchState,
   batchDir?: string,
-  deps: { writeAttachment?: ProgressAttachmentWriter } = {},
+  deps: { writeAttachment?: ProgressAttachmentWriter; gh?: (args: string[]) => string } = {},
 ): void {
   if (!progressIssue || !kaizenRepo) return;
   const issueNum = parseProgressIssueNumber(progressIssue);
@@ -2564,8 +2564,12 @@ export function closeBatchProgressIssue(
     console.log(`  [stale-pr] triage maintenance skipped: ${(err as Error).message}`);
   }
 
-  ghExec(`gh issue close ${issueNum} --repo ${kaizenRepo} --reason completed`);
-  console.log(`  [hygiene] closed batch progress issue`);
+  try {
+    (deps.gh ?? gh)(['issue', 'close', issueNum, '--repo', kaizenRepo, '--reason', 'completed']);
+    console.log(`  [hygiene] closed batch progress issue`);
+  } catch (err) {
+    console.log(`  [hygiene] progress issue close skipped: ${(err as Error).message}`);
+  }
 }
 
 // Execute Claude
@@ -3170,7 +3174,7 @@ export function postModeOutputToProgressIssue(input: {
   runNum: number;
   logFile: string;
   readLog?: (path: string) => string;
-  gh?: (args: string[]) => string;
+  writeAttachment?: ProgressAttachmentWriter;
   log?: (msg: string) => void;
 }): void {
   if (!MODE_OUTPUT_FALLBACK_MODES.has(input.mode)) return;
@@ -3214,9 +3218,13 @@ export function postModeOutputToProgressIssue(input: {
     '',
     output,
   ].join('\n');
-  const runGh = input.gh ?? ((args) => gh(args));
+  const write = input.writeAttachment ?? writeAttachment;
   try {
-    const url = runGh(['issue', 'comment', issueNum, '--repo', input.repo, '--body', body]);
+    const url = write(
+      { kind: 'issue', number: issueNum, repo: input.repo },
+      `mode-output/${input.mode}/run-${input.runNum}`,
+      body,
+    );
     log(`  [hygiene] posted ${input.mode} output fallback to progress issue${url ? `: ${url}` : ''}`);
   } catch (err) {
     log(`  [hygiene] ${input.mode} output fallback skipped: ${(err as Error).message}`);


### PR DESCRIPTION
## Story Spine

Once, #1688 moved the main auto-dent progress issue updates to named attachments.

Every day, non-exploit mode fallback output still had to survive when the agent did not post its own analysis.

But one day, #1689 captured that the fallback path was still append-only progress issue output, and the final progress issue close still used the legacy command-string adapter.

Because of that, this PR stores explore/reflect/contemplate fallback output in stable `mode-output/<mode>/run-<n>` attachments.

Because of that, it also moves the final progress issue close operation to injectable argv-based `gh(args)` while keeping the close best-effort.

Until finally, the residual non-progress output path from #912 has the same structured marker-comment contract as the run progress paths.

## Scope

Closes #1689
Parent: #1677
Split from: #912
Related: #690 owns the later human-readable dashboard surface.
Related: #1643 remains blocked on compressed run-log transport.

## Impact (goal -> before/after -> match)

Goal: make residual non-progress auto-dent output queryable/updateable without scraping append-only comments.

Before: `postModeOutputToProgressIssue()` used `gh issue comment` semantics for explore/reflect/contemplate fallback output.

After: fallback output writes named attachments: `mode-output/explore/run-<n>`, `mode-output/reflect/run-<n>`, and `mode-output/contemplate/run-<n>`.

Match: tests assert the attachment target/name/body and preserve all existing skip/fail-open cases.

## Validation Matrix

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Mode fallback output is structured | `auto-dent-run.test.ts` asserts `mode-output/explore/run-3` and `mode-output/reflect/run-4` | Existing extraction tests preserve body content | `npm run typecheck` | Review requested | PR body documents names |
| Fallback remains fail-open | Tests cover missing repo, invalid/read failure, already-posted contemplate, write failure | Existing mode-output wiring test still passes | `git diff --check` passed | Review requested | No new blocking path |
| Progress issue close avoids command strings | Structural close test asserts argv-based `gh(args)` | Finalization area tests still pass | Focused auto-dent suite passed | Review requested | Close remains best-effort |

## Verification

- `npm run typecheck`
- `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-stream.test.ts --reporter=default`
- `npx vitest run scripts/batch-artifacts-upload.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-events.test.ts --reporter=default`
- `npx vitest run scripts/auto-dent-harness.test.ts -t "bridge:|end-to-end: harness" --reporter=default`
- `git diff --check`

## Kaizen

- Impediment: #912's residual scope needed one more narrow PR to remove the non-exploit mode-output append-only comment path.
- Response: kept #1690 limited to mode-output fallback attachments plus the adjacent progress issue close command migration.
- Process learning: when splitting a large observability issue, name the remaining artifact family explicitly (`mode-output/<mode>/run-<n>`) so follow-up agents can find the contract without reading logs.
- Remaining separate scopes: #690 dashboard rendering and #1643 compressed run-log transport.