### PR TITLE
Document auto-dent trace platform path

### DIFF
--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -375,6 +375,12 @@ After a batch completes:
    ```
    Export is best-effort and fail-open: a collector outage must not block the
    auto-dent run or prevent `events.jsonl` from being written.
+   The platform decision and live-smoke boundary are documented in
+   [`docs/auto-dent-trace-platform-evaluation.md`](auto-dent-trace-platform-evaluation.md):
+   use the existing `scripts/auto-dent-otel.ts` projection first, try an OTLP
+   trace UI such as Langfuse before adding vendor-specific converters, and keep
+   complete transcript bundles on the transcript artifact transport rather than
+   raw trace span attributes.
 
 ## Scoring
 

--- a/docs/auto-dent-trace-platform-evaluation.md
+++ b/docs/auto-dent-trace-platform-evaluation.md
@@ -56,6 +56,28 @@ If Langfuse needs promoted top-level trace metadata for filterability, enrich
 the existing OTel projection in `scripts/auto-dent-otel.ts`. Do not add a
 parallel Langfuse-only converter.
 
+## Issue Questions Answered
+
+1. **Ingest:** use OTLP through `scripts/auto-dent-otel.ts`. Do not convert
+   stream-json directly to a vendor SDK format unless a live platform smoke
+   proves OTLP cannot satisfy the UI contract.
+2. **Agent hierarchy:** the current trace projection models the run as a root
+   span and review/fix work as child spans. If future subagent events need their
+   own hierarchy, add child spans to the same OTel projection.
+3. **Cross-run analytics:** use `kaizen.batch.id`, `kaizen.run.*`,
+   issue/PR-reference attributes, and score/lifecycle attributes as the first
+   filter/group-by surface. If a platform only filters top-level trace metadata,
+   promote those same fields in the OTel projection.
+4. **Scoring integration:** push score outputs as span or trace attributes that
+   point back to the scoring artifact. Keep large score artifacts in the
+   existing artifact/attachment chain rather than embedding raw blobs in spans.
+5. **Self-hosted vs cloud:** Langfuse remains first because it supports both
+   cloud and self-host modes. The choice between them depends on credentials,
+   retention, and current pricing at smoke time.
+6. **Cost/free tier:** do not hard-code a pricing claim in repo docs. The
+   credentialed smoke must check current platform pricing/free-tier limits when
+   it runs.
+
 ## Transcript Boundary
 
 Trace platforms are for timelines, span attributes, status, cost, and pointers.
@@ -87,6 +109,11 @@ application/json`. If a platform requires OTLP protobuf, gRPC, custom auth
 headers, or promoted top-level metadata, adapt the single OTel transport or
 projection behind `KAIZEN_OTEL_ENDPOINT`; keep JSONL and transcript artifacts as
 the durable fallback.
+
+Credentialed live smoke is tracked separately in #1723. That issue must verify
+the actual Langfuse UI, metadata filterability, and current pricing/free-tier
+constraints before any platform-specific converter or #556 dashboard work is
+started.
 
 ## Disqualifiers
 
@@ -122,6 +149,7 @@ OTLP payload before building #556's dashboard surface.
 ## Current Limitations
 
 This document does not claim a successful cloud ingestion smoke. That requires
-external credentials or a self-hosted endpoint. The kaizen-side contract is
+external credentials or a self-hosted endpoint and is tracked by #1723. The
+kaizen-side contract is
 covered by deterministic OTLP payload/export tests; the remaining proof is
 vendor availability and UI fidelity.

