### PR TITLE
Add auto-dent degradation signal

### DIFF
--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -749,6 +749,31 @@ describe('buildBatchReflection', () => {
     expect(stopInsight).toBeDefined();
   });
 
+  it('surfaces long-horizon degradation in reflection insights and comments', () => {
+    const batch = makeBatchInfo({
+      state: makeBatchState({
+        run: 6,
+        run_history: [
+          makeRunMetrics({ run: 1, cost_usd: 1, prs: ['pr1'], duration_seconds: 100 }),
+          makeRunMetrics({ run: 2, cost_usd: 1, prs: ['pr2'], duration_seconds: 120 }),
+          makeRunMetrics({ run: 3, cost_usd: 1, prs: ['pr3'], duration_seconds: 140 }),
+          makeRunMetrics({ run: 4, cost_usd: 4, prs: [], exit_code: 1, duration_seconds: 500 }),
+          makeRunMetrics({ run: 5, cost_usd: 4, prs: [], exit_code: 1, duration_seconds: 650 }),
+          makeRunMetrics({ run: 6, cost_usd: 4, prs: [], exit_code: 1, duration_seconds: 800 }),
+        ],
+      }),
+    });
+
+    const reflection = buildBatchReflection(batch);
+    const insight = reflection.insights.find((i) => i.message.includes('Long-horizon degradation signal'));
+    const comment = formatBatchReflectionComment(reflection);
+
+    expect(insight).toMatchObject({ type: 'failure_pattern' });
+    expect(insight?.message).toContain('degraded');
+    expect(insight?.message).toContain('success rate fell');
+    expect(comment).toContain('Long-horizon degradation signal');
+  });
+
   it('surfaces dry-sweep findings as advisory reflection insight', () => {
     const drySweepReport: DrySweepReport = {
       generatedAt: '2026-06-29T00:00:00.000Z',

--- a/scripts/auto-dent-ctl.test.ts
+++ b/scripts/auto-dent-ctl.test.ts
@@ -771,6 +771,7 @@ describe('buildBatchReflection', () => {
     expect(insight).toMatchObject({ type: 'failure_pattern' });
     expect(insight?.message).toContain('degraded');
     expect(insight?.message).toContain('success rate fell');
+    expect(reflection.insights.some((i) => i.message.includes('consecutive failures'))).toBe(false);
     expect(comment).toContain('Long-horizon degradation signal');
   });
 

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -515,7 +515,7 @@ export function buildBatchReflection(
       currentStreak = 0;
     }
   }
-  if (maxConsecFail >= 2) {
+  if (maxConsecFail >= 2 && degradationSignal?.verdict !== 'watch' && degradationSignal?.verdict !== 'degraded') {
     insights.push({
       type: 'failure_pattern',
       message: `Max ${maxConsecFail} consecutive failures detected — may indicate a systemic blocker`,

--- a/scripts/auto-dent-ctl.ts
+++ b/scripts/auto-dent-ctl.ts
@@ -441,6 +441,8 @@ export function buildBatchReflection(
   const successRate = scores.length > 0 ? successfulRuns.length / scores.length : 0;
   const avgCostPerPr = totalPrs > 0 ? totalCost / totalPrs : 0;
   const exploreExploitConversion = computeExploreExploitConversion(history);
+  const batchScore = scoreBatch(history);
+  const degradationSignal = batchScore.degradation_signal;
 
   // Insight: overall success rate
   if (scores.length >= 3) {
@@ -455,6 +457,16 @@ export function buildBatchReflection(
         message: `Low success rate: only ${(successRate * 100).toFixed(0)}% of runs produced PRs — consider narrowing guidance`,
       });
     }
+  }
+
+  if (
+    degradationSignal &&
+    (degradationSignal.verdict === 'watch' || degradationSignal.verdict === 'degraded')
+  ) {
+    insights.push({
+      type: degradationSignal.verdict === 'degraded' ? 'failure_pattern' : 'recommendation',
+      message: `Long-horizon degradation signal: ${degradationSignal.verdict} (score ${degradationSignal.score.toFixed(2)}) — ${degradationSignal.reasons.join('; ')}`,
+    });
   }
 
   // Insight: expensive failures (runs that cost > avg but produced nothing)

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -6,8 +6,10 @@ import {
   scoreModeBreakdown,
   computeModeDiversity,
   computeBatchTrend,
+  computeBatchDegradationSignal,
   formatRunScoreLine,
   formatBatchScoreTable,
+  formatDegradationSignal,
   effectiveIssuesClosed,
   formatIssuesClosedLine,
   formatModeBreakdown,
@@ -1220,6 +1222,68 @@ describe('scoreBatch trend integration', () => {
   });
 });
 
+describe('computeBatchDegradationSignal', () => {
+  it('returns insufficient_data for batches with fewer than 4 runs', () => {
+    const signal = computeBatchDegradationSignal([makeRunScore(), makeRunScore()]);
+    expect(signal.verdict).toBe('insufficient_data');
+    expect(signal.score).toBe(0);
+    expect(signal.first_half_success_rate).toBeNull();
+    expect(formatDegradationSignal(signal)).toBe('insufficient data');
+  });
+
+  it('keeps stable successful batches healthy', () => {
+    const runs = Array.from({ length: 6 }, () => makeRunScore());
+    const signal = computeBatchDegradationSignal(runs);
+    expect(signal.verdict).toBe('healthy');
+    expect(signal.score).toBe(0);
+    expect(signal.reasons).toEqual(['No within-batch degradation detected']);
+  });
+
+  it('flags degraded late-run collapse with a trailing failure streak', () => {
+    const runs = [
+      makeRunScore({ success: true, cost_usd: 1, duration_seconds: 100 }),
+      makeRunScore({ success: true, cost_usd: 1, duration_seconds: 120 }),
+      makeRunScore({ success: true, cost_usd: 1, duration_seconds: 140 }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 4, duration_seconds: 500, failure_class: 'crash' }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 4, duration_seconds: 650, failure_class: 'empty_success' }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 4, duration_seconds: 800, failure_class: 'empty_success' }),
+    ];
+
+    const signal = computeBatchDegradationSignal(runs);
+
+    expect(signal.verdict).toBe('degraded');
+    expect(signal.score).toBeGreaterThanOrEqual(0.6);
+    expect(signal.first_half_success_rate).toBe(1);
+    expect(signal.second_half_success_rate).toBe(0);
+    expect(signal.trailing_failure_count).toBe(3);
+    expect(signal.trailing_empty_success_count).toBe(2);
+    expect(formatDegradationSignal(signal)).toContain('success rate fell');
+  });
+
+  it('does not emit non-finite numeric fields when late half has no successes', () => {
+    const signal = computeBatchDegradationSignal([
+      makeRunScore({ success: true, cost_usd: 1 }),
+      makeRunScore({ success: true, cost_usd: 1 }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 3, failure_class: 'crash' }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 3, failure_class: 'crash' }),
+    ]);
+
+    expect(signal.late_cost_per_success).toBeNull();
+    expect(signal.cost_per_success_ratio).toBeNull();
+    expect(Number.isFinite(signal.score)).toBe(true);
+  });
+
+  it('scoreBatch includes the degradation signal', () => {
+    const score = scoreBatch([
+      makeRunMetrics({ run: 1, prs: ['pr1'] }),
+      makeRunMetrics({ run: 2, prs: ['pr2'] }),
+      makeRunMetrics({ run: 3, prs: [] }),
+      makeRunMetrics({ run: 4, prs: [] }),
+    ]);
+    expect(score.degradation_signal?.verdict).toBe('degraded');
+  });
+});
+
 describe('formatBatchScoreTable trend integration', () => {
   it('includes trend line when trend is present', () => {
     const score: BatchScore = {
@@ -1274,6 +1338,20 @@ describe('formatBatchScoreTable trend integration', () => {
     };
     const table = formatBatchScoreTable(score);
     expect(table).not.toContain('Trend');
+  });
+
+  it('shows degradation signal line when the signal is watch or degraded', () => {
+    const score = scoreBatch([
+      makeRunMetrics({ run: 1, prs: ['pr1'] }),
+      makeRunMetrics({ run: 2, prs: ['pr2'] }),
+      makeRunMetrics({ run: 3, prs: [] }),
+      makeRunMetrics({ run: 4, prs: [] }),
+    ]);
+
+    const table = formatBatchScoreTable(score);
+
+    expect(table).toContain('| **Degradation signal** | degraded');
+    expect(table).toContain('success rate fell');
   });
 });
 

--- a/scripts/auto-dent-score.test.ts
+++ b/scripts/auto-dent-score.test.ts
@@ -1237,6 +1237,25 @@ describe('computeBatchDegradationSignal', () => {
     expect(signal.verdict).toBe('healthy');
     expect(signal.score).toBe(0);
     expect(signal.reasons).toEqual(['No within-batch degradation detected']);
+    expect(formatDegradationSignal(signal)).toContain('healthy (0.00)');
+  });
+
+  it('flags watch for isolated late-window success-rate decline', () => {
+    const runs = [
+      makeRunScore({ success: true, cost_usd: 1 }),
+      makeRunScore({ success: true, cost_usd: 1 }),
+      makeRunScore({ success: true, cost_usd: 1 }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 0, failure_class: 'crash' }),
+      makeRunScore({ success: true, cost_usd: 1 }),
+      makeRunScore({ success: true, cost_usd: 1 }),
+    ];
+
+    const signal = computeBatchDegradationSignal(runs);
+
+    expect(signal.verdict).toBe('watch');
+    expect(signal.score).toBeCloseTo(1 / 3);
+    expect(signal.trailing_failure_count).toBe(0);
+    expect(formatDegradationSignal(signal)).toContain('watch');
   });
 
   it('flags degraded late-run collapse with a trailing failure streak', () => {
@@ -1258,6 +1277,39 @@ describe('computeBatchDegradationSignal', () => {
     expect(signal.trailing_failure_count).toBe(3);
     expect(signal.trailing_empty_success_count).toBe(2);
     expect(formatDegradationSignal(signal)).toContain('success rate fell');
+  });
+
+  it('clamps stacked degradation severity to 1', () => {
+    const runs = [
+      makeRunScore({ success: true, cost_usd: 1, duration_seconds: 100 }),
+      makeRunScore({ success: true, cost_usd: 1, duration_seconds: 120 }),
+      makeRunScore({ success: true, cost_usd: 1, duration_seconds: 140 }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 4, duration_seconds: 700, failure_class: 'empty_success' }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 4, duration_seconds: 900, failure_class: 'empty_success' }),
+      makeRunScore({ success: false, pr_count: 0, cost_usd: 4, duration_seconds: 1100, failure_class: 'empty_success' }),
+    ];
+
+    const signal = computeBatchDegradationSignal(runs);
+
+    expect(signal.score).toBe(1);
+    expect(signal.verdict).toBe('degraded');
+  });
+
+  it('uses the BatchTrend odd-count split boundary', () => {
+    const runs = [
+      makeRunScore({ success: true }),
+      makeRunScore({ success: true }),
+      makeRunScore({ success: false, pr_count: 0, failure_class: 'timeout' }),
+      makeRunScore({ success: true }),
+      makeRunScore({ success: false, pr_count: 0, failure_class: 'timeout' }),
+    ];
+
+    const signal = computeBatchDegradationSignal(runs);
+
+    expect(signal.first_half_success_rate).toBe(1);
+    expect(signal.second_half_success_rate).toBeCloseTo(1 / 3);
+    expect(signal.success_rate_delta).toBeCloseTo(-2 / 3);
+    expect(signal.reasons.join('; ')).toContain('success rate fell');
   });
 
   it('does not emit non-finite numeric fields when late half has no successes', () => {

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -892,8 +892,13 @@ export function computeBatchDegradationSignal(
   const mid = Math.floor(runs.length / 2);
   const firstHalf = runs.slice(0, mid);
   const secondHalf = runs.slice(mid);
-  const firstSuccessRate = rate(firstHalf.filter((r) => r.success).length, firstHalf.length);
-  const secondSuccessRate = rate(secondHalf.filter((r) => r.success).length, secondHalf.length);
+  const effectiveTrend = trend ?? computeBatchTrend(runs);
+  const firstSuccessRate =
+    effectiveTrend?.first_half_success_rate ??
+    rate(firstHalf.filter((r) => r.success).length, firstHalf.length);
+  const secondSuccessRate =
+    effectiveTrend?.second_half_success_rate ??
+    rate(secondHalf.filter((r) => r.success).length, secondHalf.length);
   const successDelta = secondSuccessRate - firstSuccessRate;
   const trailingFailures = trailingCount(runs, (r) => !r.success);
   const trailingEmpty = trailingCount(runs, (r) => r.failure_class === 'empty_success');
@@ -903,7 +908,7 @@ export function computeBatchDegradationSignal(
     earlyCostPerSuccess !== null && lateCostPerSuccess !== null && earlyCostPerSuccess > 0
       ? lateCostPerSuccess / earlyCostPerSuccess
       : null;
-  const durationSlope = trend?.duration_slope ?? null;
+  const durationSlope = effectiveTrend?.duration_slope ?? null;
 
   let severity = 0;
   const reasons: string[] = [];

--- a/scripts/auto-dent-score.ts
+++ b/scripts/auto-dent-score.ts
@@ -228,6 +228,8 @@ export interface BatchScore {
   post_hoc?: PostHocBatchResult;
   /** Batch trend analysis (null if fewer than 4 runs) */
   trend: BatchTrend | null;
+  /** Long-horizon quality degradation signal derived from within-batch run history. */
+  degradation_signal?: BatchDegradationSignal;
   /** Number of runs where requirements review verdict was 'fail'. Advisory signal only. */
   review_fail_count: number;
   /** Fraction of reviewed runs (runs with a PR) that failed requirements review. */
@@ -275,6 +277,24 @@ export interface BatchTrend {
   duration_slope: number;
   /** Human-readable trend summary */
   summary: string;
+}
+
+export type BatchDegradationVerdict = 'insufficient_data' | 'healthy' | 'watch' | 'degraded';
+
+export interface BatchDegradationSignal {
+  verdict: BatchDegradationVerdict;
+  /** Bounded severity score: 0 = no signal, 1 = strongest degradation signal. */
+  score: number;
+  first_half_success_rate: number | null;
+  second_half_success_rate: number | null;
+  success_rate_delta: number | null;
+  trailing_failure_count: number;
+  trailing_empty_success_count: number;
+  early_cost_per_success: number | null;
+  late_cost_per_success: number | null;
+  cost_per_success_ratio: number | null;
+  duration_slope_seconds_per_run: number | null;
+  reasons: string[];
 }
 
 export interface PostHocPRResult {
@@ -423,6 +443,7 @@ export function scoreBatch(runHistory: RunMetrics[]): BatchScore {
   const reviewFailRate = reviewedRuns.length > 0 ? reviewFailCount / reviewedRuns.length : 0;
   const reviewTotalCost = runs.reduce((s, r) => s + (r.review_cost_usd ?? 0), 0);
   const hookActivationCounts = computeHookActivationCounts(runs.map(run => run.hook_activation_status));
+  const trend = computeBatchTrend(runs);
 
   return {
     total_runs: runs.length,
@@ -445,7 +466,8 @@ export function scoreBatch(runHistory: RunMetrics[]): BatchScore {
     mode_breakdown: scoreModeBreakdown(runs),
     cost_anomaly_count: costAnomalyCount,
     mode_diversity: computeModeDiversity(runs),
-    trend: computeBatchTrend(runs),
+    trend,
+    degradation_signal: computeBatchDegradationSignal(runs, trend),
     review_fail_count: reviewFailCount,
     review_fail_rate: reviewFailRate,
     review_total_cost_usd: reviewTotalCost,
@@ -612,6 +634,9 @@ export function formatBatchScoreTable(score: BatchScore): string {
 
   if (score.trend) {
     lines.push(`| **Trend** | ${score.trend.summary} |`);
+  }
+  if (score.degradation_signal && score.degradation_signal.verdict !== 'healthy') {
+    lines.push(`| **Degradation signal** | ${formatDegradationSignal(score.degradation_signal)} |`);
   }
 
   // Append per-mode breakdown if there are multiple modes
@@ -815,6 +840,130 @@ export function computeBatchTrend(runs: RunScore[]): BatchTrend | null {
     duration_slope: durationSlope,
     summary,
   };
+}
+
+function rate(count: number, total: number): number {
+  return total > 0 ? count / total : 0;
+}
+
+function costPerSuccess(runs: RunScore[]): number | null {
+  const successes = runs.filter((r) => r.success).length;
+  if (successes === 0) return null;
+  const cost = runs.reduce((sum, r) => sum + r.cost_usd, 0);
+  return cost / successes;
+}
+
+function trailingCount<T>(items: T[], predicate: (item: T) => boolean): number {
+  let count = 0;
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (!predicate(items[i])) break;
+    count++;
+  }
+  return count;
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+/** Compute the within-batch long-horizon degradation signal (#1358). */
+export function computeBatchDegradationSignal(
+  runs: RunScore[],
+  trend: BatchTrend | null = computeBatchTrend(runs),
+): BatchDegradationSignal {
+  if (runs.length < 4) {
+    return {
+      verdict: 'insufficient_data',
+      score: 0,
+      first_half_success_rate: null,
+      second_half_success_rate: null,
+      success_rate_delta: null,
+      trailing_failure_count: trailingCount(runs, (r) => !r.success),
+      trailing_empty_success_count: trailingCount(runs, (r) => r.failure_class === 'empty_success'),
+      early_cost_per_success: null,
+      late_cost_per_success: null,
+      cost_per_success_ratio: null,
+      duration_slope_seconds_per_run: null,
+      reasons: ['Need at least 4 runs before comparing early vs late batch quality'],
+    };
+  }
+
+  const mid = Math.floor(runs.length / 2);
+  const firstHalf = runs.slice(0, mid);
+  const secondHalf = runs.slice(mid);
+  const firstSuccessRate = rate(firstHalf.filter((r) => r.success).length, firstHalf.length);
+  const secondSuccessRate = rate(secondHalf.filter((r) => r.success).length, secondHalf.length);
+  const successDelta = secondSuccessRate - firstSuccessRate;
+  const trailingFailures = trailingCount(runs, (r) => !r.success);
+  const trailingEmpty = trailingCount(runs, (r) => r.failure_class === 'empty_success');
+  const earlyCostPerSuccess = costPerSuccess(firstHalf);
+  const lateCostPerSuccess = costPerSuccess(secondHalf);
+  const costRatio =
+    earlyCostPerSuccess !== null && lateCostPerSuccess !== null && earlyCostPerSuccess > 0
+      ? lateCostPerSuccess / earlyCostPerSuccess
+      : null;
+  const durationSlope = trend?.duration_slope ?? null;
+
+  let severity = 0;
+  const reasons: string[] = [];
+
+  if (successDelta <= -0.15) {
+    severity += Math.min(0.45, Math.abs(successDelta));
+    reasons.push(
+      `success rate fell from ${(firstSuccessRate * 100).toFixed(0)}% to ${(secondSuccessRate * 100).toFixed(0)}%`,
+    );
+  }
+  if (trailingFailures >= 2) {
+    severity += trailingFailures >= 3 ? 0.35 : 0.25;
+    reasons.push(`${trailingFailures} trailing failed runs`);
+  }
+  if (trailingEmpty >= 2) {
+    severity += 0.2;
+    reasons.push(`${trailingEmpty} trailing empty-success runs`);
+  }
+  if (costRatio !== null && costRatio >= 1.5) {
+    severity += costRatio >= 2 ? 0.25 : 0.15;
+    reasons.push(`late cost per success is ${costRatio.toFixed(1)}x early cost`);
+  }
+  if (durationSlope !== null && durationSlope > 60) {
+    severity += durationSlope > 120 ? 0.15 : 0.1;
+    reasons.push(`run duration rising ${durationSlope.toFixed(0)}s/run`);
+  }
+
+  const score = clamp01(severity);
+  const collapse = firstSuccessRate >= 0.5 && secondSuccessRate <= 0.25;
+  const verdict: BatchDegradationVerdict =
+    score >= 0.6 || collapse
+      ? 'degraded'
+      : score >= 0.3
+        ? 'watch'
+        : 'healthy';
+
+  return {
+    verdict,
+    score,
+    first_half_success_rate: firstSuccessRate,
+    second_half_success_rate: secondSuccessRate,
+    success_rate_delta: successDelta,
+    trailing_failure_count: trailingFailures,
+    trailing_empty_success_count: trailingEmpty,
+    early_cost_per_success: earlyCostPerSuccess,
+    late_cost_per_success: lateCostPerSuccess,
+    cost_per_success_ratio: costRatio,
+    duration_slope_seconds_per_run: durationSlope,
+    reasons: reasons.length > 0 ? reasons : ['No within-batch degradation detected'],
+  };
+}
+
+export function formatDegradationSignal(signal: BatchDegradationSignal): string {
+  if (signal.verdict === 'insufficient_data') return 'insufficient data';
+  const label = signal.verdict === 'degraded'
+    ? 'degraded'
+    : signal.verdict === 'watch'
+      ? 'watch'
+      : 'healthy';
+  return `${label} (${signal.score.toFixed(2)}) — ${signal.reasons.join('; ')}`;
 }
 
 /** Format per-mode breakdown as a markdown table. */

--- a/scripts/batch-outcome.test.ts
+++ b/scripts/batch-outcome.test.ts
@@ -97,6 +97,20 @@ const degradedSignal = {
   reasons: ['success rate fell from 100% to 0%', '3 trailing failed runs'],
 };
 
+const watchSignal = {
+  ...degradedSignal,
+  verdict: 'watch' as const,
+  score: 0.33,
+  second_half_success_rate: 2 / 3,
+  success_rate_delta: -1 / 3,
+  trailing_failure_count: 0,
+  trailing_empty_success_count: 0,
+  late_cost_per_success: 1,
+  cost_per_success_ratio: 1,
+  duration_slope_seconds_per_run: 0,
+  reasons: ['success rate fell from 100% to 67%'],
+};
+
 describe('buildBatchOutcome — pure derivation', () => {
   it('maps state + score into a schema-valid outcome', () => {
     const outcome = buildBatchOutcome(makeState(), makeScore(), 1_600);
@@ -353,6 +367,19 @@ describe('computeSteeringRecommendations — pure analysis', () => {
     });
     expect(r.recommendations[0].text).toContain('degraded long-horizon degradation');
     expect(r.recommendations[0].text).toContain('Pause broad auto-dent guidance');
+  });
+
+  it('uses watch-specific guidance for watch degradation signals', () => {
+    const r = computeSteeringRecommendations([
+      makeOutcome({
+        batch_id: 'watch',
+        batch_start: 1,
+        degradation_signal: watchSignal,
+      }),
+    ]);
+
+    expect(r.recommendations[0].text).toContain('watch long-horizon degradation');
+    expect(r.recommendations[0].text).toContain('Watch late-run quality');
   });
 
   it('notes an improving trajectory', () => {

--- a/scripts/batch-outcome.test.ts
+++ b/scripts/batch-outcome.test.ts
@@ -82,6 +82,21 @@ function makeScore(overrides: Partial<BatchScore> = {}): BatchScore {
   };
 }
 
+const degradedSignal = {
+  verdict: 'degraded' as const,
+  score: 0.8,
+  first_half_success_rate: 1,
+  second_half_success_rate: 0,
+  success_rate_delta: -1,
+  trailing_failure_count: 3,
+  trailing_empty_success_count: 2,
+  early_cost_per_success: 1,
+  late_cost_per_success: null,
+  cost_per_success_ratio: null,
+  duration_slope_seconds_per_run: 75,
+  reasons: ['success rate fell from 100% to 0%', '3 trailing failed runs'],
+};
+
 describe('buildBatchOutcome — pure derivation', () => {
   it('maps state + score into a schema-valid outcome', () => {
     const outcome = buildBatchOutcome(makeState(), makeScore(), 1_600);
@@ -149,6 +164,17 @@ describe('buildBatchOutcome — pure derivation', () => {
     expect(outcome.totals.runs).toBe(0);
     expect(outcome.wall_seconds).toBe(1);
   });
+
+  it('persists the additive degradation signal when scoreBatch produced one', () => {
+    const outcome = buildBatchOutcome(
+      makeState(),
+      makeScore({ degradation_signal: degradedSignal }),
+      1_600,
+    );
+
+    expect(() => BatchOutcomeSchema.parse(outcome)).not.toThrow();
+    expect(outcome.degradation_signal).toEqual(degradedSignal);
+  });
 });
 
 describe('BatchOutcomeSchema — drift guard', () => {
@@ -161,6 +187,12 @@ describe('BatchOutcomeSchema — drift guard', () => {
     const good: any = buildBatchOutcome(makeState(), makeScore(), 1_600);
     delete good.totals;
     expect(() => BatchOutcomeSchema.parse(good)).toThrow();
+  });
+
+  it('accepts legacy payloads that predate degradation_signal', () => {
+    const legacy: any = buildBatchOutcome(makeState(), makeScore(), 1_600);
+    delete legacy.degradation_signal;
+    expect(BatchOutcomeSchema.parse(legacy).degradation_signal).toBeUndefined();
   });
 });
 
@@ -303,6 +335,24 @@ describe('computeSteeringRecommendations — pure analysis', () => {
     expect(traj?.text).toMatch(/declining/i);
     // Declining trajectory is the highest-priority signal → sorts first.
     expect(r.recommendations[0].kind).toBe('trajectory');
+  });
+
+  it('prioritizes explicit degradation signals from prior batch outcomes', () => {
+    const r = computeSteeringRecommendations([
+      makeOutcome({ batch_id: 'healthy', batch_start: 1 }),
+      makeOutcome({
+        batch_id: 'degraded',
+        batch_start: 2,
+        degradation_signal: degradedSignal,
+      }),
+    ]);
+
+    expect(r.recommendations[0]).toMatchObject({
+      priority: 8,
+      kind: 'trajectory',
+    });
+    expect(r.recommendations[0].text).toContain('degraded long-horizon degradation');
+    expect(r.recommendations[0].text).toContain('Pause broad auto-dent guidance');
   });
 
   it('notes an improving trajectory', () => {

--- a/scripts/batch-outcome.ts
+++ b/scripts/batch-outcome.ts
@@ -55,6 +55,22 @@ const BatchTrendSchema = z
   })
   .nullable();
 
+/** Long-horizon degradation signal (mirrors BatchDegradationSignal). */
+const BatchDegradationSignalSchema = z.object({
+  verdict: z.enum(['insufficient_data', 'healthy', 'watch', 'degraded']),
+  score: z.number(),
+  first_half_success_rate: z.number().nullable(),
+  second_half_success_rate: z.number().nullable(),
+  success_rate_delta: z.number().nullable(),
+  trailing_failure_count: z.number(),
+  trailing_empty_success_count: z.number(),
+  early_cost_per_success: z.number().nullable(),
+  late_cost_per_success: z.number().nullable(),
+  cost_per_success_ratio: z.number().nullable(),
+  duration_slope_seconds_per_run: z.number().nullable(),
+  reasons: z.array(z.string()),
+});
+
 /**
  * The structured batch outcome. Derived purely from `BatchState` + `BatchScore`.
  * This is the cross-batch learning record — keep it machine-resolvable, not prose.
@@ -85,6 +101,7 @@ export const BatchOutcomeSchema = z.object({
   cost_anomaly_count: z.number(),
   mode_diversity: z.number(),
   trend: BatchTrendSchema,
+  degradation_signal: BatchDegradationSignalSchema.optional(),
   mode_breakdown: z.array(ModeBreakdownSchema),
   prs: z.array(z.string()),
   issues_closed: z.array(z.string()),
@@ -135,6 +152,7 @@ export function buildBatchOutcome(
     cost_anomaly_count: score.cost_anomaly_count,
     mode_diversity: finite(score.mode_diversity),
     trend: score.trend,
+    ...(score.degradation_signal ? { degradation_signal: score.degradation_signal } : {}),
     mode_breakdown: score.mode_breakdown.map((m) => ({
       mode: m.mode,
       runs: m.runs,
@@ -408,6 +426,25 @@ export function computeSteeringRecommendations(
   const sorted = [...outcomes].sort((a, b) => a.batch_start - b.batch_start);
   const span = { from: sorted[0].batch_start, to: sorted[sorted.length - 1].batch_start };
   const recs: SteeringRecommendation[] = [];
+
+  // --- Explicit within-batch degradation signal -----------------------------
+  const latestDegradation = [...sorted]
+    .reverse()
+    .find((o) => {
+      const verdict = o.degradation_signal?.verdict;
+      return verdict === 'watch' || verdict === 'degraded';
+    });
+  if (latestDegradation?.degradation_signal) {
+    const signal = latestDegradation.degradation_signal;
+    const action = signal.verdict === 'degraded'
+      ? 'Pause broad auto-dent guidance, inspect late-run failures, and resume with smaller leaf issues until the signal clears.'
+      : 'Watch late-run quality: narrow scope and inspect the next reflection before expanding guidance.';
+    recs.push({
+      priority: 8,
+      kind: 'trajectory',
+      text: `Latest batch reported ${signal.verdict} long-horizon degradation (score ${signal.score.toFixed(2)}: ${signal.reasons.join('; ')}). ${action}`,
+    });
+  }
 
   // --- Mode effectiveness: prefer the mode that actually ships work ----------
   // Only rank modes with enough evidence (>=3 runs) to avoid noise.

--- a/src/verdict-binding-inventory.ts
+++ b/src/verdict-binding-inventory.ts
@@ -234,6 +234,11 @@ export const VERDICT_BINDING_INVENTORY: VerdictBindingInventory = {
       rationale: 'Analytics copy of the review verdict; terminal binding is represented by review-battery-verdict.',
     },
     {
+      signature: 'scripts/auto-dent-score.ts:type:BatchDegradationVerdict',
+      label: 'Auto-dent batch degradation verdict',
+      rationale: 'Advisory long-horizon quality signal for operators and steering prompts; it does not authorize an irreversible terminal action.',
+    },
+    {
       signature: 'scripts/auto-dent-replay.ts:field:process_verdict',
       label: 'Auto-dent replay process verdict projection',
       rationale: 'Replay-state reporting copy of the process verdict from events.jsonl; terminal binding is represented by process-evidence-verdict.',


### PR DESCRIPTION
Once upon a time, auto-dent could report per-run success, cost, failure classes, and coarse batch trends. Every day, operators could see whether a batch had a low success rate or a few consecutive failures, but no durable field answered the actual #1358 question: is this long-running batch getting worse as it goes?

One day, #1358 connected that gap to long-horizon degradation: late-run quality can decay while the system only leaves scattered prose hints. Because of that, this PR adds a first-class `BatchDegradationSignal` in the existing `scoreBatch` path, comparing early vs late success, trailing failure/empty streaks, cost per success, and duration slope. Because of that, the same signal now appears in score output, mid-batch reflection, durable `batch-outcome` attachments, and cross-batch steering recommendations. Until finally, a synthetic degraded batch now renders a concrete score-table row: `Degradation signal | degraded (0.95) — success rate fell from 100% to 0%; 3 trailing failed runs; run duration rising 156s/run`.

And ever since this branch, auto-dent has an owned, machine-readable degradation verdict to observe before any future dashboard, telemetry, or halt/replan automation is added.

## Architecture

```text
run_history
   |
   v
scoreRunMetrics[] -> scoreBatch -> BatchDegradationSignal
   |                         |              |
   |                         |              +--> formatBatchScoreTable
   |                         +------------------> buildBatchOutcome.degradation_signal
   |                                           |
   +--> buildBatchReflection ------------------+--> reflection insight/comment
                                               |
prior batch-outcome attachments ---------------+--> computeSteeringRecommendations
```

## Design decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Put the metric in `auto-dent-score.ts` / `scoreBatch` | Existing run scoring already owns success, cost, failure classes, and trend data | The signal is based on available run metrics, not raw transcript content |
| Persist `degradation_signal` as optional in `BatchOutcomeSchema` | New batches expose the signal while old GitHub attachments still parse | Consumers must handle absence for legacy outcomes |
| Emit steering guidance, not an automatic halt | #1358 needs the signal first; circuit-breaking has a dedicated follow-up (#1713) | Operators get advice now; automatic stop remains sequenced |
| Keep reasons and raw comparison fields | Reviewers/operators can inspect why a verdict fired | Slightly larger outcome payload |

## What's in this PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-score.ts` | Adds `BatchDegradationSignal`, computes it in `scoreBatch`, and renders score-table output |
| `scripts/batch-outcome.ts` | Persists the additive signal and consumes degraded prior outcomes for steering recommendations |
| `scripts/auto-dent-ctl.ts` | Surfaces watch/degraded signals in mid-batch reflection insights/comments without duplicating the old consecutive-failure insight |
| `scripts/auto-dent-score.test.ts` | Covers insufficient, healthy, watch, degraded, clamp, odd-count split, finite numeric, timeout-motivated, and rendered table behavior |
| `scripts/batch-outcome.test.ts` | Covers persistence, legacy parsing, degraded steering guidance, and watch steering guidance |
| `scripts/auto-dent-ctl.test.ts` | Covers reflection/comment visibility for degraded batches and duplicate insight suppression |
| `src/verdict-binding-inventory.ts` | Classifies the degradation verdict as advisory/non-terminal for the verdict-binding invariant |

## Impact (goal -> before/after -> match)

- Goal (#1358):        auto-dent computes and surfaces a within-batch degradation signal so operators and steering code can tell when a batch is getting worse across later runs.
- Acceptance signal: focused tests show late-run quality drops produce a degraded signal, healthy/insufficient batches do not produce alarming verdicts, and formatted/durable outputs include the signal.
- BEFORE:           `BatchTrend` had slopes and reflection had prose insights, but no named degradation verdict existed in `BatchScore`, `batch-outcome`, reflection comments, or steering.
- AFTER:            `scoreBatch` emits `degradation_signal`; `formatBatchScoreTable` renders it; `buildBatchOutcome` persists it; `computeSteeringRecommendations` reacts to it; `buildBatchReflection` comments on it.
- Delta:            one reusable signal now feeds four existing surfaces instead of adding a parallel metric family.
- Goal met?:        yes for the owned degradation signal. Dashboard field (#1715), OTel emission (#1714), and halt/replan circuit breaker (#1713) are explicitly tracked follow-ups.
- Residual scan:    reused `scoreBatch`, `BatchTrend`, `batch-outcome`, and reflection paths; no separate parser or dashboard-only metric was added.

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Insufficient data stays non-alarming | tested: `computeBatchDegradationSignal` fewer than 4 runs | n/a | n/a | n/a | n/a |
| Stable healthy batch stays healthy | tested: healthy run-score fixture and `formatDegradationSignal` healthy branch | n/a | n/a | n/a | n/a |
| Watch verdict is reachable and actionable | tested: isolated late-window success decline produces `watch` | tested: watch prior outcome creates watch-specific steering text | n/a | n/a | tested: steering consumes same durable signal |
| Late-run decay becomes degraded with reasons | tested: success collapse, failure streak, empty streak, clamp to 1, odd-count split, timeout failure-class pattern, finite numeric fields | tested: reflection insight/comment includes signal and suppresses duplicate consecutive-failure insight | tested: local score-table smoke rendered degraded row | n/a | tested: existing score/outcome/reflection surfaces consume one signal |
| Durable outcome compatibility | tested: `buildBatchOutcome` persists signal; schema accepts legacy missing field | tested: steering recommendation reads degraded/watch outcome | n/a | n/a | tested: old attachments remain readable |
| Dashboard surfacing | deferred to #1715 | deferred to #1715 | deferred to #1715 | n/a | tracked in #1715 |
| OTel signal emission | deferred to #1714 | deferred to #1714 | deferred to #1714 | n/a | tracked in #1714 |
| Circuit-breaker action | deferred to #1713 | deferred to #1713 | deferred to #1713 | n/a | tracked in #1713 |

## Validation

- [x] `npx vitest run scripts/auto-dent-score.test.ts scripts/batch-outcome.test.ts scripts/auto-dent-ctl.test.ts` -> 3 files, 244 tests passed.
- [x] `npm run typecheck` -> `tsc --noEmit` passed.
- [x] `git diff --check` -> passed.
- [x] Meet-reality smoke: rendered `formatBatchScoreTable(scoreBatch(...))` for a synthetic degraded six-run history and observed the `Degradation signal` row with degraded verdict and reasons.

## Kaizen

- **Root cause:** Auto-dent had trend fragments but no named, durable degradation verdict that later steering or operators could consume.
- **Fix level:** L3-ish architecture/data contract — `scoreBatch` now produces one signal that existing output, outcome, reflection, and steering paths reuse.
- **Repeat failure?** No for this exact signal; adjacent deferred surfaces are tracked separately.
- **Escalation needed?** Yes, for downstream actions: dashboard #1715, OTel #1714, halt/replan #1713. Review-tooling friction filed as #1716.
- **Backlog issue:** #1716 for review-fix structured evidence persistence; #1713/#1714/#1715 for downstream signal consumers.

## Known limitations

This PR creates the observable, durable, reusable degradation signal. It intentionally does not complete downstream dashboard, telemetry, or halt/replan behavior:

- Progress dashboard surfacing: #1715
- OTel event/attribute emission: #1714
- Halt/replan circuit breaker: #1713

Closes #1358
Parent: #1677
Refs: #1713 #1714 #1715



