### PR TITLE
Render auto-dent run progress narrative

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -59,6 +59,7 @@ import {
   validateRunLifecycle,
   findExistingProgressIssue,
   formatBatchProgressIssueBody,
+  formatRunProgressAttachment,
   ensureBatchProgressIssue,
   updateBatchProgressIssue,
   extractModeOutput,
@@ -5188,6 +5189,83 @@ describe('updateBatchProgressIssue', () => {
     vi.restoreAllMocks();
   });
 
+  describe('formatRunProgressAttachment', () => {
+    it('renders a readable narrative from structured run data', () => {
+      const body = formatRunProgressAttachment({
+        runNum: 3,
+        exitCode: 0,
+        duration: 3661,
+        mode: 'exploit',
+        kaizenRepo: 'Garsson-io/kaizen',
+        result: makeRunResult({
+          pickedIssue: '#1225',
+          pickedIssueTitle: 'redo CI proof gate',
+          prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+          reviewVerdict: 'pass',
+          reviewUrls: ['https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2'],
+          issuesFiled: ['#1300'],
+          issuesClosed: ['#1225'],
+          cases: ['case/260629-k1225-redo-ci-proof'],
+          cost: 1.25,
+          toolCalls: 42,
+          progressSteps: [
+            {
+              phase: 'PICK',
+              state: 'selected',
+              detail: '#1225 — redo CI proof gate',
+              url: 'https://github.com/Garsson-io/kaizen/issues/1225',
+            },
+            {
+              phase: 'REVIEW',
+              state: 'pass',
+              detail: 'round 1 passed',
+              url: 'https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2',
+            },
+          ],
+        }),
+      });
+
+      expect(body).toContain('### Run #3 - pass');
+      expect(body).toContain('exploit mode completed with PR https://github.com/Garsson-io/kaizen/pull/1227');
+      expect(body).toContain('### Outcome');
+      expect(body).toContain('- **Issue:** https://github.com/Garsson-io/kaizen/issues/1225 — redo CI proof gate');
+      expect(body).toContain('- **PR:** https://github.com/Garsson-io/kaizen/pull/1227');
+      expect(body).toContain('- **Review:** pass (https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2)');
+      expect(body).toContain('- **Issues filed:** #1300');
+      expect(body).toContain('- **Issues closed:** #1225');
+      expect(body).toContain('- **Cases:** `case/260629-k1225-redo-ci-proof`');
+      expect(body).toContain('### Run Metrics');
+      expect(body).toContain('| Duration | 61m 1s |');
+      expect(body).toContain('| Cost | $1.25 |');
+      expect(body).toContain('| Tool calls | 42 |');
+      expect(body).toContain('### Work Cycle');
+      expect(body).toContain('#### Kaizen Work Cycle');
+      expect(body).toContain('| REVIEW | pass | round 1 passed | https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2 |');
+      expect(body).not.toContain('| **Issue worked** |');
+    });
+
+    it('renders no-pr and stop-requested runs without losing stop evidence', () => {
+      const body = formatRunProgressAttachment({
+        runNum: 4,
+        exitCode: 0,
+        duration: 75,
+        kaizenRepo: 'Garsson-io/kaizen',
+        result: makeRunResult({
+          stopRequested: true,
+          stopReason: 'budget exhausted',
+          cost: 0.50,
+          toolCalls: 8,
+        }),
+      });
+
+      expect(body).toContain('### Run #4 - no-pr');
+      expect(body).toContain('completed without a PR');
+      expect(body).toContain('- **Issue:** unknown');
+      expect(body).toContain('- **STOP requested:** budget exhausted');
+      expect(body).toContain('| Duration | 1m 15s |');
+    });
+  });
+
   it('stores issue, PR, review, and structured work-cycle artifacts in a named attachment', () => {
     const writeAttachment = vi.fn(() => 'https://github.com/Garsson-io/kaizen/issues/1226#issuecomment-1');
     const result = makeRunResult({
@@ -5231,9 +5309,12 @@ describe('updateBatchProgressIssue', () => {
     expect(writeAttachment.mock.calls[0][0]).toEqual({ kind: 'issue', number: '1226', repo: 'Garsson-io/kaizen' });
     expect(writeAttachment.mock.calls[0][1]).toBe('progress/run-1');
     const body = writeAttachment.mock.calls[0][2];
-    expect(body).toContain('| **Issue worked** | https://github.com/Garsson-io/kaizen/issues/1225 — redo CI proof gate |');
-    expect(body).toContain('| **PR generated** | https://github.com/Garsson-io/kaizen/pull/1227 |');
-    expect(body).toContain('| **Review state** | fail (https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2) |');
+    expect(body).toContain('### Run #1 - fail (exit 1)');
+    expect(body).toContain('### Outcome');
+    expect(body).toContain('- **Issue:** https://github.com/Garsson-io/kaizen/issues/1225 — redo CI proof gate');
+    expect(body).toContain('- **PR:** https://github.com/Garsson-io/kaizen/pull/1227');
+    expect(body).toContain('- **Review:** fail (https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2)');
+    expect(body).not.toContain('| **Issue worked** |');
     expect(body).toContain('#### Kaizen Work Cycle');
     expect(body).toContain('| PLAN | not observed | - | - |');
     expect(body).toContain('| CASE | not observed | - | - |');

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -2669,6 +2669,84 @@ export function ensureBatchProgressIssue(
   return '';
 }
 
+export interface FormatRunProgressAttachmentInput {
+  runNum: number;
+  exitCode: number;
+  duration: number;
+  result: RunResult;
+  kaizenRepo: string;
+  mode?: string;
+}
+
+function formatRunDuration(seconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  const mins = Math.floor(safeSeconds / 60);
+  const secs = safeSeconds % 60;
+  return `${mins}m ${secs}s`;
+}
+
+function formatRunProgressStatus(score: ReturnType<typeof scoreRunResult>, exitCode: number): string {
+  if (score.success) return 'pass';
+  return exitCode === 0 ? 'no-pr' : `fail (exit ${exitCode})`;
+}
+
+function formatRunNarrativeSummary(mode: string, status: string, prs: string[]): string {
+  const prText = prs.length > 0 ? `with PR ${prs.join(', ')}` : 'without a PR';
+  if (status === 'pass') return `${mode} mode completed ${prText}.`;
+  if (status === 'no-pr') return `${mode} mode completed ${prText}.`;
+  return `${mode} mode ended as ${status} ${prText}.`;
+}
+
+export function formatRunProgressAttachment(input: FormatRunProgressAttachmentInput): string {
+  const { runNum, exitCode, duration, result, kaizenRepo } = input;
+  const mode = input.mode ?? 'exploit';
+  const score = scoreRunResult(result, exitCode, duration);
+  const status = formatRunProgressStatus(score, exitCode);
+  const lines = [
+    `### Run #${runNum} - ${status}`,
+    '',
+    formatRunNarrativeSummary(mode, status, result.prs),
+    '',
+    `> ${formatRunScoreLine(score)}`,
+    '',
+    '### Outcome',
+    '',
+    `- **Issue:** ${formatIssueForDisplay(result.pickedIssue, kaizenRepo, result.pickedIssueTitle)}`,
+    `- **PR:** ${result.prs.length > 0 ? result.prs.join(', ') : 'none'}`,
+    `- **Review:** ${formatReviewForDisplay(result)}`,
+  ];
+
+  if (result.issuesFiled.length > 0) {
+    lines.push(`- **Issues filed:** ${result.issuesFiled.join(', ')}`);
+  }
+  if (result.issuesClosed.length > 0) {
+    lines.push(`- **Issues closed:** ${result.issuesClosed.join(' ')}`);
+  }
+  if (result.cases.length > 0) {
+    lines.push(`- **Cases:** ${result.cases.map((c) => '`' + c + '`').join(', ')}`);
+  }
+  if (result.stopRequested) {
+    lines.push(`- **STOP requested:** ${result.stopReason || 'requested'}`);
+  }
+
+  lines.push(
+    '',
+    '### Run Metrics',
+    '',
+    '| Metric | Value |',
+    '|--------|-------|',
+    `| Duration | ${formatRunDuration(duration)} |`,
+    `| Cost | $${result.cost.toFixed(2)} |`,
+    `| Tool calls | ${result.toolCalls} |`,
+    '',
+    '### Work Cycle',
+    '',
+    formatProgressStepsMarkdown(result, kaizenRepo),
+  );
+
+  return lines.join('\n');
+}
+
 export function updateBatchProgressIssue(
   progressIssue: string,
   kaizenRepo: string,
@@ -2683,46 +2761,13 @@ export function updateBatchProgressIssue(
   const issueNum = parseProgressIssueNumber(progressIssue);
   if (!issueNum) return;
 
-  const score = scoreRunResult(result, exitCode, duration);
-  const status = score.success ? 'pass' : exitCode === 0 ? 'no-pr' : `fail (exit ${exitCode})`;
-  const mins = Math.floor(duration / 60);
-  const secs = duration % 60;
-
-  const lines = [
-    `### Run #${runNum} — ${status}`,
-    '',
-    `> ${formatRunScoreLine(score)}`,
-    '',
-    `| Metric | Value |`,
-    `|--------|-------|`,
-    `| **Duration** | ${mins}m ${secs}s |`,
-    `| **Cost** | $${result.cost.toFixed(2)} |`,
-    `| **Tool calls** | ${result.toolCalls} |`,
-    `| **Issue worked** | ${formatIssueForDisplay(result.pickedIssue, kaizenRepo, result.pickedIssueTitle)} |`,
-    `| **PR generated** | ${result.prs.length > 0 ? result.prs.join(', ') : 'none'} |`,
-    `| **Review state** | ${formatReviewForDisplay(result)} |`,
-  ];
-
-  if (result.issuesFiled.length > 0) {
-    lines.push(`| **Issues filed** | ${result.issuesFiled.join(', ')} |`);
-  }
-  if (result.issuesClosed.length > 0) {
-    lines.push(`| **Issues closed** | ${result.issuesClosed.join(' ')} |`);
-  }
-  if (result.cases.length > 0) {
-    lines.push(
-      `| **Cases** | ${result.cases.map((c) => '`' + c + '`').join(', ')} |`,
-    );
-  }
-  if (result.stopRequested) {
-    lines.push('', `**STOP requested:** ${result.stopReason}`);
-  }
-  const stepsTable = formatProgressStepsMarkdown(result, kaizenRepo);
-  if (stepsTable) {
-    lines.push('', stepsTable);
-  }
-
-  const comment = lines.join('\n');
+  const comment = formatRunProgressAttachment({
+    runNum,
+    exitCode,
+    duration,
+    result,
+    kaizenRepo,
+  });
   const url = writeProgressAttachment(
     progressIssue,
     kaizenRepo,


### PR DESCRIPTION
Closes #1693
Parent: #690
Parent epic: #1677

## Story

Auto-dent already posted `progress/run-<n>` attachments, but each run read like a dense metrics table. Operators could find the facts, but they had to scan rows to infer the story of the run.

This PR turns the per-run attachment into a readable narrative over the same structured data: status, summary, outcome bullets, run metrics, and the existing work-cycle evidence.

## What Changed

| File | Change |
|---|---|
| `scripts/auto-dent-run.ts` | Adds exported `formatRunProgressAttachment()` and small status/duration helpers; routes `updateBatchProgressIssue()` through the formatter while preserving the same `progress/run-${runNum}` attachment path and fail-open wrapper. |
| `scripts/auto-dent-run.test.ts` | Adds formatter coverage for PR-producing and no-PR/STOP runs, and updates the integration assertion for the named attachment body. |

## Impact (goal -> before/after -> match)

Goal: make each `progress/run-<n>` attachment immediately readable as a run narrative while keeping the structured attachment contract stable.

Before: the body began with a run heading and score line, then a table containing issue, PR, review, metrics, and optional fields.

After: the body starts with a one-line summary, then grouped sections:

```markdown
### Run #3 - pass

exploit mode completed with PR https://github.com/Garsson-io/kaizen/pull/1227.

> pass | exploit | $1.25 | 42 tools | 1 PRs | 3661s | 0.80 PR/$ | review:pass

### Outcome

- **Issue:** https://github.com/Garsson-io/kaizen/issues/1225 — redo CI proof gate
- **PR:** https://github.com/Garsson-io/kaizen/pull/1227
- **Review:** pass (https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2)
- **Issues filed:** #1300
- **Issues closed:** #1225
- **Cases:** `case/260629-k1225-redo-ci-proof`

### Run Metrics

| Metric | Value |
|--------|-------|
| Duration | 61m 1s |
| Cost | $1.25 |
| Tool calls | 42 |

### Work Cycle
```

Match: the PR changes only per-run progress attachment rendering. It does not touch the initial progress issue body (#1692), final retrospective (#1694), guidance enrichment (#1695), or mode-output fallback attachment paths.

## Validation

| Behavior | Level | Evidence |
|---|---|---|
| Formatter renders readable per-run narrative | Unit | `npx vitest run scripts/auto-dent-run.test.ts -t "formatRunProgressAttachment|updateBatchProgressIssue" --reporter=default` -> 4 passed |
| Existing auto-dent run/stream behavior remains green | Integration | `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-stream.test.ts --reporter=default` -> 481 passed |
| Adjacent artifact/outcome/replay/event contracts remain green | Integration | `npx vitest run scripts/batch-artifacts-upload.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-events.test.ts --reporter=default` -> 84 passed |
| TypeScript types remain valid | Static | `npm run typecheck` -> passed |
| Patch has no whitespace errors | Static | `git diff --check` -> passed |
| Meet-reality rendered output inspected | Manual | `npx tsx -e "import { formatRunProgressAttachment } ..."` rendered the sample shown above |

## Known Limits

- This PR formats only the per-run named attachment. Batch closing retrospective remains #1694.
- Cumulative dashboard guidance/enrichment remains #1695.