### PR TITLE
Render auto-dent terminal phase pipeline

### DIFF
--- a/scripts/auto-dent-progress.test.ts
+++ b/scripts/auto-dent-progress.test.ts
@@ -4,6 +4,7 @@ import {
   PROGRESS_PHASE_ORDER,
   buildKaizenCycleSteps,
   formatProgressStepsMarkdown,
+  formatTerminalProgressPipeline,
   hasContextDelegationProgressEvidence,
   orderedProgressSteps,
   upsertContextDelegationProgressStep,
@@ -154,6 +155,96 @@ describe('auto-dent progress rendering core (#1311)', () => {
     expect(markdown).toContain('| MERGE | merged | PR #1645 | https://github.com/Garsson-io/kaizen/pull/1645 |');
     expect(markdown).toContain('| STOP | requested | merged and cleaned up | - |');
     expect(markdown).not.toContain('[object Object]');
+  });
+
+  it('formats a complete run as a plain terminal phase pipeline', () => {
+    const output = formatTerminalProgressPipeline({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/1645'],
+      cases: ['case/260629-k1311-auto-dent-progress-coverage'],
+      pickedIssue: '#1311',
+      pickedIssueTitle: 'Progress rendering coverage',
+      progressSteps: [
+        { phase: 'PLAN', state: 'stored', detail: 'plan/test-plan stored' },
+        { phase: 'IMPLEMENT', state: 'done', detail: 'renderer added' },
+        { phase: 'TEST', state: 'passed', detail: 'focused vitest' },
+        {
+          phase: 'MERGE',
+          state: 'merged',
+          detail: 'PR #1645',
+          url: 'https://github.com/Garsson-io/kaizen/pull/1645',
+        },
+        { phase: 'REFLECT', state: 'completed', detail: '0 issues filed' },
+      ],
+      reviewVerdict: 'pass',
+      reviewUrls: ['https://github.com/Garsson-io/kaizen/pull/1645#issuecomment-1'],
+      stopRequested: true,
+      stopReason: 'merged and cleaned up',
+    }, {
+      repo: 'Garsson-io/kaizen',
+      runNum: 17,
+      durationSeconds: 432,
+      costUsd: 3.4,
+    });
+
+    expect(output).toContain('Auto-dent run 17 | 7m12s | $3.40');
+    expect(output).toContain('Phase      Status          Detail');
+    expect(output).toContain('PICK       [x] selected');
+    expect(output).toContain('https://github.com/Garsson-io/kaizen/issues/1311');
+    expect(output).toContain('PLAN       [x] stored');
+    expect(output).toContain('TEST       [x] passed');
+    expect(output).toContain('REVIEW     [x] pass');
+    expect(output).toContain('MERGE      [x] merged');
+    expect(output).toContain('REFLECT    [x] completed');
+    expect(output).toContain('STOP       [x] requested');
+    expect(output).not.toContain('[object Object]');
+  });
+
+  it('formats partial and missing phases without layout corruption', () => {
+    const output = formatTerminalProgressPipeline({
+      prs: [],
+      cases: [],
+      pickedIssue: '#1724',
+      progressSteps: [
+        { phase: 'IMPLEMENT', state: 'started', detail: 'terminal renderer' },
+      ],
+      stopRequested: false,
+    }, {
+      repo: 'Garsson-io/kaizen',
+      runNum: 2,
+      durationSeconds: 9,
+    });
+
+    expect(output).toContain('Auto-dent run 2 | 9s');
+    expect(output).toContain('IMPLEMENT  [>] started');
+    expect(output).toContain('PR         [ ] not observed');
+    expect(output).toContain('MERGE      [-] not applicable');
+    expect(output).toContain('STOP       [ ] not requested');
+    expect(output).not.toContain('[object Object]');
+    for (const line of output.split('\n').slice(3)) {
+      expect(line).toMatch(/^[A-Z-]+\s{2,}\[[x>! -]\]/);
+    }
+  });
+
+  it('preserves synthetic not-applicable defaults in terminal output', () => {
+    const output = formatTerminalProgressPipeline({
+      prs: ['https://github.com/Garsson-io/kaizen/pull/2000'],
+      cases: ['case/synthetic'],
+      pickedIssue: 'not applicable',
+      pickedIssueTitle: 'synthetic dashboard probe',
+      progressSteps: [
+        { phase: 'PLAN', state: 'done', detail: 'should not replace synthetic skip' },
+        { phase: 'DELEGATE', state: 'done', detail: 'delegated dashboard inspection' },
+      ],
+      reviewVerdict: 'pass',
+      stopRequested: true,
+      stopReason: 'synthetic complete',
+    });
+
+    expect(output).toContain('PICK       [-] not applicable synthetic dashboard probe');
+    expect(output).toContain('PLAN       [-] not applicable synthetic test task');
+    expect(output).toContain('DELEGATE   [x] done');
+    expect(output).toContain('STOP       [x] requested');
+    expect(output).toContain('synthetic complete');
   });
 });
 

