### PR TITLE
Define auto-dent dashboard data contract

### DIFF
--- a/docs/auto-dent-dashboard-data-contract.md
+++ b/docs/auto-dent-dashboard-data-contract.md
@@ -1,0 +1,74 @@
+# Auto-Dent Dashboard Data Contract
+
+#1725 defines the read-only data boundary for future #556 dashboard work. The
+dashboard is a consumer of existing progress issue artifacts and GitHub/cloud
+indexes; it does not scrape local logs, re-parse worker prose, or introduce a
+second lifecycle model.
+
+## Contract Module
+
+The typed contract lives in `scripts/auto-dent-dashboard-contract.ts`.
+
+- `DashboardDataProjectionSchema` validates the read-only projection future UI
+  code can consume.
+- `dashboardArtifactSources(progressIssue)` lists the artifact/API source for
+  each panel.
+- `buildDashboardDataProjection(input)` is pure: callers pass existing
+  artifact-shaped data, and the builder returns a schema-validated projection.
+
+The module intentionally has no GitHub I/O. #1726 can add a reader/UI around this
+contract; #1727 can add live transport around the same model.
+
+## Panel Sources
+
+| Panel | Primary source | Supporting source | Notes |
+|---|---|---|---|
+| Batch timeline | `batch-outcome` named attachment | Progress issue body | Uses `BatchOutcomeSchema` fields: `batch_id`, `guidance`, start/end, wall time, stop reason, and run totals. |
+| Run table | `progress/run-*` named attachments | `batch-outcome` PR/issue refs; GitHub issue API for titles/states | Uses existing per-run progress attachments and `RunProgressStep`; no raw log parsing. |
+| PR pipeline | `progress/run-*` named attachments | GitHub PR API for title/state enrichment | Uses the existing phase model from `scripts/auto-dent-progress.ts`, not a second phase taxonomy. |
+| Score and quality | `batch-outcome` named attachment | `progress/batch-complete`, anomaly incident refs, `rsi-improvement-proposals` | Shows success rate, review fail rate, degradation verdict, anomaly links, and RSI proposal count/verdict. |
+| Artifact links | `progress/batch-complete` named attachment | `batch-artifacts`, `batch-transcript-bundle`, GitHub Actions artifact URL | Links to drill-down artifacts; does not inline full transcripts or raw forensic payloads. |
+
+## Artifact Catalog
+
+| Artifact | Kind | Required? | Dashboard use |
+|---|---|---:|---|
+| Progress issue body | issue body | yes | Human operator index and guidance summary. Not the machine source of truth. |
+| `batch-outcome` | named attachment | yes | Machine-readable batch timeline, totals, mode breakdown, degradation signal, PR/issue refs. |
+| `progress/run-*` | named attachments | yes | Per-run outcome, run metrics, issue/PR links, and work-cycle phase rows. |
+| `progress/batch-complete` | named attachment | yes | Final scorecard, merge audit, anomaly summary, and durable artifact index. |
+| `batch-artifacts` | named attachment | no | Capped `events.jsonl`/`state.json` forensic drill-down and on-disk pointer. |
+| `batch-transcript-bundle` | named attachment | no | Manifest/index for the full scrubbed transcript bundle in GitHub Actions artifacts. |
+| `rsi-improvement-proposals` | named attachment | no | Structured proposal count, proof requirements, and cross-run improvement verdict. |
+| GitHub PR API | API enrichment | no | PR title, state, and URL for refs already present in durable artifacts. |
+| GitHub Issue API | API enrichment | no | Issue title, state, and URL for refs already present in durable artifacts. |
+
+## Retention And Privacy
+
+`batch-transcript-bundle` is only a manifest. The complete scrubbed transcript
+payload lives in a GitHub Actions artifact with retention metadata, so dashboard
+UI must show the manifest status, artifact URL, and expiry when present.
+
+`batch-artifacts` may inline capped forensic snippets, but the dashboard
+projection treats it as a link/source. Dashboard surfaces must not embed raw
+transcripts or use raw artifact text as the primary state model.
+
+## Non-Goals
+
+- No live SSE or Cloudflare Worker stream. #1727 owns live event transport.
+- No read-only dashboard UI. #1726 owns the first web surface.
+- No asciinema replay generation. #1728 owns replay output.
+- No Telegram or push notifications. #1729 owns notifications.
+- No raw transcript embedding. Link to `batch-transcript-bundle` and its Actions
+  artifact instead.
+
+## Consumer Rule
+
+Future dashboard readers should fail soft per optional artifact and fail closed
+on malformed required typed artifacts:
+
+- Missing optional drill-down links produce an unavailable badge.
+- Missing or malformed `batch-outcome` blocks the batch projection, because
+  scores and timeline would otherwise be invented.
+- Missing `progress/run-*` attachments should be visible as incomplete run rows,
+  not silently reconstructed from logs.

--- a/docs/auto-dent-operations.md
+++ b/docs/auto-dent-operations.md
@@ -368,6 +368,12 @@ After a batch completes:
    that contract uses GitHub Actions artifacts for the complete scrubbed bundle
    and keeps the progress issue as a small manifest/index.
 
