### PR TITLE
Harden transcript artifact diagnostics

### DIFF
--- a/scripts/auto-dent-analyze.ts
+++ b/scripts/auto-dent-analyze.ts
@@ -33,6 +33,7 @@ import {
   type HookActivationStatus,
 } from './auto-dent-hook-activation.js';
 import {
+  formatTranscriptBundleMissingDiagnostic,
   formatTranscriptBundleUnavailableDiagnostic,
   readProgressIssueTranscriptBundle,
 } from './transcript-bundle-download.js';
@@ -1053,6 +1054,12 @@ async function main(): Promise<void> {
 
       if (bundle.status === 'missing') {
         const parts = readArtifactPartsFromProgressIssue(progressIssue, args.repo);
+        console.error(formatTranscriptBundleMissingDiagnostic({
+          issueNumber: progressIssue,
+          repo: args.repo,
+          result: bundle,
+        }));
+        console.error('');
         console.error(formatProgressIssueAnalysisDiagnostic({
           issueNumber: progressIssue,
           repo: args.repo,

--- a/scripts/transcript-bundle-download.test.ts
+++ b/scripts/transcript-bundle-download.test.ts
@@ -10,6 +10,7 @@ import {
 import { analyzeBatch } from './auto-dent-analyze.js';
 import { formatTranscriptBundleAttachment } from './transcript-bundle-upload.js';
 import {
+  formatTranscriptBundleMissingDiagnostic,
   formatTranscriptBundleUnavailableDiagnostic,
   parseTranscriptBundleAttachment,
   parseWorkflowRunId,
@@ -131,7 +132,17 @@ describe('transcript bundle progress issue reader', () => {
     });
 
     expect(result.status).toBe('missing');
+    expect(result.reason).toBe('missing');
     expect(result.diagnostic).toContain('No batch-transcript-bundle attachment');
+    if (result.status !== 'missing') throw new Error('expected missing');
+    const diagnostic = formatTranscriptBundleMissingDiagnostic({
+      issueNumber: '1706',
+      repo: 'Garsson-io/kaizen',
+      result,
+    });
+    expect(diagnostic).toContain('missing manifest');
+    expect(diagnostic).toContain('wait for upload');
+    expect(diagnostic).toContain('Analyze the local batch directory');
   });
 
   it('reports malformed manifest attachments without downloading', async () => {
@@ -145,7 +156,14 @@ describe('transcript bundle progress issue reader', () => {
     });
 
     expect(result.status).toBe('unavailable');
+    if (result.status !== 'unavailable') throw new Error('expected unavailable');
+    expect(result.reason).toBe('malformed');
     expect(result.diagnostic).toContain('manifest is malformed');
+    expect(formatTranscriptBundleUnavailableDiagnostic({
+      issueNumber: '1706',
+      repo: 'Garsson-io/kaizen',
+      result,
+    })).toContain('malformed transcript bundle metadata');
   });
 
   it('reports missing artifacts with an unavailable diagnostic', async () => {
@@ -164,12 +182,95 @@ describe('transcript bundle progress issue reader', () => {
     expect(result.status).toBe('unavailable');
     expect(result.diagnostic).toContain('artifact not found');
     if (result.status === 'unavailable') {
+      expect(result.reason).toBe('download_failed');
       expect(formatTranscriptBundleUnavailableDiagnostic({
         issueNumber: '1706',
         repo: 'Garsson-io/kaizen',
         result,
-      })).toContain('Run transcript logs are not available');
+      })).toContain('artifact download failed');
     }
+  });
+
+  it.each([
+    {
+      status: 'absent' as const,
+      expected: ['absent run logs', 'no run-*.log transcript files', 'Rerun with transcript logging'],
+    },
+    {
+      status: 'expired' as const,
+      expected: ['expired artifact', 'retention window has elapsed', 'choose archival storage'],
+    },
+    {
+      status: 'unauthorized' as const,
+      expected: ['unauthorized artifact access', 'GITHUB_TOKEN or GH_TOKEN', 'actions:read'],
+    },
+    {
+      status: 'malformed' as const,
+      expected: ['malformed transcript bundle metadata', 'expected schema/format', 'rerun finalization'],
+    },
+    {
+      status: 'too_large' as const,
+      expected: ['bundle too large', 'withheld without truncation', 'archival storage'],
+    },
+    {
+      status: 'upload_failed' as const,
+      expected: ['artifact upload failed', 'upload failed during finalization', 'rerun finalization'],
+    },
+    {
+      status: 'scrub_failed' as const,
+      expected: ['secret scrub failed', 'failed closed', 'do not bypass scrubbing'],
+    },
+  ])('formats operator guidance for $status manifests', async ({ status, expected }) => {
+    const result = await readProgressIssueTranscriptBundle({
+      issueNumber: '1707',
+      repo: 'Garsson-io/kaizen',
+      read: () => ({
+        name: 'batch-transcript-bundle',
+        content: formatTranscriptBundleAttachment(manifest({
+          status,
+          diagnostic: `fixture diagnostic for ${status}`,
+          bundle: undefined,
+        })),
+      }),
+      download: async () => {
+        throw new Error('download should not run');
+      },
+    });
+
+    expect(result.status).toBe('unavailable');
+    if (result.status !== 'unavailable') throw new Error('expected unavailable');
+    expect(result.reason).toBe(status);
+    const diagnostic = formatTranscriptBundleUnavailableDiagnostic({
+      issueNumber: '1707',
+      repo: 'Garsson-io/kaizen',
+      result,
+    });
+    for (const phrase of expected) {
+      expect(diagnostic).toContain(phrase);
+    }
+    expect(diagnostic).toContain(`fixture diagnostic for ${status}`);
+  });
+
+  it('classifies ready manifests as expired under an injected clock before downloading', async () => {
+    const result = await readProgressIssueTranscriptBundle({
+      issueNumber: '1707',
+      repo: 'Garsson-io/kaizen',
+      nowIso: '2026-10-01T00:00:00.000Z',
+      read: () => ({
+        name: 'batch-transcript-bundle',
+        content: formatTranscriptBundleAttachment(manifest({
+          expires_at: '2026-09-27T00:00:00.000Z',
+        })),
+      }),
+      download: async () => {
+        throw new Error('download should not run for expired manifests');
+      },
+    });
+
+    expect(result.status).toBe('unavailable');
+    if (result.status !== 'unavailable') throw new Error('expected unavailable');
+    expect(result.reason).toBe('expired');
+    expect(result.diagnostic).toContain('expired at 2026-09-27T00:00:00.000Z');
   });
 
   it('rejects unsafe tar entries before extraction', () => {

--- a/scripts/transcript-bundle-download.ts
+++ b/scripts/transcript-bundle-download.ts
@@ -7,6 +7,7 @@ import { readAttachment, type AttachmentTarget } from '../src/section-editor.js'
 import {
   TRANSCRIPT_BUNDLE_MANIFEST_FILE,
   TranscriptBundleManifestSchema,
+  type TranscriptBundleStatus,
   type TranscriptBundleManifest,
 } from '../src/transcript-bundle.js';
 import { BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT } from './transcript-bundle-upload.js';
@@ -24,6 +25,11 @@ export type TranscriptArtifactDownloader = (
   },
 ) => Promise<TranscriptArtifactDownload>;
 
+export type TranscriptBundleUnavailableReason =
+  | 'missing'
+  | Exclude<TranscriptBundleStatus, 'ready'>
+  | 'download_failed';
+
 export type ProgressIssueTranscriptBundleResult =
   | {
       status: 'ready';
@@ -33,10 +39,12 @@ export type ProgressIssueTranscriptBundleResult =
     }
   | {
       status: 'missing';
+      reason: 'missing';
       diagnostic: string;
     }
   | {
       status: 'unavailable';
+      reason: Exclude<TranscriptBundleUnavailableReason, 'missing'>;
       manifest?: TranscriptBundleManifest;
       diagnostic: string;
     };
@@ -44,6 +52,7 @@ export type ProgressIssueTranscriptBundleResult =
 export interface ReadProgressIssueTranscriptBundleInput {
   issueNumber: string;
   repo: string;
+  nowIso?: string;
   env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
   read?: typeof readAttachment;
   download?: TranscriptArtifactDownloader;
@@ -84,6 +93,20 @@ function githubToken(env: NodeJS.ProcessEnv | Record<string, string | undefined>
     throw new Error('GITHUB_TOKEN or GH_TOKEN with actions:read permission is required to download transcript artifacts');
   }
   return token;
+}
+
+function isExpired(manifest: TranscriptBundleManifest, nowIso: string | undefined): boolean {
+  if (!manifest.expires_at) return false;
+  const expiresAt = new Date(manifest.expires_at).getTime();
+  const now = nowIso ? new Date(nowIso).getTime() : Date.now();
+  return Number.isFinite(expiresAt) && Number.isFinite(now) && expiresAt <= now;
+}
+
+function downloadFailureReason(err: unknown): 'unauthorized' | 'download_failed' {
+  const message = err instanceof Error ? err.message : String(err);
+  return /GITHUB_TOKEN|GH_TOKEN|actions:read|unauthori[sz]ed|authentication/i.test(message)
+    ? 'unauthorized'
+    : 'download_failed';
 }
 
 export async function defaultTranscriptArtifactDownloader(
@@ -224,6 +247,7 @@ export async function readProgressIssueTranscriptBundle(
   if (!attachment) {
     return {
       status: 'missing',
+      reason: 'missing',
       diagnostic: `No ${BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT} attachment was found on ${input.repo}#${input.issueNumber}.`,
     };
   }
@@ -234,13 +258,24 @@ export async function readProgressIssueTranscriptBundle(
   } catch (err) {
     return {
       status: 'unavailable',
+      reason: 'malformed',
       diagnostic: `Transcript bundle manifest is malformed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (manifest.status === 'ready' && isExpired(manifest, input.nowIso)) {
+    return {
+      status: 'unavailable',
+      reason: 'expired',
+      manifest,
+      diagnostic: `Transcript bundle artifact expired at ${manifest.expires_at}.`,
     };
   }
 
   if (manifest.status !== 'ready') {
     return {
       status: 'unavailable',
+      reason: manifest.status,
       manifest,
       diagnostic:
         `Transcript bundle status is ${manifest.status}.` +
@@ -269,9 +304,83 @@ export async function readProgressIssueTranscriptBundle(
     downloaded?.cleanup?.();
     return {
       status: 'unavailable',
+      reason: downloadFailureReason(err),
       manifest,
       diagnostic: `Transcript bundle artifact is unavailable: ${err instanceof Error ? err.message : String(err)}`,
     };
+  }
+}
+
+function diagnosticGuidance(reason: TranscriptBundleUnavailableReason): {
+  condition: string;
+  meaning: string;
+  action: string;
+  fallback: string;
+} {
+  switch (reason) {
+    case 'missing':
+      return {
+        condition: 'missing manifest',
+        meaning: 'No batch-transcript-bundle manifest has been posted to the progress issue.',
+        action: 'If the batch is still finalizing, wait for upload; otherwise this batch likely predates transcript bundle upload or finalized outside the Actions artifact path.',
+        fallback: 'Analyze the local batch directory when available.',
+      };
+    case 'absent':
+      return {
+        condition: 'absent run logs',
+        meaning: 'Batch finalization ran, but no run-*.log transcript files were present to bundle.',
+        action: 'Rerun with transcript logging enabled or inspect the machine that ran the batch.',
+        fallback: 'Use local logs if they exist; otherwise there is no transcript payload to analyze.',
+      };
+    case 'expired':
+      return {
+        condition: 'expired artifact',
+        meaning: 'The manifest points to an Actions artifact whose retention window has elapsed.',
+        action: 'Use a local batch directory, rerun the batch, or choose archival storage for long-term transcript retention.',
+        fallback: 'Local logs remain the authoritative fallback after artifact expiry.',
+      };
+    case 'unauthorized':
+      return {
+        condition: 'unauthorized artifact access',
+        meaning: 'The artifact cannot be uploaded or downloaded with the current credentials.',
+        action: 'Provide GITHUB_TOKEN or GH_TOKEN with actions:read permission, or rerun from an authenticated GitHub Actions environment.',
+        fallback: 'Use local logs until artifact credentials are available.',
+      };
+    case 'malformed':
+      return {
+        condition: 'malformed transcript bundle metadata',
+        meaning: 'The manifest or archive metadata did not match the expected schema/format.',
+        action: 'Inspect the batch-transcript-bundle attachment and rerun finalization/upload to recreate the manifest.',
+        fallback: 'Do not trust partial metadata; use local logs for analysis.',
+      };
+    case 'too_large':
+      return {
+        condition: 'bundle too large',
+        meaning: 'The scrubbed transcript bundle exceeded the configured size limit and was withheld without truncation.',
+        action: 'Analyze local logs or choose an archival storage transport; do not consume partial transcript data.',
+        fallback: 'Local logs are required because the cloud bundle was intentionally not uploaded.',
+      };
+    case 'scrub_failed':
+      return {
+        condition: 'secret scrub failed',
+        meaning: 'Secret scrubbing failed closed, so raw transcript logs were not uploaded.',
+        action: 'Fix the redaction failure before uploading; do not bypass scrubbing with raw logs.',
+        fallback: 'Analyze a secured local copy if needed.',
+      };
+    case 'upload_failed':
+      return {
+        condition: 'artifact upload failed',
+        meaning: 'The bundle was built, but GitHub Actions artifact upload failed during finalization.',
+        action: 'Inspect the finalize/upload logs and rerun finalization or the batch.',
+        fallback: 'Use local logs while the upload failure is unresolved.',
+      };
+    case 'download_failed':
+      return {
+        condition: 'artifact download failed',
+        meaning: 'The manifest was ready, but the artifact could not be downloaded or unpacked.',
+        action: 'Check artifact retention, artifact name, workflow run URL, and repository permissions.',
+        fallback: 'Use local logs if the artifact is unavailable.',
+      };
   }
 }
 
@@ -281,15 +390,36 @@ export function formatTranscriptBundleUnavailableDiagnostic(input: {
   result: Extract<ProgressIssueTranscriptBundleResult, { status: 'unavailable' }>;
 }): string {
   const { issueNumber, repo, result } = input;
+  const guidance = diagnosticGuidance(result.reason);
   return [
     `auto-dent-analyze cannot analyze progress issue #${issueNumber} from transcript artifacts.`,
     '',
     'This tool analyzes run transcript logs (`run-*.log`) to compute cold-start, tool-pattern, and waste metrics.',
     '',
+    `Condition: ${guidance.condition}.`,
+    `Meaning: ${guidance.meaning}`,
+    `Operator action: ${guidance.action}`,
+    `Fallback: ${guidance.fallback}`,
+    '',
     `Transcript artifact diagnostic for ${repo}#${issueNumber}: ${result.diagnostic}`,
     result.manifest ? `Manifest status: \`${result.manifest.status}\`, artifact: \`${result.manifest.artifact_name}\`.` : null,
-    '',
-    'Run transcript logs are not available from the progress issue artifact.',
-    'Use a local batch directory if the Actions artifact has expired or cannot be downloaded.',
   ].filter((line): line is string => line !== null).join('\n');
+}
+
+export function formatTranscriptBundleMissingDiagnostic(input: {
+  issueNumber: string;
+  repo: string;
+  result: Extract<ProgressIssueTranscriptBundleResult, { status: 'missing' }>;
+}): string {
+  const guidance = diagnosticGuidance(input.result.reason);
+  return [
+    `auto-dent-analyze did not find transcript bundle metadata on progress issue #${input.issueNumber}.`,
+    '',
+    `Condition: ${guidance.condition}.`,
+    `Meaning: ${guidance.meaning}`,
+    `Operator action: ${guidance.action}`,
+    `Fallback: ${guidance.fallback}`,
+    '',
+    `Transcript artifact diagnostic for ${input.repo}#${input.issueNumber}: ${input.result.diagnostic}`,
+  ].join('\n');
 }


### PR DESCRIPTION
## Story

Once upon a time, #1706 taught `auto-dent-analyze --progress-issue` to consume a ready transcript bundle manifest, download the Actions artifact, safely unpack `run-*.log`, and run the existing analyzer.

Every day, the non-ready paths still collapsed into generic text. Operators could see that transcript logs were unavailable, but the output did not clearly separate missing metadata, expired artifacts, missing credentials, malformed metadata, oversized bundles, scrub failures, upload failures, or download failures.

One day, #1707 asked for the final hardening step in #1643: make those states explicit enough that an operator knows whether to wait, reauthenticate, rerun locally, inspect metadata, or choose archival storage.

Because of that, this PR adds a typed unavailable reason to the progress-issue transcript bundle result, classifies deterministic expiry before download, and centralizes state-specific guidance in the existing transcript bundle diagnostic formatter.

Because of that, the missing-manifest CLI path now prints new transcript-bundle guidance before the preserved legacy `batch-artifacts` diagnostic, so #1706's fallback behavior remains visible while #1707 gets operator-actionable output.

Until finally, every status in the transcript transport contract has pinned diagnostics, and the ready-bundle analysis path is unchanged.

And ever since, #1643's decomposed transcript transport implementation has a complete producer/upload/consumer/fallback chain.

## Architecture

```text
readProgressIssueTranscriptBundle
  ├─ ready                  -> analyzeBatch path unchanged
  ├─ missing attachment     -> reason=missing + missing-manifest guidance + legacy diagnostic
  ├─ manifest status != ready -> reason=<manifest.status> + state-specific guidance
  ├─ ready but expires_at <= now -> reason=expired before download
  └─ download/unpack error  -> reason=unauthorized or download_failed
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Add `TranscriptBundleUnavailableReason` beside the existing result type | Keeps status classification explicit without adding schema fields. | Callers now receive one more discriminant on missing/unavailable results. |
| Keep guidance in `scripts/transcript-bundle-download.ts` | This module owns artifact result classification; tests can exercise it without CLI subprocesses. | The formatter carries operator copy as well as data plumbing. |
| Detect expired ready manifests before download | `expires_at` is deterministic and gives a clearer operator action than an artifact-not-found network failure. | Requires a `nowIso` injection point for deterministic tests. |
| Print missing-manifest guidance before legacy diagnostic | #1707 needs explicit `batch-transcript-bundle` absence; #1706 required preserving the old diagnostic. | The no-manifest output is longer, but both messages are actionable. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/transcript-bundle-download.ts` | Adds unavailable reasons, deterministic expiry classification, missing/unavailable diagnostic guidance. |
| `scripts/transcript-bundle-download.test.ts` | Pins missing, absent, expired, unauthorized, malformed, too_large, upload_failed, scrub_failed, download_failed, and ready-success behavior. |
| `scripts/auto-dent-analyze.ts` | Prints missing-manifest transcript guidance before the preserved legacy progress-issue diagnostic. |

## Impact (goal -> before/after -> match)

- Goal (#1707): `auto-dent-analyze --progress-issue` distinguishes transcript artifact absence/expiry/auth/malformed/size states and tells operators what to do.
- Acceptance signal: diagnostic matrix tests and live missing-manifest smoke.
- BEFORE: unavailable output was generic: `Transcript artifact diagnostic ...` plus `Use a local batch directory if the Actions artifact has expired or cannot be downloaded.` Missing manifests showed only the legacy `batch-artifacts` diagnostic.
- AFTER: each category has `Condition`, `Meaning`, `Operator action`, and `Fallback`; live #1707 smoke now starts with `Condition: missing manifest` and tells the operator to wait for upload or analyze the local batch directory.
- Delta: 8 unavailable categories are pinned by tests; ready bundle analysis and local analyzer tests still pass.
- Goal met?: yes.
- Residual scan: still one manifest schema/status enum, one transcript-bundle result reader, one unavailable formatter; no new transport or parser family.

## Test Plan (Behaviors × Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Missing manifest diagnostic | ✅ formatter/result test | ✅ CLI prints new guidance + legacy diagnostic | ✅ live #1707 smoke | n/a | ✅ preserves #1706 fallback content |
| `absent` status guidance | ✅ matrix test | n/a | n/a | n/a | ✅ tells operator no run logs were bundled |
| `expired` status and deterministic expiry | ✅ status test + injected-clock ready manifest test | n/a | n/a | n/a | ✅ tells operator local/rerun/archival options |
| `unauthorized` guidance | ✅ status test + token-error classification | n/a | n/a | n/a | ✅ names `GITHUB_TOKEN`/`GH_TOKEN` and `actions:read` |
| `malformed` guidance | ✅ malformed attachment + manifest-status tests | n/a | n/a | n/a | ✅ tells operator to inspect/recreate metadata |
| `too_large` guidance | ✅ matrix test | n/a | n/a | n/a | ✅ says bundle withheld without truncation |
| Adjacent upload/scrub/download failures | ✅ upload_failed, scrub_failed, download_failed tests | n/a | n/a | n/a | ✅ no generic collapse |
| Ready/local analysis unchanged | ✅ existing analyzer and bundle tests | ✅ ready tar/gzip fixture still analyzes | n/a | n/a | ✅ local analyzer code untouched except missing guidance import |

## Validation

- [x] `npx vitest run scripts/transcript-bundle-download.test.ts scripts/auto-dent-analyze.test.ts` — 2 files, 72 tests passed.
- [x] `npm run typecheck` — passed.
- [x] `git diff --check` — passed.
- [x] Live smoke: `npx tsx scripts/auto-dent-analyze.ts --progress-issue 1707 --repo Garsson-io/kaizen` exits 1 and prints `Condition: missing manifest` plus the preserved legacy diagnostic.
- [x] Related-area scan confirmed reuse of `TranscriptBundleStatusSchema`, `BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT`, and one transcript bundle reader/formatter path.

## #1643 Closure Proof

This PR is the last planned child of #1643:

| Child | Status | Evidence |
|---|---|---|
| #1702 | Done | PR #1703 selected GitHub Actions artifact transport and manifest contract. |
| #1704 | Done | PR #1708 added scrubbed tar/gzip bundle writer and typed manifest schema. |
| #1705 | Done | PR #1709 uploads transcript bundles and writes `batch-transcript-bundle`. |
| #1706 | Done | PR #1710 reads ready manifests, downloads artifacts, safely unpacks logs, and analyzes them. |
| #1707 | This PR | Pins absence/expiry/auth/malformed/size diagnostics and fallback guidance. |

#1643 acceptance after this PR:
- Upload compressed `run-*.log` artifacts at batch finalize: satisfied by #1705 using #1704 bundle writer.
- Same idempotent progress-issue semantics and scrub/size discipline: manifest attachment is idempotent; full payload is scrubbed and never silently truncated.
- `auto-dent-analyze --progress-issue` downloads/reads compressed logs when present: satisfied by #1706.
- Preserve clear diagnostic when compressed logs are absent: #1706 preserved it; this PR adds clearer missing-manifest guidance before it.
- Cover truncation/size, missing-log, and progress-issue analysis paths with tests: #1704 covers too_large/missing-log bundle builder; #1706 covers progress-issue success; this PR covers every diagnostic status.

## Known Limitations

- This does not add archival object storage. The diagnostic tells operators when archival storage is needed.
- Live retained artifact download remains covered by typed adapter plus injected fixture tests, not by a real artifact fixture in CI.

Closes #1707

Parent: #1643
Refs: #1677