--- a/scripts/auto-dent-progress.ts
+++ b/scripts/auto-dent-progress.ts
@@ -47,6 +47,13 @@ const SYNTHETIC_NOT_APPLICABLE_PHASES = new Set([
 
 export type ProgressUpsertMode = 'merge' | 'replace';
 
+export interface TerminalProgressPipelineOptions {
+  repo?: string;
+  runNum?: number;
+  durationSeconds?: number;
+  costUsd?: number;
+}
+
 export function formatIssueUrl(issue: string | undefined, repo: string): string {
   if (!issue) return '';
   if (/^https?:\/\//.test(issue)) return issue;
@@ -162,6 +169,58 @@ export function formatProgressStepsMarkdown(result: AutoDentProgressResult, repo
     lines.push(`| ${step.phase} | ${step.state} | ${step.detail || '-'} | ${step.url || '-'} |`);
   }
   return lines.join('\n');
+}
+
+export function formatTerminalProgressPipeline(
+  result: AutoDentProgressResult,
+  options: TerminalProgressPipelineOptions = {},
+): string {
+  const repo = options.repo ?? '';
+  const parts = [`run ${options.runNum ?? '?'}`];
+  if (typeof options.durationSeconds === 'number') parts.push(formatDuration(options.durationSeconds));
+  if (typeof options.costUsd === 'number') parts.push(`$${options.costUsd.toFixed(2)}`);
+
+  const lines = [
+    `Auto-dent ${parts.join(' | ')}`,
+    'Phase      Status          Detail',
+    '---------- --------------- ----------------------------------------',
+  ];
+
+  for (const step of buildKaizenCycleSteps(result, repo)) {
+    const status = `${statusGlyph(step.state)} ${step.state || 'unknown'}`;
+    const detail = terminalStepDetail(step);
+    lines.push(`${step.phase.padEnd(10)} ${status.padEnd(15)} ${detail}`);
+  }
+
+  return lines.join('\n');
+}
+
+function terminalStepDetail(step: RunProgressStep): string {
+  const detail = normalizeWhitespace(step.detail);
+  const url = normalizeWhitespace(step.url);
+  if (detail && url && !detail.includes(url)) return `${detail} (${url})`;
+  return detail || url || '-';
+}
+
+function normalizeWhitespace(value: string | undefined): string {
+  return (value || '').replace(/\s+/g, ' ').trim();
+}
+
+function statusGlyph(state: string): string {
+  const normalized = state.trim().toLowerCase().replace(/_/g, '-');
+  if (normalized === 'not applicable' || normalized === 'not-applicable') return '[-]';
+  if (normalized === 'not observed' || normalized === 'not requested') return '[ ]';
+  if (normalized.includes('fail') || normalized.includes('error')) return '[!]';
+  if (normalized.includes('pending') || normalized.includes('started') || normalized.includes('running')) return '[>]';
+  return '[x]';
+}
+
+function formatDuration(seconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainingSeconds = safeSeconds % 60;
+  if (minutes === 0) return `${remainingSeconds}s`;
+  return `${minutes}m${String(remainingSeconds).padStart(2, '0')}s`;
 }
 
 export function hasContextDelegationProgressEvidence(

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -4636,6 +4636,20 @@ describe('formatBatchFooter', () => {
   });
 });
 
+describe('terminal progress pipeline wiring (#1724)', () => {
+  it('prints the run pipeline before the batch footer from finalized run state', () => {
+    const mainSection = AUTO_DENT_RUN_SOURCE.slice(AUTO_DENT_RUN_SOURCE.indexOf('async function main()'));
+    const pipelineIndex = mainSection.indexOf('formatTerminalProgressPipeline(result, {');
+    const footerIndex = mainSection.indexOf('formatBatchFooter(previewState)');
+
+    expect(pipelineIndex).toBeGreaterThan(-1);
+    expect(footerIndex).toBeGreaterThan(-1);
+    expect(pipelineIndex).toBeLessThan(footerIndex);
+    expect(mainSection).toContain('durationSeconds: duration');
+    expect(mainSection).toContain('costUsd: result.cost');
+  });
+});
+
 describe('formatBatchProgressIssueBody', () => {
   it('renders a dashboard header, guidance section, empty scoreboard, and config details', () => {
     const state = makeBatchState({

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -73,6 +73,7 @@ import {
   formatIssueForDisplay,
   formatIssueUrl,
   formatProgressStepsMarkdown,
+  formatTerminalProgressPipeline,
   hasContextDelegationProgressEvidence,
   formatReviewForDisplay,
   upsertContextDelegationProgressStep,
@@ -4816,6 +4817,14 @@ async function main(): Promise<void> {
 
   // Batch scoreboard (cumulative stats across all runs)
   {
+    console.log(formatTerminalProgressPipeline(result, {
+      repo: state.kaizen_repo || state.host_repo || '',
+      runNum,
+      durationSeconds: duration,
+      costUsd: result.cost,
+    }));
+    console.log('');
+
     const previewState = readState(stateFile);
     // Include this run's PRs for an accurate footer
     for (const pr of result.prs) {


### PR DESCRIPTION
## Story Spine

Once upon a time, auto-dent already collected structured progress steps for each run and posted them to progress issues as markdown tables.

Every day, the local terminal still made operators piece together run state from scattered harness logs, live stream lines, and the batch footer. The data existed, but there was no compact completed-run phase pipeline in the terminal.

One day, #556 was decomposed and #1724 became the first shippable operator-surface slice. The existing seam was `scripts/auto-dent-progress.ts`: it already owns `RunProgressStep`, phase order, and cycle construction.

Because of that, this PR adds `formatTerminalProgressPipeline`, a plain-text formatter that consumes the existing progress projection rather than parsing logs or inventing another phase list.

Because of that, `auto-dent-run.ts` now prints the terminal pipeline from finalized run state before the existing batch footer.

Until finally, focused tests cover complete, partial/missing, and synthetic/not-applicable runs, plus a source-order assertion that the completed-run pipeline is printed before the batch footer.

And ever since, local auto-dent runs have a stable operator-readable summary while #556's later dashboard children can still consume the same underlying progress model.

## Architecture

```text
AUTO_DENT_PHASE / hook outputs / run state
        |
        v
RunProgressStep[]
        |
        v
buildKaizenCycleSteps(result, repo)
        |                         |
        |                         +--> progress issue markdown
        v
formatTerminalProgressPipeline()  --> terminal completed-run summary
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Put formatter in `auto-dent-progress.ts` | Reuses the existing progress projection and phase order | Keeps terminal formatting near dashboard markdown formatting |
| Use ASCII/plain text | Works in CI, logs, non-TTY terminals, and transcript artifacts | Less visually rich than ANSI, but stable and testable |
| Print after run completion before batch footer | Uses finalized run state and puts per-run summary before cumulative batch summary | It is a completed-run view, not a live streaming replacement |
| Add source-order assertion | Proves the auto-dent-run wiring exists without spawning a full provider run | Static assertion is not a full E2E run, but the formatter itself is unit-tested |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-progress.ts` | Adds `formatTerminalProgressPipeline` plus formatting helpers |
| `scripts/auto-dent-progress.test.ts` | Adds complete, partial/missing, and synthetic terminal pipeline coverage |
| `scripts/auto-dent-run.ts` | Prints the terminal pipeline after each run completes |
| `scripts/auto-dent-run.test.ts` | Pins the completed-run pipeline before the batch footer |

## Test Plan (Behaviors × Levels)

| # | Behavior | Level | Coverage |
|---|---|---|---|
| 1 | Formatter renders a complete run with issue, case, test, PR, review, merge, reflect, stop, duration, and cost from existing progress state | Unit | Added in `scripts/auto-dent-progress.test.ts` |
| 2 | Formatter handles partial/missing phases without layout corruption or `[object Object]` | Unit | Added in `scripts/auto-dent-progress.test.ts` |
| 3 | Formatter handles synthetic/not-applicable runs without overwriting synthetic defaults | Unit | Added in `scripts/auto-dent-progress.test.ts` |
| 4 | `auto-dent-run.ts` prints formatter output from finalized run state without duplicating phase parsing/order | Unit/static | Added in `scripts/auto-dent-run.test.ts` |

## Impact (goal -> before/after -> match)

- Goal (#1724): local operators should see one concise completed-run phase pipeline instead of reconstructing state from scattered logs.
- Acceptance signal: representative complete/partial/synthetic inputs render a stable terminal pipeline, and `auto-dent-run.ts` prints it before the batch footer.
- BEFORE: progress data existed and progress issue comments rendered markdown, but the local terminal lacked a completed-run phase pipeline summary.
- AFTER: formatter output looks like:

```text
Auto-dent run 3 | 1m15s | $1.23
Phase      Status          Detail
---------- --------------- ----------------------------------------
PICK       [x] selected    https://github.com/Garsson-io/kaizen/issues/1724 - Enhanced auto-dent terminal phase pipeline
PLAN       [x] stored      plan/test-plan stored
IMPLEMENT  [x] done        terminal renderer wired
TEST       [x] passed      447 focused tests
PR         [x] created     https://github.com/Garsson-io/kaizen/pull/1724
REVIEW     [x] pass        pass (https://github.com/Garsson-io/kaizen/pull/1724)
STOP       [ ] not requested -
```

- Delta: one formatter, one auto-dent-run call site, 4 new focused behavior checks; no new parser or phase-order list.
- Goal met?: yes for #1724.
- Residual scan: #556 dashboard/live/replay/notification work remains in #1725-#1729.

## Validation

- [x] `npx vitest run scripts/auto-dent-progress.test.ts scripts/auto-dent-run.test.ts` — 2 files, 448 tests passed
- [x] `npm run typecheck` — passed
- [x] `git diff --check` — passed
- [x] Formatter smoke rendered a representative terminal pipeline

## Known Limitations

- This is completed-run terminal output, not a live progress renderer; live bridge/dashboard work remains in later #556 child issues.
- The sample output in this PR body is illustrative smoke output, not a real PR URL from a completed batch run.

Closes #1724
Parent: #556
Refs: #1677
