### PR TITLE
Add auto-dent progress dashboard header

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -58,6 +58,7 @@ import {
   type PromptMetadata,
   validateRunLifecycle,
   findExistingProgressIssue,
+  formatBatchProgressIssueBody,
   ensureBatchProgressIssue,
   updateBatchProgressIssue,
   extractModeOutput,
@@ -4362,6 +4363,73 @@ describe('formatBatchFooter', () => {
   });
 });
 
+describe('formatBatchProgressIssueBody', () => {
+  it('renders a dashboard header, guidance section, empty scoreboard, and config details', () => {
+    const state = makeBatchState({
+      run: 0,
+      max_runs: 10,
+      progress_issue: undefined,
+      run_history: [],
+    });
+
+    const body = formatBatchProgressIssueBody(state, 1742681100);
+
+    expect(body).toContain('## Auto-Dent Batch: improve hooks reliability');
+    expect(body).toContain('### Guidance');
+    expect(body).toContain('> improve hooks reliability');
+    expect(body).toContain('### Scoreboard');
+    expect(body).toContain('| Runs | 0 of 10 |');
+    expect(body).toContain('| PRs created | 0 |');
+    expect(body).toContain('| Issues filed | 0 |');
+    expect(body).toContain('| Issues closed | 0 |');
+    expect(body).toContain('| Total cost | $0.00 |');
+    expect(body).toContain('| Wall time | 0h 5m |');
+    expect(body).toContain('| Modes used | none yet |');
+    expect(body).toContain('<summary>Batch config</summary>');
+    expect(body).toContain('_Run-by-run updates are stored as named kaizen attachments.');
+  });
+
+  it('keeps multiline guidance out of markdown table cells', () => {
+    const state = makeBatchState({
+      guidance: 'Priority 1: hooks\nPriority 2: tests\r\nPriority 3: docs',
+      run_history: [],
+    });
+
+    const body = formatBatchProgressIssueBody(state, 1742680800);
+
+    expect(body).toContain('> Priority 1: hooks\n> Priority 2: tests\n> Priority 3: docs');
+    expect(body).not.toContain('| **Guidance** |');
+    expect(body).not.toContain('| Priority 1: hooks');
+    expect(body).not.toContain('\\n');
+    expect(body).not.toContain('\\r');
+  });
+
+  it('renders scoreboard data from run history and batch state', () => {
+    const state = makeBatchState({
+      run: 3,
+      max_runs: 5,
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1', 'https://github.com/Garsson-io/kaizen/pull/2'],
+      issues_filed: ['#10', '#11', '#12'],
+      issues_closed: ['#10'],
+      run_history: [
+        makeRunMetrics({ run: 1, mode: 'exploit', cost_usd: 1.25, prs: ['pr1'], issues_filed: ['#10'], issues_closed: [] }),
+        makeRunMetrics({ run: 2, mode: 'explore', cost_usd: 0.5, prs: [], issues_filed: ['#11', '#12'], issues_closed: [] }),
+        makeRunMetrics({ run: 3, mode: 'exploit', cost_usd: 2, prs: ['pr2'], issues_filed: [], issues_closed: ['#10'] }),
+      ],
+    });
+
+    const body = formatBatchProgressIssueBody(state, 1742688000);
+
+    expect(body).toContain('| Runs | 3 of 5 |');
+    expect(body).toContain('| PRs created | 2 |');
+    expect(body).toContain('| Issues filed | 3 |');
+    expect(body).toContain('| Issues closed | 1 |');
+    expect(body).toContain('| Total cost | $3.75 |');
+    expect(body).toContain('| Wall time | 2h 0m |');
+    expect(body).toContain('| Modes used | exploit x2, explore x1 |');
+  });
+});
+
 describe('run state checkpointing', () => {
   it('checkpoints run identity and heartbeat before provider work finishes', () => {
     const dir = mkdtempSync(join(tmpdir(), 'run-checkpoint-start-'));
@@ -5105,6 +5173,11 @@ describe('ensureBatchProgressIssue', () => {
     expect(gh.mock.calls[0][0].slice(0, 2)).toEqual(['issue', 'list']);
     expect(gh.mock.calls[1][0].slice(0, 2)).toEqual(['issue', 'create']);
     expect(gh.mock.calls[1][0]).toContain('--body');
+    const bodyArg = gh.mock.calls[1][0][gh.mock.calls[1][0].indexOf('--body') + 1];
+    expect(bodyArg).toContain('### Scoreboard');
+    expect(bodyArg).toContain('| Runs | 0 of 5 |');
+    expect(bodyArg).toContain('### Guidance');
+    expect(bodyArg).not.toContain('| **Guidance** |');
     const saved = readState(stateFile);
     expect(saved.progress_issue).toBe(newUrl);
   });

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2486,6 +2486,77 @@ export function cleanGuidanceForTitle(guidance: string): string {
     .trim();
 }
 
+function formatGuidanceBlockquote(guidance: string): string[] {
+  const normalized = guidance.replace(/\r\n?/g, '\n').trim();
+  if (!normalized) return ['> _No guidance provided._'];
+  return normalized.split('\n').map((line) => `> ${line.trim() || ' '}`);
+}
+
+function formatProgressIssueModeDistribution(history: RunMetrics[]): string {
+  if (history.length === 0) return 'none yet';
+  const modeDist = computeModeDistribution(history);
+  const rendered = Object.entries(modeDist)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([mode, count]) => `${mode} x${count}`)
+    .join(', ');
+  return rendered || 'none yet';
+}
+
+function formatDurationHoursMinutes(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const mins = Math.floor((safe % 3600) / 60);
+  return `${hours}h ${mins}m`;
+}
+
+export function formatBatchProgressIssueBody(
+  state: BatchState,
+  nowEpoch = Math.floor(Date.now() / 1000),
+): string {
+  const history = state.run_history ?? [];
+  const totalCost = history.reduce((sum, run) => sum + run.cost_usd, 0);
+  const maxRuns = state.max_runs > 0 ? String(state.max_runs) : 'unlimited';
+  const startedAt = new Date(state.batch_start * 1000).toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+  const guidanceTitle = cleanGuidanceForTitle(state.guidance) || state.batch_id;
+
+  return [
+    `## Auto-Dent Batch: ${guidanceTitle}`,
+    '',
+    '### Guidance',
+    '',
+    ...formatGuidanceBlockquote(state.guidance),
+    '',
+    '### Scoreboard',
+    '',
+    '| Metric | Value |',
+    '|--------|-------|',
+    `| Runs | ${state.run} of ${maxRuns} |`,
+    `| PRs created | ${state.prs.length} |`,
+    `| Issues filed | ${state.issues_filed.length} |`,
+    `| Issues closed | ${state.issues_closed.length} |`,
+    `| Total cost | $${totalCost.toFixed(2)} |`,
+    `| Wall time | ${formatDurationHoursMinutes(nowEpoch - state.batch_start)} |`,
+    `| Modes used | ${formatProgressIssueModeDistribution(history)} |`,
+    '',
+    '<details>',
+    '<summary>Batch config</summary>',
+    '',
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| **Batch ID** | \`${state.batch_id}\` |`,
+    `| **Max runs** | ${state.max_runs || 'unlimited'} |`,
+    `| **Budget/run** | ${state.budget ? '$' + state.budget : 'none'} |`,
+    `| **Max budget** | ${state.max_budget ? '$' + state.max_budget : 'none'} |`,
+    `| **Cooldown** | ${state.cooldown}s |`,
+    `| **Max failures** | ${state.max_failures} |`,
+    `| **Started** | ${startedAt} |`,
+    '',
+    '</details>',
+    '',
+    '_Run-by-run updates are stored as named kaizen attachments. Auto-managed by auto-dent._',
+  ].join('\n');
+}
+
 // Batch progress issue management
 
 type ProgressAttachmentWriter = typeof writeAttachment;
@@ -2572,29 +2643,7 @@ export function ensureBatchProgressIssue(
 
   const cleanGuidance = cleanGuidanceForTitle(state.guidance);
   const title = `[Auto-Dent] ${truncateAtWordBoundary(cleanGuidance, 70)} (${state.batch_id})`;
-  const startedAt = new Date(state.batch_start * 1000).toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
-  const body = [
-    `## Auto-Dent Batch`,
-    '',
-    `> **Guidance:** ${state.guidance}`,
-    '',
-    '<details>',
-    '<summary>Batch config</summary>',
-    '',
-    `| Field | Value |`,
-    `|-------|-------|`,
-    `| **Batch ID** | \`${state.batch_id}\` |`,
-    `| **Max runs** | ${state.max_runs || 'unlimited'} |`,
-    `| **Budget/run** | ${state.budget ? '$' + state.budget : 'none'} |`,
-    `| **Max budget** | ${state.max_budget ? '$' + state.max_budget : 'none'} |`,
-    `| **Cooldown** | ${state.cooldown}s |`,
-    `| **Max failures** | ${state.max_failures} |`,
-    `| **Started** | ${startedAt} |`,
-    '',
-    '</details>',
-    '',
-    '_Run-by-run updates are stored as named kaizen attachments. Auto-managed by auto-dent._',
-  ].join('\n');
+  const body = formatBatchProgressIssueBody(state);
 
   let url = '';
   try {


### PR DESCRIPTION
Closes #1692
Parent: #690
Parent epic: #1677

## Story

Once upon a time, every auto-dent batch created a GitHub progress issue as the durable morning-after artifact for unattended work. Every day, that issue body opened with a plain heading, inline guidance text, and a hidden config table, while the actual useful run data lived elsewhere as structured attachments.

One day, #690 was decomposed because the full dashboard redesign was too broad for one PR. The first child, #1692, asked for the initial progress issue body to become a readable dashboard header and scoreboard without touching per-run narratives or final retrospectives.

Because of that, this PR extracts `formatBatchProgressIssueBody(state, nowEpoch)` and wires `ensureBatchProgressIssue()` through it. The body now renders a guidance section, a scoreboard, batch config details, and the existing named-attachment note.

Because of that, multiline guidance is rendered as blockquote lines instead of table cells, and scoreboard values come from existing `BatchState` / `run_history` data rather than a parallel dashboard model.

Until finally, the focused tests show the create path passes a body with `### Guidance` and `### Scoreboard` to `gh issue create`, while duplicate detection and `progress_issue` persistence remain unchanged.

And ever since, a newly created auto-dent progress issue starts as a scannable dashboard shell that later #690 children can enrich with per-run narratives, final retrospectives, and PR/issue lookup data.

## Architecture

```text
BatchState
   |
   v
formatBatchProgressIssueBody(state, nowEpoch)
   |-- guidance blockquote
   |-- scoreboard from state/run_history
   |-- batch config details
   |-- named attachment note
   v
ensureBatchProgressIssue()
   |-- existing duplicate search
   |-- gh issue create --body <dashboard body>
   |-- existing state.progress_issue persistence
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Extract `formatBatchProgressIssueBody` | Makes the markdown body testable without GitHub I/O and gives later #690 children a stable formatter seam. | Adds one exported helper in `auto-dent-run.ts`. |
| Render guidance as blockquote lines | Prevents the original #690 table-cell rendering failure class, especially for multiline guidance. | Long guidance remains visible in the issue body rather than hidden in config details. |
| Use current `BatchState` and `run_history` directly | Avoids a second dashboard model that could drift from the machine-readable attachments. | The initial scoreboard can only show fields already known at creation time. |
| Leave per-run and final retrospective renderers untouched | Keeps #1692 scope-matched; #1693 and #1694 own those child scopes. | #690 is not fully closed by this PR. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-run.ts` | Adds the dashboard body formatter and wires progress issue creation through it. |
| `scripts/auto-dent-run.test.ts` | Adds formatter and create-path tests for scoreboard, guidance rendering, run history values, and wiring. |

## Test Plan (Behaviors x Levels)

| # | Behavior | Level | Status | Evidence |
|---|---|---|---|---|
| 1 | Format a new progress issue body with title/header, guidance prose, scoreboard, config details, and attachment note | Unit | tested | `formatBatchProgressIssueBody` tests |
| 2 | Keep guidance out of markdown table cells, including multiline guidance | Unit | tested | multiline guidance test |
| 3 | Scoreboard renders sane empty-state values before any run history exists | Unit | tested | empty scoreboard test |
| 4 | Scoreboard reflects existing `BatchState`/`run_history` data when present | Unit | tested | run-history scoreboard test |
| 5 | `ensureBatchProgressIssue()` passes the formatted body to `gh issue create` and still persists `progress_issue` | Integration | tested | create-path test with fake `gh(args)` |
| 6 | Existing duplicate progress issue detection returns the existing URL without creating a new issue | Integration | tested | existing duplicate detection test remains green |
| 7 | No per-run narrative or final retrospective behavior is changed by this child | Scope | tested | diff only touches initial body formatter/create wiring; run/stream tests remain green |

## Impact (goal -> before/after -> match)

- Goal (#1692): make a newly created progress issue immediately scannable as a dashboard header.
- Acceptance signal: focused tests call `ensureBatchProgressIssue()` with a fake `gh(args)` and assert the created body contains dashboard/header/scoreboard sections and keeps guidance out of markdown table cells.
- BEFORE: the body had `## Auto-Dent Batch`, inline `> **Guidance:** ...`, config details, and an attachment note, but no scoreboard section or current run/PR/issue/cost/mode summary.
- AFTER: rendered body includes `### Guidance`, `### Scoreboard`, run/PR/issue/cost/wall-time/mode rows, config details, and the existing attachment note.
- Delta: new progress issues start as a readable dashboard shell instead of a bare config wrapper.
- Goal met?: yes for #1692. Parent #690 remains open for #1693-#1695.
- Residual scan: related sweep found #690/#1677 only; per-run narratives and batch retrospective remain explicitly out of scope and tracked by #1693/#1694.

## Rendered Sample

```markdown
## Auto-Dent Batch: improve hooks reliability

### Guidance

> improve hooks reliability

### Scoreboard

| Metric | Value |
|--------|-------|
| Runs | 2 of 5 |
| PRs created | 1 |
| Issues filed | 1 |
| Issues closed | 0 |
| Total cost | $1.25 |
| Wall time | 1h 0m |
| Modes used | exploit x1 |
```

## Validation

- [x] `npx vitest run scripts/auto-dent-run.test.ts -t "formatBatchProgressIssueBody|ensureBatchProgressIssue" --reporter=default` — 7 passed
- [x] `npm run typecheck`
- [x] `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-stream.test.ts --reporter=default` — 479 passed
- [x] `npx vitest run scripts/batch-artifacts-upload.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-events.test.ts --reporter=default` — 84 passed
- [x] `npx vitest run scripts/auto-dent-harness.test.ts -t "bridge:|end-to-end: harness" --reporter=default` — 13 passed, 216 skipped
- [x] `git diff --check`
- [x] Rendered sample inspected with `npx tsx -e ... formatBatchProgressIssueBody(...)`

## Known Limitations

This is the first #690 child. It does not redesign `progress/run-<n>` attachments (#1693), `progress/batch-complete` retrospectives (#1694), or guidance completion / PR-issue enrichment (#1695).