+   The read-only dashboard data contract over these progress issue artifacts is
+   documented in
+   [`docs/auto-dent-dashboard-data-contract.md`](auto-dent-dashboard-data-contract.md).
+   Dashboard UI code must consume that typed projection instead of scraping local
+   logs or inventing a second lifecycle model.
+
 4. **OpenTelemetry GenAI traces** — JSONL remains the durable source of truth.
    To mirror completed runs to an OTLP/GenAI-compatible HTTP collector, set:
    ```bash

--- a/scripts/auto-dent-dashboard-contract.test.ts
+++ b/scripts/auto-dent-dashboard-contract.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  BATCH_OUTCOME_ATTACHMENT,
+  type BatchOutcome,
+} from './batch-outcome.js';
+import {
+  BATCH_ARTIFACTS_ATTACHMENT,
+} from './batch-artifacts-upload.js';
+import {
+  BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT,
+} from './transcript-bundle-constants.js';
+import {
+  RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
+} from './auto-dent-rsi.js';
+import {
+  PROGRESS_PHASE_ORDER,
+  type RunProgressStep,
+} from './auto-dent-progress.js';
+import {
+  BATCH_COMPLETE_ATTACHMENT,
+  DashboardDataProjectionSchema,
+  PROGRESS_RUN_ATTACHMENT_PATTERN,
+  buildDashboardDataProjection,
+  dashboardArtifactSources,
+  progressRunAttachmentName,
+} from './auto-dent-dashboard-contract.js';
+import type { TranscriptBundleManifest } from '../src/transcript-bundle.js';
+
+const REPO_ROOT = resolve(__dirname, '..');
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+const outcome: BatchOutcome = {
+  schema_version: 1,
+  batch_id: 'crisp-dashboard',
+  guidance: 'surface durable auto-dent evidence',
+  batch_start: 1_000,
+  batch_end: 1_900,
+  wall_seconds: 900,
+  stop_reason: 'completed',
+  totals: {
+    runs: 2,
+    successful_runs: 1,
+    prs: 1,
+    issues_closed: 1,
+    issues_filed: 1,
+    cost_usd: 3.25,
+    duration_seconds: 850,
+    lines_deleted: 0,
+    issues_pruned: 0,
+  },
+  success_rate: 0.5,
+  avg_cost_per_success: 3.25,
+  overall_efficiency: 0.31,
+  review_fail_rate: 0,
+  cost_anomaly_count: 0,
+  mode_diversity: 2,
+  trend: null,
+  degradation_signal: {
+    verdict: 'watch',
+    score: 0.32,
+    first_half_success_rate: 1,
+    second_half_success_rate: 0,
+    success_rate_delta: -1,
+    trailing_failure_count: 1,
+    trailing_empty_success_count: 0,
+    early_cost_per_success: 1.5,
+    late_cost_per_success: null,
+    cost_per_success_ratio: null,
+    duration_slope_seconds_per_run: 40,
+    reasons: ['late run failed'],
+  },
+  mode_breakdown: [
+    { mode: 'exploit', runs: 1, successes: 1, success_rate: 1, cost_usd: 1.5, prs: 1, avg_cost: 1.5, efficiency: 0.67, lines_deleted: 0, issues_pruned: 0 },
+    { mode: 'explore', runs: 1, successes: 0, success_rate: 0, cost_usd: 1.75, prs: 0, avg_cost: 1.75, efficiency: 0, lines_deleted: 0, issues_pruned: 0 },
+  ],
+  prs: ['https://github.com/Garsson-io/kaizen/pull/1730'],
+  issues_closed: ['#1724'],
+  issues_filed: ['#1725'],
+};
+
+const progressSteps: RunProgressStep[] = [
+  { phase: 'PICK', state: 'selected', detail: '#1725' },
+  { phase: 'PLAN', state: 'stored', detail: 'plan/test-plan stored' },
+  { phase: 'IMPLEMENT', state: 'done', detail: 'contract projection built' },
+  { phase: 'TEST', state: 'passed', detail: 'focused contract tests' },
+  { phase: 'PR', state: 'created', detail: 'https://github.com/Garsson-io/kaizen/pull/1731' },
+];
+
+const transcriptManifest: TranscriptBundleManifest = {
+  version: 1,
+  batch_id: 'crisp-dashboard',
+  repo: 'Garsson-io/kaizen',
+  progress_issue: 2000,
+  transport: 'github-actions-artifact',
+  artifact_name: 'auto-dent-transcripts-crisp-dashboard',
+  artifact_url: 'https://github.com/Garsson-io/kaizen/actions/runs/1',
+  created_at: '2026-06-29T18:00:00.000Z',
+  expires_at: '2026-09-27T18:00:00.000Z',
+  content_encoding: 'tar+gzip',
+  scrubbed: true,
+  truncated: false,
+  status: 'ready',
+  bundle: {
+    path: 'auto-dent-transcripts-crisp-dashboard.tar.gz',
+    bytes: 100,
+    sha256: 'a'.repeat(64),
+  },
+  files: [
+    { path: 'run-1.log', bytes: 42, sha256: 'b'.repeat(64), redactions: 0 },
+  ],
+};
+
+describe('dashboardArtifactSources', () => {
+  it('maps required dashboard panels to existing artifact constants', () => {
+    const sources = dashboardArtifactSources(2000);
+    const byId = new Map(sources.map((source) => [source.id, source]));
+
+    expect(byId.get(BATCH_OUTCOME_ATTACHMENT)?.required).toBe(true);
+    expect(byId.get(BATCH_OUTCOME_ATTACHMENT)?.panels).toEqual(expect.arrayContaining(['batch-timeline', 'score-quality']));
+    expect(byId.get(PROGRESS_RUN_ATTACHMENT_PATTERN)?.panels).toEqual(expect.arrayContaining(['run-table', 'pr-pipeline']));
+    expect(byId.get(BATCH_COMPLETE_ATTACHMENT)?.panels).toContain('artifact-links');
+    expect(byId.get(BATCH_ARTIFACTS_ATTACHMENT)?.required).toBe(false);
+    expect(byId.get(BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT)?.provides).toContain('Actions artifact URL');
+    expect(byId.get(RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT)?.panels).toContain('score-quality');
+  });
+});
+
+describe('buildDashboardDataProjection', () => {
+  it('builds a schema-valid read-only projection from existing artifact-shaped inputs', () => {
+    const projection = buildDashboardDataProjection({
+      repo: 'Garsson-io/kaizen',
+      progressIssue: 2000,
+      progressIssueUrl: 'https://github.com/Garsson-io/kaizen/issues/2000',
+      outcome,
+      runs: [
+        {
+          run: 1,
+          mode: 'exploit',
+          status: 'pass',
+          issue: '#1725',
+          issueTitle: 'Auto-dent dashboard data contract over GitHub artifacts',
+          prs: ['https://github.com/Garsson-io/kaizen/pull/1731'],
+          durationSeconds: 420,
+          costUsd: 1.25,
+          progressSteps,
+        },
+      ],
+      transcriptBundle: transcriptManifest,
+      artifactLinks: [
+        { attachment: BATCH_ARTIFACTS_ATTACHMENT, status: 'available', source: 'batch-artifacts named attachment' },
+      ],
+      anomalyIncidents: {
+        refs: [
+          {
+            signal_key: 'crisp-dashboard:run-2:run_failed',
+            status: 'created',
+            issue: 1999,
+            url: 'https://github.com/Garsson-io/kaizen/issues/1999',
+          },
+        ],
+      },
+      rsi: {
+        proposalCount: 2,
+        crossRunVerdict: 'watch',
+      },
+    });
+
+    expect(() => DashboardDataProjectionSchema.parse(projection)).not.toThrow();
+    expect(projection.panels.batch_timeline).toMatchObject({
+      batch_id: 'crisp-dashboard',
+      source: BATCH_OUTCOME_ATTACHMENT,
+      runs: 2,
+    });
+    expect(projection.panels.run_table[0]).toMatchObject({
+      run: 1,
+      progress_attachment: progressRunAttachmentName(1),
+      issue: '#1725',
+      cost_usd: 1.25,
+    });
+    expect(projection.panels.pr_pipeline[0]).toMatchObject({
+      run: 1,
+      pr: 'https://github.com/Garsson-io/kaizen/pull/1731',
+      source: PROGRESS_RUN_ATTACHMENT_PATTERN,
+    });
+    expect(projection.panels.score_quality).toMatchObject({
+      success_rate: 0.5,
+      degradation_verdict: 'watch',
+    });
+    expect(projection.panels.score_quality.anomaly_refs[0]).toMatchObject({
+      status: 'created',
+      issue: 1999,
+    });
+    expect(projection.panels.score_quality.rsi_proposals).toEqual({
+      attachment: RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
+      proposal_count: 2,
+      cross_run_verdict: 'watch',
+    });
+  });
+
+  it('treats transcripts and raw artifacts as links, never embedded raw payloads', () => {
+    const projection = buildDashboardDataProjection({
+      repo: 'Garsson-io/kaizen',
+      progressIssue: 2000,
+      outcome,
+      runs: [{ run: 1, status: 'pass', prs: [], progressSteps }],
+      transcriptBundle: transcriptManifest,
+      artifactLinks: [{ attachment: BATCH_ARTIFACTS_ATTACHMENT, status: 'available' }],
+    });
+
+    const byAttachment = new Map(projection.panels.artifact_links.map((link) => [link.attachment, link]));
+    expect(byAttachment.get(BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT)).toMatchObject({
+      status: 'ready',
+      url: transcriptManifest.artifact_url,
+      embeds_raw_payload: false,
+    });
+    expect(byAttachment.get(BATCH_ARTIFACTS_ATTACHMENT)).toMatchObject({
+      status: 'available',
+      embeds_raw_payload: false,
+    });
+    expect(JSON.stringify(projection)).not.toContain('run-1 transcript raw text');
+  });
+
+  it('keeps the PR pipeline on the existing progress-step phase names', () => {
+    const projection = buildDashboardDataProjection({
+      repo: 'Garsson-io/kaizen',
+      progressIssue: 2000,
+      outcome,
+      runs: [{ run: 1, status: 'pass', prs: ['https://github.com/Garsson-io/kaizen/pull/1731'], progressSteps }],
+    });
+
+    const phases = projection.panels.pr_pipeline[0].phases.map((step) => step.phase);
+    expect(PROGRESS_PHASE_ORDER).toEqual(expect.arrayContaining(phases));
+  });
+
+  it('states sibling child issues as non-goals', () => {
+    const projection = buildDashboardDataProjection({
+      repo: 'Garsson-io/kaizen',
+      progressIssue: 2000,
+      outcome,
+      runs: [{ run: 1, status: 'pass', prs: [], progressSteps }],
+    });
+
+    expect(projection.non_goals.join('\n')).toContain('#1727');
+    expect(projection.non_goals.join('\n')).toContain('#1726');
+    expect(projection.non_goals.join('\n')).toContain('#1728');
+    expect(projection.non_goals.join('\n')).toContain('#1729');
+  });
+});
+
+describe('dashboard data contract docs', () => {
+  const doc = read('docs/auto-dent-dashboard-data-contract.md');
+
+  it('documents every required panel and durable artifact source', () => {
+    for (const panel of ['Batch timeline', 'Run table', 'PR pipeline', 'Score and quality', 'Artifact links']) {
+      expect(doc).toContain(panel);
+    }
+    for (const artifact of [
+      BATCH_OUTCOME_ATTACHMENT,
+      PROGRESS_RUN_ATTACHMENT_PATTERN,
+      BATCH_COMPLETE_ATTACHMENT,
+      BATCH_ARTIFACTS_ATTACHMENT,
+      BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT,
+      RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
+    ]) {
+      expect(doc).toContain(artifact);
+    }
+  });
+
+  it('excludes live stream, replay, notification, and raw transcript concerns', () => {
+    expect(doc).toContain('No live SSE or Cloudflare Worker stream');
+    expect(doc).toContain('No asciinema replay generation');
+    expect(doc).toContain('No Telegram or push notifications');
+    expect(doc).toContain('must not embed raw');
+  });
+});

--- a/scripts/auto-dent-dashboard-contract.test.ts
+++ b/scripts/auto-dent-dashboard-contract.test.ts
@@ -189,7 +189,7 @@ describe('buildDashboardDataProjection', () => {
     });
     expect(projection.panels.score_quality).toMatchObject({
       success_rate: 0.5,
-      degradation_verdict: 'watch',
+      degradation_status: 'watch',
     });
     expect(projection.panels.score_quality.anomaly_refs[0]).toMatchObject({
       status: 'created',
@@ -198,7 +198,7 @@ describe('buildDashboardDataProjection', () => {
     expect(projection.panels.score_quality.rsi_proposals).toEqual({
       attachment: RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
       proposal_count: 2,
-      cross_run_verdict: 'watch',
+      cross_run_status: 'watch',
     });
   });
 

--- a/scripts/auto-dent-dashboard-contract.ts
+++ b/scripts/auto-dent-dashboard-contract.ts
@@ -1,0 +1,373 @@
+import { z } from 'zod';
+import {
+  BATCH_OUTCOME_ATTACHMENT,
+  type BatchOutcome,
+} from './batch-outcome.js';
+import {
+  BATCH_ARTIFACTS_ATTACHMENT,
+} from './batch-artifacts-upload.js';
+import {
+  BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT,
+} from './transcript-bundle-constants.js';
+import {
+  RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
+} from './auto-dent-rsi.js';
+import type {
+  AutoDentAnomalyIncidentResult,
+} from './auto-dent-anomaly-incidents.js';
+import type {
+  RunProgressStep,
+} from './auto-dent-progress.js';
+import type {
+  TranscriptBundleManifest,
+} from '../src/transcript-bundle.js';
+
+export const DASHBOARD_CONTRACT_VERSION = 1;
+
+export const PROGRESS_RUN_ATTACHMENT_PATTERN = 'progress/run-*';
+export const BATCH_COMPLETE_ATTACHMENT = 'progress/batch-complete';
+
+export const DASHBOARD_PANEL_IDS = [
+  'batch-timeline',
+  'run-table',
+  'pr-pipeline',
+  'score-quality',
+  'artifact-links',
+] as const;
+
+export const DashboardPanelIdSchema = z.enum(DASHBOARD_PANEL_IDS);
+export type DashboardPanelId = z.infer<typeof DashboardPanelIdSchema>;
+
+export const DashboardArtifactKindSchema = z.enum([
+  'issue-body',
+  'named-attachment',
+  'github-api',
+  'actions-artifact',
+  'derived',
+]);
+
+export const DashboardArtifactSourceSchema = z.object({
+  id: z.string().min(1),
+  kind: DashboardArtifactKindSchema,
+  name: z.string().min(1),
+  required: z.boolean(),
+  panels: z.array(DashboardPanelIdSchema).min(1),
+  provides: z.array(z.string().min(1)).min(1),
+  description: z.string().min(1),
+});
+export type DashboardArtifactSource = z.infer<typeof DashboardArtifactSourceSchema>;
+
+export const DashboardProgressStepSchema = z.object({
+  phase: z.string().min(1),
+  state: z.string().min(1),
+  detail: z.string(),
+  url: z.string().optional(),
+});
+
+export const DashboardRunRowSchema = z.object({
+  run: z.number().int().positive(),
+  mode: z.string().optional(),
+  status: z.string().min(1),
+  issue: z.string().optional(),
+  issue_title: z.string().optional(),
+  prs: z.array(z.string()),
+  duration_seconds: z.number().nonnegative().optional(),
+  cost_usd: z.number().nonnegative().optional(),
+  progress_attachment: z.string().min(1),
+  phases: z.array(DashboardProgressStepSchema),
+});
+
+export const DashboardArtifactLinkSchema = z.object({
+  id: z.string().min(1),
+  attachment: z.string().min(1),
+  status: z.string().min(1),
+  url: z.string().optional(),
+  source: z.string().min(1),
+  embeds_raw_payload: z.literal(false),
+});
+
+export const DashboardDataProjectionSchema = z.object({
+  schema_version: z.literal(DASHBOARD_CONTRACT_VERSION),
+  source: z.object({
+    repo: z.string().min(1),
+    progress_issue: z.number().int().positive(),
+    progress_issue_url: z.string().optional(),
+  }),
+  artifact_sources: z.array(DashboardArtifactSourceSchema),
+  panels: z.object({
+    batch_timeline: z.object({
+      batch_id: z.string().min(1),
+      guidance: z.string(),
+      batch_start: z.number(),
+      batch_end: z.number(),
+      wall_seconds: z.number().nonnegative(),
+      stop_reason: z.string().min(1),
+      runs: z.number().int().nonnegative(),
+      source: z.literal(BATCH_OUTCOME_ATTACHMENT),
+    }),
+    run_table: z.array(DashboardRunRowSchema),
+    pr_pipeline: z.array(z.object({
+      run: z.number().int().positive(),
+      pr: z.string().min(1),
+      phases: z.array(DashboardProgressStepSchema),
+      source: z.literal(PROGRESS_RUN_ATTACHMENT_PATTERN),
+    })),
+    score_quality: z.object({
+      success_rate: z.number(),
+      review_fail_rate: z.number(),
+      overall_efficiency: z.number(),
+      degradation_verdict: z.string().nullable(),
+      anomaly_refs: z.array(z.object({
+        status: z.string().min(1),
+        issue: z.number().int().positive().optional(),
+        url: z.string().optional(),
+      })),
+      rsi_proposals: z.object({
+        attachment: z.literal(RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT),
+        proposal_count: z.number().int().nonnegative(),
+        cross_run_verdict: z.string().optional(),
+      }),
+      source: z.literal(BATCH_OUTCOME_ATTACHMENT),
+    }),
+    artifact_links: z.array(DashboardArtifactLinkSchema),
+  }),
+  non_goals: z.array(z.string().min(1)),
+});
+export type DashboardDataProjection = z.infer<typeof DashboardDataProjectionSchema>;
+
+export interface DashboardRunInput {
+  run: number;
+  mode?: string;
+  status: string;
+  issue?: string;
+  issueTitle?: string;
+  prs?: string[];
+  durationSeconds?: number;
+  costUsd?: number;
+  progressSteps: RunProgressStep[];
+}
+
+export interface DashboardArtifactLinkInput {
+  attachment: string;
+  status: string;
+  url?: string;
+  source?: string;
+}
+
+export interface DashboardRsiSummaryInput {
+  proposalCount: number;
+  crossRunVerdict?: string;
+}
+
+export interface BuildDashboardDataProjectionInput {
+  repo: string;
+  progressIssue: number;
+  progressIssueUrl?: string;
+  outcome: BatchOutcome;
+  runs: DashboardRunInput[];
+  transcriptBundle?: TranscriptBundleManifest;
+  artifactLinks?: DashboardArtifactLinkInput[];
+  anomalyIncidents?: Pick<AutoDentAnomalyIncidentResult, 'refs'>;
+  rsi?: DashboardRsiSummaryInput;
+}
+
+export function dashboardArtifactSources(progressIssue: number): DashboardArtifactSource[] {
+  return [
+    {
+      id: 'progress-issue-body',
+      kind: 'issue-body',
+      name: `issue/${progressIssue}.body`,
+      required: true,
+      panels: ['batch-timeline', 'artifact-links'],
+      provides: ['operator header', 'guidance summary', 'progress issue index'],
+      description: 'Human-readable progress issue body created by auto-dent; it is an index, not the machine source of truth.',
+    },
+    {
+      id: BATCH_OUTCOME_ATTACHMENT,
+      kind: 'named-attachment',
+      name: BATCH_OUTCOME_ATTACHMENT,
+      required: true,
+      panels: ['batch-timeline', 'run-table', 'score-quality'],
+      provides: ['batch totals', 'mode breakdown', 'quality score', 'degradation signal', 'PR and issue refs'],
+      description: 'Schema-validated batch summary written at progress issue close.',
+    },
+    {
+      id: PROGRESS_RUN_ATTACHMENT_PATTERN,
+      kind: 'named-attachment',
+      name: PROGRESS_RUN_ATTACHMENT_PATTERN,
+      required: true,
+      panels: ['run-table', 'pr-pipeline'],
+      provides: ['per-run outcome', 'run metrics', 'work-cycle phase rows'],
+      description: 'One named attachment per run containing the existing kaizen progress-step model.',
+    },
+    {
+      id: BATCH_COMPLETE_ATTACHMENT,
+      kind: 'named-attachment',
+      name: BATCH_COMPLETE_ATTACHMENT,
+      required: true,
+      panels: ['score-quality', 'artifact-links'],
+      provides: ['final scorecard', 'merge audit', 'anomaly incident summary', 'durable attachment index'],
+      description: 'Batch closing attachment that links durable finalization artifacts.',
+    },
+    {
+      id: BATCH_ARTIFACTS_ATTACHMENT,
+      kind: 'named-attachment',
+      name: BATCH_ARTIFACTS_ATTACHMENT,
+      required: false,
+      panels: ['artifact-links'],
+      provides: ['capped events.jsonl', 'capped state.json', 'forensic pointer'],
+      description: 'Capped raw forensic attachment for drill-down only; the dashboard must not parse it as its primary model.',
+    },
+    {
+      id: BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT,
+      kind: 'named-attachment',
+      name: BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT,
+      required: false,
+      panels: ['artifact-links'],
+      provides: ['transcript bundle manifest', 'Actions artifact URL', 'retention status'],
+      description: 'Small manifest/index for scrubbed transcript bundles stored as GitHub Actions artifacts.',
+    },
+    {
+      id: RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
+      kind: 'named-attachment',
+      name: RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
+      required: false,
+      panels: ['score-quality', 'artifact-links'],
+      provides: ['proposal count', 'cross-run verdict', 'proof requirements'],
+      description: 'Structured RSI improvement proposal set derived from batch outcome signals.',
+    },
+    {
+      id: 'github-pr-api',
+      kind: 'github-api',
+      name: 'gh pr view --json title,state,url',
+      required: false,
+      panels: ['pr-pipeline', 'artifact-links'],
+      provides: ['PR title', 'PR state', 'PR URL'],
+      description: 'Best-effort enrichment for refs already present in durable attachments.',
+    },
+    {
+      id: 'github-issue-api',
+      kind: 'github-api',
+      name: 'gh issue view --json title,state,url',
+      required: false,
+      panels: ['run-table', 'artifact-links'],
+      provides: ['issue title', 'issue state', 'issue URL'],
+      description: 'Best-effort enrichment for refs already present in durable attachments.',
+    },
+  ].map((source) => DashboardArtifactSourceSchema.parse(source));
+}
+
+export function buildDashboardDataProjection(
+  input: BuildDashboardDataProjectionInput,
+): DashboardDataProjection {
+  const runRows = input.runs.map((run) => DashboardRunRowSchema.parse({
+    run: run.run,
+    ...(run.mode ? { mode: run.mode } : {}),
+    status: run.status,
+    ...(run.issue ? { issue: run.issue } : {}),
+    ...(run.issueTitle ? { issue_title: run.issueTitle } : {}),
+    prs: run.prs ?? [],
+    ...(typeof run.durationSeconds === 'number' ? { duration_seconds: Math.max(0, run.durationSeconds) } : {}),
+    ...(typeof run.costUsd === 'number' ? { cost_usd: Math.max(0, run.costUsd) } : {}),
+    progress_attachment: progressRunAttachmentName(run.run),
+    phases: run.progressSteps.map((step) => DashboardProgressStepSchema.parse(step)),
+  }));
+
+  const artifactLinks = [
+    ...defaultArtifactLinks(input),
+    ...(input.artifactLinks ?? []),
+  ].map((link) => DashboardArtifactLinkSchema.parse({
+    id: link.attachment,
+    attachment: link.attachment,
+    status: link.status,
+    ...(link.url ? { url: link.url } : {}),
+    source: link.source ?? `progress issue #${input.progressIssue}`,
+    embeds_raw_payload: false,
+  }));
+
+  return DashboardDataProjectionSchema.parse({
+    schema_version: DASHBOARD_CONTRACT_VERSION,
+    source: {
+      repo: input.repo,
+      progress_issue: input.progressIssue,
+      ...(input.progressIssueUrl ? { progress_issue_url: input.progressIssueUrl } : {}),
+    },
+    artifact_sources: dashboardArtifactSources(input.progressIssue),
+    panels: {
+      batch_timeline: {
+        batch_id: input.outcome.batch_id,
+        guidance: input.outcome.guidance,
+        batch_start: input.outcome.batch_start,
+        batch_end: input.outcome.batch_end,
+        wall_seconds: input.outcome.wall_seconds,
+        stop_reason: input.outcome.stop_reason,
+        runs: input.outcome.totals.runs,
+        source: BATCH_OUTCOME_ATTACHMENT,
+      },
+      run_table: runRows,
+      pr_pipeline: runRows.flatMap((run) =>
+        run.prs.map((pr) => ({
+          run: run.run,
+          pr,
+          phases: run.phases,
+          source: PROGRESS_RUN_ATTACHMENT_PATTERN,
+        })),
+      ),
+      score_quality: {
+        success_rate: input.outcome.success_rate,
+        review_fail_rate: input.outcome.review_fail_rate,
+        overall_efficiency: input.outcome.overall_efficiency,
+        degradation_verdict: input.outcome.degradation_signal?.verdict ?? null,
+        anomaly_refs: (input.anomalyIncidents?.refs ?? []).map((ref) => ({
+          status: ref.status,
+          ...(ref.issue ? { issue: ref.issue } : {}),
+          ...(ref.url ? { url: ref.url } : {}),
+        })),
+        rsi_proposals: {
+          attachment: RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
+          proposal_count: input.rsi?.proposalCount ?? 0,
+          ...(input.rsi?.crossRunVerdict ? { cross_run_verdict: input.rsi.crossRunVerdict } : {}),
+        },
+        source: BATCH_OUTCOME_ATTACHMENT,
+      },
+      artifact_links: artifactLinks,
+    },
+    non_goals: [
+      'No live SSE or Cloudflare Worker stream; #1727 owns live event transport.',
+      'No read-only dashboard UI; #1726 owns the first web surface.',
+      'No asciinema replay generator; #1728 owns replay output.',
+      'No Telegram or push notifications; #1729 owns notifications.',
+      'No raw transcript embedding; use the transcript bundle manifest and artifact URL.',
+    ],
+  });
+}
+
+export function progressRunAttachmentName(run: number): string {
+  return `progress/run-${run}`;
+}
+
+function defaultArtifactLinks(input: BuildDashboardDataProjectionInput): DashboardArtifactLinkInput[] {
+  const links: DashboardArtifactLinkInput[] = [
+    {
+      attachment: BATCH_OUTCOME_ATTACHMENT,
+      status: 'required',
+      source: 'progress issue named attachment',
+    },
+    {
+      attachment: BATCH_COMPLETE_ATTACHMENT,
+      status: 'required',
+      source: 'progress issue named attachment',
+    },
+  ];
+
+  if (input.transcriptBundle) {
+    links.push({
+      attachment: BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT,
+      status: input.transcriptBundle.status,
+      url: input.transcriptBundle.artifact_url,
+      source: input.transcriptBundle.artifact_name,
+    });
+  }
+
+  return links;
+}