--- a/docs/auto-dent-trace-platform-evaluation.md
+++ b/docs/auto-dent-trace-platform-evaluation.md
@@ -1,0 +1,127 @@
+# Auto-Dent Trace Platform Evaluation
+
+This document resolves #545's first decision point: which trace platform path
+auto-dent should use for remote run observability without creating another
+conversion surface.
+
+## Decision
+
+Use the existing OpenTelemetry projection as the single trace ingestion contract.
+
+- `logs/auto-dent/<batch>/events.jsonl` remains the durable structured source of
+  truth.
+- `scripts/auto-dent-otel.ts` is the only stream-to-trace projection for
+  auto-dent run lifecycle, cost, review, and fix spans.
+- `KAIZEN_OTEL_ENDPOINT` is the operator switch for mirroring completed runs to
+  an OTLP HTTP collector.
+- `docs/auto-dent-transcript-transport.md` remains the contract for complete
+  scrubbed transcript bundles. Trace spans should carry IDs, cost, status,
+  duration, issue/PR references, and artifact pointers, not raw reasoning logs.
+
+Try Langfuse first for an interactive trace UI. Keep LangSmith, Braintrust, and
+Phoenix as comparison/fallback targets because all have OpenTelemetry paths, but
+none justify a vendor-specific `log-to-langfuse.ts` style converter before a live
+endpoint proves a concrete gap in the current OTLP payload.
+
+## Platform Matrix
+
+| Platform | Store | View | Mine | Fit for current auto-dent path |
+| --- | --- | --- | --- | --- |
+| Langfuse | Accepts OTLP HTTP traces at `/api/public/otel`; cloud and self-host options exist. | LLM trace UI, costs, scores, sessions, and metadata filtering are close to #545's operator view. | Metadata filters and scores can support cross-run slices if auto-dent maps batch/run/case fields onto trace metadata. | First candidate. It matches the existing `HttpOtelTransport` shape best; only live smoke can prove UI fidelity. |
+| LangSmith | Has an OpenTelemetry tracing path and collector/fanout guidance. | Mature trace UI and dataset/eval features. | Good analytics/eval surface, but LangChain-native workflows may be the easiest path. | Comparison target. Do not switch the exporter contract just to adopt LangSmith SDK conventions. |
+| Braintrust | Supports OpenTelemetry integration/exporter paths. | Strong eval/logging workflow; observability is useful but more eval-centered. | Strong dataset/eval mining surface. | Secondary candidate if #545's "mine" goal outweighs trace-debug UI. Keep OTel boundary. |
+| Phoenix | OTel/OpenInference-oriented and accepts OTLP-style configuration. | Strong ML/LLM trace inspection and eval workflows. | Good for OpenInference-rich traces. | Viable if auto-dent later enriches spans with OpenInference semantics; current GenAI OTel payload may render less richly. |
+| Generic OTel backend | Any OTLP collector can store the spans. | Jaeger/Grafana-style views are reliable but less agent-aware. | Requires external metrics/log queries or custom dashboards. | Operational fallback, not the preferred human trace UI. |
+
+## Metadata Contract
+
+For the first UI smoke, the exported trace must make these fields filterable or
+visible at trace/span level:
+
+- `kaizen.batch.id`
+- `kaizen.run.id`
+- `kaizen.run.number`
+- `kaizen.run.mode`
+- `kaizen.run.outcome`
+- `kaizen.run.exit_code`
+- `kaizen.run.cost_usd`
+- `kaizen.run.prs_created`
+- `kaizen.run.issues_filed_refs`
+- `kaizen.run.issues_closed_refs`
+- `kaizen.run.cases`
+- `kaizen.run.lifecycle_health`
+- `kaizen.run.review_verdict`
+
+If Langfuse needs promoted top-level trace metadata for filterability, enrich
+the existing OTel projection in `scripts/auto-dent-otel.ts`. Do not add a
+parallel Langfuse-only converter.
+
+## Transcript Boundary
+
+Trace platforms are for timelines, span attributes, status, cost, and pointers.
+Complete transcript retention is a separate artifact-chain concern.
+
+The full `run-*.log` transcript bundle can contain sensitive reasoning, tool
+outputs, and credentials accidentally echoed by tools. It must follow
+`docs/auto-dent-transcript-transport.md`: scrub first, fail closed on scrub
+failure, upload complete bundles through the chosen transcript transport, and
+store only compact manifests/pointers on issues.
+
+## Operator Smoke
+
+Local deterministic proof:
+
+```bash
+npx vitest run scripts/auto-dent-otel.test.ts scripts/auto-dent-events.test.ts
+```
+
+Live platform proof requires a collector endpoint and credentials. For Langfuse,
+configure the endpoint to its OTLP HTTP route and run an auto-dent batch with:
+
+```bash
+KAIZEN_OTEL_ENDPOINT=https://<langfuse-host>/api/public/otel
+```
+
+The current `HttpOtelTransport` posts OTLP JSON with `content-type:
+application/json`. If a platform requires OTLP protobuf, gRPC, custom auth
+headers, or promoted top-level metadata, adapt the single OTel transport or
+projection behind `KAIZEN_OTEL_ENDPOINT`; keep JSONL and transcript artifacts as
+the durable fallback.
+
+## Disqualifiers
+
+Disqualify the first-candidate path and revisit the matrix if a live smoke shows
+one of these failures:
+
+- completed auto-dent runs are not visible as one trace per run
+- batch/run IDs cannot be filtered or searched
+- costs, issue/PR references, lifecycle health, and review status are invisible
+- raw transcripts are required for useful UI rendering
+- export failures can block auto-dent lifecycle completion
+
+If only metadata shape is missing, file a schema-enrichment issue against
+`scripts/auto-dent-otel.ts`. If the UI cannot satisfy store/view/mine even with
+metadata enrichment, compare LangSmith, Braintrust, and Phoenix using the same
+OTLP payload before building #556's dashboard surface.
+
+## Sources Checked
+
+- Langfuse OpenTelemetry integration:
+  `https://langfuse.com/integrations/native/opentelemetry`
+- LangSmith OpenTelemetry tracing:
+  `https://docs.langchain.com/langsmith/trace-with-opentelemetry`
+- Braintrust OpenTelemetry integration:
+  `https://www.braintrust.dev/docs/integrations/sdk-integrations/opentelemetry`
+- Braintrust OTel JS exporter reference:
+  `https://www.braintrust.dev/docs/reference/integrations/otel-js/0.2.0/otel-js`
+- Phoenix OTel setup:
+  `https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel`
+- Phoenix OpenInference exporter:
+  `https://arize.com/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter`
+
+## Current Limitations
+
+This document does not claim a successful cloud ingestion smoke. That requires
+external credentials or a self-hosted endpoint. The kaizen-side contract is
+covered by deterministic OTLP payload/export tests; the remaining proof is
+vendor availability and UI fidelity.

