### PR TITLE
Fix auto-dent provider workspace provisioning

### DIFF
--- a/scripts/auto-dent-provider-workspace.ts
+++ b/scripts/auto-dent-provider-workspace.ts
@@ -1,14 +1,16 @@
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync, mkdirSync, symlinkSync } from 'fs';
 import { isAbsolute, join, relative, resolve } from 'path';
 
 import { parseWorktreePorcelain, type WorktreeEntry } from '../src/hooks/worktree-integrity.js';
-import { makeGitRun, readBoundIssue } from '../src/issue-binding.js';
+import { bindIssue, makeGitRun, readBoundIssue } from '../src/issue-binding.js';
 
 export interface ProviderWorkspaceInput {
   repoRoot: string;
   invocationRoot: string;
   assignedIssue?: unknown;
   knownCases?: string[];
+  runTag?: string;
 }
 
 export type ProviderWorkspaceResolution =
@@ -16,11 +18,14 @@ export type ProviderWorkspaceResolution =
       ok: true;
       providerRoot: string;
       issue: number | null;
-      source: 'unassigned' | 'invocation-root' | 'known-case' | 'worktree-list';
+      source: 'unassigned' | 'invocation-root' | 'known-case' | 'worktree-list' | 'created-worktree';
+      caseId?: string;
+      branch?: string;
+      created?: boolean;
     }
   | {
       ok: false;
-      reason: 'binding-mismatch' | 'missing-binding' | 'missing-worktree';
+      reason: 'binding-mismatch' | 'missing-binding' | 'missing-worktree' | 'create-failed';
       issue: number;
       providerRoot?: string;
       actualIssue?: number | null;
@@ -30,6 +35,11 @@ export type ProviderWorkspaceResolution =
 export interface ProviderWorkspaceDeps {
   listWorktrees?: (repoRoot: string) => WorktreeEntry[];
   readBoundIssue?: (root: string) => number | null;
+  runGit?: (repoRoot: string, args: string[]) => { code: number; stdout: string; stderr: string };
+  bindIssue?: (root: string, issue: number) => void;
+  now?: () => Date;
+  randomSuffix?: () => string;
+  setupArtifacts?: (repoRoot: string, providerRoot: string) => void;
 }
 
 export function issueNumberFromRef(value: unknown): number | null {
@@ -56,6 +66,22 @@ function defaultReadBoundIssue(root: string): number | null {
   return readBoundIssue(makeGitRun(root));
 }
 
+function defaultRunGit(repoRoot: string, args: string[]): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync('git', ['-C', repoRoot, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    code: r.status ?? 1,
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+  };
+}
+
+function defaultBindIssue(root: string, issue: number): void {
+  bindIssue(issue, makeGitRun(root));
+}
+
 function isWithin(parent: string, child: string): boolean {
   const rel = relative(resolve(parent), resolve(child));
   return rel === '' || (rel.length > 0 && !rel.startsWith('..') && !isAbsolute(rel));
@@ -74,6 +100,33 @@ function caseRoot(repoRoot: string, nameOrPath: string): string | null {
 function worktreeLooksAssigned(entry: WorktreeEntry, issue: number): boolean {
   const issueToken = new RegExp(`(^|[-/])k${issue}($|[-/])`);
   return Boolean(issueToken.test(entry.branch ?? '') || issueToken.test(entry.path));
+}
+
+function timestampForCaseId(now: Date): string {
+  const yy = String(now.getFullYear()).slice(-2);
+  const mo = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mi = String(now.getMinutes()).padStart(2, '0');
+  return `${yy}${mo}${dd}${hh}${mi}`;
+}
+
+function randomHexSuffix(): string {
+  return Math.random().toString(16).slice(2, 6).padEnd(4, '0').slice(0, 4);
+}
+
+function setupProviderWorkspaceArtifacts(repoRoot: string, providerRoot: string): void {
+  for (const artifact of ['node_modules', 'dist']) {
+    const source = join(repoRoot, artifact);
+    const target = join(providerRoot, artifact);
+    if (existsSync(target) || !existsSync(source)) continue;
+    try {
+      symlinkSync(source, target, 'dir');
+    } catch {
+      // Advisory parity with kaizen-worktree-setup.sh: missing links should not
+      // hide the real provider failure if the workspace can otherwise run.
+    }
+  }
 }
 
 function validateAssignedRoot(
@@ -162,9 +215,85 @@ export function resolveProviderWorkspaceRoot(
   };
 }
 
+export function ensureProviderWorkspaceRoot(
+  input: ProviderWorkspaceInput,
+  deps: ProviderWorkspaceDeps = {},
+): ProviderWorkspaceResolution {
+  const initial = resolveProviderWorkspaceRoot(input, deps);
+  if (initial.ok || initial.reason !== 'missing-worktree') return initial;
+
+  const issue = initial.issue;
+  const repoRoot = resolve(input.repoRoot);
+  const worktreesDir = join(repoRoot, '.claude', 'worktrees');
+  const runGit = deps.runGit ?? defaultRunGit;
+  const bind = deps.bindIssue ?? defaultBindIssue;
+  const now = deps.now ?? (() => new Date());
+  const suffix = deps.randomSuffix ?? randomHexSuffix;
+  const setupArtifacts = deps.setupArtifacts ?? setupProviderWorkspaceArtifacts;
+  mkdirSync(worktreesDir, { recursive: true });
+
+  let lastError = '';
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const extra = attempt === 0 ? '' : `-${suffix()}`;
+    const caseId = `${timestampForCaseId(now())}-k${issue}-auto-dent${extra}`;
+    const branch = `case/${caseId}`;
+    const providerRoot = join(worktreesDir, caseId);
+    if (existsSync(providerRoot)) continue;
+
+    for (const base of ['origin/main', 'HEAD']) {
+      const added = runGit(repoRoot, ['worktree', 'add', '-q', '-b', branch, providerRoot, base]);
+      if (added.code !== 0) {
+        lastError = (added.stderr || added.stdout || `git worktree add exited ${added.code}`).trim();
+        continue;
+      }
+
+      try {
+        bind(providerRoot, issue);
+        if (input.runTag) {
+          runGit(providerRoot, ['config', 'extensions.worktreeConfig', 'true']);
+          runGit(providerRoot, ['config', '--worktree', 'kaizen.runtag', input.runTag]);
+        }
+        setupArtifacts(repoRoot, providerRoot);
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+        return {
+          ok: false,
+          reason: 'create-failed',
+          issue,
+          providerRoot,
+          detail: `created provider workspace ${providerRoot} for #${issue}, but failed to bind it: ${lastError}`,
+        };
+      }
+
+      return {
+        ok: true,
+        providerRoot,
+        issue,
+        source: 'created-worktree',
+        caseId,
+        branch,
+        created: true,
+      };
+    }
+  }
+
+  return {
+    ok: false,
+    reason: 'create-failed',
+    issue,
+    detail: `failed to create non-main case worktree for assigned issue #${issue}${lastError ? `: ${lastError}` : ''}`,
+  };
+}
+
 export function formatProviderWorkspaceResolution(resolution: ProviderWorkspaceResolution): string {
   if (resolution.ok) {
-    return `provider_workspace=${resolution.providerRoot} issue=${resolution.issue ?? 'unassigned'} source=${resolution.source}`;
+    return [
+      `provider_workspace=${resolution.providerRoot}`,
+      `issue=${resolution.issue ?? 'unassigned'}`,
+      `source=${resolution.source}`,
+      resolution.caseId ? `case=${resolution.caseId}` : '',
+      resolution.branch ? `branch=${resolution.branch}` : '',
+    ].filter(Boolean).join(' ');
   }
   return [
     `provider_workspace_error=${resolution.reason}`,

--- a/scripts/auto-dent-run.test.ts
+++ b/scripts/auto-dent-run.test.ts
@@ -84,6 +84,7 @@ import {
 } from './auto-dent-run.js';
 import { analyzeContextDelegation } from './auto-dent-context-delegation.js';
 import {
+  ensureProviderWorkspaceRoot,
   resolveProviderWorkspaceRoot,
 } from './auto-dent-provider-workspace.js';
 import { deriveRunTestHealth } from './auto-dent-test-health.js';
@@ -5414,6 +5415,79 @@ describe('provider workspace contract', () => {
     });
   });
 
+  it('creates and binds a missing assigned provider worktree before provider spawn', () => {
+    const localRepoRoot = mkdtempSync(join(tmpdir(), 'provider-workspace-main-'));
+    const created: Array<{ repoRoot: string; args: string[] }> = [];
+    const bound: Array<{ root: string; issue: number }> = [];
+    const resolved = ensureProviderWorkspaceRoot({
+      repoRoot: localRepoRoot,
+      invocationRoot: localRepoRoot,
+      assignedIssue: '#1164',
+      runTag: 'batch/run-1',
+    }, {
+      listWorktrees: () => [{ path: localRepoRoot, branch: 'main' }],
+      readBoundIssue: () => null,
+      now: () => new Date(2026, 5, 30, 14, 15, 0),
+      runGit: (root, args) => {
+        created.push({ repoRoot: root, args });
+        return { code: 0, stdout: '', stderr: '' };
+      },
+      bindIssue: (root, issue) => bound.push({ root, issue }),
+      setupArtifacts: () => {},
+    });
+
+    expect(resolved).toMatchObject({
+      ok: true,
+      issue: 1164,
+      source: 'created-worktree',
+      caseId: '2606301415-k1164-auto-dent',
+      branch: 'case/2606301415-k1164-auto-dent',
+      created: true,
+    });
+    const providerRoot = join(localRepoRoot, '.claude', 'worktrees', '2606301415-k1164-auto-dent');
+    expect(resolved.providerRoot).toBe(providerRoot);
+    expect(created[0]).toEqual({
+      repoRoot: localRepoRoot,
+      args: [
+        'worktree',
+        'add',
+        '-q',
+        '-b',
+        'case/2606301415-k1164-auto-dent',
+        providerRoot,
+        'origin/main',
+      ],
+    });
+    expect(created).toContainEqual({
+      repoRoot: providerRoot,
+      args: ['config', '--worktree', 'kaizen.runtag', 'batch/run-1'],
+    });
+    expect(bound).toEqual([{ root: providerRoot, issue: 1164 }]);
+    rmSync(localRepoRoot, { recursive: true, force: true });
+  });
+
+  it('reports worktree creation failures as provider workspace failures', () => {
+    const localRepoRoot = mkdtempSync(join(tmpdir(), 'provider-workspace-main-'));
+    const resolved = ensureProviderWorkspaceRoot({
+      repoRoot: localRepoRoot,
+      invocationRoot: localRepoRoot,
+      assignedIssue: '#1164',
+    }, {
+      listWorktrees: () => [{ path: localRepoRoot, branch: 'main' }],
+      readBoundIssue: () => null,
+      runGit: () => ({ code: 128, stdout: '', stderr: 'fatal: branch exists' }),
+    });
+
+    expect(resolved).toMatchObject({
+      ok: false,
+      reason: 'create-failed',
+      issue: 1164,
+    });
+    expect(resolved.detail).toContain('failed to create non-main case worktree for assigned issue #1164');
+    expect(formatProviderWorkspaceFailureDiagnosis(resolved as any).nextAction).toContain('Fix the git worktree creation or binding error');
+    rmSync(localRepoRoot, { recursive: true, force: true });
+  });
+
   it('formats provider workspace failures as diagnosis-first harness failures', () => {
     const resolved = resolveProviderWorkspaceRoot({
       repoRoot,
@@ -5522,7 +5596,7 @@ describe('provider workspace contract', () => {
     const runClaudeStart = source.indexOf('async function runClaude');
     const runClaudeEnd = source.indexOf('// Execute one run', runClaudeStart);
     const runClaudeSection = source.slice(runClaudeStart, runClaudeEnd);
-    const resolverIndex = runClaudeSection.indexOf('resolveProviderWorkspaceRoot');
+    const resolverIndex = runClaudeSection.indexOf('ensureProviderWorkspaceRoot');
     const codexIndex = runClaudeSection.indexOf('runCodex({');
     const claudeSpawnIndex = runClaudeSection.indexOf("spawn('claude'");
 

--- a/scripts/auto-dent-run.ts
+++ b/scripts/auto-dent-run.ts
@@ -244,9 +244,10 @@ import { runBacklogHealthMaintenance } from './backlog-health.js';
 import { gh as ghArgs } from '../src/lib/gh-exec.js';
 import {
   formatProviderWorkspaceResolution,
-  resolveProviderWorkspaceRoot,
+  ensureProviderWorkspaceRoot,
   type ProviderWorkspaceResolution,
 } from './auto-dent-provider-workspace.js';
+export { resolveProviderWorkspaceRoot } from './auto-dent-provider-workspace.js';
 
 // Types
 
@@ -3442,6 +3443,7 @@ export function formatProviderWorkspaceFailureDiagnosis(
     'missing-worktree': `Create or enter a non-main case worktree bound to ${issue}, then rerun auto-dent for that issue.`,
     'missing-binding': `Bind the provider workspace to ${issue} with cli-issue-binding before spawning the provider.`,
     'binding-mismatch': `Use the case worktree bound to ${issue}, or fix the stale kaizen.issue binding before spawning the provider.`,
+    'create-failed': `Fix the git worktree creation or binding error for ${issue}, then rerun auto-dent.`,
   };
   return {
     phase: 'provider workspace resolution',
@@ -3671,10 +3673,12 @@ async function runClaude(
   const candidateManifestPath = modeSelection.mode === 'explore'
     ? candidateTaskManifestPath(logDir, runNum)
     : undefined;
-  const providerWorkspace = resolveProviderWorkspaceRoot({
+  const agentRunTag = `${state.batch_id}/run-${runNum}`;
+  const providerWorkspace = ensureProviderWorkspaceRoot({
     repoRoot,
     invocationRoot,
     assignedIssue: promptMeta.claimedPlanIssue,
+    runTag: agentRunTag,
     knownCases: [
       ...state.cases,
       state.last_case,
@@ -3692,6 +3696,16 @@ async function runClaude(
       promptMeta,
       workspace: providerWorkspace,
     });
+  }
+  if (providerWorkspace.created && providerWorkspace.caseId) {
+    if (!result.cases.includes(providerWorkspace.caseId)) result.cases.push(providerWorkspace.caseId);
+    upsertProgressStep(result, {
+      phase: 'CASE',
+      state: 'created',
+      detail: providerWorkspace.caseId,
+    });
+    checkpointRunState(stateFile, { runNum, result });
+    console.log(`  [case] created ${providerWorkspace.branch ?? `case/${providerWorkspace.caseId}`} at ${providerWorkspace.providerRoot}`);
   }
 
   if (shouldRunCodexProvider(state)) {
@@ -3742,7 +3756,6 @@ async function runClaude(
   // run-scoped attribution signal independent of stream markers.
   // (Local names are agent-prefixed to stay clear of the canonical post-run
   // `runId` declaration guarded by the #1128 regression test.)
-  const agentRunTag = `${state.batch_id}/run-${runNum}`;
   const agentRunId = makeRunId(state.batch_id, runNum);
 
   return new Promise((resolvePromise) => {

--- a/scripts/auto-dent.test.ts
+++ b/scripts/auto-dent.test.ts
@@ -22,6 +22,8 @@ import {
   checkHaltFile,
   checkBudget,
   stopDecision,
+  afterRunStopDecision,
+  handleShutdownSignal,
   writeBatchSummary,
   formatBatchSummary,
   postStructuredSummary,
@@ -484,6 +486,17 @@ describe('stopDecision and budget', () => {
     });
   });
 
+  it('stops immediately after a run reaches the consecutive failure threshold', () => {
+    expect(afterRunStopDecision(makeState({
+      run: 3,
+      consecutive_failures: 3,
+      max_failures: 3,
+    }))).toEqual({
+      stop: true,
+      reason: '3 consecutive failures',
+    });
+  });
+
   it('reports budget status and stops on exhaustion', () => {
     const state = makeState({
       max_budget: '10.00',
@@ -498,6 +511,39 @@ describe('stopDecision and budget', () => {
       stop: true,
       reason: 'budget exhausted ($10.00 >= $10.00)',
     });
+  });
+});
+
+describe('shutdown signal handling', () => {
+  it('records a graceful stop request on the first signal', () => {
+    const flag = { value: false };
+    const logs: string[] = [];
+    const updates: Array<[string, string, unknown]> = [];
+
+    handleShutdownSignal(flag, '/tmp/state.json', {
+      log: (message) => logs.push(message),
+      updateStateKey: (stateFile, key, value) => updates.push([stateFile, key, value]),
+      exit: () => { throw new Error('exit should not be called'); },
+    });
+
+    expect(flag.value).toBe(true);
+    expect(logs).toContain('>>> Received shutdown signal. Finishing current run, then stopping...');
+    expect(updates).toEqual([['/tmp/state.json', 'stop_reason', 'signal (SIGTERM/SIGINT)']]);
+  });
+
+  it('exits immediately on a second signal during finalization', () => {
+    const flag = { value: true };
+    const logs: string[] = [];
+    const exits: number[] = [];
+
+    handleShutdownSignal(flag, '/tmp/state.json', {
+      log: (message) => logs.push(message),
+      updateStateKey: () => { throw new Error('state should not be updated on second signal'); },
+      exit: (code) => { exits.push(code); },
+    });
+
+    expect(logs).toContain('>>> Second shutdown signal received. Exiting now; finalization may be incomplete.');
+    expect(exits).toEqual([130]);
   });
 });
 

--- a/scripts/auto-dent.ts
+++ b/scripts/auto-dent.ts
@@ -422,6 +422,10 @@ export function stopDecision(state: BatchState, nextRun: number): StopDecision {
   return { stop: false, reason: '' };
 }
 
+export function afterRunStopDecision(state: BatchState): StopDecision {
+  return stopDecision(state, state.run + 1);
+}
+
 export function writeBatchSummary(stateFile: string, nowEpoch = Math.floor(Date.now() / 1000)): string {
   const state = readState(stateFile);
   const duration = nowEpoch - state.batch_start;
@@ -757,6 +761,37 @@ export function postStructuredSummary(
   }
 }
 
+export interface ShutdownSignalState {
+  value: boolean;
+}
+
+export interface ShutdownSignalDeps {
+  log?: (message: string) => void;
+  updateStateKey?: (stateFile: string, key: string, value: unknown) => void;
+  exit?: (code: number) => void;
+}
+
+export function handleShutdownSignal(
+  state: ShutdownSignalState,
+  stateFile: string,
+  deps: ShutdownSignalDeps = {},
+): void {
+  const log = deps.log ?? console.log;
+  const update = deps.updateStateKey ?? updateStateKey;
+  const exit = deps.exit ?? process.exit;
+
+  log('');
+  if (state.value) {
+    log('>>> Second shutdown signal received. Exiting now; finalization may be incomplete.');
+    exit(130);
+    return;
+  }
+
+  state.value = true;
+  log('>>> Received shutdown signal. Finishing current run, then stopping...');
+  update(stateFile, 'stop_reason', 'signal (SIGTERM/SIGINT)');
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -838,13 +873,9 @@ async function main(): Promise<void> {
     writeState(stateFile, state);
   }
 
-  let shuttingDown = false;
+  const shutdownState = { value: false };
   const handleShutdown = () => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    console.log('');
-    console.log('>>> Received shutdown signal. Finishing current run, then stopping...');
-    updateStateKey(stateFile, 'stop_reason', 'signal (SIGTERM/SIGINT)');
+    handleShutdownSignal(shutdownState, stateFile);
   };
   process.on('SIGTERM', handleShutdown);
   process.on('SIGINT', handleShutdown);
@@ -871,7 +902,7 @@ async function main(): Promise<void> {
   }
 
   while (true) {
-    if (shuttingDown) break;
+    if (shutdownState.value) break;
     if (checkHaltFile(haltFile, stateFile)) break;
 
     const current = readState(stateFile);
@@ -923,7 +954,7 @@ async function main(): Promise<void> {
       console.log(`>>> Stopping: ${afterRun.stop_reason}`);
       break;
     }
-    if (shuttingDown) break;
+    if (shutdownState.value) break;
 
     const elapsed = Math.floor(Date.now() / 1000) - batchStart;
     const hours = Math.floor(elapsed / 3600);
@@ -935,13 +966,15 @@ async function main(): Promise<void> {
     console.log(`  Time: ${hours}h ${mins}m elapsed`);
     console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
 
-    if (afterRun.max_runs > 0 && afterRun.run >= afterRun.max_runs) {
-      updateStateKey(stateFile, 'stop_reason', `max runs reached (${afterRun.max_runs})`);
+    const afterRunDecision = afterRunStopDecision(afterRun);
+    if (afterRunDecision.stop) {
+      console.log(`>>> Stopping: ${afterRunDecision.reason}`);
+      if (!afterRun.stop_reason) updateStateKey(stateFile, 'stop_reason', afterRunDecision.reason);
       break;
     }
-    if (shuttingDown) break;
+    if (shutdownState.value) break;
     if (checkHaltFile(haltFile, stateFile)) break;
-    if (await cooldown(afterRun.current_cooldown || afterRun.cooldown, haltFile, stateFile, () => shuttingDown)) break;
+    if (await cooldown(afterRun.current_cooldown || afterRun.cooldown, haltFile, stateFile, () => shutdownState.value)) break;
   }
 
   const summaryPath = writeBatchSummary(stateFile);

--- a/scripts/transcript-bundle-download.ts
+++ b/scripts/transcript-bundle-download.ts
@@ -1,4 +1,4 @@
-import artifactClient, { type ArtifactClient, type FindOptions } from '@actions/artifact';
+import type { ArtifactClient, FindOptions } from '@actions/artifact';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -109,6 +109,17 @@ function downloadFailureReason(err: unknown): 'unauthorized' | 'download_failed'
     : 'download_failed';
 }
 
+async function loadActionsArtifactClient(): Promise<typeof import('@actions/artifact').default> {
+  try {
+    const actionsArtifact = await import('@actions/artifact');
+    return actionsArtifact.default;
+  } catch (err) {
+    throw new Error(
+      `@actions/artifact is required to download transcript bundles: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export async function defaultTranscriptArtifactDownloader(
   manifest: TranscriptBundleManifest,
   options: {
@@ -126,7 +137,7 @@ export async function defaultTranscriptArtifactDownloader(
     repositoryOwner: owner,
     repositoryName: name,
   };
-  const client = options.client ?? artifactClient;
+  const client = options.client ?? await loadActionsArtifactClient();
   const artifact = await client.getArtifact(manifest.artifact_name, { findBy });
   const artifactDir = mkdtempSync(join(tmpdir(), 'kaizen-transcript-artifact-'));
   try {

--- a/scripts/transcript-bundle-upload.ts
+++ b/scripts/transcript-bundle-upload.ts
@@ -1,5 +1,5 @@
 import { dirname } from 'node:path';
-import artifactClient, { type UploadArtifactOptions, type UploadArtifactResponse } from '@actions/artifact';
+import type { UploadArtifactOptions, UploadArtifactResponse } from '@actions/artifact';
 import { writeAttachment, type AttachmentTarget } from '../src/section-editor.js';
 import {
   TranscriptBundleManifestSchema,
@@ -86,12 +86,24 @@ export function formatTranscriptBundleAttachment(manifest: TranscriptBundleManif
   ].join('\n');
 }
 
+async function loadActionsArtifactClient(): Promise<typeof import('@actions/artifact').default> {
+  try {
+    const actionsArtifact = await import('@actions/artifact');
+    return actionsArtifact.default;
+  } catch (err) {
+    throw new Error(
+      `@actions/artifact is required to upload transcript bundles: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export async function defaultActionsArtifactUpload(
   name: string,
   files: string[],
   rootDirectory: string,
   options?: UploadArtifactOptions,
 ): Promise<UploadArtifactResponse> {
+  const artifactClient = await loadActionsArtifactClient();
   return artifactClient.uploadArtifact(name, files, rootDirectory, options);
 }
 


### PR DESCRIPTION
## Story

Once upon a time, `./scripts/auto-dent.sh ... --provider codex` could build a useful batch plan and still do no work. Every planned run expected an already-existing non-main case worktree for the assigned issue.

Every day, that resolver was a good fail-closed guard for stale or mismatched workspaces, but it also meant a fresh planned Codex item had no way to reach provider startup.

One day, batch `disciplinary-roundworm` assigned #1213, #1189, and #1176. All three runs failed in 0s with `no non-main case worktree found for assigned issue`, marked plan items skipped, and then cooled down even after reaching 3/3 failures. A second Ctrl+C during finalization also left the terminal stuck waiting.

Because of that, this PR makes the harness provision the missing provider workspace itself: it creates a `.claude/worktrees/<timestamp>-k<issue>-auto-dent` case worktree, binds `kaizen.issue`, stamps `kaizen.runtag`, links runtime artifacts, and records the created case before spawning Codex or Claude.

Because of that, creation failures still fail closed, but with an explicit `create-failed` provider-workspace diagnosis instead of silently becoming another zero-tool run.

Because startup and shutdown paths should not fail before the requested operation is reached, this PR also makes transcript artifact upload/download load `@actions/artifact` lazily. Auto-dent can now import those modules during ordinary local startup/finalization without paying the artifact-client module-load cost unless upload/download actually runs.

Until finally, the outer loop now checks stop conditions immediately after a completed run summary and before cooldown, and a second shutdown signal exits finalization with code 130.

And ever since, a planned Codex batch can move from plan assignment to a real provider workspace, while systemic fast failures stop promptly and the operator keeps terminal control.

Closes #1746

## Architecture

```text
plan item -> ensureProviderWorkspaceRoot()
          -> existing bound worktree: use it
          -> missing worktree: git worktree add case/...
                            -> bind kaizen.issue --worktree
                            -> stamp kaizen.runtag
                            -> link node_modules/dist
          -> record CASE progress
          -> spawn provider in providerRoot

summary/finalization imports -> transcript bundle modules
                            -> no artifact client load at module import
                            -> dynamic import only when upload/download runs
```

## Design Decisions

| Decision | Why | Tradeoff |
|---|---|---|
| Auto-provision only on `missing-worktree` | Preserves existing fail-closed behavior for missing bindings and mismatches | Does not paper over stale workspace state |
| Create case branches under `.claude/worktrees` | Matches existing auto-dent/case conventions and resolver trust boundary | Leaves a real worktree artifact for cleanup tooling |
| Bind with `src/issue-binding.ts` helper | Keeps per-worktree `kaizen.issue` semantics and avoids shared config leaks | Adds harness-side provisioning responsibility |
| Check stop conditions after every run | Prevents cooldown after threshold/budget exhaustion | Slightly more loop branching, covered by tests |
| Second signal exits with 130 | Gives operators a clean escape during finalization | Finalization may be incomplete after explicit second interrupt |
| Lazy-load `@actions/artifact` | Keeps local auto-dent startup/finalization from depending on artifact upload/download at module load | Upload/download still fails explicitly if the package is unavailable when actually used |

## What Changed

| File | Purpose |
|---|---|
| `scripts/auto-dent-provider-workspace.ts` | Adds `ensureProviderWorkspaceRoot`, worktree creation, binding, runtime artifact setup, and create-failed diagnostics |
| `scripts/auto-dent-run.ts` | Uses workspace ensure before provider spawn and records created case progress |
| `scripts/auto-dent.ts` | Adds post-run stop checks and first/second shutdown signal handling |
| `scripts/transcript-bundle-upload.ts` | Defers `@actions/artifact` import until artifact upload is actually invoked |
| `scripts/transcript-bundle-download.ts` | Defers `@actions/artifact` import until artifact download is actually invoked |
| `scripts/auto-dent-run.test.ts` | Covers provider workspace creation/failure and spawn-order contract |
| `scripts/auto-dent.test.ts` | Covers immediate stop-after-threshold and shutdown signal behavior |

## Impact (goal -> before/after -> match)

- Goal (#1746): Planned Codex auto-dent runs should either enter a bound non-main provider workspace and start work, or fail with an actionable harness error; batches should stop immediately once `max_failures` is reached. Startup/finalization imports should not pull optional artifact upload/download behavior before it is used.
- Acceptance signal: Unit coverage demonstrates provider workspace auto-provisioning, worktree creation failure diagnostics, immediate post-run stop at the failure threshold, first/second shutdown signal handling, and transcript bundle upload/download behavior under injected adapters.
- BEFORE: `disciplinary-roundworm` run #1-#3 each failed at provider workspace resolution with `no non-main case worktree found`, produced zero tool calls, marked plan items skipped, and still entered cooldown after 3/3 consecutive failures. Transcript bundle modules statically imported the Actions artifact client during module load.
- AFTER: `ensureProviderWorkspaceRoot` creates and binds a missing assigned provider worktree before provider spawn; `afterRunStopDecision` stops before cooldown; `handleShutdownSignal` exits on the second signal; transcript bundle upload/download dynamically imports the Actions artifact client only when those paths run.
- Delta: Zero-tool planned runs caused by missing case worktrees are replaced by deterministic workspace provisioning; threshold exhaustion no longer waits for another loop turn; artifact-client load is moved out of startup/import time.
- Goal met?: yes.
- Residual scan: no additional same-scope dirty files remain.

## Test Plan (Behaviors x Levels)

| Behavior | Level | Coverage | Status |
|---|---|---|---|
| Missing assigned provider worktree is auto-created and issue-bound | unit | `scripts/auto-dent-run.test.ts` provider workspace contract | tested |
| Worktree creation/binding failures remain actionable harness failures | unit | `scripts/auto-dent-run.test.ts` provider workspace contract | tested |
| Hitting `max_failures` after a run stops before cooldown | unit | `scripts/auto-dent.test.ts` stopDecision and budget | tested |
| First Ctrl+C records graceful stop; second Ctrl+C exits immediately | unit | `scripts/auto-dent.test.ts` shutdown signal handling | tested |
| Transcript bundle upload/download modules stay testable through injected adapters | unit | `scripts/transcript-bundle-upload.test.ts`, `scripts/transcript-bundle-download.test.ts` | tested |
| Changed auto-dent surface remains type-safe and regression-safe | local integration | `npm run typecheck`, `npm run test:fast` | tested |

## Validation

- [x] `npx vitest run scripts/transcript-bundle-upload.test.ts scripts/transcript-bundle-download.test.ts scripts/auto-dent-run.test.ts scripts/auto-dent.test.ts` - 498 tests passed.
- [x] `npm run typecheck` - passed.
- [x] `npm run test:fast` - 808 passed, 3 skipped.
- [x] `git diff --check -- scripts/auto-dent-provider-workspace.ts scripts/auto-dent-run.ts scripts/auto-dent.ts scripts/auto-dent-run.test.ts scripts/auto-dent.test.ts` - passed before the transcript files were included; no whitespace issues were introduced in the final staged diff.

## Known Limitations

- I did not run a live full Codex auto-dent batch from this branch. The coverage verifies the harness decision points directly.
- The harness-created worktree is intentionally durable and will be cleaned by the existing worktree cleanup flows, not removed immediately after provider spawn.
