### PR TITLE
Render auto-dent batch completion retrospective

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -60,6 +60,7 @@ import {
   findExistingProgressIssue,
   formatBatchProgressIssueBody,
   formatRunProgressAttachment,
+  formatBatchCompletionAttachment,
   ensureBatchProgressIssue,
   updateBatchProgressIssue,
   extractModeOutput,
@@ -83,6 +84,7 @@ import type { ProviderCapability } from './auto-dent-provider.js';
 import { makeBatchState, makeRunResult } from './auto-dent-test-utils.js';
 import { decideAutoMergeSafety } from './auto-dent-merge-policy.js';
 import { projectReplayRuns } from './auto-dent-replay.js';
+import { postHocScoreBatch, scoreBatch } from './auto-dent-score.js';
 
 const AUTO_DENT_RUN_SOURCE = readFileSync(new URL('./auto-dent-run.ts', import.meta.url), 'utf8');
 
@@ -253,6 +255,116 @@ describe('buildPrompt', () => {
 });
 
 describe('closeBatchProgressIssue maintenance wiring', () => {
+  describe('formatBatchCompletionAttachment', () => {
+    it('renders a final retrospective from structured batch state and score data', () => {
+      const state = makeBatchState({
+        batch_id: 'batch-260629-demo',
+        batch_start: 1742680800,
+        run: 3,
+        max_runs: 5,
+        guidance: 'improve auto-dent observability',
+        prs: [
+          'https://github.com/Garsson-io/kaizen/pull/1227',
+          'https://github.com/Garsson-io/kaizen/pull/1228',
+        ],
+        issues_filed: ['#1300'],
+        issues_closed: ['#1225'],
+        stop_reason: 'budget exhausted',
+        run_history: [
+          makeRunMetrics({
+            run: 1,
+            mode: 'exploit',
+            prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+            issues_closed: ['#1225'],
+            cost_usd: 1.25,
+            duration_seconds: 120,
+          }),
+          makeRunMetrics({
+            run: 2,
+            mode: 'explore',
+            issues_filed: ['#1300'],
+            exit_code: 0,
+            cost_usd: 0.75,
+            duration_seconds: 90,
+          }),
+          makeRunMetrics({
+            run: 3,
+            mode: 'exploit',
+            prs: ['https://github.com/Garsson-io/kaizen/pull/1228'],
+            exit_code: 1,
+            cost_usd: 2.00,
+            duration_seconds: 60,
+          }),
+        ],
+      });
+      const batchScore = scoreBatch(state.run_history || []);
+      batchScore.reconciled_issues_closed = 2;
+      batchScore.post_hoc = postHocScoreBatch([
+        { url: 'https://github.com/Garsson-io/kaizen/pull/1227', status: 'merged' },
+        { url: 'https://github.com/Garsson-io/kaizen/pull/1228', status: 'open' },
+      ], batchScore.total_cost_usd);
+
+      const body = formatBatchCompletionAttachment({
+        state,
+        batchScore,
+        wallTimeSeconds: 3661,
+        reconciledClosed: ['#1225', '#1226'],
+        progressIssueNumber: '1226',
+        kaizenRepo: 'Garsson-io/kaizen',
+        batchDir: '/tmp/auto-dent/batch-260629-demo',
+      });
+
+      expect(body).toContain('### Batch Complete: improve auto-dent observability');
+      expect(body).toContain('### Final Scorecard');
+      expect(body).toContain('| **Runs** | 3 (1 successful) |');
+      expect(body).toContain('| **Issues closed** | 2 |');
+      expect(body).toContain('### Batch Activity');
+      expect(body).toContain('- **Runs:** 3 of 5');
+      expect(body).toContain('- **Wall time:** 1h 1m');
+      expect(body).toContain('- **Stop reason:** budget exhausted');
+      expect(body).toContain('- **PRs:** https://github.com/Garsson-io/kaizen/pull/1227, https://github.com/Garsson-io/kaizen/pull/1228');
+      expect(body).toContain('- **Issues filed:** #1300');
+      expect(body).toContain('- **Issues closed:** #1225 #1226');
+      expect(body).toContain('### Modes And Failures');
+      expect(body).toContain('- **Modes:** exploit x2, explore x1');
+      expect(body).toContain('- **Failures:** crash:1');
+      expect(body).toContain('### Merge Audit');
+      expect(body).toContain('- **Merged PRs:** 1/2');
+      expect(body).toContain('### Durable Attachments');
+      expect(body).toContain('- **Machine outcome:** `batch-outcome` on #1226');
+      expect(body).toContain('- **Raw artifacts:** `batch-artifacts` on #1226');
+      expect(body).not.toContain('\n**PRs:**');
+    });
+
+    it('renders empty-state defaults without batch artifacts', () => {
+      const state = makeBatchState({
+        run: 0,
+        max_runs: 0,
+        prs: [],
+        issues_filed: [],
+        issues_closed: [],
+        run_history: [],
+        stop_reason: '',
+      });
+
+      const body = formatBatchCompletionAttachment({
+        state,
+        batchScore: scoreBatch([]),
+        wallTimeSeconds: 30,
+        reconciledClosed: null,
+        progressIssueNumber: '1226',
+        kaizenRepo: 'Garsson-io/kaizen',
+      });
+
+      expect(body).toContain('### Batch Complete: improve hooks reliability');
+      expect(body).toContain('- **Runs:** 0 of unlimited');
+      expect(body).toContain('- **PRs:** none');
+      expect(body).toContain('- **Issues filed:** none');
+      expect(body).toContain('- **Issues closed:** none');
+      expect(body).toContain('- **Raw artifacts:** not uploaded for this close path');
+    });
+  });
+
   it('runs backlog-health maintenance during batch finalize', () => {
     const closeSection = AUTO_DENT_RUN_SOURCE.slice(
       AUTO_DENT_RUN_SOURCE.indexOf('export function closeBatchProgressIssue'),
@@ -280,6 +392,17 @@ describe('closeBatchProgressIssue maintenance wiring', () => {
       AUTO_DENT_RUN_SOURCE.indexOf('// Execute Claude'),
     );
 
+    expect(closeSection).toContain("'progress/batch-complete'");
+    expect(closeSection).toContain('writeProgressAttachment');
+  });
+
+  it('wires the formatted batch completion retrospective to the stable attachment key', () => {
+    const closeSection = AUTO_DENT_RUN_SOURCE.slice(
+      AUTO_DENT_RUN_SOURCE.indexOf('export function closeBatchProgressIssue'),
+      AUTO_DENT_RUN_SOURCE.indexOf('// Execute Claude'),
+    );
+
+    expect(closeSection).toContain('formatBatchCompletionAttachment({');
     expect(closeSection).toContain("'progress/batch-complete'");
     expect(closeSection).toContain('writeProgressAttachment');
   });

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -25,7 +25,7 @@ import { createHash } from 'crypto';
 import { readFileSync, writeFileSync, appendFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { createInterface } from 'readline';
 import { basename, dirname, join, resolve } from 'path';
-import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, formatIssuesClosedLine, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution } from './auto-dent-score.js';
+import { scoreRunResult, scoreBatch, formatRunScoreLine, formatBatchScoreTable, formatIssuesClosedLine, postHocScoreBatch, formatPostHocLine, detectCostAnomaly, classifyFailure, failureClassLabel, formatFailureDistribution, type BatchScore } from './auto-dent-score.js';
 import { firstHookReason } from './hook-signals.js';
 import { claimNextItem, markItem, resetAssignedItems, readPlan, themeProgress } from './auto-dent-plan.js';
 import { writeAttachment, addSection } from '../src/section-editor.js';
@@ -2794,6 +2794,94 @@ export function runPostHocScoring(
   return postHocScoreBatch(prStatuses, totalCostUsd);
 }
 
+export interface FormatBatchCompletionAttachmentInput {
+  state: BatchState;
+  batchScore: BatchScore;
+  wallTimeSeconds: number;
+  reconciledClosed: string[] | null;
+  progressIssueNumber: string;
+  kaizenRepo: string;
+  batchDir?: string;
+}
+
+function formatRunLimit(state: BatchState): string {
+  return state.max_runs > 0 ? String(state.max_runs) : 'unlimited';
+}
+
+function formatModeDistributionLine(history: RunMetrics[]): string {
+  if (history.length === 0) return 'none';
+  const rendered = Object.entries(computeModeDistribution(history))
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([mode, count]) => `${mode} x${count}`)
+    .join(', ');
+  return rendered || 'none';
+}
+
+export function formatBatchCompletionAttachment(input: FormatBatchCompletionAttachmentInput): string {
+  const {
+    state,
+    batchScore,
+    wallTimeSeconds,
+    reconciledClosed,
+    progressIssueNumber,
+    batchDir,
+  } = input;
+  const history = state.run_history ?? [];
+  const failures = formatFailureDistribution(
+    batchScore.runs
+      .map((run) => run.failure_class)
+      .filter((failureClass) => failureClass !== 'success'),
+  );
+  const postHoc = batchScore.post_hoc;
+  const guidanceTitle = cleanGuidanceForTitle(state.guidance) || state.batch_id;
+
+  const lines = [
+    `### Batch Complete: ${guidanceTitle}`,
+    '',
+    '### Final Scorecard',
+    '',
+    formatBatchScoreTable(batchScore),
+    '',
+    '### Batch Activity',
+    '',
+    `- **Runs:** ${state.run} of ${formatRunLimit(state)}`,
+    `- **Wall time:** ${formatDurationHoursMinutes(wallTimeSeconds)}`,
+    `- **Stop reason:** ${state.stop_reason || 'completed'}`,
+    `- **PRs:** ${state.prs.length > 0 ? state.prs.join(', ') : 'none'}`,
+    `- **Issues filed:** ${state.issues_filed.length > 0 ? state.issues_filed.join(', ') : 'none'}`,
+    `- **Issues closed:** ${formatIssuesClosedLine(reconciledClosed, state.issues_closed)}`,
+    '',
+    '### Modes And Failures',
+    '',
+    `- **Modes:** ${formatModeDistributionLine(history)}`,
+    `- **Failures:** ${failures || 'none'}`,
+    '',
+    '### Merge Audit',
+    '',
+  ];
+
+  if (postHoc) {
+    lines.push(
+      `- **Merged PRs:** ${postHoc.merged_count}/${postHoc.prs.length}`,
+      `- **Pending PRs:** ${postHoc.pending_count}`,
+      `- **Closed PRs:** ${postHoc.closed_count}`,
+      `- **Effective efficiency:** ${postHoc.effective_efficiency.toFixed(2)} merged/$`,
+    );
+  } else {
+    lines.push('- **Merged PRs:** not checked');
+  }
+
+  lines.push(
+    '',
+    '### Durable Attachments',
+    '',
+    `- **Machine outcome:** \`batch-outcome\` on #${progressIssueNumber}`,
+    `- **Raw artifacts:** ${batchDir ? `\`batch-artifacts\` on #${progressIssueNumber}` : 'not uploaded for this close path'}`,
+  );
+
+  return lines.join('\n');
+}
+
 export function closeBatchProgressIssue(
   progressIssue: string,
   kaizenRepo: string,
@@ -2806,8 +2894,6 @@ export function closeBatchProgressIssue(
   if (!issueNum) return;
 
   const elapsed = Math.floor(Date.now() / 1000) - state.batch_start;
-  const hours = Math.floor(elapsed / 3600);
-  const mins = Math.floor((elapsed % 3600) / 60);
 
   const batchScore = scoreBatch(state.run_history || []);
 
@@ -2836,17 +2922,15 @@ export function closeBatchProgressIssue(
     console.log(`  [post-hoc] ${formatPostHocLine(postHoc)}`);
   }
 
-  const summary = [
-    `### Batch Complete`,
-    '',
-    formatBatchScoreTable(batchScore),
-    `| **Wall time** | ${hours}h ${mins}m |`,
-    `| **Stop reason** | ${state.stop_reason || 'completed'} |`,
-    '',
-    `**PRs:** ${state.prs.length > 0 ? state.prs.join(', ') : 'none'}`,
-    `**Issues filed:** ${state.issues_filed.length > 0 ? state.issues_filed.join(', ') : 'none'}`,
-    `**Issues closed:** ${formatIssuesClosedLine(reconciledClosed, state.issues_closed)}`,
-  ].join('\n');
+  const summary = formatBatchCompletionAttachment({
+    state,
+    batchScore,
+    wallTimeSeconds: elapsed,
+    reconciledClosed,
+    progressIssueNumber: issueNum,
+    kaizenRepo,
+    batchDir,
+  });
 
   writeProgressAttachment(
     progressIssue,


### PR DESCRIPTION
Closes #1694
Parent: #690
Parent epic: #1677

## Story

Auto-dent already writes a final `progress/batch-complete` attachment, but it was table-first and terse. It included useful facts, but not a retrospective shape a human can quickly scan at the end of a batch.

This PR keeps the same named attachment and machine-readable siblings, while turning the human-facing close attachment into a grouped batch retrospective.

## What Changed

| File | Change |
|---|---|
| `scripts/auto-dent-run.ts` | Adds exported `formatBatchCompletionAttachment()` plus small mode/run-limit helpers; routes `closeBatchProgressIssue()` through the formatter after reconciliation and post-hoc scoring are computed. |
| `scripts/auto-dent-run.test.ts` | Adds focused formatter coverage for representative and empty-state batch closes, and structural wiring coverage that preserves `progress/batch-complete` without invoking live close maintenance. |

## Impact (goal -> before/after -> match)

Goal: make the final `progress/batch-complete` attachment read as a batch retrospective while preserving structured cloud contracts.

Before: the close attachment started with `### Batch Complete`, a score table, wall time/stop reason rows, then ungrouped PR/issues lines.

After: the attachment is grouped:

```markdown
### Batch Complete: improve auto-dent observability

### Final Scorecard

| Metric | Value |
|--------|-------|
| **Runs** | 2 (1 successful) |
| **Success rate** | 50% |
| **Total cost** | $2.00 |
| **Total PRs** | 1 |
| **Issues closed** | 1 |

### Batch Activity

- **Runs:** 3 of 5
- **Wall time:** 1h 1m
- **Stop reason:** budget exhausted
- **PRs:** https://github.com/Garsson-io/kaizen/pull/1227
- **Issues filed:** #1300
- **Issues closed:** #1225

### Modes And Failures

- **Modes:** exploit x1, explore x1
- **Failures:** none

### Merge Audit

- **Merged PRs:** 1/1

### Durable Attachments

- **Machine outcome:** `batch-outcome` on #1226
- **Raw artifacts:** `batch-artifacts` on #1226
```

Match: this PR only changes the human-readable `progress/batch-complete` rendering and tests. It does not change the `batch-outcome` schema, `batch-artifacts` upload, initial progress body (#1692), per-run narrative (#1693), or guidance completion (#1695).

## Validation

| Behavior | Level | Evidence |
|---|---|---|
| Final retrospective formatter and close-path wiring | Unit/structural | `npx vitest run scripts/auto-dent-run.test.ts -t "formatBatchCompletionAttachment|closeBatchProgressIssue" --reporter=default` -> 7 passed |
| Existing auto-dent run/stream behavior remains green | Integration | `npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-stream.test.ts --reporter=default` -> 484 passed |
| Machine-readable siblings remain green | Integration | `npx vitest run scripts/batch-artifacts-upload.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-events.test.ts --reporter=default` -> 84 passed |
| TypeScript types remain valid | Static | `npm run typecheck` -> passed |
| Patch has no whitespace errors | Static | `git diff --check` -> passed |
| Meet-reality rendered output inspected | Manual | `npx tsx -e "import { formatBatchCompletionAttachment } ..."` rendered the sample summarized above |

## Notes

A RED test initially called `closeBatchProgressIssue()` directly and triggered live maintenance comments on #1226. I deleted those comments and filed #1699. The final test avoids the live side-effect path and uses pure formatter coverage plus structural wiring coverage.

## Known Limits

- This PR does not implement #1695's guidance completion/enrichment matrix.
- It preserves existing `formatBatchScoreTable()` output inside the scorecard, including per-mode table details when present.