### PR TITLE
Read transcript bundles from progress issues

### DIFF
--- a/scripts/auto-dent-analyze.ts
+++ b/scripts/auto-dent-analyze.ts
@@ -32,6 +32,10 @@ import {
   hookActivationStatus,
   type HookActivationStatus,
 } from './auto-dent-hook-activation.js';
+import {
+  formatTranscriptBundleUnavailableDiagnostic,
+  readProgressIssueTranscriptBundle,
+} from './transcript-bundle-download.js';
 
 // Types
 
@@ -1024,7 +1028,7 @@ export function formatProgressIssueAnalysisDiagnostic(
   return lines.join('\n');
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const args = parseBatchArtifactCliArgs(process.argv.slice(2));
   const progressIssue = args.progressIssues[0];
 
@@ -1034,15 +1038,36 @@ function main(): void {
       process.exit(1);
     }
     try {
-      const parts = readArtifactPartsFromProgressIssue(progressIssue, args.repo);
-      console.error(formatProgressIssueAnalysisDiagnostic({
+      const bundle = await readProgressIssueTranscriptBundle({
         issueNumber: progressIssue,
         repo: args.repo,
-        parts,
-      }));
+      });
+      if (bundle.status === 'ready') {
+        try {
+          console.log(formatBatchAnalysis(analyzeBatch(bundle.batchDir)));
+        } finally {
+          bundle.cleanup();
+        }
+        return;
+      }
+
+      if (bundle.status === 'missing') {
+        const parts = readArtifactPartsFromProgressIssue(progressIssue, args.repo);
+        console.error(formatProgressIssueAnalysisDiagnostic({
+          issueNumber: progressIssue,
+          repo: args.repo,
+          parts,
+        }));
+      } else {
+        console.error(formatTranscriptBundleUnavailableDiagnostic({
+          issueNumber: progressIssue,
+          repo: args.repo,
+          result: bundle,
+        }));
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error(`Could not read batch-artifacts from ${args.repo}#${progressIssue}: ${message}`);
+      console.error(`Could not read progress-issue artifacts from ${args.repo}#${progressIssue}: ${message}`);
     }
     process.exit(1);
   }
@@ -1128,5 +1153,8 @@ const isDirectRun =
   process.argv[1]?.endsWith('auto-dent-analyze.js');
 
 if (isDirectRun) {
-  main();
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
 }

--- a/scripts/transcript-bundle-download.test.ts
+++ b/scripts/transcript-bundle-download.test.ts
@@ -1,0 +1,191 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { makeIgnoredTestDir } from '../src/lib/test-dirs.js';
+import {
+  TRANSCRIPT_BUNDLE_MANIFEST_FILE,
+  type TranscriptBundleManifest,
+} from '../src/transcript-bundle.js';
+import { analyzeBatch } from './auto-dent-analyze.js';
+import { formatTranscriptBundleAttachment } from './transcript-bundle-upload.js';
+import {
+  formatTranscriptBundleUnavailableDiagnostic,
+  parseTranscriptBundleAttachment,
+  parseWorkflowRunId,
+  readProgressIssueTranscriptBundle,
+  unpackTranscriptBundleArtifact,
+} from './transcript-bundle-download.js';
+
+function manifest(overrides: Partial<TranscriptBundleManifest> = {}): TranscriptBundleManifest {
+  return {
+    version: 1,
+    batch_id: 'batch-test',
+    repo: 'Garsson-io/kaizen',
+    progress_issue: 1706,
+    transport: 'github-actions-artifact',
+    artifact_name: 'auto-dent-transcripts-batch-test',
+    artifact_url: 'https://github.com/Garsson-io/kaizen/actions/runs/123456',
+    created_at: '2026-06-29T00:00:00.000Z',
+    expires_at: '2026-09-27T00:00:00.000Z',
+    content_encoding: 'tar+gzip',
+    scrubbed: true,
+    truncated: false,
+    status: 'ready',
+    bundle: {
+      path: 'auto-dent-transcripts-batch-test.tar.gz',
+      bytes: 123,
+      sha256: 'a'.repeat(64),
+    },
+    files: [
+      {
+        path: 'run-1-test.log',
+        bytes: 123,
+        sha256: 'b'.repeat(64),
+        redactions: 0,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function jsonLine(value: Record<string, unknown>): string {
+  return JSON.stringify(value);
+}
+
+function writeBundleArtifact(manifestValue: TranscriptBundleManifest): string {
+  const artifactDir = makeIgnoredTestDir('transcript-artifact');
+  const stageDir = makeIgnoredTestDir('transcript-stage');
+  writeFileSync(
+    join(stageDir, 'run-1-test.log'),
+    [
+      jsonLine({ type: 'user', timestamp: '2026-06-29T00:00:00.000Z', message: { content: [] } }),
+      jsonLine({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'Read', input: { file_path: 'x' } }] },
+      }),
+      jsonLine({ type: 'user', timestamp: '2026-06-29T00:01:00.000Z', message: { content: [] } }),
+      jsonLine({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: 'x' } }] },
+      }),
+    ].join('\n') + '\n',
+  );
+  writeFileSync(
+    join(stageDir, TRANSCRIPT_BUNDLE_MANIFEST_FILE),
+    `${JSON.stringify(manifestValue, null, 2)}\n`,
+  );
+
+  const archivePath = join(artifactDir, 'auto-dent-transcripts-batch-test.tar.gz');
+  const result = spawnSync(
+    'tar',
+    ['-czf', archivePath, 'run-1-test.log', TRANSCRIPT_BUNDLE_MANIFEST_FILE],
+    { cwd: stageDir, encoding: 'utf8' },
+  );
+  expect(result.status).toBe(0);
+  return artifactDir;
+}
+
+describe('transcript bundle progress issue reader', () => {
+  it('parses the manifest attachment body produced by the upload helper', () => {
+    const parsed = parseTranscriptBundleAttachment(formatTranscriptBundleAttachment(manifest()));
+
+    expect(parsed.batch_id).toBe('batch-test');
+    expect(parsed.artifact_name).toBe('auto-dent-transcripts-batch-test');
+  });
+
+  it('extracts workflow run id from Actions artifact URLs', () => {
+    expect(parseWorkflowRunId('https://github.com/Garsson-io/kaizen/actions/runs/987654321')).toBe(987654321);
+  });
+
+  it('downloads, safely unpacks, and feeds a ready bundle to analyzeBatch', async () => {
+    const manifestValue = manifest();
+    const artifactDir = writeBundleArtifact(manifestValue);
+    const result = await readProgressIssueTranscriptBundle({
+      issueNumber: '1706',
+      repo: 'Garsson-io/kaizen',
+      read: () => ({
+        name: 'batch-transcript-bundle',
+        content: formatTranscriptBundleAttachment(manifestValue),
+      }),
+      download: async () => ({ artifactDir }),
+    });
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') throw new Error(result.diagnostic);
+    try {
+      const analysis = analyzeBatch(result.batchDir);
+      expect(analysis.batchId).toBe('batch-test');
+      expect(analysis.runs).toHaveLength(1);
+      expect(analysis.runs[0].coldStartSec).toBe(60);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('preserves a missing-manifest result for the legacy diagnostic path', async () => {
+    const result = await readProgressIssueTranscriptBundle({
+      issueNumber: '1706',
+      repo: 'Garsson-io/kaizen',
+      read: () => null,
+    });
+
+    expect(result.status).toBe('missing');
+    expect(result.diagnostic).toContain('No batch-transcript-bundle attachment');
+  });
+
+  it('reports malformed manifest attachments without downloading', async () => {
+    const result = await readProgressIssueTranscriptBundle({
+      issueNumber: '1706',
+      repo: 'Garsson-io/kaizen',
+      read: () => ({ name: 'batch-transcript-bundle', content: 'not a manifest' }),
+      download: async () => {
+        throw new Error('download should not run');
+      },
+    });
+
+    expect(result.status).toBe('unavailable');
+    expect(result.diagnostic).toContain('manifest is malformed');
+  });
+
+  it('reports missing artifacts with an unavailable diagnostic', async () => {
+    const result = await readProgressIssueTranscriptBundle({
+      issueNumber: '1706',
+      repo: 'Garsson-io/kaizen',
+      read: () => ({
+        name: 'batch-transcript-bundle',
+        content: formatTranscriptBundleAttachment(manifest()),
+      }),
+      download: async () => {
+        throw new Error('artifact not found');
+      },
+    });
+
+    expect(result.status).toBe('unavailable');
+    expect(result.diagnostic).toContain('artifact not found');
+    if (result.status === 'unavailable') {
+      expect(formatTranscriptBundleUnavailableDiagnostic({
+        issueNumber: '1706',
+        repo: 'Garsson-io/kaizen',
+        result,
+      })).toContain('Run transcript logs are not available');
+    }
+  });
+
+  it('rejects unsafe tar entries before extraction', () => {
+    const manifestValue = manifest({ bundle: { path: 'unsafe.tar.gz', bytes: 1, sha256: 'c'.repeat(64) } });
+    const artifactDir = makeIgnoredTestDir('transcript-unsafe-artifact');
+    const stageDir = makeIgnoredTestDir('transcript-unsafe-stage');
+    mkdirSync(join(stageDir, 'safe'), { recursive: true });
+    writeFileSync(join(stageDir, 'safe', 'run-1-test.log'), 'x\n');
+    const archivePath = join(artifactDir, 'unsafe.tar.gz');
+    const result = spawnSync(
+      'tar',
+      ['--transform=s#safe/run-1-test.log#../evil.log#', '-czf', archivePath, 'safe/run-1-test.log'],
+      { cwd: stageDir, encoding: 'utf8' },
+    );
+    expect(result.status).toBe(0);
+
+    expect(() => unpackTranscriptBundleArtifact(artifactDir, manifestValue)).toThrow(/Unsafe transcript bundle entry/);
+  });
+});

--- a/scripts/transcript-bundle-download.ts
+++ b/scripts/transcript-bundle-download.ts
@@ -1,0 +1,295 @@
+import artifactClient, { type ArtifactClient, type FindOptions } from '@actions/artifact';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, normalize } from 'node:path';
+import { readAttachment, type AttachmentTarget } from '../src/section-editor.js';
+import {
+  TRANSCRIPT_BUNDLE_MANIFEST_FILE,
+  TranscriptBundleManifestSchema,
+  type TranscriptBundleManifest,
+} from '../src/transcript-bundle.js';
+import { BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT } from './transcript-bundle-upload.js';
+
+export interface TranscriptArtifactDownload {
+  artifactDir: string;
+  cleanup?: () => void;
+}
+
+export type TranscriptArtifactDownloader = (
+  manifest: TranscriptBundleManifest,
+  options: {
+    repo: string;
+    env: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  },
+) => Promise<TranscriptArtifactDownload>;
+
+export type ProgressIssueTranscriptBundleResult =
+  | {
+      status: 'ready';
+      manifest: TranscriptBundleManifest;
+      batchDir: string;
+      cleanup: () => void;
+    }
+  | {
+      status: 'missing';
+      diagnostic: string;
+    }
+  | {
+      status: 'unavailable';
+      manifest?: TranscriptBundleManifest;
+      diagnostic: string;
+    };
+
+export interface ReadProgressIssueTranscriptBundleInput {
+  issueNumber: string;
+  repo: string;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  read?: typeof readAttachment;
+  download?: TranscriptArtifactDownloader;
+}
+
+export function parseTranscriptBundleAttachment(body: string): TranscriptBundleManifest {
+  const jsonFence = body.match(/```json\n([\s\S]*?)\n```/);
+  if (!jsonFence) {
+    throw new Error('batch-transcript-bundle attachment does not contain a JSON manifest fence');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonFence[1]);
+  } catch (err) {
+    throw new Error(`batch-transcript-bundle manifest is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return TranscriptBundleManifestSchema.parse(parsed);
+}
+
+function splitRepo(repo: string): { owner: string; name: string } {
+  const [owner, name] = repo.split('/');
+  if (!owner || !name) throw new Error(`Repository must be owner/repo, got ${repo}`);
+  return { owner, name };
+}
+
+export function parseWorkflowRunId(artifactUrl: string | undefined): number {
+  if (!artifactUrl) throw new Error('Transcript bundle manifest has no artifact_url');
+  const match = artifactUrl.match(/\/actions\/runs\/(\d+)(?:[/?#]|$)/);
+  if (!match) throw new Error(`Transcript bundle artifact_url does not contain a workflow run id: ${artifactUrl}`);
+  return Number(match[1]);
+}
+
+function githubToken(env: NodeJS.ProcessEnv | Record<string, string | undefined>): string {
+  const token = env.GITHUB_TOKEN ?? env.GH_TOKEN;
+  if (!token) {
+    throw new Error('GITHUB_TOKEN or GH_TOKEN with actions:read permission is required to download transcript artifacts');
+  }
+  return token;
+}
+
+export async function defaultTranscriptArtifactDownloader(
+  manifest: TranscriptBundleManifest,
+  options: {
+    repo: string;
+    env: NodeJS.ProcessEnv | Record<string, string | undefined>;
+    client?: ArtifactClient;
+  },
+): Promise<TranscriptArtifactDownload> {
+  const { owner, name } = splitRepo(options.repo);
+  const workflowRunId = parseWorkflowRunId(manifest.artifact_url);
+  const token = githubToken(options.env);
+  const findBy: NonNullable<FindOptions['findBy']> = {
+    token,
+    workflowRunId,
+    repositoryOwner: owner,
+    repositoryName: name,
+  };
+  const client = options.client ?? artifactClient;
+  const artifact = await client.getArtifact(manifest.artifact_name, { findBy });
+  const artifactDir = mkdtempSync(join(tmpdir(), 'kaizen-transcript-artifact-'));
+  try {
+    const downloaded = await client.downloadArtifact(artifact.artifact.id, {
+      path: artifactDir,
+      ...(artifact.artifact.digest ? { expectedHash: artifact.artifact.digest } : {}),
+      findBy,
+    });
+    if (downloaded.digestMismatch) {
+      throw new Error(`Downloaded artifact digest did not match ${artifact.artifact.digest}`);
+    }
+    return {
+      artifactDir: downloaded.downloadPath ?? artifactDir,
+      cleanup: () => rmSync(artifactDir, { recursive: true, force: true }),
+    };
+  } catch (err) {
+    rmSync(artifactDir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
+function tarEntries(archivePath: string): string[] {
+  const result = spawnSync('tar', ['-tzf', archivePath], { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`tar list failed for ${archivePath}: ${result.stderr.trim()}`);
+  }
+  return result.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+function validateTarEntry(entry: string): void {
+  const normalized = normalize(entry).replace(/\\/g, '/');
+  const allowed =
+    /^run-[^/]+\.log$/.test(entry) ||
+    entry === TRANSCRIPT_BUNDLE_MANIFEST_FILE;
+
+  if (
+    !entry ||
+    entry.startsWith('/') ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.includes('/../') ||
+    basename(entry) !== entry ||
+    !allowed
+  ) {
+    throw new Error(`Unsafe transcript bundle entry: ${entry}`);
+  }
+}
+
+function findArchive(artifactDir: string, manifest: TranscriptBundleManifest): string {
+  const expected = manifest.bundle?.path ? basename(manifest.bundle.path) : null;
+  const candidates = readdirSync(artifactDir)
+    .filter((file) => file.endsWith('.tar.gz'))
+    .sort();
+
+  if (expected && candidates.includes(expected)) return join(artifactDir, expected);
+  if (candidates.length === 1) return join(artifactDir, candidates[0]);
+  if (candidates.length === 0) {
+    throw new Error(`Downloaded artifact does not contain a transcript .tar.gz bundle`);
+  }
+  throw new Error(`Downloaded artifact contains multiple transcript bundles; expected ${expected ?? 'one .tar.gz file'}`);
+}
+
+export function unpackTranscriptBundleArtifact(
+  artifactDir: string,
+  manifest: TranscriptBundleManifest,
+): { batchDir: string; cleanup: () => void } {
+  const archivePath = findArchive(artifactDir, manifest);
+  const entries = tarEntries(archivePath);
+  for (const entry of entries) validateTarEntry(entry);
+  if (!entries.some((entry) => /^run-[^/]+\.log$/.test(entry))) {
+    throw new Error('Transcript bundle archive contains no run-*.log files');
+  }
+
+  const batchDir = mkdtempSync(join(tmpdir(), 'kaizen-transcript-batch-'));
+  try {
+    const result = spawnSync('tar', ['-xzf', archivePath, '-C', batchDir], { encoding: 'utf8' });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`tar extract failed for ${archivePath}: ${result.stderr.trim()}`);
+    }
+
+    const archiveManifestPath = join(batchDir, TRANSCRIPT_BUNDLE_MANIFEST_FILE);
+    try {
+      const archiveManifest = TranscriptBundleManifestSchema.parse(
+        JSON.parse(readFileSync(archiveManifestPath, 'utf8')),
+      );
+      if (
+        archiveManifest.batch_id !== manifest.batch_id ||
+        archiveManifest.artifact_name !== manifest.artifact_name
+      ) {
+        throw new Error('archive manifest does not match progress-issue manifest');
+      }
+      writeFileSync(
+        join(batchDir, 'state.json'),
+        `${JSON.stringify({ batch_id: archiveManifest.batch_id }, null, 2)}\n`,
+      );
+    } catch (err) {
+      throw new Error(`Transcript bundle archive manifest is invalid: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return {
+      batchDir,
+      cleanup: () => rmSync(batchDir, { recursive: true, force: true }),
+    };
+  } catch (err) {
+    rmSync(batchDir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
+export async function readProgressIssueTranscriptBundle(
+  input: ReadProgressIssueTranscriptBundleInput,
+): Promise<ProgressIssueTranscriptBundleResult> {
+  const read = input.read ?? readAttachment;
+  const target: AttachmentTarget = { kind: 'issue', number: input.issueNumber, repo: input.repo };
+  const attachment = read(target, BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT);
+  if (!attachment) {
+    return {
+      status: 'missing',
+      diagnostic: `No ${BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT} attachment was found on ${input.repo}#${input.issueNumber}.`,
+    };
+  }
+
+  let manifest: TranscriptBundleManifest;
+  try {
+    manifest = parseTranscriptBundleAttachment(attachment.content);
+  } catch (err) {
+    return {
+      status: 'unavailable',
+      diagnostic: `Transcript bundle manifest is malformed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (manifest.status !== 'ready') {
+    return {
+      status: 'unavailable',
+      manifest,
+      diagnostic:
+        `Transcript bundle status is ${manifest.status}.` +
+        (manifest.diagnostic ? ` ${manifest.diagnostic}` : ''),
+    };
+  }
+
+  const download = input.download ?? ((m, options) => defaultTranscriptArtifactDownloader(m, { ...options }));
+  let downloaded: TranscriptArtifactDownload | null = null;
+  try {
+    downloaded = await download(manifest, {
+      repo: input.repo,
+      env: input.env ?? process.env,
+    });
+    const unpacked = unpackTranscriptBundleArtifact(downloaded.artifactDir, manifest);
+    return {
+      status: 'ready',
+      manifest,
+      batchDir: unpacked.batchDir,
+      cleanup: () => {
+        unpacked.cleanup();
+        downloaded?.cleanup?.();
+      },
+    };
+  } catch (err) {
+    downloaded?.cleanup?.();
+    return {
+      status: 'unavailable',
+      manifest,
+      diagnostic: `Transcript bundle artifact is unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+export function formatTranscriptBundleUnavailableDiagnostic(input: {
+  issueNumber: string;
+  repo: string;
+  result: Extract<ProgressIssueTranscriptBundleResult, { status: 'unavailable' }>;
+}): string {
+  const { issueNumber, repo, result } = input;
+  return [
+    `auto-dent-analyze cannot analyze progress issue #${issueNumber} from transcript artifacts.`,
+    '',
+    'This tool analyzes run transcript logs (`run-*.log`) to compute cold-start, tool-pattern, and waste metrics.',
+    '',
+    `Transcript artifact diagnostic for ${repo}#${issueNumber}: ${result.diagnostic}`,
+    result.manifest ? `Manifest status: \`${result.manifest.status}\`, artifact: \`${result.manifest.artifact_name}\`.` : null,
+    '',
+    'Run transcript logs are not available from the progress issue artifact.',
+    'Use a local batch directory if the Actions artifact has expired or cannot be downloaded.',
+  ].filter((line): line is string => line !== null).join('\n');
+}


### PR DESCRIPTION
## Story

Once upon a time, `auto-dent-analyze --progress-issue` could inspect cloud-backed `batch-artifacts`, but those artifacts only contained `events.jsonl`, `state.json`, and a summary. Every day, transcript-oriented analysis still needed local `logs/auto-dent/<batch>/run-*.log` files to compute cold start, repeated tool patterns, phase markers, and waste.

One day, #1643 was split into a transport sequence. #1704 created the scrubbed tar/gzip bundle and typed manifest; #1705 uploaded that bundle as a GitHub Actions artifact and wrote the `batch-transcript-bundle` manifest attachment. The remaining gap was the consumer: `auto-dent-analyze --progress-issue` still always explained why it could not analyze progress issues directly.

Because of that, this PR adds a progress-issue transcript bundle reader that parses the existing manifest attachment with `TranscriptBundleManifestSchema`, locates/downloads the Actions artifact through `@actions/artifact`, validates the tar entries before extraction, and feeds the extracted `run-*.log` files into the existing `analyzeBatch` path.

Because of that, the no-bundle path stays intentionally boring: when `batch-transcript-bundle` is absent, the command still prints the current diagnostic explaining that progress issue artifacts lack run transcript logs.

Until finally, the analyzer now has both halves: local batch analysis remains unchanged, and recent cloud-backed batches with a ready transcript bundle can produce normal formatted batch analysis from a progress issue.

And ever since, #1707 can focus on expiry/fallback UX instead of inventing another transport or analyzer path.

## Architecture

```text
progress issue
  ├─ batch-artifacts attachment       -> existing fallback diagnostic
  └─ batch-transcript-bundle manifest -> TranscriptBundleManifestSchema
                                          |
                                          v
                                    @actions/artifact
                                          |
                                          v
                               downloaded .tar.gz bundle
                                          |
                                          v
                           safe tar list validation + extract
                                          |
                                          v
                              existing analyzeBatch/formatBatchAnalysis
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Reuse `TranscriptBundleManifestSchema` | Keeps producer and consumer on one typed manifest contract. | Parser expects the JSON fence emitted by the upload helper. |
| Use `BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT` and `readAttachment` | Avoids a second attachment key or ad hoc GitHub comment reader. | Analyzer now imports a focused helper for progress-issue transcript bundles. |
| Validate tar entries before extraction | Prevents absolute path/traversal archive content from writing outside the temp directory. | Restricts bundle contents to direct `run-*.log` files plus `transcript-bundle-manifest.json`. |
| Generate temp `state.json` from the archive manifest | Preserves the real batch id in formatted analysis even though the bundle intentionally carries only logs + manifest. | Prompt metadata from local `state.json` remains unavailable for cloud-only bundles. |
| Keep no-manifest fallback unchanged | #1706 explicitly requires preserving the current diagnostic when no manifest exists. | The fallback wording still says upload support is needed; #1707 owns richer fallback diagnostics. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/transcript-bundle-download.ts` | New progress-issue manifest reader, Actions artifact downloader adapter, safe tar unpacker, and unavailable diagnostic formatter. |
| `scripts/transcript-bundle-download.test.ts` | Tar/gzip fixture tests for success, malformed manifest, missing artifact, and unsafe archive rejection. |
| `scripts/auto-dent-analyze.ts` | Wires `--progress-issue` to analyze a ready transcript bundle, otherwise preserving current diagnostics. |

## Impact (goal -> before/after -> match)

- Goal (#1706): `auto-dent-analyze --progress-issue <issue> --repo <owner/repo>` can run existing transcript analysis from cloud-backed full run logs when a ready bundle exists.
- Acceptance signal: focused tests simulate a progress issue manifest and downloaded artifact, then prove `analyzeBatch` consumes extracted `run-*.log` files; live CLI smoke proves missing-bundle fallback remains intact.
- BEFORE: `scripts/auto-dent-analyze.ts` always called `formatProgressIssueAnalysisDiagnostic` for `--progress-issue`, including `auto-dent-analyze cannot analyze progress issue #N directly.`
- AFTER: ready manifest + downloaded tar/gzip fixture returns status `ready`, extracts safe logs, writes manifest-derived `state.json`, and `analyzeBatch` reports `batch-test` with one run and `coldStartSec = 60`.
- Delta: progress issues with ready transcript artifacts now take the normal batch-analysis path; missing manifests still return the existing diagnostic.
- Goal met?: yes.
- Residual scan: reused existing schema/attachment primitives and found no competing transcript transport/parser; expiry/fallback hardening remains tracked by #1707.

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Parse `batch-transcript-bundle` manifest with shared schema | ✅ `parseTranscriptBundleAttachment` test | ✅ upload-helper formatted body consumed | n/a | n/a | ✅ producer/consumer schema reuse scan |
| Analyze a valid progress-issue transcript artifact | ✅ downloader injection + tar fixture | ✅ extracted fixture feeds `analyzeBatch` | ⏳ live retained artifact not required; adapter typechecked | n/a | ✅ CLI wiring sends ready result to `formatBatchAnalysis` |
| Preserve no-manifest diagnostic | ✅ missing result test | ✅ existing analyzer diagnostic tests | ✅ live `--progress-issue 1706` smoke exits 1 with old diagnostic | n/a | ✅ fallback still reads `batch-artifacts` detail |
| Malformed/missing artifact diagnostics | ✅ malformed manifest and downloader failure tests | ✅ unavailable formatter includes run-log guidance | n/a | n/a | ✅ #1707 left for richer expiry/fallback wording |
| Safe unpacking | ✅ traversal tar entry rejected before extraction | ✅ valid tar/gzip fixture accepted | n/a | n/a | ✅ one extraction helper, no duplicate tar path |
| Local batch/log analysis unchanged | ✅ existing `auto-dent-analyze.test.ts` coverage | ✅ focused analyzer suite still passes | n/a | n/a | ✅ CLI local branches untouched except async wrapper |

## Validation

- [x] `npx vitest run scripts/transcript-bundle-download.test.ts scripts/auto-dent-analyze.test.ts` — 2 files, 64 tests passed.
- [x] `npm run typecheck` — passed.
- [x] `git diff --check` — passed.
- [x] Live fallback smoke: `npx tsx scripts/auto-dent-analyze.ts --progress-issue 1706 --repo Garsson-io/kaizen` exits 1 and preserves the existing no-bundle diagnostic.
- [x] Related-area scan: `rg "batch-transcript-bundle|TranscriptBundleManifestSchema|downloadArtifact|getArtifact" scripts src docs` showed this PR reuses the existing schema/attachment contract and adds one consumer helper.

## Known Limitations

- Live artifact download requires `GITHUB_TOKEN` or `GH_TOKEN` with `actions:read`; missing credentials produce an unavailable diagnostic.
- Artifact expiry and more detailed fallback wording are intentionally left to #1707.
- Cloud-only transcript bundles do not include the original local `state.json` run history, so prompt-template enrichment remains local-only for now.

Closes #1706

Parent: #1643
Refs: #1677