--- a/scripts/auto-dent-dashboard-contract.ts
+++ b/scripts/auto-dent-dashboard-contract.ts
@@ -116,7 +116,7 @@ export const DashboardDataProjectionSchema = z.object({
       success_rate: z.number(),
       review_fail_rate: z.number(),
       overall_efficiency: z.number(),
-      degradation_verdict: z.string().nullable(),
+      degradation_status: z.string().nullable(),
       anomaly_refs: z.array(z.object({
         status: z.string().min(1),
         issue: z.number().int().positive().optional(),
@@ -125,7 +125,7 @@ export const DashboardDataProjectionSchema = z.object({
       rsi_proposals: z.object({
         attachment: z.literal(RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT),
         proposal_count: z.number().int().nonnegative(),
-        cross_run_verdict: z.string().optional(),
+        cross_run_status: z.string().optional(),
       }),
       source: z.literal(BATCH_OUTCOME_ATTACHMENT),
     }),
@@ -317,7 +317,7 @@ export function buildDashboardDataProjection(
         success_rate: input.outcome.success_rate,
         review_fail_rate: input.outcome.review_fail_rate,
         overall_efficiency: input.outcome.overall_efficiency,
-        degradation_verdict: input.outcome.degradation_signal?.verdict ?? null,
+        degradation_status: input.outcome.degradation_signal?.verdict ?? null,
         anomaly_refs: (input.anomalyIncidents?.refs ?? []).map((ref) => ({
           status: ref.status,
           ...(ref.issue ? { issue: ref.issue } : {}),
@@ -326,7 +326,7 @@ export function buildDashboardDataProjection(
         rsi_proposals: {
           attachment: RSI_IMPROVEMENT_PROPOSALS_ATTACHMENT,
           proposal_count: input.rsi?.proposalCount ?? 0,
-          ...(input.rsi?.crossRunVerdict ? { cross_run_verdict: input.rsi.crossRunVerdict } : {}),
+          ...(input.rsi?.crossRunVerdict ? { cross_run_status: input.rsi.crossRunVerdict } : {}),
         },
         source: BATCH_OUTCOME_ATTACHMENT,
       },

--- a/scripts/transcript-bundle-constants.ts
+++ b/scripts/transcript-bundle-constants.ts
@@ -1,0 +1,1 @@
+export const BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT = 'batch-transcript-bundle';

--- a/scripts/transcript-bundle-upload.ts
+++ b/scripts/transcript-bundle-upload.ts
@@ -8,8 +8,13 @@ import {
   type BuildTranscriptBundleResult,
   type TranscriptBundleManifest,
 } from '../src/transcript-bundle.js';
+import {
+  BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT,
+} from './transcript-bundle-constants.js';
 
-export const BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT = 'batch-transcript-bundle';
+export {
+  BATCH_TRANSCRIPT_BUNDLE_ATTACHMENT,
+};
 export const DEFAULT_TRANSCRIPT_ARTIFACT_RETENTION_DAYS = 90;
 
 export type ArtifactUploader = (


### PR DESCRIPTION
## Story Spine

Once upon a time, auto-dent already wrote rich progress evidence to GitHub: progress issue bodies, per-run `progress/run-*` attachments, `batch-outcome`, `batch-artifacts`, transcript bundle manifests, anomaly incident refs, RSI proposals, and PR/issue links.

Every day, future dashboard work still had to infer which artifact powered which panel. That creates the exact risk #1725 calls out: a UI could scrape local logs, parse Markdown prose, or invent a second lifecycle model even though the durable artifacts already exist.

One day, #556 was split into child issues and #1725 became the contract boundary before the read-only dashboard and live bridge work. The success condition was not a screen; it was a typed projection and documentation proving a dashboard can be built from existing GitHub/cloud artifacts.

Because of that, this PR adds `DashboardDataProjectionSchema`, `dashboardArtifactSources()`, and `buildDashboardDataProjection()` in `scripts/auto-dent-dashboard-contract.ts`. The builder is pure: callers provide existing artifact-shaped data and receive a Zod-validated projection for batch timeline, run table, PR pipeline, score/quality, and artifact links.

Because of that, the contract imports the existing artifact names and progress-step types instead of adding a new lifecycle parser. The `batch-transcript-bundle` name now has a lightweight constants module so contract consumers can import the name without loading `@actions/artifact` upload machinery.

Until finally, the focused test slice passes with 485 tests, typecheck passes, and a direct `tsx` sample can print the panel-to-source mapping without triggering uploader dependencies.

And ever since, #1726/#1727 can build UI and live transport around a stable read-only contract rather than rediscovering the data boundary.

## Architecture

```text
Progress issue / named attachments
  ├─ issue body                     -> operator index
  ├─ batch-outcome                  -> batch timeline + score/quality
  ├─ progress/run-*                 -> run table + PR pipeline phases
  ├─ progress/batch-complete        -> final scorecard + artifact index
  ├─ batch-artifacts                -> forensic drill-down link
  ├─ batch-transcript-bundle        -> transcript manifest / Actions artifact link
  └─ rsi-improvement-proposals      -> learning/proposal summary
                    |
                    v
scripts/auto-dent-dashboard-contract.ts
  └─ DashboardDataProjectionSchema / buildDashboardDataProjection()
                    |
                    v
Future #1726 read-only dashboard / #1727 live transport
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Pure projection builder, no GitHub I/O | #1725 is the contract slice; #1726 can add a reader/UI after the boundary is stable. | Tests use artifact-shaped fixtures instead of live API reads. |
| Reuse existing artifact constants and `RunProgressStep` | Prevents drift from `batch-outcome`, progress attachments, and the canonical phase model. | Added `scripts/transcript-bundle-constants.ts` to avoid importing upload code for one constant. |
| Treat raw artifacts/transcripts as links | Keeps dashboard surfaces from embedding sensitive or oversized payloads. | Full transcript inspection remains behind the existing Actions artifact transport. |
| Explicit non-goals in schema/docs | Keeps #1725 separate from #1726 read-only UI, #1727 live SSE, #1728 replay, and #1729 notifications. | Later issues must add their own reader/UI behavior against this contract. |

## What's In This PR

| File | Purpose |
|---|---|
| `scripts/auto-dent-dashboard-contract.ts` | Zod schemas, artifact source catalog, pure projection builder, and non-goal contract. |
| `scripts/auto-dent-dashboard-contract.test.ts` | Fixture-backed contract tests for panel sources, projection validity, phase reuse, artifact-link privacy, and docs coverage. |
| `docs/auto-dent-dashboard-data-contract.md` | Human-readable panel-to-artifact/API contract for future dashboard work. |
| `docs/auto-dent-operations.md` | Cross-link from existing progress issue artifact docs to the dashboard contract. |
| `scripts/transcript-bundle-constants.ts` | Lightweight source for `batch-transcript-bundle` attachment name. |
| `scripts/transcript-bundle-upload.ts` | Re-exports the lightweight constant so existing importers keep working. |

## Test Plan (Behaviors x Levels)

| Behavior | Unit | Integration | System | Agentic | Workflow |
|---|---|---|---|---|---|
| Projection builds from artifact-shaped inputs and validates with Zod | tested: `auto-dent-dashboard-contract.test.ts` | not required | not required | not required | not required |
| Panels map to existing named attachments/API sources | tested: `auto-dent-dashboard-contract.test.ts` | not required | not required | not required | not required |
| PR pipeline consumes existing `RunProgressStep` phases | tested: `auto-dent-dashboard-contract.test.ts` | not required | not required | not required | not required |
| Transcript/raw artifacts remain links, not embedded payloads | tested: `auto-dent-dashboard-contract.test.ts` | not required | not required | not required | not required |
| Docs cover panels and explicit non-goals | tested: `auto-dent-dashboard-contract.test.ts` | not required | not required | not required | not required |
| Existing progress/batch producers still pass nearby tests | not enough alone | tested: `auto-dent-run.test.ts`, `batch-outcome.test.ts`, `transcript-bundle-upload.test.ts` | not required | not required | not required |

## Impact (goal -> before/after -> match)

- Goal (#1725): future dashboard work has a stable read-only contract over durable GitHub/cloud artifacts.
- Acceptance signal: a typed projection/schema and docs map each dashboard panel to durable artifact/API sources and explicitly exclude live SSE/worker concerns.
- BEFORE: dashboard data was scattered across progress issue Markdown, `progress/run-*`, `batch-outcome`, `batch-artifacts`, `batch-transcript-bundle`, anomaly refs, RSI proposals, and PR/issue refs with no single consumer contract.
- AFTER: `DashboardDataProjectionSchema` plus `docs/auto-dent-dashboard-data-contract.md` define the read-only contract; a direct `tsx` sample prints the panel-to-source mapping successfully.
- Delta: 5 dashboard panels now map to 9 explicit source entries, backed by 7 focused contract tests and the existing progress/batch regression slice.
- Goal met?: yes.
- Residual scan: live UI, live SSE, replay, and notifications remain intentionally out of scope in #1726, #1727, #1728, and #1729.

Sample source mapping:

```json
[
  { "id": "batch-outcome", "panels": ["batch-timeline", "run-table", "score-quality"] },
  { "id": "progress/run-*", "panels": ["run-table", "pr-pipeline"] },
  { "id": "batch-transcript-bundle", "panels": ["artifact-links"] }
]
```

## Validation

- [x] `npx vitest run scripts/auto-dent-dashboard-contract.test.ts scripts/auto-dent-run.test.ts scripts/batch-outcome.test.ts scripts/transcript-bundle-upload.test.ts` — 485 tests passed.
- [x] `npm run typecheck` — passed.
- [x] `git diff --check` — passed.
- [x] `npx tsx -e "import { dashboardArtifactSources } from './scripts/auto-dent-dashboard-contract.ts'; console.log(JSON.stringify(dashboardArtifactSources(2000).map(s => ({ id: s.id, panels: s.panels })), null, 2));"` — printed the expected panel/source catalog without loading Actions artifact upload code.

## Known Limitations

- This PR does not fetch GitHub artifacts or render a dashboard; #1726 owns the read-only UI/reader.
- This PR does not add live SSE/Cloudflare Worker transport; #1727 owns that.
- This PR does not generate asciinema replays or notifications; #1728/#1729 own those.

Closes #1725
Parent: #556
Refs: #1677
