### PR TITLE
Archive explore candidate novelty

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -586,6 +586,25 @@ describe('candidate task archive', () => {
     });
     expect(result.candidateArchiveEntryId).toBeTruthy();
   });
+
+  it('fails open with a warning when the existing archive is malformed', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-archive-malformed-'));
+    const path = join(tmpDir, 'run-1-candidate-tasks-manifest.json');
+    writeCandidateManifest(path);
+    writeFileSync(candidateTaskArchivePath(tmpDir), '{');
+
+    const result = appendCandidateTaskArchiveEntry(path, '2026-06-29T00:00:00.000Z');
+
+    expect(result).toMatchObject({
+      archivePath: candidateTaskArchivePath(tmpDir),
+      entryCount: 1,
+      backlogFingerprint: 'backlog-fp-1',
+      noveltyScore: 2,
+      warnings: [expect.stringContaining('candidate task archive malformed JSON; starting fresh')],
+    });
+    const archive = JSON.parse(readFileSync(candidateTaskArchivePath(tmpDir), 'utf8'));
+    expect(archive.entries).toHaveLength(1);
+  });
 });
 
 // Reflection feedback loop (#603)

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -31,6 +31,9 @@ import {
   banditExplorationC,
   modeSuccess,
   parseCandidateTaskManifest,
+  appendCandidateTaskArchiveEntry,
+  attachCandidateTaskManifest,
+  candidateTaskArchivePath,
   derivePostMergeVerification,
   deriveRunOutcome,
   buildRunMetrics,
@@ -80,6 +83,44 @@ import { decideAutoMergeSafety } from './auto-dent-merge-policy.js';
 import { projectReplayRuns } from './auto-dent-replay.js';
 
 const AUTO_DENT_RUN_SOURCE = readFileSync(new URL('./auto-dent-run.ts', import.meta.url), 'utf8');
+
+function writeCandidateManifest(path: string, overrides: Record<string, unknown> = {}): void {
+  writeFileSync(path, JSON.stringify({
+    version: 1,
+    runTag: 'batch/run-1',
+    generatedAt: '2026-06-29T00:00:00.000Z',
+    backlog_fingerprint: 'backlog-fp-1',
+    candidates: [
+      {
+        id: 'a',
+        title: 'First',
+        rationale: 'why',
+        refs: ['#1'],
+        suggested_mode: 'exploit',
+        dedup: {
+          query: 'First in:title repo:Garsson-io/kaizen',
+          matches: [],
+          decision: 'file_new',
+          reason: 'No existing issue matched this specific gap',
+        },
+      },
+      {
+        id: 'b',
+        title: 'Second',
+        rationale: 'why',
+        refs: ['#2'],
+        suggested_mode: 'subtract',
+        dedup: {
+          query: 'Second in:title repo:Garsson-io/kaizen',
+          matches: ['#2'],
+          decision: 'comment_existing',
+          reason: 'Existing issue covers the candidate',
+        },
+      },
+    ],
+    ...overrides,
+  }));
+}
 
 describe('buildPrompt', () => {
   it('includes run tag with batch id and run number', () => {
@@ -338,6 +379,7 @@ describe('buildTemplateVars', () => {
     expect(meta.prompt).toContain('Required artifact');
     expect(meta.prompt).toContain(join(tmpDir, 'run-2-candidate-tasks-manifest.json'));
     expect(meta.prompt).toContain('candidate-task manifest');
+    expect(meta.prompt).toContain('backlog_fingerprint');
     expect(meta.prompt).toContain('Search-before-file gate');
     expect(meta.prompt).toContain('gh issue list --search');
     expect(meta.prompt).toContain('comment_existing');
@@ -356,39 +398,7 @@ describe('parseCandidateTaskManifest', () => {
   it('counts candidates from a valid manifest', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-manifest-valid-'));
     const path = join(tmpDir, 'run-1-candidate-tasks-manifest.json');
-    writeFileSync(path, JSON.stringify({
-      version: 1,
-      runTag: 'batch/run-1',
-      generatedAt: '2026-06-29T00:00:00.000Z',
-      candidates: [
-        {
-          id: 'a',
-          title: 'First',
-          rationale: 'why',
-          refs: ['#1'],
-          suggested_mode: 'exploit',
-          dedup: {
-            query: 'First in:title repo:Garsson-io/kaizen',
-            matches: [],
-            decision: 'file_new',
-            reason: 'No existing issue matched this specific gap',
-          },
-        },
-        {
-          id: 'b',
-          title: 'Second',
-          rationale: 'why',
-          refs: ['#2'],
-          suggested_mode: 'subtract',
-          dedup: {
-            query: 'Second in:title repo:Garsson-io/kaizen',
-            matches: ['#2'],
-            decision: 'comment_existing',
-            reason: 'Existing issue covers the candidate',
-          },
-        },
-      ],
-    }));
+    writeCandidateManifest(path);
 
     const parsed = parseCandidateTaskManifest(path);
 
@@ -511,6 +521,70 @@ describe('parseCandidateTaskManifest', () => {
       count: 0,
       warnings: [expect.stringContaining('candidates')],
     });
+  });
+});
+
+describe('candidate task archive', () => {
+  it('appends explore manifests and scores repeated same-fingerprint candidates as zero novelty', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-archive-'));
+    const firstPath = join(tmpDir, 'run-1-candidate-tasks-manifest.json');
+    const secondPath = join(tmpDir, 'run-2-candidate-tasks-manifest.json');
+    writeCandidateManifest(firstPath, { runTag: 'batch/run-1' });
+    writeCandidateManifest(secondPath, { runTag: 'batch/run-2' });
+
+    const first = appendCandidateTaskArchiveEntry(firstPath, '2026-06-29T00:00:00.000Z');
+    const second = appendCandidateTaskArchiveEntry(secondPath, '2026-06-29T00:01:00.000Z');
+
+    expect(first).toMatchObject({
+      archivePath: candidateTaskArchivePath(tmpDir),
+      entryCount: 1,
+      backlogFingerprint: 'backlog-fp-1',
+      noveltyScore: 2,
+      warnings: [],
+    });
+    expect(first.entryId).toBeTruthy();
+    expect(second).toMatchObject({
+      archivePath: candidateTaskArchivePath(tmpDir),
+      entryCount: 2,
+      backlogFingerprint: 'backlog-fp-1',
+      noveltyScore: 0,
+      warnings: [],
+    });
+
+    const archive = JSON.parse(readFileSync(candidateTaskArchivePath(tmpDir), 'utf8'));
+    expect(archive.entries).toHaveLength(2);
+    expect(archive.entries[0]).toMatchObject({
+      run_tag: 'batch/run-1',
+      candidate_keys: ['id:a', 'id:b'],
+      novelty_score: 2,
+    });
+    expect(archive.entries[1]).toMatchObject({
+      run_tag: 'batch/run-2',
+      candidate_keys: ['id:a', 'id:b'],
+      novelty_score: 0,
+    });
+  });
+
+  it('attaches archive metrics to the run result when finalizing a manifest', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'candidate-archive-result-'));
+    const path = join(tmpDir, 'run-1-candidate-tasks-manifest.json');
+    writeCandidateManifest(path);
+    const result = makeRunResult();
+
+    attachCandidateTaskManifest(result, path);
+
+    expect(result).toMatchObject({
+      candidateManifestPath: path,
+      candidateManifestCount: 2,
+      candidateManifestDedupCheckedCount: 2,
+      candidateManifestFileNewCount: 1,
+      candidateArchivePath: candidateTaskArchivePath(tmpDir),
+      candidateArchiveEntryCount: 1,
+      candidateArchiveBacklogFingerprint: 'backlog-fp-1',
+      candidateArchiveNoveltyScore: 2,
+      candidateArchiveWarnings: [],
+    });
+    expect(result.candidateArchiveEntryId).toBeTruthy();
   });
 });
 
@@ -3168,7 +3242,20 @@ describe('modeSuccess', () => {
     expect(modeSuccess('exploit', makeRunMetrics({ prs: [] }))).toBe(0);
   });
 
-  it('explore uses dedup-checked candidate manifests plus capped issues_filed', () => {
+  it('explore uses candidate archive novelty plus capped issues_filed', () => {
+    expect(modeSuccess('explore', makeRunMetrics({
+      issues_filed: [],
+      candidate_manifest_count: 4,
+      candidate_archive_novelty_score: 0,
+    }))).toBe(0);
+    expect(modeSuccess('explore', makeRunMetrics({
+      issues_filed: ['#1', '#2', '#3'],
+      candidate_manifest_count: 4,
+      candidate_archive_novelty_score: 2,
+    }))).toBe(4);
+  });
+
+  it('explore falls back to dedup-checked candidate manifests for older history', () => {
     expect(modeSuccess('explore', makeRunMetrics({ issues_filed: ['#1', '#2', '#3'] }))).toBe(2);
     expect(modeSuccess('explore', makeRunMetrics({ issues_filed: [], candidate_manifest_count: 4 }))).toBe(4);
     expect(modeSuccess('explore', makeRunMetrics({ issues_filed: ['#1'], candidate_manifest_count: 2 }))).toBe(3);
@@ -3428,14 +3515,30 @@ describe('buildRunMetrics', () => {
       result: makeRunResult({
         candidateManifestPath: '/tmp/run-5-candidate-tasks-manifest.json',
         candidateManifestCount: 3,
+        candidateManifestDedupCheckedCount: 2,
+        candidateManifestFileNewCount: 1,
         candidateManifestWarnings: ['warning'],
+        candidateArchivePath: '/tmp/candidate-task-archive.json',
+        candidateArchiveEntryId: 'abc123',
+        candidateArchiveEntryCount: 4,
+        candidateArchiveBacklogFingerprint: 'backlog-fp-1',
+        candidateArchiveNoveltyScore: 0,
+        candidateArchiveWarnings: ['archive warning'],
       }),
     });
 
     expect(metrics).toMatchObject({
       candidate_manifest_path: '/tmp/run-5-candidate-tasks-manifest.json',
       candidate_manifest_count: 3,
+      candidate_manifest_dedup_checked_count: 2,
+      candidate_manifest_file_new_count: 1,
       candidate_manifest_warnings: ['warning'],
+      candidate_archive_path: '/tmp/candidate-task-archive.json',
+      candidate_archive_entry_id: 'abc123',
+      candidate_archive_entry_count: 4,
+      candidate_archive_backlog_fingerprint: 'backlog-fp-1',
+      candidate_archive_novelty_score: 0,
+      candidate_archive_warnings: ['archive warning'],
     });
   });
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -75,7 +75,7 @@ import {
   type ContextDelegationAnalysis,
 } from './auto-dent-context-delegation.js';
 import { truncateAtWordBoundary } from './auto-dent-display.js';
-import { parseJsonObject } from '../src/lib/json-value.js';
+import { parseJsonObject, parseJsonValue } from '../src/lib/json-value.js';
 import { readDurableJsonValueFile, readJsonValueFile, writeDurableJsonValueFile } from '../src/lib/json-file.js';
 import { subscriptionAgentProvider } from '../src/provider-contract.js';
 import { hasHardQualityFailure, type PostMergeVerificationVerdict } from '../src/verdict-binding-policy.js';
@@ -822,8 +822,20 @@ function candidateArchiveBacklogFingerprint(parsedManifest: Record<string, unkno
 }
 
 function readCandidateTaskArchive(path: string): { archive: CandidateTaskArchive; warnings: string[] } {
-  const value = readJsonValueFile(path);
-  if (value === null) return { archive: { version: 1, entries: [] }, warnings: [] };
+  if (!existsSync(path)) return { archive: { version: 1, entries: [] }, warnings: [] };
+
+  let value: unknown;
+  try {
+    value = parseJsonValue(readFileSync(path, 'utf8'));
+  } catch {
+    value = null;
+  }
+  if (value === null) {
+    return {
+      archive: { version: 1, entries: [] },
+      warnings: [`candidate task archive malformed JSON; starting fresh: ${path}`],
+    };
+  }
 
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -323,6 +323,18 @@ export interface RunMetrics {
   candidate_manifest_file_new_count?: number;
   /** Non-fatal candidate manifest parse/read warnings (#1196). */
   candidate_manifest_warnings?: string[];
+  /** Cumulative explore-mode candidate archive path (#1202). */
+  candidate_archive_path?: string;
+  /** Entry id appended to the cumulative candidate archive for this run (#1202). */
+  candidate_archive_entry_id?: string;
+  /** Number of entries in the cumulative candidate archive after this run (#1202). */
+  candidate_archive_entry_count?: number;
+  /** Backlog fingerprint used to compare this manifest with prior explore output (#1202). */
+  candidate_archive_backlog_fingerprint?: string;
+  /** Number of candidate keys not previously seen for the same backlog fingerprint (#1202). */
+  candidate_archive_novelty_score?: number;
+  /** Non-fatal candidate archive read/write warnings (#1202). */
+  candidate_archive_warnings?: string[];
   /** Durable UCB1 decision breakdown used for mode selection (#1178). */
   bandit_decision?: BanditDecisionTelemetry;
   /** Prompt template file name used for this run */
@@ -421,6 +433,18 @@ export interface RunResult {
   candidateManifestFileNewCount?: number;
   /** Non-fatal candidate manifest parse/read warnings (#1196). */
   candidateManifestWarnings?: string[];
+  /** Cumulative explore-mode candidate archive path (#1202). */
+  candidateArchivePath?: string;
+  /** Entry id appended to the cumulative candidate archive for this run (#1202). */
+  candidateArchiveEntryId?: string;
+  /** Number of entries in the cumulative candidate archive after this run (#1202). */
+  candidateArchiveEntryCount?: number;
+  /** Backlog fingerprint used to compare this manifest with prior explore output (#1202). */
+  candidateArchiveBacklogFingerprint?: string;
+  /** Number of candidate keys not previously seen for the same backlog fingerprint (#1202). */
+  candidateArchiveNoveltyScore?: number;
+  /** Non-fatal candidate archive read/write warnings (#1202). */
+  candidateArchiveWarnings?: string[];
   /** Structured failure classification */
   failureClass?: string;
   /** Whether the run was killed by the wall-clock timeout watchdog (#686) */
@@ -465,7 +489,15 @@ type RunMetricsBaseField =
   | 'issues_pruned'
   | 'candidate_manifest_path'
   | 'candidate_manifest_count'
+  | 'candidate_manifest_dedup_checked_count'
+  | 'candidate_manifest_file_new_count'
   | 'candidate_manifest_warnings'
+  | 'candidate_archive_path'
+  | 'candidate_archive_entry_id'
+  | 'candidate_archive_entry_count'
+  | 'candidate_archive_backlog_fingerprint'
+  | 'candidate_archive_novelty_score'
+  | 'candidate_archive_warnings'
   | 'bandit_decision'
   | 'final_claim_status'
   | 'final_claim'
@@ -513,6 +545,12 @@ export function buildRunMetrics(input: BuildRunMetricsInput): RunMetrics {
     candidate_manifest_dedup_checked_count: result.candidateManifestDedupCheckedCount,
     candidate_manifest_file_new_count: result.candidateManifestFileNewCount,
     candidate_manifest_warnings: result.candidateManifestWarnings,
+    candidate_archive_path: result.candidateArchivePath,
+    candidate_archive_entry_id: result.candidateArchiveEntryId,
+    candidate_archive_entry_count: result.candidateArchiveEntryCount,
+    candidate_archive_backlog_fingerprint: result.candidateArchiveBacklogFingerprint,
+    candidate_archive_novelty_score: result.candidateArchiveNoveltyScore,
+    candidate_archive_warnings: result.candidateArchiveWarnings,
     bandit_decision: buildBanditDecisionTelemetry(runMode, modeReason, bandit),
     final_claim_status: result.finalClaimStatus,
     final_claim: result.finalClaim,
@@ -593,8 +631,41 @@ export interface CandidateTaskManifestParseResult {
   warnings: string[];
 }
 
+export interface CandidateTaskArchiveAppendResult {
+  archivePath: string;
+  entryId: string;
+  entryCount: number;
+  backlogFingerprint: string;
+  noveltyScore: number;
+  warnings: string[];
+}
+
+interface CandidateTaskArchiveEntry {
+  id: string;
+  run_tag?: string;
+  generated_at: string;
+  manifest_path: string;
+  backlog_fingerprint: string;
+  candidate_keys: string[];
+  candidate_count: number;
+  dedup_checked_count: number;
+  file_new_count: number;
+  novelty_score: number;
+}
+
+interface CandidateTaskArchive {
+  version: 1;
+  entries: CandidateTaskArchiveEntry[];
+}
+
+export const CANDIDATE_TASK_ARCHIVE_FILE = 'candidate-task-archive.json';
+
 export function candidateTaskManifestPath(logDir: string, runNum: number): string {
   return join(logDir, `run-${runNum}-candidate-tasks-manifest.json`);
+}
+
+export function candidateTaskArchivePath(logDir: string): string {
+  return join(logDir, CANDIDATE_TASK_ARCHIVE_FILE);
 }
 
 export const CANDIDATE_TASK_MANIFEST_SCHEMA = [
@@ -602,6 +673,7 @@ export const CANDIDATE_TASK_MANIFEST_SCHEMA = [
   '  "version": 1,',
   '  "runTag": "<batch-id>/run-<N>",',
   '  "generatedAt": "<ISO timestamp>",',
+  '  "backlog_fingerprint": "<stable fingerprint for the backlog/search state inspected>",',
   '  "candidates": [',
   '    {',
   '      "id": "<stable short id>",',
@@ -688,13 +760,204 @@ export function parseCandidateTaskManifest(path: string): CandidateTaskManifestP
   return { path, count: candidates.length, dedupCheckedCount, fileNewCount, warnings };
 }
 
-function attachCandidateTaskManifest(result: RunResult, path: string): void {
+function stableHash(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value) ?? String(value)).digest('hex').slice(0, 16);
+}
+
+function normalizeCandidateArchiveString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function candidateArchiveKey(candidate: unknown, index: number): string {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return `candidate:${index}:${stableHash(candidate)}`;
+  }
+
+  const raw = candidate as Record<string, unknown>;
+  const id = normalizeCandidateArchiveString(raw.id);
+  if (id) return `id:${id}`;
+
+  const title = normalizeCandidateArchiveString(raw.title);
+  const refs = Array.isArray(raw.refs)
+    ? raw.refs.filter((ref): ref is string => typeof ref === 'string').map((ref) => ref.trim()).filter(Boolean).sort()
+    : [];
+  if (title || refs.length > 0) return `candidate:${stableHash({ title, refs })}`;
+
+  return `candidate:${index}:${stableHash(raw)}`;
+}
+
+function candidateArchiveKeys(parsedManifest: Record<string, unknown>): string[] {
+  const candidates = parsedManifest.candidates;
+  if (!Array.isArray(candidates)) return [];
+  return [...new Set(candidates.map((candidate, index) => candidateArchiveKey(candidate, index)))].sort();
+}
+
+function candidateArchiveBacklogFingerprint(parsedManifest: Record<string, unknown>): { fingerprint: string; warnings: string[] } {
+  const explicit = normalizeCandidateArchiveString(parsedManifest.backlog_fingerprint);
+  if (explicit) return { fingerprint: explicit, warnings: [] };
+
+  const candidates = Array.isArray(parsedManifest.candidates) ? parsedManifest.candidates : [];
+  const fallbackFingerprint = `legacy:${stableHash(candidates.map((candidate, index) => {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      return { index, value: candidate };
+    }
+    const raw = candidate as Record<string, unknown>;
+    const dedup = raw.dedup && typeof raw.dedup === 'object' && !Array.isArray(raw.dedup)
+      ? raw.dedup as Record<string, unknown>
+      : {};
+    return {
+      key: candidateArchiveKey(candidate, index),
+      title: raw.title,
+      refs: raw.refs,
+      query: dedup.query,
+      matches: dedup.matches,
+    };
+  }))}`;
+  return {
+    fingerprint: fallbackFingerprint,
+    warnings: ['candidate task manifest missing backlog_fingerprint; derived legacy fingerprint from manifest content'],
+  };
+}
+
+function readCandidateTaskArchive(path: string): { archive: CandidateTaskArchive; warnings: string[] } {
+  const value = readJsonValueFile(path);
+  if (value === null) return { archive: { version: 1, entries: [] }, warnings: [] };
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {
+      archive: { version: 1, entries: [] },
+      warnings: [`candidate task archive malformed; starting fresh: ${path}`],
+    };
+  }
+
+  const rawEntries = (value as { entries?: unknown }).entries;
+  if (!Array.isArray(rawEntries)) {
+    return {
+      archive: { version: 1, entries: [] },
+      warnings: [`candidate task archive entries must be an array; starting fresh: ${path}`],
+    };
+  }
+
+  const entries: CandidateTaskArchiveEntry[] = [];
+  const warnings: string[] = [];
+  rawEntries.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      warnings.push(`candidate task archive entry[${index}] must be an object: ${path}`);
+      return;
+    }
+    const raw = entry as Record<string, unknown>;
+    const id = normalizeCandidateArchiveString(raw.id);
+    const generatedAt = normalizeCandidateArchiveString(raw.generated_at);
+    const manifestPath = normalizeCandidateArchiveString(raw.manifest_path);
+    const backlogFingerprint = normalizeCandidateArchiveString(raw.backlog_fingerprint);
+    const candidateKeys = Array.isArray(raw.candidate_keys)
+      ? raw.candidate_keys.filter((key): key is string => typeof key === 'string' && key.trim().length > 0)
+      : [];
+    if (!id || !generatedAt || !manifestPath || !backlogFingerprint || candidateKeys.length === 0) {
+      warnings.push(`candidate task archive entry[${index}] missing required fields: ${path}`);
+      return;
+    }
+    entries.push({
+      id,
+      run_tag: normalizeCandidateArchiveString(raw.run_tag) ?? undefined,
+      generated_at: generatedAt,
+      manifest_path: manifestPath,
+      backlog_fingerprint: backlogFingerprint,
+      candidate_keys: [...new Set(candidateKeys)].sort(),
+      candidate_count: typeof raw.candidate_count === 'number' ? raw.candidate_count : candidateKeys.length,
+      dedup_checked_count: typeof raw.dedup_checked_count === 'number' ? raw.dedup_checked_count : 0,
+      file_new_count: typeof raw.file_new_count === 'number' ? raw.file_new_count : 0,
+      novelty_score: typeof raw.novelty_score === 'number' ? raw.novelty_score : 0,
+    });
+  });
+
+  return { archive: { version: 1, entries }, warnings };
+}
+
+export function appendCandidateTaskArchiveEntry(manifestPath: string, nowIso = new Date().toISOString()): CandidateTaskArchiveAppendResult {
+  const archivePath = candidateTaskArchivePath(dirname(manifestPath));
+  const parsed = parseCandidateTaskManifest(manifestPath);
+  const warnings = [...parsed.warnings];
+
+  const manifest = existsSync(manifestPath) ? parseJsonObject(readFileSync(manifestPath, 'utf8')) : null;
+  if (!manifest) {
+    warnings.push(`candidate task archive skipped malformed manifest: ${manifestPath}`);
+    return {
+      archivePath,
+      entryId: '',
+      entryCount: 0,
+      backlogFingerprint: '',
+      noveltyScore: 0,
+      warnings,
+    };
+  }
+
+  const { archive, warnings: archiveWarnings } = readCandidateTaskArchive(archivePath);
+  warnings.push(...archiveWarnings);
+
+  const keys = candidateArchiveKeys(manifest);
+  const fingerprint = candidateArchiveBacklogFingerprint(manifest);
+  warnings.push(...fingerprint.warnings);
+
+  const previousKeys = new Set(
+    archive.entries
+      .filter((entry) => entry.backlog_fingerprint === fingerprint.fingerprint)
+      .flatMap((entry) => entry.candidate_keys),
+  );
+  const noveltyScore = keys.filter((key) => !previousKeys.has(key)).length;
+  const runTag = normalizeCandidateArchiveString(manifest.runTag);
+  const entryId = stableHash({
+    runTag,
+    manifestPath: basename(manifestPath),
+    backlogFingerprint: fingerprint.fingerprint,
+    sequence: archive.entries.length + 1,
+  });
+
+  const entry: CandidateTaskArchiveEntry = {
+    id: entryId,
+    run_tag: runTag ?? undefined,
+    generated_at: nowIso,
+    manifest_path: manifestPath,
+    backlog_fingerprint: fingerprint.fingerprint,
+    candidate_keys: keys,
+    candidate_count: parsed.count,
+    dedup_checked_count: parsed.dedupCheckedCount,
+    file_new_count: parsed.fileNewCount,
+    novelty_score: noveltyScore,
+  };
+  const nextArchive: CandidateTaskArchive = {
+    version: 1,
+    entries: [...archive.entries, entry],
+  };
+  writeDurableJsonValueFile(archivePath, nextArchive, { backup: true });
+
+  return {
+    archivePath,
+    entryId,
+    entryCount: nextArchive.entries.length,
+    backlogFingerprint: fingerprint.fingerprint,
+    noveltyScore,
+    warnings,
+  };
+}
+
+export function attachCandidateTaskManifest(result: RunResult, path: string): void {
   const parsed = parseCandidateTaskManifest(path);
   result.candidateManifestPath = parsed.path;
   result.candidateManifestCount = parsed.count;
   result.candidateManifestDedupCheckedCount = parsed.dedupCheckedCount;
   result.candidateManifestFileNewCount = parsed.fileNewCount;
   result.candidateManifestWarnings = parsed.warnings;
+
+  const archive = appendCandidateTaskArchiveEntry(path);
+  result.candidateArchivePath = archive.archivePath;
+  result.candidateArchiveEntryId = archive.entryId || undefined;
+  result.candidateArchiveEntryCount = archive.entryCount;
+  result.candidateArchiveBacklogFingerprint = archive.backlogFingerprint || undefined;
+  result.candidateArchiveNoveltyScore = archive.noveltyScore;
+  result.candidateArchiveWarnings = archive.warnings;
 }
 
 export interface ManifestForcedTarget {
@@ -1358,7 +1621,7 @@ function learnedSignalMode(
  * Compute mode-appropriate success metric for a run.
  * Each mode has its own definition of "success":
  *   - exploit: PRs produced
- *   - explore: dedup-checked candidate-task entries + capped issues filed (durable scouting)
+ *   - explore: novel candidate-task archive entries + capped issues filed (durable scouting)
  *   - reflect: issues filed (insights that become actionable issues)
  *   - subtract: lines deleted + issues pruned (reduction, not addition)
  *   - contemplate: fixed baseline (strategic value not measurable per-run)
@@ -1368,7 +1631,10 @@ export function modeSuccess(mode: string, metrics: RunMetrics): number {
     case 'exploit':
       return metrics.prs.length;
     case 'explore': {
-      const manifestReward = metrics.candidate_manifest_dedup_checked_count ?? metrics.candidate_manifest_count ?? 0;
+      const manifestReward = metrics.candidate_archive_novelty_score
+        ?? metrics.candidate_manifest_dedup_checked_count
+        ?? metrics.candidate_manifest_count
+        ?? 0;
       return Math.min(metrics.issues_filed.length, 2) + manifestReward;
     }
     case 'reflect':


### PR DESCRIPTION
Closes #1202
Parent: #1677

## Story

Once upon a time, auto-dent explore runs wrote per-run candidate manifests and the scheduler treated each manifest as fresh value. Every day, `modeSuccess('explore')` rewarded current-run manifest count or dedup count, even when the run re-derived the same saturated backlog conclusion.

One day, issue #1202 captured four consecutive explore runs that circled the same backlog state. The missing mechanism was not another per-run manifest; it was a cumulative stepping-stone archive with a backlog fingerprint and a novelty signal.

Because of that, this PR adds `candidate-task-archive.json` beside the existing manifest artifacts. Each finalized manifest appends an archive entry with a backlog fingerprint, stable candidate keys, entry metadata, and `novelty_score` computed against prior entries with the same fingerprint.

Because of that, run results and run metrics now carry archive path, entry id/count, fingerprint, novelty score, and warnings. Explore scoring prefers `candidate_archive_novelty_score` when present, while older run history still falls back to existing candidate manifest rewards.

Until finally, focused tests demonstrate the failure mode directly: the first manifest for a fingerprint scores novelty 2, the repeated same-fingerprint manifest scores novelty 0, and `modeSuccess('explore')` uses that zero instead of raw manifest count.

And ever since, explore mode has a durable signal the bandit can learn from: repeated saturation against unchanged backlog state no longer earns full reward merely because a manifest exists.

## Architecture

```text
explore manifest path
        |
        v
parseCandidateTaskManifest()
        |
        +--> existing per-run candidate_manifest_* metrics
        |
        v
appendCandidateTaskArchiveEntry()
        |
        +--> candidate-task-archive.json
        |      - backlog_fingerprint
        |      - candidate_keys
        |      - novelty_score vs prior same fingerprint
        |
        v
RunResult candidateArchive* fields
        |
        v
RunMetrics candidate_archive_* fields
        |
        v
modeSuccess('explore') prefers archive novelty
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep archive helpers adjacent to existing manifest helpers in `auto-dent-run.ts` | The existing manifest attach path is the finalization choke point that already feeds run metrics. | Adds more code to a large file; avoids a premature module split for a two-file deterministic slice. |
| Use explicit `backlog_fingerprint` when present and a legacy manifest-content hash when absent | New manifests can compare actual backlog state, while older/malformed test fixtures remain fail-open. | Legacy fingerprints are weaker and warning-bearing; they preserve compatibility rather than claiming perfect state identity. |
| Prefer archive novelty in `modeSuccess`, fall back to manifest count/dedup count | New runs stop rewarding repeated manifests; old history still scores as before. | Mixed old/new history will have different reward semantics based on field availability. |
| Preserve manifest-forced target logic | #1202 is about reward/memory, not replacing the separate exploit-forcing consumer. | Later work can make exploit/deepen selection consume the archive more directly. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-run.ts` | Adds archive fields, archive path/helper functions, append/novelty calculation, manifest finalization wiring, prompt schema fingerprint field, and explore scoring preference for novelty. |
| `scripts/auto-dent-run.test.ts` | Adds archive append/repeat tests, result/metrics mapping coverage, prompt fingerprint assertion, and archive-aware explore scoring tests. |

## Test Plan (Behaviors × Levels)

| # | Behavior | Level | Status | Evidence |
|---|---|---|---|---|
| 1 | Preserve existing manifest parsing and warning/count behavior | Unit | tested | `npx vitest run scripts/auto-dent-run.test.ts --reporter=default` |
| 2 | Append first manifest to cumulative archive with fingerprint and metadata | Unit | tested | `candidate task archive` tests |
| 3 | Append repeated same-fingerprint manifest with `novelty_score: 0` | Unit | tested | `candidate task archive` tests |
| 4 | Explore reward prefers archive novelty over raw manifest count | Unit | tested | `modeSuccess` archive novelty test |
| 5 | Manifest finalization attaches archive metrics to result/metrics | Integration | tested | `attachCandidateTaskManifest` and `buildRunMetrics` tests |
| 6 | Existing manifest-forced selection remains intact | Integration | tested | full `scripts/auto-dent-run.test.ts` coverage remains green |
| 7 | Auto-dent pipeline still typechecks and neighboring suites compose | System | tested | typecheck, run/stream, artifact/outcome/replay/event, harness commands below |
| 8 | Real explore prompt asks for backlog fingerprint | Workflow | tested | prompt test asserts `backlog_fingerprint` appears in rendered explore prompt |
| 9 | Live LLM agent deepening behavior | Agentic | deferred | Not in this deterministic PR; future prompt steering can consume the archive signal. |

## Impact (goal -> before/after -> match)

- Goal (#1202): Stop explore from repeatedly getting positive reward for unchanged backlog/manifests.
- Acceptance signal: two explore manifests sharing the same backlog fingerprint produce a second archive entry with novelty 0, and explore scoring uses archive novelty when available.
- BEFORE: `modeSuccess('explore', { issues_filed: [], candidate_manifest_count: 4 }) === 4` even if that manifest repeats an unchanged backlog state.
- AFTER: tests write two same-fingerprint manifests; archive entry 1 has `novelty_score: 2`, archive entry 2 has `novelty_score: 0`, and `modeSuccess('explore')` returns 0 when `candidate_archive_novelty_score: 0` is present.
- Delta: repeated same-fingerprint manifests stop earning manifest-count reward; old run history still falls back to prior scoring fields.
- Goal met?: yes for the durable archive and novelty-scoring slice; prompt-level deepening behavior is intentionally left to later archive consumers.
- Residual scan: related issue search found only #1202 and parent #1677; existing manifest-forced target logic was left intact and covered by the focused test file.

## Validation

- [x] `npx vitest run scripts/auto-dent-run.test.ts --reporter=default` — 416 passed\n- [x] `npm run typecheck`\n- [x] `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-stream.test.ts --reporter=default` — 476 passed\n- [x] `npx vitest run scripts/batch-artifacts-upload.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-events.test.ts --reporter=default` — 84 passed\n- [x] `npx vitest run scripts/auto-dent-harness.test.ts -t "bridge:|end-to-end: harness" --reporter=default` — 13 passed, 216 skipped\n- [x] `git diff --check`

## Known Limitations

This PR creates and scores the cumulative archive. It does not yet teach a later explore run to deepen an existing archived bundle instead of scanning again; the new archive and novelty metrics are the durable signal needed for that follow-up behavior.