### PR TITLE
Enrich auto-dent dashboard artifacts

### DIFF
--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -61,6 +61,9 @@ import {
   formatBatchProgressIssueBody,
   formatRunProgressAttachment,
   formatBatchCompletionAttachment,
+  extractGuidancePriorities,
+  formatGuidanceCompletionMatrix,
+  fetchDashboardEnrichment,
   ensureBatchProgressIssue,
   updateBatchProgressIssue,
   extractModeOutput,
@@ -362,6 +365,60 @@ describe('closeBatchProgressIssue maintenance wiring', () => {
       expect(body).toContain('- **Issues filed:** none');
       expect(body).toContain('- **Issues closed:** none');
       expect(body).toContain('- **Raw artifacts:** not uploaded for this close path');
+    });
+
+    it('renders enriched PR and issue summaries plus guidance completion', () => {
+      const state = makeBatchState({
+        guidance: '- Improve hook reliability\n- Surface PR titles',
+        run: 1,
+        prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+        issues_filed: ['#1300'],
+        issues_closed: ['#1225'],
+        run_history: [
+          makeRunMetrics({
+            run: 1,
+            mode: 'exploit',
+            prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+            issues_filed: ['#1300'],
+            issues_closed: ['#1225'],
+          }),
+        ],
+      });
+
+      const body = formatBatchCompletionAttachment({
+        state,
+        batchScore: scoreBatch(state.run_history || []),
+        wallTimeSeconds: 120,
+        reconciledClosed: ['#1225'],
+        progressIssueNumber: '1226',
+        kaizenRepo: 'Garsson-io/kaizen',
+        enrichment: {
+          prs: {
+            'https://github.com/Garsson-io/kaizen/pull/1227': {
+              ref: 'https://github.com/Garsson-io/kaizen/pull/1227',
+              title: 'Improve hook reliability',
+              state: 'MERGED',
+            },
+          },
+          issues: {
+            '#1225': {
+              ref: '#1225',
+              title: 'Hook reliability issue',
+              state: 'CLOSED',
+            },
+            '#1300': {
+              ref: '#1300',
+              title: 'Dashboard follow-up',
+              state: 'OPEN',
+            },
+          },
+        },
+      });
+
+      expect(body).toContain('https://github.com/Garsson-io/kaizen/pull/1227 — Improve hook reliability (MERGED)');
+      expect(body).toContain('https://github.com/Garsson-io/kaizen/issues/1300 — Dashboard follow-up (OPEN)');
+      expect(body).toContain('https://github.com/Garsson-io/kaizen/issues/1225 — Hook reliability issue (CLOSED)');
+      expect(body).toContain('| Improve hook reliability | observed | https://github.com/Garsson-io/kaizen/pull/1227 — Improve hook reliability (MERGED) |');
     });
   });
 
@@ -4552,6 +4609,135 @@ describe('formatBatchProgressIssueBody', () => {
     expect(body).toContain('| Wall time | 2h 0m |');
     expect(body).toContain('| Modes used | exploit x2, explore x1 |');
   });