--- a/src/policy-docs.test.ts
+++ b/src/policy-docs.test.ts
@@ -378,6 +378,44 @@ describe('.agents/kaizen/README.md — Core Invariants points to canonical', () 
   });
 });
 
+describe('auto-dent trace platform evaluation docs', () => {
+  const evaluation = read('docs/auto-dent-trace-platform-evaluation.md');
+  const operations = read('docs/auto-dent-operations.md');
+
+  it('keeps the existing OTel projection as the single ingestion path', () => {
+    expect(evaluation).toContain('scripts/auto-dent-otel.ts');
+    expect(evaluation).toContain('KAIZEN_OTEL_ENDPOINT');
+    expect(evaluation).toMatch(/single trace ingestion contract/i);
+    expect(evaluation).not.toContain('scripts/log-to-langfuse.ts');
+  });
+
+  it('covers #545 store, view, and mine criteria across current candidates', () => {
+    expect(evaluation).toMatch(/\| Platform \| Store \| View \| Mine \|/);
+    for (const platform of ['Langfuse', 'LangSmith', 'Braintrust', 'Phoenix']) {
+      expect(evaluation).toContain(platform);
+    }
+    expect(evaluation).toMatch(/Generic OTel backend/);
+  });
+
+  it('preserves transcript transport as separate from trace spans', () => {
+    expect(evaluation).toContain('docs/auto-dent-transcript-transport.md');
+    expect(evaluation).toMatch(/not raw reasoning logs/i);
+    expect(evaluation).toMatch(/scrub first/i);
+  });
+
+  it('documents the credentialed live-smoke boundary honestly', () => {
+    expect(evaluation).toMatch(/does not claim a successful cloud ingestion smoke/i);
+    expect(evaluation).toMatch(/external credentials or a self-hosted endpoint/i);
+    expect(evaluation).toMatch(/npx vitest run scripts\/auto-dent-otel\.test\.ts scripts\/auto-dent-events\.test\.ts/);
+  });
+
+  it('links operations guidance from KAIZEN_OTEL_ENDPOINT to the evaluation', () => {
+    expect(operations).toContain('KAIZEN_OTEL_ENDPOINT=https://otel.example/v1/traces');
+    expect(operations).toContain('auto-dent-trace-platform-evaluation.md');
+    expect(operations).toContain('scripts/auto-dent-otel.ts');
+  });
+});
+
 // ── review-requirements.md — check #7 (B18) ────────────────────────
 
 describe('review-requirements.md — B18: premature epic closure check', () => {

--- a/src/policy-docs.test.ts
+++ b/src/policy-docs.test.ts
@@ -406,7 +406,22 @@ describe('auto-dent trace platform evaluation docs', () => {
   it('documents the credentialed live-smoke boundary honestly', () => {
     expect(evaluation).toMatch(/does not claim a successful cloud ingestion smoke/i);
     expect(evaluation).toMatch(/external credentials or a self-hosted endpoint/i);
+    expect(evaluation).toContain('#1723');
     expect(evaluation).toMatch(/npx vitest run scripts\/auto-dent-otel\.test\.ts scripts\/auto-dent-events\.test\.ts/);
+  });
+
+  it('answers #545 explicit platform questions without hard-coding pricing claims', () => {
+    for (const question of [
+      'Ingest',
+      'Agent hierarchy',
+      'Cross-run analytics',
+      'Scoring integration',
+      'Self-hosted vs cloud',
+      'Cost/free tier',
+    ]) {
+      expect(evaluation).toContain(`**${question}:**`);
+    }
+    expect(evaluation).toMatch(/do not hard-code a pricing claim/i);
   });
 
   it('links operations guidance from KAIZEN_OTEL_ENDPOINT to the evaluation', () => {


### PR DESCRIPTION
## Story Spine

Once upon a time, auto-dent already had rich run evidence: JSONL events, transcript artifacts, and an OpenTelemetry projection in `scripts/auto-dent-otel.ts`.

Every day, operators could preserve local and GitHub-backed artifacts, but #545 still had no durable platform decision for the store/view/mine trace UI question. The issue body still suggested writing `log-to-langfuse.ts`, even though the repo now has a vendor-neutral OTel projection.

One day, the #1677 Phase 6 queue reached #545 after the artifact and anomaly work landed. Re-reading the current code and official platform docs showed the missing piece is not another converter; it is a decision record that keeps the existing OTel path as the contract and names the live-smoke boundary.

Because of that, this PR adds `docs/auto-dent-trace-platform-evaluation.md`. It selects the existing OTel projection as the single ingestion path, recommends Langfuse as the first interactive trace UI candidate, compares LangSmith/Braintrust/Phoenix as fallback targets, and keeps raw transcript retention under `docs/auto-dent-transcript-transport.md`.

Because of that, `docs/auto-dent-operations.md` now routes `KAIZEN_OTEL_ENDPOINT` operators to the evaluation doc instead of leaving the platform choice implicit.

Until finally, `src/policy-docs.test.ts` pins the decision so future edits cannot quietly reintroduce a second vendor-specific converter, omit the transcript boundary, skip #545's explicit platform questions, or claim a live cloud smoke that was not run.

And ever since, #545's first platform decision is durable: auto-dent remains JSONL/transcript-artifact first, mirrors traces through OTel, and tracks credentialed live platform smoke in #1723 before any vendor-specific enrichment.

## Architecture

```text
auto-dent events.jsonl
        |
        v
scripts/auto-dent-otel.ts  -- KAIZEN_OTEL_ENDPOINT --> OTLP HTTP trace UI
        |
        +--> docs/auto-dent-trace-platform-evaluation.md
        |
        +--> docs/auto-dent-transcript-transport.md for complete scrubbed run logs
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Keep `scripts/auto-dent-otel.ts` as the single ingestion projection | The converter already exists and is tested; a Langfuse-only script would duplicate schema ownership | Live vendor smoke may still require metadata enrichment later |
| Try Langfuse first | Official docs expose an OTLP HTTP route and the UI shape is closest to #545's trace-debug goal | The PR does not claim successful cloud ingestion without credentials; #1723 owns that proof |
| Keep transcripts out of trace spans | Full run logs need scrub/fail-closed artifact handling | Trace UI gets pointers/metadata, not full reasoning bodies |
| Add doc invariants | This is a decision artifact; tests prevent drift in the doc contract | Unit doc assertions are structural, not a replacement for live endpoint smoke |

## What's In This PR

| File | Purpose |
|---|---|
| `docs/auto-dent-trace-platform-evaluation.md` | Platform decision, matrix, #545 question answers, metadata contract, transcript boundary, smoke steps, disqualifiers, and official source links |
| `docs/auto-dent-operations.md` | Links `KAIZEN_OTEL_ENDPOINT` operator guidance to the evaluation doc |
| `src/policy-docs.test.ts` | Adds regression coverage for single OTel path, store/view/mine matrix, transcript separation, #545 question coverage, live-smoke boundary, and operations link |

## Test Plan (Behaviors × Levels)

| # | Behavior | Level | Coverage |
|---|---|---|---|
| 1 | Existing auto-dent events still project run lifecycle/cost/status into OTLP-compatible GenAI traces without raw sensitive content attributes | Unit | Covered by existing `scripts/auto-dent-otel.test.ts`; rerun in this PR |
| 2 | `KAIZEN_OTEL_ENDPOINT` wires auto-dent events to the OTel sink while preserving JSONL and failing open | Integration | Covered by existing `scripts/auto-dent-events.test.ts`; rerun in this PR |
| 3 | Evaluation doc identifies the existing OTel projection as the single ingestion path and avoids a duplicate vendor converter contract | Unit | Added assertions in `src/policy-docs.test.ts` |
| 4 | Operations guide links `KAIZEN_OTEL_ENDPOINT` setup to the platform evaluation and names the live-endpoint boundary | Unit | Added assertions in `src/policy-docs.test.ts` |
| 5 | Platform decision covers store/view/mine, metadata/filtering, transcript/security, and fallback criteria | Unit | Added assertions in `src/policy-docs.test.ts` |

Deferred: live Langfuse/LangSmith/Braintrust/Phoenix ingestion smoke requires external credentials or a self-hosted endpoint. #1723 tracks that independent live proof, including current pricing/free-tier checks.

## Impact (goal -> before/after -> match)

- Goal (#545): operators need a remote trace observability platform direction for store/view/mine auto-dent runs.
- Acceptance signal: a reviewer can open one doc and answer selected first platform, fallback/comparison order, ingestion shape, metadata requirements, transcript/security boundary, #545's six platform questions, and validation commands.
- BEFORE: the repo had `scripts/auto-dent-otel.ts` and a short `KAIZEN_OTEL_ENDPOINT` operations snippet, but no platform selection document tying official docs to the existing JSONL/OTel/transcript architecture. The issue still suggested a vendor-specific `log-to-langfuse.ts` converter.
- AFTER: `docs/auto-dent-trace-platform-evaluation.md` selects OTel-first, recommends Langfuse first, compares LangSmith/Braintrust/Phoenix, answers ingest/hierarchy/analytics/scoring/self-host/cost questions, keeps transcripts separate, lists disqualifiers, links official sources, and points live smoke to #1723. Operations docs point to it.
- Delta: one durable decision artifact plus six doc-invariant checks; no new converter surface.
- Goal met?: yes for the scoped #545 exploration/decision artifact; live endpoint smoke is explicitly tracked by #1723.
- Residual scan: `rg "log-to-langfuse|vendor-specific converter|raw reasoning logs|KAIZEN_OTEL_ENDPOINT" docs scripts src .agents/AGENTS.md` found no stale repo converter guidance beyond the new doc's explicit rejection.

## Validation

- [x] `npx vitest run scripts/auto-dent-otel.test.ts scripts/auto-dent-events.test.ts src/policy-docs.test.ts` — 3 files, 90 tests passed
- [x] `npm run typecheck` — passed
- [x] `git diff --check` — passed
- [x] Workflow status shows plan/test-plan, worktree/case, implementation, DRY, and meet-reality evidence done for #545

## Known Limitations

- No live platform ingestion smoke was run; that needs external credentials or a self-hosted endpoint and is tracked by #1723.
- If Langfuse needs promoted top-level metadata for filtering, the follow-up should enrich `scripts/auto-dent-otel.ts` rather than add a platform-only converter.

Closes #545
Parent: #1677
Refs: #1723
