### PR TITLE
Add scrubbed transcript bundle builder

### DIFF
--- a/src/transcript-bundle.test.ts
+++ b/src/transcript-bundle.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { makeIgnoredTestDir } from './lib/test-dirs.js';
+import { SCRUB_FAILED } from './scrub-secrets.js';
+import {
+  TRANSCRIPT_BUNDLE_MANIFEST_FILE,
+  TranscriptBundleManifestSchema,
+  buildTranscriptBundle,
+} from './transcript-bundle.js';
+
+const NOW = '2026-06-29T16:00:00.000Z';
+const EXPIRES = '2026-09-27T16:00:00.000Z';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function freshBatchDir(): string {
+  const dir = makeIgnoredTestDir('transcript-bundle');
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function tarRead(archivePath: string, file: string): string {
+  const result = spawnSync('tar', ['-xOzf', archivePath, file], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `tar exited ${result.status}`);
+  }
+  return result.stdout;
+}
+
+describe('buildTranscriptBundle', () => {
+  it('creates a scrubbed tar/gzip bundle with file metadata and a typed manifest', () => {
+    const dir = freshBatchDir();
+    writeFileSync(
+      join(dir, 'run-1.log'),
+      'start\nANTHROPIC_API_KEY=sk-ant-deadbeefdeadbeef0000\nfinish\n',
+    );
+    writeFileSync(join(dir, 'run-2.log'), 'second run\n');
+    writeFileSync(join(dir, 'events.jsonl'), '{"ignored":true}\n');
+
+    const result = buildTranscriptBundle({
+      batchDir: dir,
+      nowIso: NOW,
+      expiresAtIso: EXPIRES,
+      repo: 'Garsson-io/kaizen',
+      progressIssue: 1704,
+    });
+
+    expect(result.bundlePath).toBeTruthy();
+    expect(existsSync(result.bundlePath!)).toBe(true);
+    expect(result.manifest.status).toBe('ready');
+    expect(result.manifest.batch_id).toBe(dir.split('/').pop());
+    expect(result.manifest.repo).toBe('Garsson-io/kaizen');
+    expect(result.manifest.progress_issue).toBe(1704);
+    expect(result.manifest.expires_at).toBe(EXPIRES);
+    expect(result.manifest.content_encoding).toBe('tar+gzip');
+    expect(result.manifest.scrubbed).toBe(true);
+    expect(result.manifest.truncated).toBe(false);
+    expect(result.manifest.files.map((f) => f.path)).toEqual(['run-1.log', 'run-2.log']);
+    expect(result.manifest.files[0].sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.manifest.files[0].redactions).toBeGreaterThan(0);
+    expect(result.manifest.bundle?.bytes).toBeGreaterThan(0);
+    expect(result.manifest.bundle?.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(TranscriptBundleManifestSchema.parse(result.manifest)).toEqual(result.manifest);
+
+    const scrubbedRun = tarRead(result.bundlePath!, 'run-1.log');
+    expect(scrubbedRun).not.toContain('sk-ant-deadbeefdeadbeef0000');
+    expect(scrubbedRun).toContain('ANTHROPIC_API_KEY=');
+
+    const archivedManifest = TranscriptBundleManifestSchema.parse(
+      JSON.parse(tarRead(result.bundlePath!, TRANSCRIPT_BUNDLE_MANIFEST_FILE)),
+    );
+    expect(archivedManifest.status).toBe('ready');
+    expect(archivedManifest.files).toHaveLength(2);
+  });
+
+  it('returns an absent diagnostic manifest when no run logs exist', () => {
+    const dir = freshBatchDir();
+    writeFileSync(join(dir, 'events.jsonl'), '{}\n');
+
+    const result = buildTranscriptBundle({ batchDir: dir, nowIso: NOW });
+
+    expect(result.bundlePath).toBeNull();
+    expect(result.manifest.status).toBe('absent');
+    expect(result.manifest.diagnostic).toContain('No run transcript logs found');
+    expect(result.manifest.files).toEqual([]);
+    expect(result.manifest.truncated).toBe(false);
+  });
+
+  it('fails closed when scrubbing fails and does not write an upload-ready archive', () => {
+    const dir = freshBatchDir();
+    writeFileSync(join(dir, 'run-1.log'), 'raw secret sk-ant-deadbeefdeadbeef0000\n');
+
+    const result = buildTranscriptBundle({
+      batchDir: dir,
+      nowIso: NOW,
+      scrub: () => ({ text: SCRUB_FAILED, redactions: -1 }),
+    });
+
+    expect(result.bundlePath).toBeNull();
+    expect(result.manifest.status).toBe('scrub_failed');
+    expect(result.manifest.diagnostic).toContain('failed closed');
+    expect(readdirSync(dir).filter((file) => file.endsWith('.tar.gz'))).toEqual([]);
+  });
+
+  it('returns a too_large diagnostic instead of truncating or leaving a partial bundle', () => {
+    const dir = freshBatchDir();
+    writeFileSync(join(dir, 'run-1.log'), 'x'.repeat(2000));
+
+    const result = buildTranscriptBundle({
+      batchDir: dir,
+      nowIso: NOW,
+      maxBundleBytes: 1,
+    });
+
+    expect(result.bundlePath).toBeNull();
+    expect(result.manifest.status).toBe('too_large');
+    expect(result.manifest.diagnostic).toContain('exceeds maxBundleBytes');
+    expect(result.manifest.truncated).toBe(false);
+    expect(readdirSync(dir).filter((file) => file.endsWith('.tar.gz'))).toEqual([]);
+  });
+
+  it('rejects manifest shape drift through the Zod schema', () => {
+    const dir = freshBatchDir();
+    writeFileSync(join(dir, 'run-1.log'), 'ok\n');
+    const { manifest } = buildTranscriptBundle({ batchDir: dir, nowIso: NOW });
+
+    expect(TranscriptBundleManifestSchema.safeParse({ ...manifest, version: 2 }).success).toBe(
+      false,
+    );
+    expect(
+      TranscriptBundleManifestSchema.safeParse({ ...manifest, transport: 'issue-comment' })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/src/transcript-bundle.ts
+++ b/src/transcript-bundle.ts
@@ -1,0 +1,303 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { z } from 'zod';
+import { SCRUB_FAILED, scrubSecrets, type ScrubResult } from './scrub-secrets.js';
+
+export const TRANSCRIPT_BUNDLE_MANIFEST_FILE = 'transcript-bundle-manifest.json';
+export const TRANSCRIPT_BUNDLE_VERSION = 1;
+export const TRANSCRIPT_BUNDLE_TRANSPORT = 'github-actions-artifact';
+export const TRANSCRIPT_BUNDLE_CONTENT_ENCODING = 'tar+gzip';
+
+export const TranscriptBundleStatusSchema = z.enum([
+  'ready',
+  'absent',
+  'scrub_failed',
+  'too_large',
+  'expired',
+  'unauthorized',
+  'malformed',
+]);
+
+export const TranscriptBundleFileSchema = z.object({
+  path: z.string().min(1),
+  bytes: z.number().int().nonnegative(),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  redactions: z.number().int().nonnegative(),
+});
+
+export const TranscriptBundleManifestSchema = z.object({
+  version: z.literal(TRANSCRIPT_BUNDLE_VERSION),
+  batch_id: z.string().min(1),
+  repo: z.string().min(1).optional(),
+  progress_issue: z.number().int().positive().optional(),
+  transport: z.literal(TRANSCRIPT_BUNDLE_TRANSPORT),
+  artifact_name: z.string().min(1),
+  artifact_url: z.string().url().optional(),
+  created_at: z.string().min(1),
+  expires_at: z.string().min(1).optional(),
+  content_encoding: z.literal(TRANSCRIPT_BUNDLE_CONTENT_ENCODING),
+  scrubbed: z.boolean(),
+  truncated: z.literal(false),
+  status: TranscriptBundleStatusSchema,
+  diagnostic: z.string().min(1).optional(),
+  bundle: z
+    .object({
+      path: z.string().min(1),
+      bytes: z.number().int().nonnegative(),
+      sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    })
+    .optional(),
+  files: z.array(TranscriptBundleFileSchema),
+});
+
+export type TranscriptBundleStatus = z.infer<typeof TranscriptBundleStatusSchema>;
+export type TranscriptBundleFile = z.infer<typeof TranscriptBundleFileSchema>;
+export type TranscriptBundleManifest = z.infer<typeof TranscriptBundleManifestSchema>;
+
+export interface BuildTranscriptBundleOptions {
+  batchDir: string;
+  outputDir?: string;
+  batchId?: string;
+  repo?: string;
+  progressIssue?: number;
+  nowIso?: string;
+  expiresAtIso?: string;
+  artifactName?: string;
+  artifactUrl?: string;
+  maxBundleBytes?: number;
+  scrub?: (text: unknown) => ScrubResult;
+}
+
+export interface BuildTranscriptBundleResult {
+  manifest: TranscriptBundleManifest;
+  bundlePath: string | null;
+}
+
+interface ScrubbedTranscript {
+  path: string;
+  content: string;
+  meta: TranscriptBundleFile;
+}
+
+function sha256(data: string | Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+function fileSha256(path: string): string {
+  return sha256(readFileSync(path));
+}
+
+function safeArtifactFileName(artifactName: string): string {
+  return artifactName.replace(/[^A-Za-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '') || 'auto-dent-transcripts';
+}
+
+function manifestFor(
+  options: {
+    batchId: string;
+    repo?: string;
+    progressIssue?: number;
+    nowIso: string;
+    expiresAtIso?: string;
+    artifactName: string;
+    artifactUrl?: string;
+  },
+  fields: {
+    status: TranscriptBundleStatus;
+    scrubbed: boolean;
+    diagnostic?: string;
+    files?: TranscriptBundleFile[];
+    bundle?: TranscriptBundleManifest['bundle'];
+  },
+): TranscriptBundleManifest {
+  return TranscriptBundleManifestSchema.parse({
+    version: TRANSCRIPT_BUNDLE_VERSION,
+    batch_id: options.batchId,
+    ...(options.repo ? { repo: options.repo } : {}),
+    ...(options.progressIssue ? { progress_issue: options.progressIssue } : {}),
+    transport: TRANSCRIPT_BUNDLE_TRANSPORT,
+    artifact_name: options.artifactName,
+    ...(options.artifactUrl ? { artifact_url: options.artifactUrl } : {}),
+    created_at: options.nowIso,
+    ...(options.expiresAtIso ? { expires_at: options.expiresAtIso } : {}),
+    content_encoding: TRANSCRIPT_BUNDLE_CONTENT_ENCODING,
+    scrubbed: fields.scrubbed,
+    truncated: false,
+    status: fields.status,
+    ...(fields.diagnostic ? { diagnostic: fields.diagnostic } : {}),
+    ...(fields.bundle ? { bundle: fields.bundle } : {}),
+    files: fields.files ?? [],
+  });
+}
+
+function runLogFiles(batchDir: string): string[] {
+  if (!existsSync(batchDir)) return [];
+  return readdirSync(batchDir)
+    .filter((name) => {
+      if (!/^run-[^/]+\.log$/.test(name)) return false;
+      try {
+        return statSync(join(batchDir, name)).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function scrubRunLogs(
+  batchDir: string,
+  files: string[],
+  scrub: (text: unknown) => ScrubResult,
+): ScrubbedTranscript[] | { error: string } {
+  const scrubbed: ScrubbedTranscript[] = [];
+
+  for (const file of files) {
+    const raw = readFileSync(join(batchDir, file), 'utf8');
+    const result = scrub(raw);
+    if (result.redactions < 0 || result.text === SCRUB_FAILED) {
+      return { error: `Secret scrubbing failed closed for ${file}; upload-ready bundle withheld.` };
+    }
+
+    scrubbed.push({
+      path: file,
+      content: result.text,
+      meta: {
+        path: file,
+        bytes: Buffer.byteLength(result.text, 'utf8'),
+        sha256: sha256(result.text),
+        redactions: result.redactions,
+      },
+    });
+  }
+
+  return scrubbed;
+}
+
+function writeStage(stageDir: string, scrubbed: ScrubbedTranscript[], manifest: TranscriptBundleManifest): void {
+  for (const file of scrubbed) {
+    writeFileSync(join(stageDir, file.path), file.content);
+  }
+  writeFileSync(join(stageDir, TRANSCRIPT_BUNDLE_MANIFEST_FILE), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function createTarGzip(stageDir: string, archivePath: string, entries: string[]): void {
+  const result = spawnSync('tar', ['-czf', archivePath, ...entries], {
+    cwd: stageDir,
+    encoding: 'utf8',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`tar exited ${result.status}: ${result.stderr.trim()}`);
+  }
+}
+
+export function buildTranscriptBundle(options: BuildTranscriptBundleOptions): BuildTranscriptBundleResult {
+  const batchId = options.batchId ?? basename(options.batchDir);
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const artifactName = options.artifactName ?? `auto-dent-transcripts-${batchId}`;
+  const manifestOptions = {
+    batchId,
+    repo: options.repo,
+    progressIssue: options.progressIssue,
+    nowIso,
+    expiresAtIso: options.expiresAtIso,
+    artifactName,
+    artifactUrl: options.artifactUrl,
+  };
+
+  const files = runLogFiles(options.batchDir);
+  if (files.length === 0) {
+    return {
+      bundlePath: null,
+      manifest: manifestFor(manifestOptions, {
+        status: 'absent',
+        scrubbed: true,
+        diagnostic: `No run transcript logs found in ${options.batchDir}.`,
+      }),
+    };
+  }
+
+  const scrubbed = scrubRunLogs(options.batchDir, files, options.scrub ?? scrubSecrets);
+  if ('error' in scrubbed) {
+    return {
+      bundlePath: null,
+      manifest: manifestFor(manifestOptions, {
+        status: 'scrub_failed',
+        scrubbed: false,
+        diagnostic: scrubbed.error,
+      }),
+    };
+  }
+
+  const fileMetadata = scrubbed.map((file) => file.meta);
+  const archiveManifest = manifestFor(manifestOptions, {
+    status: 'ready',
+    scrubbed: true,
+    files: fileMetadata,
+  });
+
+  const outputDir = options.outputDir ?? options.batchDir;
+  mkdirSync(outputDir, { recursive: true });
+  const archivePath = join(outputDir, `${safeArtifactFileName(artifactName)}.tar.gz`);
+  const stageDir = mkdtempSync(join(tmpdir(), 'kaizen-transcript-bundle-'));
+
+  try {
+    rmSync(archivePath, { force: true });
+    writeStage(stageDir, scrubbed, archiveManifest);
+    createTarGzip(stageDir, archivePath, [...files, TRANSCRIPT_BUNDLE_MANIFEST_FILE]);
+
+    const archiveBytes = statSync(archivePath).size;
+    if (options.maxBundleBytes !== undefined && archiveBytes > options.maxBundleBytes) {
+      rmSync(archivePath, { force: true });
+      return {
+        bundlePath: null,
+        manifest: manifestFor(manifestOptions, {
+          status: 'too_large',
+          scrubbed: true,
+          files: fileMetadata,
+          diagnostic:
+            `Transcript bundle ${archiveBytes} bytes exceeds maxBundleBytes ` +
+            `${options.maxBundleBytes}; bundle withheld without truncation.`,
+        }),
+      };
+    }
+
+    return {
+      bundlePath: archivePath,
+      manifest: manifestFor(manifestOptions, {
+        status: 'ready',
+        scrubbed: true,
+        files: fileMetadata,
+        bundle: {
+          path: archivePath,
+          bytes: archiveBytes,
+          sha256: fileSha256(archivePath),
+        },
+      }),
+    };
+  } catch (err) {
+    rmSync(archivePath, { force: true });
+    return {
+      bundlePath: null,
+      manifest: manifestFor(manifestOptions, {
+        status: 'malformed',
+        scrubbed: true,
+        files: fileMetadata,
+        diagnostic: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  } finally {
+    rmSync(stageDir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
Once upon a time, #1643 needed cloud-readable full auto-dent run transcripts, but PR #1703 deliberately split the work: first choose the transport, then build the bundle contract, then upload, then analyze.

Every day, the repo already had two nearby artifact patterns: capped GitHub comments for `batch-artifacts` / `run-transcript`, and raw tar/gzip bundles from `scripts/auto-dent-artifacts.ts`. Both are useful, but neither is the contract #1643 needs. The comment path can truncate by design, and the raw bundle path does not scrub transcript payloads.

One day, #1704 became the first implementation boundary after the transport decision: build a scrubbed tar/gzip bundle model and manifest object for `run-*.log` without uploading anything yet.

Because of that, this PR adds `src/transcript-bundle.ts`: a Zod-backed manifest schema, run-log discovery, canonical `scrubSecrets` use, sha256/byte/redaction metadata, diagnostic statuses, and archive creation from a temporary scrubbed staging directory.

Because of that, the failure paths are explicit. Missing logs return `absent`, scrub failure returns `scrub_failed`, over-budget output returns `too_large`, tar/build failures return `malformed`, and every path keeps `truncated: false` rather than silently creating partial analysis input.

Until finally, `src/transcript-bundle.test.ts` proves the actual archive path by extracting the generated tar/gzip, checking the secret is gone, validating the archived manifest, and covering the diagnostic cases.

And ever since, #1705 can consume one stable builder/manifest contract for Actions artifact upload instead of deciding redaction, schema, and truncation behavior again.

## Architecture

```text
logs/auto-dent/<batch-id>/
  run-*.log
      |
      v
buildTranscriptBundle()
  discover direct run logs
  scrub with src/scrub-secrets.ts
  compute bytes + sha256 + redactions
  write temporary scrubbed staging dir
  tar -czf upload-ready bundle
      |
      +--> TranscriptBundleManifestSchema
      +--> diagnostic manifest when absent/scrub_failed/too_large/malformed
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| New `src/transcript-bundle.ts` module | Keeps the full-transcript transport contract separate from capped comments and raw artifact bundling | Adds one module, but prevents contract drift before #1705/#1706 |
| Import canonical `scrubSecrets` | Reuses the existing fail-closed I19 scrubber | Scrub-failed bundles are withheld instead of being partially useful |
| Zod manifest schema | Keeps the progress-issue/upload/analyzer contract parseable and drift-resistant | Slightly more verbose than a TypeScript-only interface |
| `truncated: false` plus `too_large` diagnostic | Full transcript bundles must not masquerade as complete when they are partial | Oversized bundles fail open for operators instead of producing analysis input |
| Upload excluded | #1705 owns Actions artifact upload; #1704 only creates the local upload-ready boundary | This PR does not yet make progress issues cloud-downloadable |

## What's In This PR

| File | Purpose |
|---|---|
| `src/transcript-bundle.ts` | Defines the transcript bundle manifest schema and builds scrubbed tar/gzip bundles or diagnostic manifests |
| `src/transcript-bundle.test.ts` | Covers ready bundle creation, absent logs, scrub failure, too-large diagnostics, and schema drift rejection |

## Impact (goal -> before/after -> match)

- Goal (#1704): build the first transcript transport implementation boundary: scrubbed tar/gzip bundle model plus manifest object for `run-*.log`, without uploading.
- Acceptance signal: focused tests build and inspect a scrubbed archive, then observe typed diagnostic manifests for absent logs, scrub failure, and too-large output.
- BEFORE: `bundleArtifacts()` could tar raw artifact files, and capped attachment builders could scrub comment bodies, but there was no typed transcript-bundle builder that scrubs `run-*.log` and refuses incomplete upload-ready output.
- AFTER: `buildTranscriptBundle()` returns either a `ready` manifest with bundle/file sha256, byte, redaction, created/expiry metadata, or a diagnostic manifest with no upload-ready archive.
- Delta: 2 new files, 446 lines; 5 focused tests pass and extract the generated tar/gzip to prove the payload is scrubbed.
- Goal met?: yes.
- Residual scan: done in PR; the new module imports canonical `scrubSecrets` and does not use `buildCappedBody` / `truncateMiddle` for full transcript payloads. Upload remains tracked by #1705 and analyzer readback by #1706.

## Test Plan (Behaviors × Levels)

| # | Behavior | Perspective | Level | Coverage |
|---|----------|-------------|-------|----------|
| 1 | Normal batch directory with `run-*.log` files produces a `ready` manifest, sha256/byte/redaction metadata, and a tar/gzip archive containing scrubbed logs and manifest JSON. | code | Integration | ✅ `src/transcript-bundle.test.ts` extracts generated archive |
| 2 | No matching `run-*.log` files produces an `absent` diagnostic manifest and no upload-ready archive. | user/operator | Unit | ✅ `src/transcript-bundle.test.ts` |
| 3 | Scrubber failure returns a `scrub_failed` diagnostic manifest and writes no archive containing raw transcript content. | code | Unit | ✅ `src/transcript-bundle.test.ts` |
| 4 | Payload over the configured maximum returns a `too_large` diagnostic manifest and does not truncate or write a partial bundle. | code | Unit | ✅ `src/transcript-bundle.test.ts` |
| 5 | Manifest parsing/validation rejects drift from the transport contract shape through a Zod schema. | code | Unit | ✅ `src/transcript-bundle.test.ts` |

Deferred by design:

| Behavior | Tracking issue |
|---|---|
| Upload bundle as a GitHub Actions artifact and write progress-issue manifest | #1705 |
| Read/download artifact from `auto-dent-analyze --progress-issue` | #1706 |
| Expiry/fallback diagnostics across artifact lifecycle | #1707 |

## Validation

- [x] `npx vitest run src/transcript-bundle.test.ts` — 5 tests passed.
- [x] `npm run typecheck` — passed.
- [x] `git diff --check` — clean.
- [x] Related-area DRY scan: `rg "function scrubSecrets|const scrubSecrets|buildCappedBody|truncateMiddle|SCRUB_FAILED|TranscriptBundle" ...` confirms the new module imports the canonical scrubber and does not use capped truncation for full transcript bundles.

## Known Limitations

- This PR does not upload the bundle. #1705 owns Actions artifact integration.
- This PR does not teach `auto-dent-analyze --progress-issue` to download/read artifacts. #1706 owns that path.
- This PR includes future manifest statuses (`expired`, `unauthorized`, `malformed`) so downstream readers can share one enum, but #1707 owns full expiry/fallback hardening.

Closes #1704

Parent: #1643
Epic: #1677