+
+  it('renders enriched work artifacts when lookup data is available', () => {
+    const state = makeBatchState({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+      issues_filed: ['#1300'],
+      issues_closed: ['#1225'],
+    });
+
+    const body = formatBatchProgressIssueBody(state, 1742688000, {
+      prs: {
+        'https://github.com/Garsson-io/kaizen/pull/1227': {
+          ref: 'https://github.com/Garsson-io/kaizen/pull/1227',
+          title: 'Dashboard guidance renderer',
+          state: 'MERGED',
+        },
+      },
+      issues: {
+        '#1300': {
+          ref: '#1300',
+          title: 'Dashboard follow-up',
+          state: 'OPEN',
+        },
+        '#1225': {
+          ref: '#1225',
+          title: 'Hook reliability issue',
+          state: 'CLOSED',
+        },
+      },
+    });
+
+    expect(body).toContain('### Work Artifacts');
+    expect(body).toContain('- **PRs:** https://github.com/Garsson-io/kaizen/pull/1227 — Dashboard guidance renderer (MERGED)');
+    expect(body).toContain('- **Issues filed:** https://github.com/Garsson-io/kaizen/issues/1300 — Dashboard follow-up (OPEN)');
+    expect(body).toContain('- **Issues closed:** https://github.com/Garsson-io/kaizen/issues/1225 — Hook reliability issue (CLOSED)');
+  });
+});
+
+describe('dashboard guidance and enrichment helpers', () => {
+  it('extracts readable guidance priorities from multiline bullets', () => {
+    expect(extractGuidancePriorities([
+      '- Improve hook reliability',
+      '* Surface PR titles in dashboards',
+      '3. Keep GitHub failures fail-open',
+      '',
+    ].join('\n'))).toEqual([
+      'Improve hook reliability',
+      'Surface PR titles in dashboards',
+      'Keep GitHub failures fail-open',
+    ]);
+  });
+
+  it('renders guidance completion evidence against observed titles', () => {
+    const matrix = formatGuidanceCompletionMatrix(
+      '- Improve hook reliability\n- Add stale dashboard magic\n- Escape a\\\\b | markdown',
+      [
+        'PR #1227 Improve hook reliability (MERGED)',
+        'Issue #1300 Dashboard follow-up (OPEN)',
+        'Escape a\\\\b | markdown evidence',
+      ],
+    );
+
+    expect(matrix).toContain('### Guidance Completion');
+    expect(matrix).toContain('| Improve hook reliability | observed | PR #1227 Improve hook reliability (MERGED) |');
+    expect(matrix).toContain('| Add stale dashboard magic | not observed | - |');
+    expect(matrix).toContain('| Escape a\\\\\\\\b \\| markdown | observed | Escape a\\\\\\\\b \\| markdown evidence |');
+  });
+
+  it('fetches PR and issue enrichment with argv gh calls', () => {
+    const calls: string[][] = [];
+    const gh = vi.fn((args: string[]) => {
+      calls.push(args);
+      if (args[0] === 'pr') {
+        return JSON.stringify({
+          title: 'Dashboard guidance renderer',
+          state: 'MERGED',
+          url: 'https://github.com/Garsson-io/kaizen/pull/1227',
+        });
+      }
+      return JSON.stringify({
+        title: 'Hook reliability issue',
+        state: 'CLOSED',
+        url: 'https://github.com/Garsson-io/kaizen/issues/1225',
+      });
+    });
+    const state = makeBatchState({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+      issues_closed: ['#1225'],
+      run_history: [
+        makeRunMetrics({
+          prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+          issues_closed: ['#1225'],
+        }),
+      ],
+    });
+
+    const enrichment = fetchDashboardEnrichment(state, 'Garsson-io/kaizen', gh);
+
+    expect(enrichment.prs?.['https://github.com/Garsson-io/kaizen/pull/1227']).toMatchObject({
+      title: 'Dashboard guidance renderer',
+      state: 'MERGED',
+    });
+    expect(enrichment.issues?.['#1225']).toMatchObject({
+      title: 'Hook reliability issue',
+      state: 'CLOSED',
+    });
+    expect(calls).toContainEqual([
+      'pr', 'view', '1227',
+      '--repo', 'Garsson-io/kaizen',
+      '--json', 'title,state,url',
+    ]);
+    expect(calls).toContainEqual([
+      'issue', 'view', '1225',
+      '--repo', 'Garsson-io/kaizen',
+      '--json', 'title,state,url',
+    ]);
+  });
+
+  it('keeps enrichment fail-open when GitHub lookup fails', () => {
+    const state = makeBatchState({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+      issues_filed: ['#1300'],
+    });
+
+    const enrichment = fetchDashboardEnrichment(state, 'Garsson-io/kaizen', () => {
+      throw new Error('offline');
+    });
+
+    expect(enrichment).toEqual({ prs: {}, issues: {} });
+  });
 });
 
 describe('run state checkpointing', () => {
@@ -5365,6 +5551,41 @@ describe('updateBatchProgressIssue', () => {
       expect(body).toContain('#### Kaizen Work Cycle');
       expect(body).toContain('| REVIEW | pass | round 1 passed | https://github.com/Garsson-io/kaizen/pull/1227#issuecomment-2 |');
       expect(body).not.toContain('| **Issue worked** |');
+    });
+
+    it('renders enriched issue and PR labels when lookup data is available', () => {
+      const body = formatRunProgressAttachment({
+        runNum: 3,
+        exitCode: 0,
+        duration: 3661,
+        mode: 'exploit',
+        kaizenRepo: 'Garsson-io/kaizen',
+        enrichment: {
+          prs: {
+            'https://github.com/Garsson-io/kaizen/pull/1227': {
+              ref: 'https://github.com/Garsson-io/kaizen/pull/1227',
+              title: 'Dashboard guidance renderer',
+              state: 'MERGED',
+            },
+          },
+          issues: {
+            '#1225': {
+              ref: '#1225',
+              title: 'Hook reliability issue',
+              state: 'CLOSED',
+            },
+          },
+        },
+        result: makeRunResult({
+          pickedIssue: '#1225',
+          prs: ['https://github.com/Garsson-io/kaizen/pull/1227'],
+          cost: 1.25,
+          toolCalls: 42,
+        }),
+      });
+
+      expect(body).toContain('- **Issue:** https://github.com/Garsson-io/kaizen/issues/1225 — Hook reliability issue (CLOSED)');
+      expect(body).toContain('- **PR:** https://github.com/Garsson-io/kaizen/pull/1227 — Dashboard guidance renderer (MERGED)');
     });
 
     it('renders no-pr and stop-requested runs without losing stop evidence', () => {

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -81,6 +81,7 @@ import { subscriptionAgentProvider } from '../src/provider-contract.js';
 import { hasHardQualityFailure, type PostMergeVerificationVerdict } from '../src/verdict-binding-policy.js';
 import { extractPlanText } from '../src/structured-data.js';
 import { gh } from '../src/lib/gh-exec.js';
+import { parseGithubIssueUrl, parseGithubPrUrl, parseIssueNumber } from '../src/lib/github-pr.js';
 
 // Re-export from extracted modules for backward compatibility
 export {
@@ -2492,6 +2493,230 @@ function formatGuidanceBlockquote(guidance: string): string[] {
   return normalized.split('\n').map((line) => `> ${line.trim() || ' '}`);
 }
 
+export interface DashboardLinkedItemSummary {
+  ref: string;
+  title?: string;
+  state?: string;
+  url?: string;
+}
+
+export interface DashboardEnrichment {
+  prs: Record<string, DashboardLinkedItemSummary>;
+  issues: Record<string, DashboardLinkedItemSummary>;
+}
+
+export type DashboardGhRunner = (args: string[]) => string;
+
+export function extractGuidancePriorities(guidance: string): string[] {
+  const normalized = guidance.replace(/\r\n?/g, '\n').trim();
+  if (!normalized) return [];
+
+  const bulletPriorities = normalized
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s+/, '').replace(/^\d+[.)]\s+/, '').trim())
+    .filter(Boolean);
+
+  if (bulletPriorities.length > 1) return bulletPriorities;
+
+  return normalized
+    .split(/[.;\n]+/)
+    .map((part) => part.replace(/^[-*]\s+/, '').replace(/^\d+[.)]\s+/, '').trim())
+    .filter(Boolean);
+}
+
+function guidanceTokens(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= 4);
+}
+
+function markdownTableCell(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\r?\n/g, ' ').replace(/\|/g, '\\|').trim();
+}
+
+export function formatGuidanceCompletionMatrix(guidance: string, evidence: string[]): string {
+  const priorities = extractGuidancePriorities(guidance);
+  if (priorities.length === 0) return '';
+
+  const evidenceRows = evidence.map((item) => item.trim()).filter(Boolean);
+  const lines = [
+    '### Guidance Completion',
+    '',
+    '| Priority | Status | Evidence |',
+    '|----------|--------|----------|',
+  ];
+
+  for (const priority of priorities) {
+    const tokens = guidanceTokens(priority);
+    const matched = evidenceRows.find((item) => {
+      const lower = item.toLowerCase();
+      const matchCount = tokens.filter((token) => lower.includes(token)).length;
+      return tokens.length > 0 && matchCount >= Math.min(2, tokens.length);
+    });
+    lines.push(`| ${markdownTableCell(priority)} | ${matched ? 'observed' : 'not observed'} | ${matched ? markdownTableCell(matched) : '-'} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function dashboardEmptyEnrichment(): DashboardEnrichment {
+  return { prs: {}, issues: {} };
+}
+
+function collectUnique(values: Array<string | undefined | null>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of values) {
+    const value = raw?.trim();
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function parseDashboardPrRef(ref: string, fallbackRepo: string): { repo: string; number: number; url: string } | null {
+  const parsedUrl = parseGithubPrUrl(ref);
+  if (parsedUrl) return { ...parsedUrl, url: ref };
+
+  const match = ref.match(/(?:^|[^\d])(\d+)(?:$|[^\d])/);
+  if (!match || !fallbackRepo) return null;
+  const number = Number(match[1]);
+  if (!Number.isInteger(number) || number <= 0) return null;
+  return { repo: fallbackRepo, number, url: `https://github.com/${fallbackRepo}/pull/${number}` };
+}
+
+function parseDashboardIssueRef(ref: string, fallbackRepo: string): { repo: string; number: number; url: string } | null {
+  const parsedUrl = parseGithubIssueUrl(ref);
+  if (parsedUrl) return { ...parsedUrl, url: ref };
+
+  const number = parseIssueNumber(ref);
+  if (!number || !fallbackRepo) return null;
+  return { repo: fallbackRepo, number, url: `https://github.com/${fallbackRepo}/issues/${number}` };
+}
+
+function parseDashboardSummary(output: string): { title?: string; state?: string; url?: string } | null {
+  const parsed = parseJsonObject(output);
+  if (!parsed) return null;
+  const title = typeof parsed.title === 'string' && parsed.title.trim() ? parsed.title.trim() : undefined;
+  const state = typeof parsed.state === 'string' && parsed.state.trim() ? parsed.state.trim() : undefined;
+  const url = typeof parsed.url === 'string' && parsed.url.trim() ? parsed.url.trim() : undefined;
+  if (!title && !state && !url) return null;
+  return { title, state, url };
+}
+
+function collectDashboardPrRefs(state: BatchState): string[] {
+  const history = state.run_history ?? [];
+  return collectUnique([
+    ...state.prs,
+    ...(state.rescue_prs ?? []),
+    state.last_pr,
+    ...history.flatMap((run) => run.prs),
+  ]);
+}
+
+function collectDashboardIssueRefs(state: BatchState): string[] {
+  const history = state.run_history ?? [];
+  return collectUnique([
+    ...state.issues_filed,
+    ...state.issues_closed,
+    state.last_issue,
+    ...history.flatMap((run) => [...run.issues_filed, ...run.issues_closed]),
+  ]);
+}
+
+export function fetchDashboardEnrichment(
+  state: BatchState,
+  repo: string,
+  runGh: DashboardGhRunner = ghArgs,
+): DashboardEnrichment {
+  const enrichment = dashboardEmptyEnrichment();
+
+  for (const ref of collectDashboardPrRefs(state)) {
+    const parsed = parseDashboardPrRef(ref, repo);
+    if (!parsed) continue;
+    try {
+      const summary = parseDashboardSummary(runGh([
+        'pr', 'view', String(parsed.number),
+        '--repo', parsed.repo,
+        '--json', 'title,state,url',
+      ]));
+      if (summary) {
+        enrichment.prs[ref] = { ref, url: summary.url ?? parsed.url, title: summary.title, state: summary.state };
+      }
+    } catch {
+      // Best-effort enrichment only. Dashboard rendering must survive gh failures.
+    }
+  }
+
+  for (const ref of collectDashboardIssueRefs(state)) {
+    const parsed = parseDashboardIssueRef(ref, repo);
+    if (!parsed) continue;
+    try {
+      const summary = parseDashboardSummary(runGh([
+        'issue', 'view', String(parsed.number),
+        '--repo', parsed.repo,
+        '--json', 'title,state,url',
+      ]));
+      if (summary) {
+        enrichment.issues[ref] = { ref, url: summary.url ?? parsed.url, title: summary.title, state: summary.state };
+      }
+    } catch {
+      // Best-effort enrichment only. Dashboard rendering must survive gh failures.
+    }
+  }
+
+  return enrichment;
+}
+
+function dashboardPrEvidence(prs: string[], enrichment?: DashboardEnrichment): string[] {
+  return prs.map((pr) => formatPrForDashboard(pr, enrichment));
+}
+
+function dashboardIssueEvidence(issues: string[], repo: string, enrichment?: DashboardEnrichment): string[] {
+  return issues.map((issue) => formatIssueForDashboard(issue, repo, enrichment));
+}
+
+function formatDashboardSummary(ref: string, summary: DashboardLinkedItemSummary | undefined, fallbackUrl?: string): string {
+  if (!summary?.title && !summary?.state) return fallbackUrl ?? ref;
+  const url = summary.url ?? fallbackUrl ?? ref;
+  const state = summary.state ? ` (${summary.state})` : '';
+  return `${url} — ${summary.title ?? ref}${state}`;
+}
+
+function formatPrForDashboard(pr: string, enrichment?: DashboardEnrichment): string {
+  const parsed = parseDashboardPrRef(pr, '');
+  const fallback = parsed?.url ?? pr;
+  return formatDashboardSummary(pr, enrichment?.prs[pr], fallback);
+}
+
+function formatIssueForDashboard(
+  issue: string | undefined,
+  repo: string,
+  enrichment?: DashboardEnrichment,
+  fallbackTitle?: string,
+): string {
+  if (!issue) return 'unknown';
+  const parsed = parseDashboardIssueRef(issue, repo);
+  const fallback = parsed?.url ?? issue;
+  const summary = enrichment?.issues[issue];
+  if (summary) return formatDashboardSummary(issue, summary, fallback);
+  if (fallbackTitle !== undefined) return formatIssueForDisplay(issue, repo, fallbackTitle);
+  if (issue.startsWith('#')) return issue;
+  return formatIssueForDisplay(issue, repo, fallbackTitle);
+}
+
+function formatDashboardList(values: string[], noneLabel = 'none'): string {
+  return values.length > 0 ? values.join(', ') : noneLabel;
+}
+
+function hasDashboardEnrichment(enrichment: DashboardEnrichment | undefined): boolean {
+  return Object.keys(enrichment?.prs ?? {}).length > 0 || Object.keys(enrichment?.issues ?? {}).length > 0;
+}
+
 function formatProgressIssueModeDistribution(history: RunMetrics[]): string {
   if (history.length === 0) return 'none yet';
   const modeDist = computeModeDistribution(history);
@@ -2512,6 +2737,7 @@ function formatDurationHoursMinutes(seconds: number): string {
 export function formatBatchProgressIssueBody(
   state: BatchState,
   nowEpoch = Math.floor(Date.now() / 1000),
+  enrichment?: DashboardEnrichment,
 ): string {
   const history = state.run_history ?? [];
   const totalCost = history.reduce((sum, run) => sum + run.cost_usd, 0);
@@ -2537,6 +2763,12 @@ export function formatBatchProgressIssueBody(
     `| Total cost | $${totalCost.toFixed(2)} |`,
     `| Wall time | ${formatDurationHoursMinutes(nowEpoch - state.batch_start)} |`,
     `| Modes used | ${formatProgressIssueModeDistribution(history)} |`,
+    '',
+    '### Work Artifacts',
+    '',
+    `- **PRs:** ${formatDashboardList(dashboardPrEvidence(state.prs, enrichment))}`,
+    `- **Issues filed:** ${formatDashboardList(dashboardIssueEvidence(state.issues_filed, state.kaizen_repo, enrichment))}`,
+    `- **Issues closed:** ${formatDashboardList(dashboardIssueEvidence(state.issues_closed, state.kaizen_repo, enrichment))}`,
     '',
     '<details>',
     '<summary>Batch config</summary>',
@@ -2643,7 +2875,8 @@ export function ensureBatchProgressIssue(
 
   const cleanGuidance = cleanGuidanceForTitle(state.guidance);
   const title = `[Auto-Dent] ${truncateAtWordBoundary(cleanGuidance, 70)} (${state.batch_id})`;
-  const body = formatBatchProgressIssueBody(state);
+  const enrichment = fetchDashboardEnrichment(state, kaizenRepo, runGh);
+  const body = formatBatchProgressIssueBody(state, undefined, enrichment);
 
   let url = '';
   try {
@@ -2676,6 +2909,7 @@ export interface FormatRunProgressAttachmentInput {
   result: RunResult;
   kaizenRepo: string;
   mode?: string;
+  enrichment?: DashboardEnrichment;
 }
 
 function formatRunDuration(seconds: number): string {
@@ -2711,16 +2945,16 @@ export function formatRunProgressAttachment(input: FormatRunProgressAttachmentIn
     '',
     '### Outcome',
     '',
-    `- **Issue:** ${formatIssueForDisplay(result.pickedIssue, kaizenRepo, result.pickedIssueTitle)}`,
-    `- **PR:** ${result.prs.length > 0 ? result.prs.join(', ') : 'none'}`,
+    `- **Issue:** ${formatIssueForDashboard(result.pickedIssue, kaizenRepo, input.enrichment, result.pickedIssueTitle)}`,
+    `- **PR:** ${formatDashboardList(dashboardPrEvidence(result.prs, input.enrichment))}`,
     `- **Review:** ${formatReviewForDisplay(result)}`,
   ];
 
   if (result.issuesFiled.length > 0) {
-    lines.push(`- **Issues filed:** ${result.issuesFiled.join(', ')}`);
+    lines.push(`- **Issues filed:** ${formatDashboardList(dashboardIssueEvidence(result.issuesFiled, kaizenRepo, input.enrichment))}`);
   }
   if (result.issuesClosed.length > 0) {
-    lines.push(`- **Issues closed:** ${result.issuesClosed.join(' ')}`);
+    lines.push(`- **Issues closed:** ${dashboardIssueEvidence(result.issuesClosed, kaizenRepo, input.enrichment).join(' ')}`);
   }
   if (result.cases.length > 0) {
     lines.push(`- **Cases:** ${result.cases.map((c) => '`' + c + '`').join(', ')}`);
@@ -2802,6 +3036,7 @@ export interface FormatBatchCompletionAttachmentInput {
   progressIssueNumber: string;
   kaizenRepo: string;
   batchDir?: string;
+  enrichment?: DashboardEnrichment;
 }
 
 function formatRunLimit(state: BatchState): string {
@@ -2825,6 +3060,7 @@ export function formatBatchCompletionAttachment(input: FormatBatchCompletionAtta
     reconciledClosed,
     progressIssueNumber,
     batchDir,
+    enrichment,
   } = input;
   const history = state.run_history ?? [];
   const failures = formatFailureDistribution(
@@ -2834,6 +3070,8 @@ export function formatBatchCompletionAttachment(input: FormatBatchCompletionAtta
   );
   const postHoc = batchScore.post_hoc;
   const guidanceTitle = cleanGuidanceForTitle(state.guidance) || state.batch_id;
+  const closedIssueRefs = reconciledClosed ?? state.issues_closed;
+  const enriched = hasDashboardEnrichment(enrichment);
 
   const lines = [
     `### Batch Complete: ${guidanceTitle}`,
@@ -2847,9 +3085,9 @@ export function formatBatchCompletionAttachment(input: FormatBatchCompletionAtta
     `- **Runs:** ${state.run} of ${formatRunLimit(state)}`,
     `- **Wall time:** ${formatDurationHoursMinutes(wallTimeSeconds)}`,
     `- **Stop reason:** ${state.stop_reason || 'completed'}`,
-    `- **PRs:** ${state.prs.length > 0 ? state.prs.join(', ') : 'none'}`,
-    `- **Issues filed:** ${state.issues_filed.length > 0 ? state.issues_filed.join(', ') : 'none'}`,
-    `- **Issues closed:** ${formatIssuesClosedLine(reconciledClosed, state.issues_closed)}`,
+    `- **PRs:** ${formatDashboardList(dashboardPrEvidence(state.prs, enriched ? enrichment : undefined))}`,
+    `- **Issues filed:** ${formatDashboardList(dashboardIssueEvidence(state.issues_filed, input.kaizenRepo, enriched ? enrichment : undefined))}`,
+    `- **Issues closed:** ${enriched ? formatDashboardList(dashboardIssueEvidence(closedIssueRefs, input.kaizenRepo, enrichment)) : formatIssuesClosedLine(reconciledClosed, state.issues_closed)}`,
     '',
     '### Modes And Failures',
     '',
@@ -2869,6 +3107,16 @@ export function formatBatchCompletionAttachment(input: FormatBatchCompletionAtta
     );
   } else {
     lines.push('- **Merged PRs:** not checked');
+  }
+
+  const guidanceEvidence = [
+    ...dashboardPrEvidence(state.prs, enriched ? enrichment : undefined),
+    ...dashboardIssueEvidence(state.issues_filed, input.kaizenRepo, enriched ? enrichment : undefined),
+    ...dashboardIssueEvidence(closedIssueRefs, input.kaizenRepo, enriched ? enrichment : undefined),
+  ];
+  const guidanceCompletion = formatGuidanceCompletionMatrix(state.guidance, guidanceEvidence);
+  if (guidanceCompletion) {
+    lines.push('', guidanceCompletion);
   }
 
   lines.push(
@@ -2922,6 +3170,8 @@ export function closeBatchProgressIssue(
     console.log(`  [post-hoc] ${formatPostHocLine(postHoc)}`);
   }
 
+  const enrichment = fetchDashboardEnrichment(state, kaizenRepo, deps.gh ?? ghArgs);
+
   const summary = formatBatchCompletionAttachment({
     state,
     batchScore,
@@ -2930,6 +3180,7 @@ export function closeBatchProgressIssue(
     progressIssueNumber: issueNum,
     kaizenRepo,
     batchDir,
+    enrichment,
   });
 
   writeProgressAttachment(


### PR DESCRIPTION
## Story

Auto-dent dashboard artifacts had the right counts, but they still forced readers to chase raw PR URLs and issue numbers to understand what happened. The final gap in #690 was the guidance/enrichment layer: titles, states, readable evidence links, and a lightweight answer to whether the batch guidance showed up in observed work.

This PR adds a fail-open dashboard enrichment path around the existing argv-based `gh(args)` helper. It gathers PR and issue refs from batch state/run history, looks up title/state/url summaries, and feeds those summaries into the existing markdown renderers without letting GitHub failures block batch close or progress updates.

## Impact (goal -> before/after -> match)

Goal: complete #1695 by adding guidance completion and PR/issue enrichment helpers for the auto-dent dashboard surfaces.

Before: progress issue bodies, per-run attachments, and final retrospectives mostly showed raw URLs or issue refs; readers could not see PR/issue titles or a guidance completion matrix from the dashboard artifact itself.

After: the renderers accept optional enrichment data, final close fetches enrichment best-effort, resumed progress issue creation can include enriched artifacts, run attachments show enriched issue/PR labels when supplied, and final retrospectives include an observed/not-observed guidance matrix.

Match: the change stays scoped to `scripts/auto-dent-run.ts` and its tests, reuses the shared argv `gh` runner, and preserves old fallback output when enrichment is absent or lookup fails.

## Validation

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Extract guidance priorities and match evidence without one-word false positives | `auto-dent-run.test.ts` dashboard helper tests | N/A | N/A | N/A | N/A |
| Fetch PR/issue titles/states through argv `gh(args)` and fail open on errors | `fetchDashboardEnrichment` tests | Covered through runner module import/typecheck | N/A | N/A | N/A |
| Render enriched progress issue, per-run, and final dashboard artifacts | Formatter tests for all three surfaces | `auto-dent-run.test.ts` full file | N/A | N/A | N/A |
| Preserve adjacent auto-dent artifact behavior | Full adjacent vitest set | `auto-dent-stream`, batch artifact/outcome/replay/events tests | N/A | N/A | N/A |

Commands run:

```bash
npx vitest run scripts/auto-dent-run.test.ts -t "dashboard guidance|formatBatchProgressIssueBody|formatRunProgressAttachment|formatBatchCompletionAttachment" --reporter=default
npx vitest run scripts/auto-dent-run.test.ts -t "DashboardEnrichment|GuidanceCompletion|formatRunProgressAttachment|formatBatchCompletionAttachment" --reporter=default
npm run typecheck
npx vitest run scripts/auto-dent-run.test.ts scripts/auto-dent-stream.test.ts --reporter=default
npx vitest run scripts/batch-artifacts-upload.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-replay.test.ts scripts/auto-dent-events.test.ts --reporter=default
git diff --check
```

Closes #1695
Parent: #690
Epic: #1677
